### PR TITLE
Configmgr 2.0 Initial Baseline

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,6 +127,10 @@ if (APPLE OR WIN32)
   HPCC_ADD_SUBDIRECTORY (lib2)
 endif (APPLE OR WIN32)
 
+if (MAKE_CONFIGURATOR)
+    HPCC_ADD_SUBDIRECTORY (configuration)
+endif()
+
 ###
 ## CPack install and packaging setup.
 ###

--- a/cmake_modules/commonSetup.cmake
+++ b/cmake_modules/commonSetup.cmake
@@ -91,6 +91,17 @@ IF ("${COMMONSETUP_DONE}" STREQUAL "")
   option(USE_RINSIDE "Enable R support" ON)
   option(USE_MEMCACHED "Enable Memcached support" ON)
   option(USE_REDIS "Enable Redis support" ON)
+  option(MAKE_CONFIGURATOR "Build Configurator" ON)
+  option(CONFIGURATOR_LIB "Build Configurator static library (.a)" OFF)
+  option(CONFIGURATOR_QT_UI "Build Configurator with QT based UI" OFF)
+
+  if (CONFIGURATOR_QT_UI OR CONFIGURATOR_LIB )
+        set( MAKE_CONFIGURATOR ON )
+  endif()
+
+  if ( (CONFIGURATOR_QT_UI AND CONFIGURATOR_LIB) )
+        MESSAGE( FATAL_ERROR "Only 1 type of configurator target possible" )
+  endif()
 
   if (APPLE OR WIN32)
       option(USE_TBB "Enable Threading Building Block support" OFF)

--- a/configuration/CMakeLists.txt
+++ b/configuration/CMakeLists.txt
@@ -1,0 +1,38 @@
+################################################################################
+#    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+################################################################################
+
+
+# Check if environment variable QTDIR is set.
+IF( CONFIGURATOR_QT_UI AND DEFINED ENV{QTDIR} )
+    SET( CMAKE_PREFIX_PATH $ENV{QTDIR} ${CMAKE_PREFIX_PATH} )
+    SET( Qt5_INCLUDE_DIRS ${CMAKE_PREFIX_PATH}/include )
+    SET( Qt5_LIB_DIR ${CMAKE_PREFIX_PATH}/lib )
+    SET( QT_MODULE_PATH ${CMAKE_PREFIX_PATH}/lib/cmake)
+    SET( CMAKE_MODULE_PATH ${CONFIGURATOR_MODULE_PATH}  ${QT_MODULE_PATH} )
+
+    MESSAGE( "Set CMAKE_MODULE_PATH to ${CMAKE_MODULE_PATH}" )
+    MESSAGE( "-- Qt5_INCLUDE_DIRS is set to ${Qt5_INCLUDE_DIRS}" )
+    MESSAGE( "-- Qt5_LIB_DIR is set to ${Qt5_LIB_DIR}" )
+
+    HPCC_ADD_SUBDIRECTORY (configurator_ui)
+    HPCC_ADD_SUBDIRECTORY (configurator_app)
+
+ELSEIF ( CONFIGURATOR_QT_UI )
+    MESSAGE( FATAL_ERROR "ERROR: Environment variable QTDIR is not set. Please locate your Qt folder and set QTDIR.")
+ENDIF()
+
+
+HPCC_ADD_SUBDIRECTORY (configurator)

--- a/configuration/configurator/BuildSet.cpp
+++ b/configuration/configurator/BuildSet.cpp
@@ -1,0 +1,244 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include "BuildSet.hpp"
+#include "jptree.hpp"
+#include "XMLTags.h"
+#include "SchemaCommon.hpp"
+
+#define LOOP_THRU_BUILD_SET for (int idx = 0; idx < m_buildSetArray.length(); idx++)
+
+static CBuildSetManager *s_pBuildSetManager = NULL;
+
+CBuildSetManager* CBuildSetManager::getInstance(const char* pBuildSetFile, const char* pBuildSetDirectory)
+{
+    if (s_pBuildSetManager == NULL)
+    {
+        s_pBuildSetManager = new CBuildSetManager();
+
+        if (pBuildSetFile != NULL)
+            s_pBuildSetManager->m_buildSetFile.set(pBuildSetFile);
+        else
+            s_pBuildSetManager->m_buildSetFile.set(DEFAULT_BUILD_SET_XML_FILE);
+
+        if (pBuildSetDirectory != NULL)
+            s_pBuildSetManager->m_buildSetDir.set(pBuildSetDirectory);
+        else
+            s_pBuildSetManager->m_buildSetDir.set(DEFAULT_BUILD_SET_DIRECTORY);
+
+        pBuildSetFile = s_pBuildSetManager->m_buildSetFile;
+        pBuildSetDirectory = s_pBuildSetManager->m_buildSetDir;
+
+        s_pBuildSetManager->m_buildSetPath.clear().appendf("%s%s%s", pBuildSetDirectory, pBuildSetDirectory[strlen(pBuildSetDirectory)-1] == '/' ? "" : "/", pBuildSetFile);
+        s_pBuildSetManager->populateBuildSet();
+    }
+    return s_pBuildSetManager;
+}
+
+CBuildSetManager::CBuildSetManager(const char* pBuildSetFile, const char* pBuildSetDir) : m_buildSetFile(pBuildSetFile), m_buildSetDir(pBuildSetDir)
+{
+    if (pBuildSetFile != NULL && pBuildSetDir != NULL)
+       m_buildSetPath.clear().appendf("%s%s%s", pBuildSetDir, pBuildSetDir[strlen(pBuildSetDir)-1] == '/' ? "" : "/", pBuildSetFile);
+}
+
+CBuildSetManager::CBuildSetManager()
+{
+}
+
+CBuildSetManager::~CBuildSetManager()
+{
+    m_buildSetArray.kill();
+}
+
+void CBuildSetManager::getBuildSetComponents(StringArray& buildSetArray) const
+{
+    int nLength = this->getBuildSetComponentCount();
+
+    for (int idx = 0; idx < nLength; idx++)
+    {
+        buildSetArray.append(this->getBuildSetComponentName(idx));
+    }
+}
+
+void CBuildSetManager::getBuildSetServices(StringArray& buildSetArray) const
+{
+    int nLength = this->getBuildSetServiceCount();
+
+    for (int idx = 0; idx < nLength; idx++)
+    {
+        buildSetArray.append(this->getBuildSetServiceName(idx));
+    }
+}
+
+const char* CBuildSetManager::getBuildSetServiceName(int index) const
+{
+    return this->getBuildSetService(index)->getName();
+}
+
+const char* CBuildSetManager::getBuildSetServiceFileName(int index) const
+{
+    return this->getBuildSetService(index)->getSchema();
+}
+
+const char* CBuildSetManager::getBuildSetComponentName(int index) const
+{
+    return this->getBuildSetComponent(index)->getName();
+}
+
+const char* CBuildSetManager::getBuildSetComponentFileName(int index) const
+{
+    return this->getBuildSetComponent(index)->getSchema();
+}
+
+const char* CBuildSetManager::getBuildSetProcessName(int index) const
+{
+    return this->getBuildSetComponent(index)->getProcessName();
+}
+
+bool CBuildSetManager::populateBuildSet()
+{
+    StringBuffer xpath;
+
+    if (m_buildSetTree.get() != NULL)
+        return false;
+
+    try
+    {
+        m_buildSetTree.set(createPTreeFromXMLFile(m_buildSetPath.str()));
+    }
+    catch(...)
+    {
+        return false;
+    }
+
+    xpath.appendf("./%s/%s/%s", XML_TAG_PROGRAMS, XML_TAG_BUILD, XML_TAG_BUILDSET);
+
+    Owned<IPropertyTreeIterator> iter = m_buildSetTree->getElements(xpath.str());
+
+    ForEach(*iter)
+    {
+        IPropertyTree* pTree = &iter->query();
+
+        if ( pTree->queryProp(XML_ATTR_PROCESS_NAME) == NULL || pTree->queryProp(XML_ATTR_OVERIDE) != NULL || ( (pTree->queryProp(XML_ATTR_DEPLOYABLE) != NULL && \
+                stricmp(pTree->queryProp(XML_ATTR_DEPLOYABLE), "no") == 0 && stricmp(pTree->queryProp(XML_ATTR_PROCESS_NAME), XML_TAG_ESPSERVICE) != 0) ) )
+            continue;
+
+        Owned<CBuildSet> pBuildSet = new CBuildSet(pTree->queryProp(XML_ATTR_INSTALLSET), pTree->queryProp(XML_ATTR_NAME), pTree->queryProp(XML_ATTR_PROCESS_NAME),\
+                                                   pTree->queryProp(XML_ATTR_SCHEMA), pTree->queryProp(XML_ATTR_DEPLOYABLE), pTree->queryProp(XML_ATTR_OVERIDE));
+
+        m_buildSetArray.append(*pBuildSet.getLink());
+    }
+    return true;
+}
+
+void CBuildSetManager::setBuildSetArray(const StringArray &strArray)
+{
+    m_buildSetArray.kill();
+
+    for (int idx = 0; idx < strArray.length(); idx++)
+    {
+        Owned<CBuildSet> pBSet = new CBuildSet(NULL, strArray.item(idx), NULL, strArray.item(idx));
+        assert (pBSet != NULL);
+        m_buildSetArray.append(*pBSet.getClear());
+    }
+}
+
+const char* CBuildSetManager::getBuildSetSchema(int index) const
+{
+    assert(index < m_buildSetArray.length());
+    if (index < m_buildSetArray.length())
+        return m_buildSetArray.item(index).getSchema();
+    else
+        return NULL;
+}
+
+const int CBuildSetManager::getBuildSetSchemaCount() const
+{
+    return m_buildSetArray.length();
+}
+
+const int CBuildSetManager::getBuildSetServiceCount() const
+{
+    int nCount = 0;
+
+    LOOP_THRU_BUILD_SET
+    {
+        if (m_buildSetArray.item(idx).getProcessName() != NULL && strcmp(m_buildSetArray.item(idx).getProcessName(), XML_TAG_ESPSERVICE) == 0 && \
+                (m_buildSetArray.item(idx).getDeployable() != NULL && stricmp(m_buildSetArray.item(idx).getDeployable(), "no") == 0))
+            nCount++;
+    }
+    return nCount;
+}
+
+const int CBuildSetManager::getBuildSetComponentCount() const
+{
+    int nCount = 0;
+
+    LOOP_THRU_BUILD_SET
+    {
+        if ( ((m_buildSetArray.item(idx).getProcessName() == NULL) || (strcmp(m_buildSetArray.item(idx).getProcessName(), XML_TAG_ESPSERVICE) != 0)) && \
+                ( (m_buildSetArray.item(idx).getDeployable() == NULL) || (stricmp(m_buildSetArray.item(idx).getDeployable(), "no") != 0) ) && \
+                ( (m_buildSetArray.item(idx).getOveride() == NULL) || (stricmp(m_buildSetArray.item(idx).getOveride(), "no")    != 0) ) )
+            nCount++;
+    }
+    return nCount;
+}
+
+const CBuildSet* CBuildSetManager::getBuildSetComponent(int index) const
+{
+    int nCount = 0;
+
+    LOOP_THRU_BUILD_SET
+    {
+        if (index == 0)
+        {
+            if ( ((m_buildSetArray.item(idx).getProcessName() == NULL) || (strcmp(m_buildSetArray.item(idx).getProcessName(), XML_TAG_ESPSERVICE) != 0)) && \
+                    ( (m_buildSetArray.item(idx).getDeployable() == NULL) || (stricmp(m_buildSetArray.item(idx).getDeployable(), "no") != 0) ) && \
+                    ( (m_buildSetArray.item(idx).getOveride() == NULL) || (stricmp(m_buildSetArray.item(idx).getOveride(), "no") != 0) ) )
+                return &(m_buildSetArray.item(idx));
+            else
+                continue;
+        }
+        if ( ((m_buildSetArray.item(idx).getProcessName() == NULL) || (strcmp(m_buildSetArray.item(idx).getProcessName(), XML_TAG_ESPSERVICE) != 0)) && \
+                ( (m_buildSetArray.item(idx).getDeployable() == NULL)|| (stricmp(m_buildSetArray.item(idx).getDeployable(), "no") != 0) ) && \
+                ( (m_buildSetArray.item(idx).getOveride() == NULL) || (stricmp(m_buildSetArray.item(idx).getOveride(), "no") != 0) ) )
+            index--;
+    }
+    assert(!"index invalid");
+    return NULL;
+}
+
+const CBuildSet* CBuildSetManager::getBuildSetService(int index) const
+{
+    LOOP_THRU_BUILD_SET
+    {
+        if (index == 0)
+        {
+            if (m_buildSetArray.item(idx).getProcessName() != NULL && strcmp(m_buildSetArray.item(idx).getProcessName(), XML_TAG_ESPSERVICE) == 0 && \
+                    (m_buildSetArray.item(idx).getDeployable() != NULL && stricmp(m_buildSetArray.item(idx).getDeployable(), "no") == 0))
+                return &(m_buildSetArray.item(idx));
+            else
+                continue;
+        }
+        if (m_buildSetArray.item(idx).getProcessName() != NULL && strcmp(m_buildSetArray.item(idx).getProcessName(), XML_TAG_ESPSERVICE) == 0 && \
+                (m_buildSetArray.item(idx).getDeployable() != NULL && stricmp(m_buildSetArray.item(idx).getDeployable(), "no") == 0))
+            index--;
+    }
+
+    assert(!"index invalid");
+    return NULL;
+}

--- a/configuration/configurator/BuildSet.hpp
+++ b/configuration/configurator/BuildSet.hpp
@@ -1,0 +1,119 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef _BUILD_SET_HPP_
+#define _BUILD_SET_HPP_
+
+#include "jstring.hpp"
+#include "jlib.hpp"
+
+static const char* DEFAULT_BUILD_SET_XML_FILE("buildset.xml");
+static const char* DEFAULT_BUILD_SET_DIRECTORY("/opt/HPCCSystems/componentfiles/configxml/");
+
+class StringArray;
+class CBuildSet;
+
+class CBuildSetManager
+{
+public:
+
+    static CBuildSetManager* getInstance(const char* pBuildSetFile =  NULL, const char* pBuildSetDirectory = NULL);
+
+    virtual ~CBuildSetManager();
+    void getBuildSetComponents(StringArray& buildSetArray) const;
+    void getBuildSetServices(StringArray& buildSetArray) const;
+    void setBuildSetArray(const StringArray &strArray);
+    const char* getBuildSetServiceName(int index) const;
+    const char* getBuildSetServiceFileName(int index) const;
+    const char* getBuildSetComponentName(int index) const;
+    const char* getBuildSetComponentFileName(int index) const;
+    const char* getBuildSetProcessName(int index) const;
+    const char* getBuildSetSchema(int index) const;
+    const int getBuildSetSchemaCount() const;
+    const int getBuildSetServiceCount() const;
+    const int getBuildSetComponentCount() const;\
+    bool populateBuildSet();
+
+protected:
+
+    CBuildSetManager();
+    CBuildSetManager(const char* pBuildSetFile, const char* pBuildSetDir);
+    const CBuildSet* getBuildSetComponent(int index) const;
+    const CBuildSet* getBuildSetService(int index) const;
+    CIArrayOf<CBuildSet> m_buildSetArray;
+    Owned<IPropertyTree> m_buildSetTree;
+    StringBuffer m_buildSetFile;
+    StringBuffer m_buildSetDir;
+    StringBuffer m_buildSetPath;
+};
+
+
+class CBuildSet : public CInterface
+{
+public:
+
+    IMPLEMENT_IINTERFACE
+
+    CBuildSet(const char* pInstallSet = NULL, const char* pName = NULL, const char* pProcessName = NULL, const char* pSchema = NULL, const char* pDeployable = NULL, const char *pOveride = NULL) : m_pInstallSet(pInstallSet), m_pName(pName), m_pProcessName(pProcessName), m_pSchema(pSchema), m_pDeployable(pDeployable), m_pOveride(pOveride)
+    {
+    }
+
+    virtual ~CBuildSet()
+    {
+    }
+
+    const char* getInstallSet() const
+    {
+        return m_pInstallSet;
+    }
+    const char* getName() const
+    {
+        return m_pName;
+    }
+    const char* getProcessName() const
+    {
+        return m_pProcessName;
+    }
+    const char* getSchema() const
+    {
+        return m_pSchema;
+    }
+    const char* getDeployable() const
+    {
+        return m_pDeployable;
+    }
+    const char* getOveride() const
+    {
+        return m_pOveride;
+    }
+
+protected:
+
+    CBuildSet();
+    CBuildSet(const CBuildSet& buildSet) : m_pInstallSet(buildSet.m_pInstallSet), m_pName(buildSet.m_pName), m_pProcessName(buildSet.m_pProcessName), m_pSchema(buildSet.m_pSchema), m_pDeployable(buildSet.m_pDeployable)
+    {}
+    const char* m_pInstallSet;
+    const char* m_pName;
+    const char* m_pProcessName;
+    const char* m_pSchema;
+    const char* m_pDeployable;
+    const char* m_pOveride;
+
+private:
+};
+
+#endif // _BUILD_SET_HPP_

--- a/configuration/configurator/CMakeLists.txt
+++ b/configuration/configurator/CMakeLists.txt
@@ -1,0 +1,46 @@
+project ( configurator )
+
+SET(  SRCS QMLMarkup.cpp QMLMarkup.hpp ConfiguratorMain.cpp ConfigFileComponentUtils.cpp ConfigFileUtils.cpp
+      ConfigFileUtilsObservable.cpp EnvironmentConfiguration.cpp WizardBase.cpp ConfigSchemaHelper.cpp
+      SchemaAttributes.cpp SchemaComplexType.cpp SchemaSequence.cpp SchemaElement.cpp
+      SchemaAppInfo.cpp SchemaAnnotation.cpp SchemaComplexContent.cpp SchemaComplexType.cpp SchemaDocumentation.cpp
+      SchemaExtension.cpp SchemaChoice.cpp SchemaInclude.cpp SchemaSchema.cpp SchemaSimpleType.cpp SchemaRestriction.cpp 
+      SchemaEnumeration.cpp SchemaCommon.cpp ExceptionStrings.cpp SchemaEnumeration.cpp SchemaAttributeGroup.cpp DocumentationMarkup.hpp
+      SchemaCommon.hpp BuildSet.cpp ConfiguratorAPI.cpp SchemaMapManager.cpp EnvironmentModel.cpp SchemaFractionDigits.cpp SchemaLength.cpp SchemaMaxExclusive.cpp
+      SchemaMaxInclusive.cpp SchemaMaxLength.cpp SchemaMinInclusive.cpp SchemaMinExclusive.cpp SchemaMinLength.cpp SchemaPattern.cpp SchemaTotalDigits.cpp SchemaWhiteSpace.cpp
+      SchemaKey.cpp SchemaKeyRef.cpp SchemaSelector.cpp SchemaUnique.cpp SchemaField.cpp SchemaSimpleContent.cpp ConfigNotifications.cpp)
+
+  INCLUDE_DIRECTORIES(
+        ${Qt5_INCLUDE_DIRS}
+        ${Qt5_INCLUDE_DIRS}/QtGui
+        ${Qt5_INCLUDE_DIRS}/QtCore
+        ${Qt5_INCLUDE_DIRS}/QtNetwork
+        ${Qt5_INCLUDE_DIRS}/QtQml
+        ${Qt5_INCLUDE_DIRS}/QtQuick
+        ${HPCC_SOURCE_DIR}/system/include
+        ${HPCC_SOURCE_DIR}/system/jlib
+        ${HPCC_SOURCE_DIR}/deployment/deploy
+        ${CMAKE_PREFIX_PATH}/mkspecs/linux-g++
+        ${CMAKE_CURRENT_SOURCE_DIR}/configurator_ui
+        ${CMAKE_CURRENT_SOURCE_DIR}/configurator_app
+)
+
+IF( CONFIGURATOR_QT_UI OR CONFIGURATOR_LIB )
+    MESSAGE( "-- configurator target is a library file" )
+
+    ADD_DEFINITIONS( -D_USRDLL -DCONFIGURATOR_LIB)
+    HPCC_ADD_LIBRARY( configurator SHARED ${SRCS} )
+    TARGET_LINK_LIBRARIES( configurator jlib )
+
+    INSTALL( TARGETS configurator LIBRARY DESTINATION ${LIB_DIR} )
+
+ELSE()
+    MESSAGE( "-- configurator target is a binary executable" )
+
+    ADD_DEFINITIONS( -D_CONSOLE )
+    HPCC_ADD_EXECUTABLE( configurator  ${SRCS} )
+    TARGET_LINK_LIBRARIES( configurator jlib )
+
+    INSTALL( TARGETS configurator RUNTIME DESTINATION ${EXEC_DIR} )
+
+ENDIF()

--- a/configuration/configurator/ConfigFileComponentUtils.cpp
+++ b/configuration/configurator/ConfigFileComponentUtils.cpp
@@ -1,0 +1,53 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include "ConfigFileComponentUtils.hpp"
+#include "jexcept.hpp"
+
+CConfigFileComponentUtils::CConfigFileComponentUtils()
+{
+    UNIMPLEMENTED;
+}
+
+CConfigFileComponentUtils::~CConfigFileComponentUtils()
+{
+    UNIMPLEMENTED;
+}
+
+void CConfigFileComponentUtils::getAvailableComponets(StringArray& compArray) const
+{
+    UNIMPLEMENTED;
+}
+
+void CConfigFileComponentUtils::getAvailableESPServices(StringArray& compArray) const
+{
+    UNIMPLEMENTED;
+}
+
+void CConfigFileComponentUtils::getDefinedDirectories(StringArray& definedDirectoriesArray) const
+{
+    UNIMPLEMENTED;
+}
+
+void CConfigFileComponentUtils::getDirectoryPath(const char *pkey, StringBuffer& path) const
+{
+    UNIMPLEMENTED;
+}
+
+void CConfigFileComponentUtils::setDirectoryPath(const char* pkey, const char* pval)
+{
+}

--- a/configuration/configurator/ConfigFileComponentUtils.hpp
+++ b/configuration/configurator/ConfigFileComponentUtils.hpp
@@ -1,0 +1,44 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef _CONFIG_FILE_COMPONENT_UTILS_HPP_
+#define _CONFIG_FILE_COMPONENT_UTILS_HPP_
+
+#include "jiface.hpp"
+#include "jutil.hpp"
+#include "jstring.hpp"
+
+class CConfigFileComponentUtils : public CInterface
+{
+public:
+
+    IMPLEMENT_IINTERFACE
+
+    CConfigFileComponentUtils();
+    virtual ~CConfigFileComponentUtils();
+
+    void getAvailableComponets(StringArray& compArray) const;
+    void getAvailableESPServices(StringArray& compArray) const;
+    void getDefinedDirectories(StringArray& definedDirectoriesArray) const;
+    void getDirectoryPath(const char *pkey, StringBuffer& path) const;
+    void setDirectoryPath(const char* pkey, const char* pval);
+
+protected:
+private:
+};
+
+#endif // _CONFIG_FILE_COMPONENT_UTILS_HPP_

--- a/configuration/configurator/ConfigFileUtils.cpp
+++ b/configuration/configurator/ConfigFileUtils.cpp
@@ -1,0 +1,155 @@
+﻿/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+
+#include "ConfigFileUtils.hpp"
+#include "jfile.hpp"
+#include "jmutex.hpp"
+
+CConfigFileUtils* CConfigFileUtils::getInstance()
+{
+    static Owned<CConfigFileUtils> s_configFileSingleton;
+    static CSingletonLock slock;
+
+    if (slock.lock() == true)
+    {
+      if (s_configFileSingleton.get() == NULL)
+        s_configFileSingleton.setown(new CConfigFileUtils(DEFAULT_CONFIGURATION_PATH));
+
+      slock.unlock();
+    }
+    return s_configFileSingleton.get();
+}
+
+CConfigFileUtils::CConfigFileUtils(const char* pDir, const char* pMask) : m_pDirPath(pDir), m_pMask(pMask)
+{
+}
+
+CConfigFileUtils::~CConfigFileUtils()
+{
+    closeConfigurationFile();
+}
+
+enum CConfigFileUtils::CF_ERROR_CODES CConfigFileUtils::createNewConfigurationFile(const char* pConfigFileName)
+{
+    notify(IConfigFileUtilsObserver::CF_FILE_CREATE_EVENT);
+    return CF_NO_ERROR;
+}
+
+enum CConfigFileUtils::CF_ERROR_CODES CConfigFileUtils::openConfigurationFile(const char* pConfigFileName)
+{
+    if (m_pFileIO.get() != NULL)
+        return CF_FILE_ALREADY_OPEN;
+    else if (m_pFileIO.get() == NULL)
+        return CF_FILE_NOT_OPEN;
+    else
+    {
+        m_pFile.setown(createIFile(pConfigFileName));
+        m_pFileIO.setown(m_pFile->open(IFOcreaterw));
+
+        notify(IConfigFileUtilsObserver::CF_FILE_OPEN_EVENT);
+        return CF_NO_ERROR;
+    }
+}
+
+enum CConfigFileUtils::CF_ERROR_CODES CConfigFileUtils::closeConfigurationFile()
+{
+    if (m_pFileIO.get() != NULL)
+    {
+        m_pFileIO->close();
+        m_pFileIO.clear();
+        m_pFile.clear();
+        notify(IConfigFileUtilsObserver::CF_FILE_CLOSE_EVENT);
+
+        return CF_NO_ERROR;
+    }
+    else
+        return CF_FILE_NOT_OPEN;
+}
+
+enum CConfigFileUtils::CF_ERROR_CODES CConfigFileUtils::writeToOpenConfigurationFile(const char* pBuffer, unsigned int length)
+{
+    if (length == 0)
+        return CF_WRITE_BUFFER_EMPTY;
+    else if (m_pFile.get() == NULL)
+        return CF_FILE_NOT_OPEN;
+    else
+    {
+        m_pFileIO->write(0, length, pBuffer);
+        notify(IConfigFileUtilsObserver::CF_FILE_WRITE_EVENT);
+        return CF_NO_ERROR;
+    }
+}
+
+enum CConfigFileUtils::CF_ERROR_CODES CConfigFileUtils::populateConfigFileArray()
+{
+    m_configFileArray.kill();
+
+    if (m_pDir.get() == NULL)
+    {
+        m_pDir.set(createIFile(m_pDirPath));
+
+        if ( (m_pDir.get() == NULL) || (m_pDir->exists() != true) || (m_pDir->isDirectory() == false) )
+            return CF_DIRECTORY_ACCESS_ERROR;
+    }
+
+    Owned<IDirectoryIterator> dirIter = m_pDir->directoryFiles(m_pMask);
+
+    if(dirIter.get() != NULL)
+    {
+        IFile &file = dirIter->query();
+        StringBuffer fname(file.queryFilename());
+        getFileNameOnly(fname, false);
+        m_configFileArray.append(fname);
+
+        return CF_NO_ERROR;
+    }
+    else
+        return CF_DIRECTORY_ACCESS_ERROR;
+}
+
+enum CConfigFileUtils::CF_ERROR_CODES CConfigFileUtils::writeConfigurationToFile(const char *pFilePath, const char* pBuffer, unsigned int length)
+{
+    assert(pBuffer != NULL);
+    assert(length != 0);
+    assert(pBuffer != NULL && *pBuffer != 0);
+
+    Owned<IFile>   pFile;
+    Owned<IFileIO> pFileIO;
+    IFileIO *pFIO = NULL;
+
+    pFile.setown(createIFile(pFilePath));
+
+    try
+    {
+        pFIO = pFile->open(IFOcreaterw);
+    }
+    catch(IErrnoException *pException)
+    {
+        pException->Release();
+    }
+
+
+    if (pFIO == NULL)
+        return CF_FILE_PERMISSIONS;
+
+    pFileIO.setown(pFIO);
+    pFileIO->write(0, length, pBuffer);
+    notify(IConfigFileUtilsObserver::CF_FILE_WRITE_NO_CHECK);
+
+    return CF_NO_ERROR;
+}

--- a/configuration/configurator/ConfigFileUtils.hpp
+++ b/configuration/configurator/ConfigFileUtils.hpp
@@ -1,0 +1,68 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef _CONFIG_FILE_HPP_
+#define _CONFIG_FILE_HPP_
+
+#include "jiface.hpp"
+#include "jmutex.hpp"
+#include "jutil.hpp"
+#include "ConfigFileUtilsObservable.hpp"
+
+static const char* DEFAULT_CONFIGURATION_PATH("/etc/HPCCSystems/source/");
+static const char* DEFAULT_CONFIGURATION_MASK("*.xml");
+
+class CConfigFileUtils : public CConfigFileUtilsObservable
+{
+public:
+
+    enum CF_ERROR_CODES { CF_NO_ERROR = 0,
+                          CF_FILE_EXISTS,
+                          CF_FILE_PERMISSIONS,
+                          CF_FILE_NOT_OPEN,
+                          CF_FILE_ALREADY_OPEN,
+                          CF_FILE_DOES_NOT_EXIST,
+                          CF_WRITE_BUFFER_EMPTY,
+                          CF_DIRECTORY_ACCESS_ERROR,
+                          CF_OTHER = 99 };
+
+    static CConfigFileUtils* getInstance();
+    virtual ~CConfigFileUtils();
+    const StringArray& getAvailableConfigurationFiles() const;
+    enum CF_ERROR_CODES writeConfigurationToFile(const char *pFilePath, const char* pBuffer, unsigned int length);
+    enum CF_ERROR_CODES createNewConfigurationFile(const char* pConfigFileName);
+    enum CF_ERROR_CODES openConfigurationFile(const char* pConfigFileName);
+    enum CF_ERROR_CODES closeConfigurationFile();
+    enum CF_ERROR_CODES writeToOpenConfigurationFile(const char* pBuffer, unsigned int length);
+
+protected:
+
+    enum CF_ERROR_CODES populateConfigFileArray();
+
+private:
+
+    CConfigFileUtils(const char* pDir = DEFAULT_CONFIGURATION_PATH, const char* pMask = DEFAULT_CONFIGURATION_MASK);
+
+    StringArray     m_configFileArray;
+    const char*     m_pDirPath;
+    const char*     m_pMask;
+    Owned<IFile>    m_pDir;
+    Owned<IFile>    m_pFile;
+    Owned<IFileIO>  m_pFileIO;
+};
+
+#endif // _CONFIG_FILE_HPP_

--- a/configuration/configurator/ConfigFileUtilsObservable.cpp
+++ b/configuration/configurator/ConfigFileUtilsObservable.cpp
@@ -1,0 +1,48 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include "ConfigFileUtilsObservable.hpp"
+
+void CConfigFileUtilsObservable::addObserver(IConfigFileUtilsObserver& observer)
+{
+   CriticalBlock block(m_critsecObserverQueue);
+
+   //allow observers to register only once
+   if (m_qObservers.find(&observer) == (unsigned)-1)
+     m_qObservers.enqueue(&observer);
+}
+
+void CConfigFileUtilsObservable::removeObserver(IConfigFileUtilsObserver& observer)
+{
+    CriticalBlock block(m_critsecObserverQueue);
+    m_qObservers.dequeue(&observer);
+}
+
+void CConfigFileUtilsObservable::notify(enum IConfigFileUtilsObserver::CF_EVENT_TYPES eventType)
+{
+    CriticalBlock block(m_critsecObserverQueue);
+
+    for (unsigned int idxObservers = 0; idxObservers < m_qObservers.ordinality(); idxObservers++)
+    {
+        IConfigFileUtilsObserver *pConfigFileUtilsObserver = m_qObservers.query(idxObservers);
+
+        if (pConfigFileUtilsObserver->getEventType() == eventType || pConfigFileUtilsObserver->getEventType() == IConfigFileUtilsObserver::CF_FILE_ANY_EVENT)
+        {
+            //m_qObservers.query(idxObservers)->onNotify(eventType);
+        }
+    }
+}

--- a/configuration/configurator/ConfigFileUtilsObservable.hpp
+++ b/configuration/configurator/ConfigFileUtilsObservable.hpp
@@ -1,0 +1,55 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef _CONFIG_FILE_UTILS_OBSERVALBE_HPP_
+#define _CONFIG_FILE_UTILS_OBSERVALBE_HPP_
+
+#include "ConfigFileUtilsObserver.ipp"
+#include "jlib.hpp"
+#include "jqueue.tpp"
+#include "jmutex.hpp"
+
+
+class CConfigFileUtilsObservable : public CInterface, implements IObservable
+{
+public:
+    IMPLEMENT_IINTERFACE
+
+    virtual void addObserver(IConfigFileUtilsObserver& observer);
+    virtual void removeObserver(IConfigFileUtilsObserver& observer);
+
+    void enableNotifications(bool bEnable)
+    {
+        m_bEnableNotifications = bEnable;
+    }
+    bool getNotificationsEnabled() const
+    {
+        return m_bEnableNotifications;
+    }
+
+protected:
+
+    virtual void notify( enum IConfigFileUtilsObserver::CF_EVENT_TYPES eventType);
+
+private:
+
+    QueueOf<IConfigFileUtilsObserver,false> m_qObservers;
+    CriticalSection m_critsecObserverQueue;
+    bool m_bEnableNotifications;
+};
+
+#endif // _CONFIG_FILE_UTILS_OBSERVALBE_HPP_

--- a/configuration/configurator/ConfigFileUtilsObserver.ipp
+++ b/configuration/configurator/ConfigFileUtilsObserver.ipp
@@ -1,0 +1,22 @@
+#ifndef _CONFIG_FILE_UTILS_OBSERVER_IPP_
+#define _CONFIG_FILE_UTILS_OBSERVER_IPP_
+
+#include "jobserve.hpp"
+
+interface IConfigFileUtilsObserver : extends IObserver
+{
+public:
+
+    enum CF_EVENT_TYPES { CF_FILE_OPEN_EVENT = 0x1,
+                          CF_FILE_CLOSE_EVENT,
+                          CF_FILE_WRITE_EVENT,
+                          CF_FILE_DELETE_EVENT,
+                          CF_FILE_CREATE_EVENT,
+                          CF_FILE_WRITE_NO_CHECK,
+                          CF_FILE_ANY_EVENT,
+                          CF_FILE_OTHER_EVENT = 0xFF };
+
+    virtual enum CF_EVENT_TYPES getEventType() = 0;
+};
+
+#endif // _CONFIG_FILE_UTILS_OBSERVER_IPP_

--- a/configuration/configurator/ConfigNotifications.cpp
+++ b/configuration/configurator/ConfigNotifications.cpp
@@ -1,0 +1,104 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include "SchemaCommon.hpp"
+#include "ConfigNotifications.hpp"
+#include "jlib.hpp"
+#include "jhash.ipp"
+#include "jhash.hpp"
+#include "jstring.hpp"
+
+CNotificationManager* CNotificationManager::s_pNotificationManager = NULL;
+
+CNotificationManager::CNotificationManager()
+{
+}
+
+CNotificationManager *CNotificationManager::getInstance()
+{
+    if (s_pNotificationManager == NULL)
+        s_pNotificationManager = new CNotificationManager();
+
+    return s_pNotificationManager;
+}
+
+int CNotificationManager::getNumberOfNotifications(enum ENotificationType eNotifyType) const
+{
+    int nCount = 0;
+    HashIterator iterHash(m_EnvXPathToNotification);
+
+    ForEach(iterHash)
+    {
+        CNotification *pNotification = m_EnvXPathToNotification.mapToValue(&iterHash.query());
+
+        for (int i = 0; i < eUnknown; i++)
+        {
+            nCount += pNotification->m_NotificationMessagesArrays[i].length();
+        }
+    }
+    return nCount;
+}
+
+void CNotificationManager::setNotification(const CXSDNodeBase *pNodeBase, enum ENotificationType eNotifyType, const char* pNotificationText)
+{
+    assert (pNodeBase != NULL);
+    assert (pNotificationText != NULL);
+
+    if (pNodeBase != NULL)
+    {
+        const char* pEnvXPath = pNodeBase->getEnvXPath();
+
+        assert(pEnvXPath != NULL && *pEnvXPath != 0);
+        if (pEnvXPath != NULL)
+        {
+            CNotification *pNotification = m_EnvXPathToNotification.getValue(pEnvXPath);
+
+            if (pNotification == NULL)
+            {
+                pNotification = new CNotification();
+                m_EnvXPathToNotification.setValue(pEnvXPath, pNotification);
+            }
+            pNotification->m_NotificationMessagesArrays[eNotifyType].append(pNotificationText);
+        }
+    }
+}
+
+void CNotificationManager::resetNotifications(const CXSDNodeBase *pNodeBase)
+{
+    assert(pNodeBase != NULL);
+    if (pNodeBase != NULL)
+    {
+        const char* pEnvXPath = pNodeBase->getEnvXPath();
+
+        assert(pEnvXPath != NULL && *pEnvXPath != 0);
+
+        if (pEnvXPath != NULL && *pEnvXPath != 0)
+        {
+            CNotification *pNotification = m_EnvXPathToNotification.getValue(pEnvXPath);
+
+            if (pNotification != NULL)
+            {
+                m_EnvXPathToNotification.remove(pEnvXPath);
+                delete pNotification;
+            }
+        }
+    }
+}
+const char* CNotificationManager::getNotification(enum ENotificationType eNotifyType, int idx) const
+{
+    return NULL;
+}

--- a/configuration/configurator/ConfigNotifications.hpp
+++ b/configuration/configurator/ConfigNotifications.hpp
@@ -1,0 +1,99 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef _CONFIG_NOTIFICATIONS_HPP_
+#define _CONFIG_NOTIFICATIONS_HPP_
+
+#include "jiface.hpp"
+#include "jhash.ipp"
+#include "jutil.hpp"
+
+enum ENotificationType
+{
+    eInformational = 1,
+    eAlert,
+    eWarning,
+    eError,
+    eCritical,
+    eUnknown // needs to be last
+};
+
+static const char NotificationTypeNames[eUnknown][1024] = {     "Informational",
+                                                                "Alert",
+                                                                "Warning",
+                                                                "Error",
+                                                                "Critical",
+                                                                "Unknown" };
+
+class CNotification;
+class CNotificationManager;
+
+class CNotificationManager : public InterfaceImpl
+{
+public:
+
+    static CNotificationManager* getInstance();
+
+    virtual ~CNotificationManager(){}
+
+    int getNumberOfNotificationTypes() const
+    {
+        return eUnknown-1;
+    }
+
+    const char* getNotificationTypeName(int idx)
+    {
+        if (idx >= 0 && idx < eUnknown)
+            return NotificationTypeNames[idx];
+        else
+            return NULL;
+    }
+
+    int getNumberOfNotifications(enum ENotificationType eNotifyType) const;
+    const char* getNotification(enum ENotificationType eNotifyType, int idx) const;
+
+    void setNotification(const CXSDNodeBase *pNodeBase, enum ENotificationType eNotifyType, const char* pNotificationText);
+    void resetNotifications(const CXSDNodeBase *pNodeBase);
+
+protected:
+
+    CNotificationManager();
+
+    typedef MapStringToMyClass<CNotification> MapStringToCNotification;
+    MapStringToCNotification m_EnvXPathToNotification;
+
+private:
+
+    static CNotificationManager *s_pNotificationManager;
+};
+
+class CNotification : public InterfaceImpl
+{
+    friend class CNotificationManager;
+
+public:
+
+    CNotification()
+    {
+    }
+    virtual ~CNotification()
+    {
+    }
+    StringArray m_NotificationMessagesArrays[eUnknown];
+};
+
+#endif // _CONFIG_NOTIFICATIONS_HPP_

--- a/configuration/configurator/ConfigSchemaHelper.cpp
+++ b/configuration/configurator/ConfigSchemaHelper.cpp
@@ -1,0 +1,681 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include "ConfigSchemaHelper.hpp"
+#include "SchemaAttributes.hpp"
+#include "SchemaElement.hpp"
+#include "SchemaEnumeration.hpp"
+#include "jptree.hpp"
+#include "XMLTags.h"
+#include "ExceptionStrings.hpp"
+#include <cstring>
+#include "jfile.hpp"
+#include "BuildSet.hpp"
+#include "SchemaMapManager.hpp"
+#include "ConfigSchemaHelper.hpp"
+#include "ConfigFileUtils.hpp"
+
+#define LOOP_THRU_BUILD_SET_MANAGER_BUILD_SET \
+int nComponentCount = CBuildSetManager::getInstance()->getBuildSetComponentCount();         \
+\
+for (int idx = 0; idx < nComponentCount; idx++)
+
+CConfigSchemaHelper* CConfigSchemaHelper::s_pCConfigSchemaHelper = NULL;
+
+CConfigSchemaHelper* CConfigSchemaHelper::getInstance(const char* pDefaultDirOverride)
+{
+    // not thread safe!!!
+    if (s_pCConfigSchemaHelper == NULL)
+    {
+        s_pCConfigSchemaHelper = new CConfigSchemaHelper();
+        s_pCConfigSchemaHelper->m_nTables = 0;
+
+        if (pDefaultDirOverride != NULL && pDefaultDirOverride[0] != 0)
+            s_pCConfigSchemaHelper->setBasePath(pDefaultDirOverride);
+    }
+    return s_pCConfigSchemaHelper;
+}
+
+CConfigSchemaHelper* CConfigSchemaHelper::getInstance(const char* pBuildSetFileName, const char *pBaseDirectory, const char *pDefaultDirOverride)
+{
+    assert(pBuildSetFileName != NULL);
+    assert(pBaseDirectory != NULL);
+
+    if (s_pCConfigSchemaHelper == NULL && pBuildSetFileName != NULL && pBaseDirectory != NULL)
+    {
+       s_pCConfigSchemaHelper = new CConfigSchemaHelper(pBuildSetFileName, pBaseDirectory, pDefaultDirOverride);
+       s_pCConfigSchemaHelper->m_nTables = 0;
+    }
+    return s_pCConfigSchemaHelper;
+}
+
+CConfigSchemaHelper::CConfigSchemaHelper(const char* pBuildSetFile, const char* pBuildSetDir, const char* pDefaultDirOverride) : m_pBasePath(NULL), m_nTables(0),\
+    m_pEnvPropertyTree(NULL), m_pSchemaMapManager(NULL)
+{
+    assert(pBuildSetFile != NULL);
+    assert(pBuildSetDir != NULL);
+
+    CBuildSetManager::getInstance(pBuildSetFile, pBuildSetDir);
+    m_pSchemaMapManager = new CSchemaMapManager();
+}
+
+CConfigSchemaHelper::~CConfigSchemaHelper()
+{
+    delete[] m_pBasePath;
+    delete CConfigSchemaHelper::m_pSchemaMapManager;
+    CConfigSchemaHelper::m_pSchemaMapManager = NULL;
+    CConfigSchemaHelper::s_pCConfigSchemaHelper = NULL;
+}
+
+bool CConfigSchemaHelper::populateSchema()
+{
+    assert(m_pSchemaMapManager != NULL);
+
+    LOOP_THRU_BUILD_SET_MANAGER_BUILD_SET
+    {
+        const char *pSchemaName = CBuildSetManager::getInstance()->getBuildSetComponentFileName(idx);
+
+        if (pSchemaName != NULL)
+        {
+            CXSDNodeBase *pNull = NULL;
+            CSchema *pSchema = CSchema::load(pSchemaName, pNull);
+
+            assert(pSchema->getLinkCount() == 1);
+            m_pSchemaMapManager->setSchemaForXSD(pSchemaName, pSchema);
+        }
+    }
+    populateEnvXPath();
+
+    return true;
+}
+
+void CConfigSchemaHelper::printConfigSchema(StringBuffer &strXML) const
+{
+    assert(m_pSchemaMapManager != NULL);
+
+    const char *pComponent = NULL;
+    CSchema* pSchema = NULL;
+
+    LOOP_THRU_BUILD_SET_MANAGER_BUILD_SET
+    {
+        const char *pSchemaName = CBuildSetManager::getInstance()->getBuildSetComponentFileName(idx);
+
+        if (pComponent == NULL || strcmp(pComponent, pSchemaName) == 0)
+        {
+            const char* pXSDSchema = pSchemaName;
+
+            if (pXSDSchema == NULL)
+                continue;
+
+            pSchema = m_pSchemaMapManager->getSchemaForXSD(pSchemaName);
+
+            if (pSchema != NULL)
+            {
+                if (strXML.length() > 0 ? strcmp(strXML.str(), pXSDSchema) == 0 : true)
+                    pSchema->dump(std::cout);
+            }
+        }
+    }
+}
+
+const char* CConfigSchemaHelper::printDocumentation(const char* comp)
+{
+    assert(comp != NULL && *comp != 0);
+    assert(m_pSchemaMapManager != NULL);
+
+    if (comp == NULL || *comp == 0)
+        return NULL;
+
+    CSchema* pSchema = NULL;
+
+    LOOP_THRU_BUILD_SET_MANAGER_BUILD_SET
+    {
+        const char *pSchemaName = CBuildSetManager::getInstance()->getBuildSetComponentFileName(idx);
+
+        if (pSchemaName != NULL && strcmp(comp, pSchemaName) == 0)
+        {
+             pSchema = m_pSchemaMapManager->getSchemaForXSD(pSchemaName);
+
+             assert(pSchema != NULL);
+
+             if (pSchema != NULL)
+             {
+                static StringBuffer strDoc;
+                strDoc.clear(); // needed when printing more than 1 component
+                pSchema->getDocumentation(strDoc);
+
+                return strDoc.str();
+             }
+        }
+    }
+    return NULL;
+}
+
+void CConfigSchemaHelper::printQML(const char* comp, char **pOutput, int nIdx) const
+{
+    if (! (comp != NULL && *comp != 0) )
+    {
+        DBGLOG("no component selected for QML, index = %d", nIdx);
+        return;
+    }
+    assert(m_pSchemaMapManager != NULL);
+
+    StringBuffer strQML;
+
+    strQML.clear();
+    resetTables();
+
+    if (comp == NULL || *comp == 0)
+        return;
+
+    CSchema* pSchema = NULL;
+
+    LOOP_THRU_BUILD_SET_MANAGER_BUILD_SET
+    {
+        const char *pSchemaName = CBuildSetManager::getInstance()->getBuildSetComponentFileName(idx);
+
+        if (pSchemaName != NULL && strcmp(comp, pSchemaName) == 0)
+        {
+             pSchema = m_pSchemaMapManager->getSchemaForXSD(pSchemaName);
+             assert(pSchema != NULL);
+
+             if (pSchema != NULL)
+             {
+                 pSchema->getQML3(strQML, nIdx);
+                 *pOutput = (char*)malloc((sizeof(char))* (strQML.length())+1);
+                 sprintf(*pOutput,"%s",strQML.str());
+
+                 return;
+             }
+        }
+    }
+}
+
+void CConfigSchemaHelper::printDump(const char* comp) const
+{
+    assert(comp != NULL && *comp != 0);
+    assert(m_pSchemaMapManager != NULL);
+
+    if (comp == NULL || *comp == 0)
+        return;
+
+    CSchema* pSchema = NULL;
+
+    LOOP_THRU_BUILD_SET_MANAGER_BUILD_SET
+    {
+        const char *pSchemaName = CBuildSetManager::getInstance()->getBuildSetComponentFileName(idx);
+
+        if (pSchemaName != NULL && strcmp(comp, pSchemaName) == 0)
+        {
+             pSchema = m_pSchemaMapManager->getSchemaForXSD(pSchemaName);
+             assert(pSchema != NULL);
+
+             if (pSchema != NULL)
+                pSchema->dump(std::cout);
+        }
+    }
+}
+
+//test purposes
+bool CConfigSchemaHelper::getXMLFromSchema(StringBuffer& strXML, const char* pComponent)
+{
+    assert (m_pSchemaMapManager != NULL);
+
+    CAttributeArray *pAttributeArray = NULL;
+    CElementArray *pElementArray = NULL;
+    CSchema* pSchema = NULL;
+
+    strXML.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Environment>\n\t<Software>");
+
+    LOOP_THRU_BUILD_SET_MANAGER_BUILD_SET
+    {
+        const char *pSchemaName = CBuildSetManager::getInstance()->getBuildSetComponentFileName(idx);
+
+        if (pComponent == NULL || strcmp(pComponent, pSchemaName) == 0)
+        {
+            if (pSchemaName == NULL)
+                continue;
+
+            pSchema =  m_pSchemaMapManager->getSchemaForXSD(pSchemaName);
+
+            if (pSchema != NULL)
+                strXML.append(pSchema->getXML(NULL));
+        }
+    }
+    strXML.append("\t</Software>\n</Environment>\n");
+
+    return true;
+}
+
+void CConfigSchemaHelper::addExtensionToBeProcessed(CExtension *pExtension)
+{
+    assert(pExtension != NULL);
+    if (pExtension != NULL)
+        m_extensionArr.append(*pExtension);
+}
+
+void CConfigSchemaHelper::addAttributeGroupToBeProcessed(CAttributeGroup *pAttributeGroup)
+{
+    assert(pAttributeGroup != NULL);
+    if (pAttributeGroup != NULL)
+        m_attributeGroupArr.append(*pAttributeGroup);
+}
+
+void CConfigSchemaHelper::addNodeForTypeProcessing(CXSDNodeWithType *pNode)
+{
+    assert(pNode != NULL);
+    if (pNode != NULL)
+        m_nodeWithTypeArr.append(*pNode);
+}
+
+void CConfigSchemaHelper::addNodeForBaseProcessing(CXSDNodeWithBase *pNode)
+{
+    assert(pNode != NULL);
+    if (pNode != NULL)
+        m_nodeWithBaseArr.append(*pNode);
+}
+
+void CConfigSchemaHelper::processExtensionArr()
+{
+    int length = m_extensionArr.length();
+
+    for (int idx = 0; idx < length; idx++)
+    {
+        CExtension &Extension = (m_extensionArr.item(idx));
+        const char *pName = Extension.getBase();
+
+        assert(pName != NULL);
+
+        if (pName != NULL)
+        {
+            CXSDNode *pNodeBase = NULL;
+            pNodeBase = m_pSchemaMapManager->getSimpleTypeWithName(pName) != NULL ? dynamic_cast<CSimpleType*>(m_pSchemaMapManager->getSimpleTypeWithName(pName)) : NULL;
+
+            if (pNodeBase == NULL)
+                pNodeBase = m_pSchemaMapManager->getComplexTypeWithName(pName) != NULL ? dynamic_cast<CComplexType*>(m_pSchemaMapManager->getComplexTypeWithName(pName)) : NULL ;
+
+            assert(pNodeBase != NULL);
+
+            if (pNodeBase != NULL)
+                Extension.setBaseNode(pNodeBase);
+        }
+    }
+    m_extensionArr.popAll(false);
+}
+
+void CConfigSchemaHelper::processAttributeGroupArr()
+{
+    aindex_t length = m_attributeGroupArr.length();
+
+    for (aindex_t idx = 0; idx < length; idx++)
+    {
+        CAttributeGroup &AttributeGroup = (m_attributeGroupArr.item(idx));
+        const char *pRef = AttributeGroup.getRef();
+
+        assert(pRef != NULL && pRef[0] != 0);
+        if (pRef != NULL && pRef[0] != 0)
+        {
+            assert(m_pSchemaMapManager != NULL);
+            CAttributeGroup *pAttributeGroup = m_pSchemaMapManager->getAttributeGroupFromXPath(pRef);
+
+            assert(pAttributeGroup != NULL);
+            if (pAttributeGroup != NULL)
+                AttributeGroup.setRefNode(pAttributeGroup);
+        }
+    }
+    m_attributeGroupArr.popAll(true);
+}
+
+void CConfigSchemaHelper::processNodeWithTypeArr(CXSDNodeBase *pParentNode)
+{
+    int length = m_nodeWithTypeArr.length();
+
+    for (int idx = 0; idx < length; idx++)
+    {
+        CXSDNodeWithType *pNodeWithType = &(m_nodeWithTypeArr.item(idx));
+        const char *pTypeName = pNodeWithType->getType();
+
+        assert(pTypeName != NULL);
+        if (pTypeName != NULL)
+        {
+            CXSDNode *pNode = NULL;
+            pNode = m_pSchemaMapManager->getSimpleTypeWithName(pTypeName) != NULL ? dynamic_cast<CSimpleType*>(m_pSchemaMapManager->getSimpleTypeWithName(pTypeName)) : NULL;
+
+            if (pNode == NULL)
+                pNode = m_pSchemaMapManager->getComplexTypeWithName(pTypeName) != NULL ? dynamic_cast<CComplexType*>(m_pSchemaMapManager->getComplexTypeWithName(pTypeName)) : NULL;
+            if (pNode == NULL)
+                pNode = CXSDBuiltInDataType::create(pNodeWithType, pTypeName);
+            if (pNode != NULL)
+                pNodeWithType->setTypeNode(pNode);
+            else
+                PROGLOG("Unsupported type '%s'", pTypeName);
+        }
+    }
+    m_nodeWithTypeArr.popAll(true);
+}
+
+void CConfigSchemaHelper::processNodeWithBaseArr()
+{
+    int length = m_nodeWithBaseArr.length();
+
+    for (int idx = 0; idx < length; idx++)
+    {
+        CXSDNodeWithBase *pNodeWithBase = &(this->m_nodeWithBaseArr.item(idx));
+        const char *pBaseName = pNodeWithBase->getBase();
+
+        assert(pBaseName != NULL);
+        if (pBaseName != NULL)
+        {
+            CXSDNode *pNode = NULL;
+            pNode = m_pSchemaMapManager->getSimpleTypeWithName(pBaseName) != NULL ? dynamic_cast<CSimpleType*>(m_pSchemaMapManager->getSimpleTypeWithName(pBaseName)) : NULL;
+
+            if (pNode == NULL)
+                pNode = m_pSchemaMapManager->getComplexTypeWithName(pBaseName) != NULL ? dynamic_cast<CComplexType*>(m_pSchemaMapManager->getComplexTypeWithName(pBaseName)) : NULL;
+            if (pNode == NULL)
+                pNode = CXSDBuiltInDataType::create(pNode, pBaseName);
+
+            assert(pNode != NULL);
+            if (pNode != NULL)
+                pNodeWithBase->setBaseNode(pNode);
+            else
+                PROGLOG("Unsupported type '%s'", pBaseName);
+        }
+    }
+    m_nodeWithBaseArr.popAll(false);
+}
+
+void CConfigSchemaHelper::addElementForRefProcessing(CElement *pElement)
+{
+    assert (pElement != NULL);
+    if (pElement != NULL)
+        m_ElementArr.append(*pElement);
+}
+
+void CConfigSchemaHelper::processElementArr(CElement *pElement)
+{
+    int length = m_nodeWithBaseArr.length();
+
+    for (int idx = 0; idx < length; idx++)
+    {
+        CElement *pElement = &(this->m_ElementArr.item(idx));
+        const char *pRef = pElement->getRef();
+
+        assert(pRef != NULL);
+        if (pRef != NULL)
+        {
+            CElement *pRefElementNode = NULL;
+            pRefElementNode = m_pSchemaMapManager->getElementWithName(pRef);
+
+            if (pRefElementNode != NULL)
+                pElement->setRefElementNode(pRefElementNode);
+            else
+                //TODO: throw exception
+                assert(!"Unknown element referenced");
+        }
+    }
+    m_ElementArr.popAll(false);
+}
+
+void CConfigSchemaHelper::populateEnvXPath()
+{
+    CSchema* pSchema = NULL;
+    StringBuffer strXPath;
+
+    LOOP_THRU_BUILD_SET_MANAGER_BUILD_SET
+    {
+        pSchema = m_pSchemaMapManager->getSchemaForXSD(CBuildSetManager::getInstance()->getBuildSetComponentFileName(idx));
+
+        if (pSchema != NULL)
+            pSchema->populateEnvXPath(strXPath);
+    }
+}
+
+void CConfigSchemaHelper::loadEnvFromConfig(const char *pEnvFile)
+{
+    assert(pEnvFile != NULL);
+
+    Linked<IPropertyTree> pEnvXMLRoot;
+
+    try
+    {
+        pEnvXMLRoot.setown(createPTreeFromXMLFile(pEnvFile));
+    }
+    catch (...)
+    {
+        MakeExceptionFromMap(EX_STR_CAN_NOT_PROCESS_ENV_XML);
+    }
+
+    CSchema* pSchema = NULL;
+
+    this->setEnvPropertyTree(pEnvXMLRoot.getLink());
+    this->setEnvFilePath(pEnvFile);
+
+    LOOP_THRU_BUILD_SET_MANAGER_BUILD_SET
+    {
+        pSchema = m_pSchemaMapManager->getSchemaForXSD(CBuildSetManager::getInstance()->getBuildSetComponentFileName(idx));
+
+        if (pSchema != NULL)
+            pSchema->loadXMLFromEnvXml(pEnvXMLRoot);
+    }
+}
+
+void CConfigSchemaHelper::addToolTip(const char *js)
+{
+    assert (js != NULL);
+    assert (js[0] != 0);
+
+    if (js == NULL || js[0] == 0)
+        return;
+
+    m_strToolTipsJS.append(js);
+}
+
+const char* CConfigSchemaHelper::getToolTipJS() const
+{
+    static StringBuffer strJS;
+    strJS.clear();
+
+    for (int idx = 0; idx < m_strToolTipsJS.length(); idx++)
+    {
+        strJS.append(m_strToolTipsJS.item(idx));
+    }
+    return strJS.str();
+}
+
+void CConfigSchemaHelper::setEnvTreeProp(const char *pXPath, const char* pValue)
+{
+    assert(pXPath != NULL && pXPath[0] != 0);
+    assert(m_pSchemaMapManager != NULL);
+
+    CAttribute *pAttribute = m_pSchemaMapManager->getAttributeFromXPath(pXPath);
+    assert(pAttribute != NULL);
+
+    StringBuffer strPropName("@");
+    strPropName.append(pAttribute->getName());
+
+    if (this->getEnvPropertyTree()->queryPropTree(pAttribute->getConstAncestorNode(1)->getEnvXPath())->queryProp(strPropName.str()) == NULL)
+        //should check if this attribute is optional for validation
+        this->getEnvPropertyTree()->queryPropTree(pAttribute->getConstAncestorNode(1)->getEnvXPath())->setProp(strPropName.str(), pValue);
+    else if (strcmp (this->getEnvPropertyTree()->queryPropTree(pAttribute->getConstAncestorNode(1)->getEnvXPath())->queryProp(strPropName.str()), pValue) == 0)
+        return; // nothing changed
+    else
+        this->getEnvPropertyTree()->queryPropTree(pAttribute->getConstAncestorNode(1)->getEnvXPath())->setProp(strPropName.str(), pValue);
+}
+
+const char* CConfigSchemaHelper::getTableValue(const char* pXPath,  int nRow) const
+{
+    assert(pXPath != NULL);
+    assert(m_pSchemaMapManager != NULL);
+
+    CAttribute *pAttribute = m_pSchemaMapManager->getAttributeFromXPath(pXPath);
+    CElement *pElement = NULL;
+
+    if (pAttribute == NULL)
+    {
+        pElement = m_pSchemaMapManager->getElementFromXPath(pXPath);
+        assert(pElement != NULL);
+        return pElement->getEnvValueFromXML();
+    }
+    else
+    {
+        assert(pAttribute != NULL);
+        if (nRow == 1)
+            return pAttribute->getEnvValueFromXML();
+        else
+        {
+            StringBuffer strXPath(pXPath);
+            StringBuffer strXPathOrignal(pXPath);
+
+            CConfigSchemaHelper::stripXPathIndex(strXPath);
+
+            strXPath.appendf("[%d]", nRow);
+            char pTemp[64];
+            int offset = strXPath.length() - (strlen(itoa(nRow, pTemp, 10)) - 1);
+
+            strXPath.append(strXPathOrignal, strXPath.length(), strXPathOrignal.length()-offset);
+
+            pAttribute = m_pSchemaMapManager->getAttributeFromXPath(strXPath.str());
+
+            if (pAttribute == NULL)
+                return NULL;
+
+            return pAttribute->getEnvValueFromXML();
+        }
+    }
+}
+
+int CConfigSchemaHelper::getElementArraySize(const char *pXPath) const
+{
+    assert(pXPath != NULL);
+    assert(m_pSchemaMapManager != NULL);
+
+    CElementArray *pElementArray = m_pSchemaMapManager->getElementArrayFromXSDXPath(pXPath);
+
+    if (pElementArray == NULL)
+        return 0;
+
+    return pElementArray->getCountOfSiblingElements(pXPath);
+}
+
+const char* CConfigSchemaHelper::getAttributeXSDXPathFromEnvXPath(const char* pEnvXPath) const
+{
+    assert(pEnvXPath != NULL && *pEnvXPath != 0);
+    assert(m_pSchemaMapManager != NULL);
+    CAttribute *pAttribute = m_pSchemaMapManager->getAttributeFromXPath(pEnvXPath);
+
+    assert(pAttribute != NULL);
+    return pAttribute->getXSDXPath();
+}
+
+const char* CConfigSchemaHelper::getElementArrayXSDXPathFromEnvXPath(const char* pXSDXPath) const
+{
+    assert(pXSDXPath != NULL);
+    assert(m_pSchemaMapManager != NULL);
+    CElementArray *pElementArray = m_pSchemaMapManager->getElementArrayFromXSDXPath(pXSDXPath);
+
+    assert(pElementArray != NULL);
+    return pElementArray->getXSDXPath();
+}
+
+void CConfigSchemaHelper::appendAttributeXPath(const char* pXPath)
+{
+    m_strArrayEnvXPaths.append(pXPath);
+}
+
+void CConfigSchemaHelper::appendElementXPath(const char* pXPath)
+{
+    m_strArrayEnvXPaths.append(pXPath);
+}
+
+int CConfigSchemaHelper::stripXPathIndex(StringBuffer &strXPath)
+{
+    int nLen = strXPath.length()-3;
+    int nLengthOfStringInBracket = 3;
+
+    while (nLen > 0)
+    {
+        if (strXPath[nLen] == '[')
+        {
+            strXPath.reverse().remove(0,strXPath.length()-nLen).reverse();
+            return nLengthOfStringInBracket;
+        }
+        nLen--;
+        nLengthOfStringInBracket++;
+    }
+    return nLengthOfStringInBracket;
+}
+
+bool CConfigSchemaHelper::isXPathTailAttribute(const StringBuffer &strXPath)
+{
+    int nLen = strXPath.length()-3;
+
+    while (nLen > 0)
+    {
+        if (strXPath[nLen] == '[')
+        {
+            if (strXPath[nLen+1] == '@')
+                return true;
+            else
+                return false;
+        }
+        nLen--;
+    }
+    assert(!"Control should not reach here");
+    return false;
+}
+
+void CConfigSchemaHelper::setBasePath(const char *pBasePath)
+{
+    assert(m_pBasePath == NULL);
+    int nLength = strlen(pBasePath);
+    m_pBasePath = new char[nLength+1];
+    strcpy(m_pBasePath, pBasePath);
+}
+
+
+bool CConfigSchemaHelper::saveConfigurationFile() const
+{
+    assert(m_strEnvFilePath.length() != 0);
+
+    if (m_strEnvFilePath.length() == 0)
+        return false;
+
+    StringBuffer strXML;
+    strXML.appendf("<"XML_HEADER">\n<!-- Edited with THE CONFIGURATOR -->\n");
+    toXML(this->getConstEnvPropertyTree(), strXML, 0, XML_SortTags | XML_Format);
+
+    if (CConfigFileUtils::getInstance()->writeConfigurationToFile(m_strEnvFilePath.str(), strXML.str(), strXML.length()) == CConfigFileUtils::CF_NO_ERROR)
+        return true;
+    else
+        return false;
+}
+
+void CConfigSchemaHelper::addKeyRefForReverseAssociation(const CKeyRef *pKeyRef) const
+{
+}
+
+void CConfigSchemaHelper::processKeyRefReverseAssociation() const
+{
+}
+
+void CConfigSchemaHelper::addKeyForReverseAssociation(const CKey *pKeyRef) const
+{
+}
+
+void CConfigSchemaHelper::processKeyReverseAssociation() const
+{
+}

--- a/configuration/configurator/ConfigSchemaHelper.hpp
+++ b/configuration/configurator/ConfigSchemaHelper.hpp
@@ -1,0 +1,177 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef _CONFIG_SCHEMA_HELPER_HPP_
+#define _CONFIG_SCHEMA_HELPER_HPP_
+
+#include "jiface.hpp"
+#include "jptree.hpp"
+#include "jutil.hpp"
+#include "jarray.hpp"
+#include "jhash.hpp"
+#include "SchemaAttributes.hpp"
+#include "SchemaAttributeGroup.hpp"
+#include "SchemaElement.hpp"
+#include "SchemaSchema.hpp"
+#include "SchemaExtension.hpp"
+#include "BuildSet.hpp"
+#include "ConfiguratorAPI.hpp"
+
+class CSchemaMapManager;
+class CSimpleType;
+
+class CConfigSchemaHelper : public CInterface
+{
+public:
+
+    IMPLEMENT_IINTERFACE
+
+    static CConfigSchemaHelper* getInstance(const char* pDefaultDirOverride =  NULL);
+    static CConfigSchemaHelper* getInstance(const char* pBuildSetFileName, const char *pBaseDirectory, const char *pDefaultDirOverride = NULL);
+
+    virtual ~CConfigSchemaHelper();
+
+    bool populateSchema();
+    void printConfigSchema(StringBuffer &str) const;
+
+    CSchemaMapManager* getSchemaMapManager()
+    {
+        return m_pSchemaMapManager;
+    }
+
+    void addExtensionToBeProcessed(CExtension *pExtension);
+    void processExtensionArr();
+
+    void addAttributeGroupToBeProcessed(CAttributeGroup *pAttributeGroup);
+    void processAttributeGroupArr();
+
+    void addNodeForBaseProcessing(CXSDNodeWithBase *pNode);
+    void processNodeWithBaseArr();
+
+    void addNodeForTypeProcessing(CXSDNodeWithType *pNode);
+    void processNodeWithTypeArr(CXSDNodeBase *pParentNode = NULL);
+
+    void addElementForRefProcessing(CElement *pElement);
+    void processElementArr(CElement *pElement);
+
+    void addKeyRefForReverseAssociation(const CKeyRef *pKeyRef) const;
+    void processKeyRefReverseAssociation() const;
+
+    void addKeyForReverseAssociation(const CKey *pKeyRef) const;
+    void processKeyReverseAssociation() const;
+
+    bool getXMLFromSchema(StringBuffer& strXML, const char* pXSD); //test purposes
+    void populateEnvXPath();
+    void loadEnvFromConfig(const char *pEnvFile);
+    const char* printDocumentation(const char* comp);
+    void printQML(const char* comp, char **pOutput, int nIdx = -1) const;
+    void printDump(const char* comp) const;
+    void dumpStdOut() const;
+    void addToolTip(const char *js);
+    const char* getToolTipJS() const;
+
+    const char* getBasePath() const
+    {
+        return m_pBasePath;
+    }
+
+    void setBasePath(const char *pBasePath);
+    void setEnvTreeProp(const char *pXPath, const char* pValue);
+    const char* getTableValue(const char* pXPath, int nRow = 1) const;
+
+    int getEnvironmentXPathSize() const
+    {
+        return m_strArrayEnvXPaths.length();
+    }
+    const char* getEnvironmentXPaths(int idx) const
+    {
+        assert(idx >= 0);
+        assert(m_strArrayEnvXPaths.length() > idx);
+        return m_strArrayEnvXPaths.item(idx);
+    }
+
+    const char* getAttributeXSDXPathFromEnvXPath(const char* pEnvXPath) const;
+    const char* getElementArrayXSDXPathFromEnvXPath(const char* pXSDXPath) const;
+    int getElementArraySize(const char *pXPath) const;
+    void appendAttributeXPath(const char *pXPath);
+    void appendElementXPath(const char *pXPath);
+
+    static int stripXPathIndex(StringBuffer &strXPath);
+    static bool isXPathTailAttribute(const StringBuffer &strXPath);
+
+    IPropertyTree* getEnvPropertyTree()
+    {
+        return m_pEnvPropertyTree;
+    }
+    const IPropertyTree* getConstEnvPropertyTree() const
+    {
+        return m_pEnvPropertyTree;
+    }
+    int getNumberOfTables() const
+    {
+        return m_nTables;
+    }
+    void incTables()
+    {
+        m_nTables++;
+    }
+    void resetTables() const
+    {
+        m_nTables = 0;
+    }
+    bool saveConfigurationFile() const;
+
+protected:
+
+    CConfigSchemaHelper(const char* pBuildSetFile = DEFAULT_BUILD_SET_XML_FILE, const char* pBuildSetDir = DEFAULT_BUILD_SET_DIRECTORY, const char* pDefaultDirOverride = NULL);
+
+    CSchemaMapManager *m_pSchemaMapManager;
+    CIArrayOf<CExtension> m_extensionArr;
+    CIArrayOf<CAttributeGroup> m_attributeGroupArr;
+    CIArrayOf<CXSDNodeWithType> m_nodeWithTypeArr;
+    CIArrayOf<CXSDNodeWithBase> m_nodeWithBaseArr;
+    CIArrayOf<CElement> m_ElementArr;
+    CIArrayOf<CKeyRef> m_KeyRefArr;
+    StringArray m_strToolTipsJS;
+    StringArray m_strArrayEnvXPaths;
+    StringArray m_strArrayEnvXMLComponentInstances;
+
+    void setEnvPropertyTree(IPropertyTree *pEnvTree)
+    {
+        m_pEnvPropertyTree =  pEnvTree;
+    }
+    void setEnvFilePath(const char* pEnvFilePath)
+    {
+        assert(pEnvFilePath != NULL);
+        m_strEnvFilePath.set(pEnvFilePath);
+    }
+    const char* getEnvFilePath() const
+    {
+        return m_strEnvFilePath.str();
+    }
+
+private:
+
+    static CConfigSchemaHelper* s_pCConfigSchemaHelper;
+    mutable int m_nTables;
+    char *m_pBasePath;
+
+    StringBuffer m_strEnvFilePath;
+    IPropertyTree *m_pEnvPropertyTree;
+};
+
+#endif // _CONFIG_SCHEMA_HELPER_HPP_

--- a/configuration/configurator/ConfiguratorAPI.cpp
+++ b/configuration/configurator/ConfiguratorAPI.cpp
@@ -1,0 +1,520 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include "ConfiguratorAPI.hpp"
+#include "ConfiguratorMain.hpp"
+#include "BuildSet.hpp"
+#include "ConfigSchemaHelper.hpp"
+#include "ConfiguratorMain.hpp"
+#include "jstring.hpp"
+#include "SchemaMapManager.hpp"
+#include "SchemaEnumeration.hpp"
+#include "SchemaCommon.hpp"
+#include "ConfiguratorMain.hpp"
+#include "EnvironmentModel.hpp"
+#include "ConfigNotifications.hpp"
+#include <iostream>
+#include "jlog.hpp"
+
+static int nAllocatedTables = 0;
+static  char *modelName[MAX_ARRAY_X];
+
+const char* getTableDataModelName(int index)
+{
+    if (index < nAllocatedTables)
+        return modelName[index];
+    else
+    {
+        modelName[index] = new char[MAX_ARRAY_Y];
+        sprintf(modelName[index],"tableDataModel%d", index);
+
+        nAllocatedTables++;
+        return modelName[index];
+    }
+}
+
+void deleteTableModels()
+{
+    while (nAllocatedTables > 0)
+    {
+        delete[] modelName[nAllocatedTables];
+    }
+}
+
+namespace CONFIGURATOR_API
+{
+static CConfigSchemaHelper *s_pConfigSchemaHelper = NULL;
+
+void reload(const char *pFile)
+{
+    assert(pFile != NULL && *pFile != 0);
+    delete s_pConfigSchemaHelper;
+
+    s_pConfigSchemaHelper = NULL;
+    s_pConfigSchemaHelper = CConfigSchemaHelper::getInstance();
+    s_pConfigSchemaHelper->populateSchema();
+
+    CConfigSchemaHelper::getInstance()->loadEnvFromConfig(pFile);
+}
+
+int getNumberOfAvailableComponents()
+{
+    assert(s_pConfigSchemaHelper != NULL);
+    return CBuildSetManager::getInstance()->getBuildSetComponentCount();
+}
+
+int getNumberOfAvailableServices()
+{
+    assert(s_pConfigSchemaHelper != NULL);
+    return  CBuildSetManager::getInstance()->getBuildSetServiceCount();
+}
+
+#ifdef CONFIGURATOR_LIB
+
+int initialize()
+{
+    assert(s_pConfigSchemaHelper == NULL);
+
+    static bool bOnce = true;
+
+    if (bOnce == true)
+    {
+        bOnce = false;
+
+        InitModuleObjects();
+
+    }
+
+    s_pConfigSchemaHelper = CConfigSchemaHelper::getInstance();
+    s_pConfigSchemaHelper->populateSchema();
+
+    return 1;
+}
+
+#else // CONFIGURATOR_LIB
+
+int initialize(int argc, char *argv[])
+{
+    assert(s_pConfigSchemaHelper == NULL);
+    InitModuleObjects();
+
+    s_pConfigSchemaHelper = CConfigSchemaHelper::getInstance();
+
+    return 0;
+}
+
+#endif // CONFIGURATOR_LIB
+
+int getValue(const char *pXPath, char *pValue)
+{
+    // By Default, return xPath as value.
+    strcpy(pValue, pXPath);
+    CAttribute *pAttribute = CConfigSchemaHelper::getInstance()->getSchemaMapManager()->getAttributeFromXPath(pXPath);
+
+    if(pAttribute == NULL)
+        std::cout << "xPath: " << pXPath << "| value: " << pXPath << std::endl;
+    else if (pAttribute->isInstanceValueValid() == true)
+    {
+        strcpy(pValue, pAttribute->getInstanceValue());
+        std::cout << "xPath: " << pXPath << "| value: " << pValue << std::endl;
+    }
+    return true;
+}
+
+void setValue(const char *pXPath, const char *pValue)
+{
+    assert(pXPath != NULL && pXPath[0] != 0);
+    assert(pValue != NULL);
+    CAttribute *pAttribute = CConfigSchemaHelper::getInstance()->getSchemaMapManager()->getAttributeFromXPath(pXPath);
+
+    assert(pAttribute != NULL);
+    pAttribute->setEnvValueFromXML(pValue);
+
+    CConfigSchemaHelper::getInstance()->setEnvTreeProp(pXPath, pValue);
+}
+
+int getIndex(const char *pXPath)
+{
+    CRestriction *pRestriction = CConfigSchemaHelper::getInstance()->getSchemaMapManager()->getRestrictionFromXPath(pXPath);
+    assert(pRestriction != NULL);
+    assert(pRestriction->getEnumerationArray() != NULL);
+
+    return pRestriction->getEnumerationArray()->getEnvValueNodeIndex();
+}
+
+void setIndex(const char *pXPath, int newIndex)
+{
+    assert(newIndex >= 0);
+
+    CRestriction *pRestriction = CConfigSchemaHelper::getInstance()->getSchemaMapManager()->getRestrictionFromXPath(pXPath);
+
+    assert(pRestriction != NULL);
+    assert(pRestriction->getEnumerationArray() != NULL);
+    pRestriction->getEnumerationArray()->setEnvValueNodeIndex(newIndex);
+
+    CConfigSchemaHelper::getInstance()->setEnvTreeProp(pXPath, pRestriction->getEnumerationArray()->item(newIndex).getValue());
+}
+
+const char* getTableValue(const char *pXPath, int nRow)
+{
+    assert(pXPath != NULL && *pXPath != 0);
+
+    CAttribute *pAttribute = NULL;
+    CElement *pElement = NULL;
+
+    if (CConfigSchemaHelper::isXPathTailAttribute(pXPath) == true)
+       pAttribute = CConfigSchemaHelper::getInstance()->getSchemaMapManager()->getAttributeFromXPath(pXPath);
+
+    if (pAttribute == NULL)
+    {
+        pElement =  CConfigSchemaHelper::getInstance()->getSchemaMapManager()->getElementFromXPath(pXPath);
+        assert(pElement != NULL);
+
+        return pAttribute->getInstanceValue();
+    }
+    else
+    {
+        assert(pAttribute != NULL);
+        if (nRow == 1)
+            return pAttribute->getInstanceValue();
+        else
+        {
+            StringBuffer strXPath(pXPath);
+            const StringBuffer strXPathOriginal(pXPath);
+
+            int offset = strXPathOriginal.length() - (CConfigSchemaHelper::stripXPathIndex(strXPath) + 1) ;
+            CConfigSchemaHelper::stripXPathIndex(strXPath);
+
+            strXPath.appendf("[%d]", nRow);
+            strXPath.append(strXPathOriginal, offset, strXPathOriginal.length() - offset);
+            pAttribute =  CConfigSchemaHelper::getInstance()->getSchemaMapManager()->getAttributeFromXPath(strXPath.str());
+
+            if (STRICTNESS_LEVEL >= DEFAULT_STRICTNESS)
+                assert(pAttribute != NULL);
+
+            if (pAttribute == NULL)
+                return NULL;
+
+            return pAttribute->getInstanceValue();
+        }
+    }
+}
+
+void setTableValue(const char *pXPath, int index, const char *pValue)
+{
+    UNIMPLEMENTED;
+}
+
+int getNumberOfUniqueColumns()
+{
+    return CConfigSchemaHelper::getInstance()->getEnvironmentXPathSize();
+}
+
+const char* getColumnName(int idx)
+{
+    if (idx < CConfigSchemaHelper::getInstance()->getEnvironmentXPathSize())
+        return CConfigSchemaHelper::getInstance()->getEnvironmentXPaths(idx);
+    else
+        return NULL;
+}
+
+int getNumberOfRows(const char* pXPath)
+{
+    assert(pXPath != NULL && *pXPath != 0);
+    PROGLOG("Get number of rows for %s = %d", pXPath, CConfigSchemaHelper::getInstance()->getElementArraySize(pXPath));
+
+    return CConfigSchemaHelper::getInstance()->getElementArraySize(pXPath);
+}
+
+int getNumberOfTables()
+{
+    return CConfigSchemaHelper::getInstance()->getNumberOfTables();
+}
+
+const char* getServiceName(int idx, char *pName)
+{
+    if (pName != NULL)
+        strcpy (pName, CBuildSetManager::getInstance()->getBuildSetServiceName(idx));
+
+    return CBuildSetManager::getInstance()->getBuildSetServiceName(idx);
+}
+
+const char* getComponentName(int idx, char *pName)
+{
+    if (pName != NULL)
+        strcpy (pName, CBuildSetManager::getInstance()->getBuildSetComponentName(idx));
+
+    return CBuildSetManager::getInstance()->getBuildSetComponentName(idx);
+}
+
+int openConfigurationFile(const char* pFile)
+{
+    CConfigSchemaHelper::getInstance()->loadEnvFromConfig(pFile);
+    return 1;
+}
+
+int getNumberOfComponentsInConfiguration(void *pData)
+{
+    if (pData == NULL)
+    {
+        return CConfigSchemaHelper::getInstance()->getSchemaMapManager()->getNumberOfComponents();
+    }
+    else
+    {
+        CElement *pElement = static_cast<CElement*>(pData);
+        assert(pElement->getNodeType() == XSD_ELEMENT);
+
+        CElementArray *pElementArray = static_cast<CElementArray*>(pElement->getParentNode());
+        assert(pElementArray->getNodeType() == XSD_ELEMENT_ARRAY);
+
+        return pElementArray->length();
+    }
+}
+
+void* getComponentInConfiguration(int idx)
+{
+    assert(idx < CConfigSchemaHelper::getInstance()->getSchemaMapManager()->getNumberOfComponents());
+    return CConfigSchemaHelper::getInstance()->getSchemaMapManager()->getComponent(idx);
+}
+
+void* getComponentInstance(int idx, void *pData)
+{
+    assert(pData != NULL);
+    assert(((static_cast<CElement*>(pData))->getNodeType()) == XSD_ELEMENT);
+
+    CElement *pElement = static_cast<CElement*>(pData);
+    CElementArray *pElementArray = static_cast<CElementArray*>(pElement->getParentNode());
+
+    if (pElementArray->length() >= idx)
+        idx = 0;
+
+    return  &(pElementArray->item(idx));
+}
+
+const char* getComponentNameInConfiguration(int idx, void *pData)
+{
+    if (pData == NULL)
+        return CConfigSchemaHelper::getInstance()->getSchemaMapManager()->getComponent(idx)->getName();
+
+    assert(!"Invalid component index");
+    return NULL;
+}
+
+
+const void* getPointerToComponentInConfiguration(int idx, void *pData, int compIdx)
+{
+    if (pData == NULL)
+    {
+        const CElement *pElement = CConfigSchemaHelper::getInstance()->getSchemaMapManager()->getComponent(idx);
+        assert(pElement != NULL);
+
+        const CXSDNodeBase *pNodeBase = pElement->getConstParentNode();
+        const CElementArray *pElementArray = dynamic_cast<const CElementArray*>(pNodeBase);
+        assert(pElementArray != NULL);
+
+        return pElementArray;
+    }
+    else
+    {
+        assert( compIdx >= 0);
+        CElementArray *pElementArray = static_cast<CElementArray*>(pData);
+        assert(pElementArray->getNodeType() == XSD_ELEMENT_ARRAY);
+
+        const CXSDNodeBase *pNodeBase = &(pElementArray->item(compIdx+idx));
+        return(dynamic_cast<const CElement*>(pNodeBase));
+    }
+}
+
+const void* getPointerToComponentTypeInConfiguration(void *pData)
+{
+    assert (pData != NULL);
+    CElement *pElement = static_cast<CElement*>(pData);
+    assert (pElement->getNodeType() == XSD_ELEMENT);
+
+    CElementArray *pElementArray = static_cast<CElementArray*>(pElement->getParentNode());
+
+    return &(pElementArray->item(0));
+}
+
+int getIndexOfParent(void *pData)
+{
+    assert (pData != NULL);
+    assert((static_cast<CElement*>(pData))->getNodeType() == XSD_ELEMENT);
+
+    int nIndexOfParent = CConfigSchemaHelper::getInstance()->getSchemaMapManager()->getIndexOfElement(static_cast<CElement*>(pData));
+    assert(nIndexOfParent >= 0);
+
+    return nIndexOfParent;
+}
+
+const void* getPointerToComponents()
+{
+    assert(CConfigSchemaHelper::getInstance()->getSchemaMapManager()->getComponent(0)->getConstParentNode()->getNodeType() == XSD_ELEMENT_ARRAY);
+    return (CConfigSchemaHelper::getInstance()->getSchemaMapManager()->getComponent(0)->getConstParentNode());
+}
+
+int getNumberOfChildren(void *pData)
+{
+    int nRetVal = 0;
+
+    if (pData == NULL)
+    {
+        assert(!"Should not be null"); // why ever null?
+        return 0;
+    }
+
+    if (pData == (void*)(CEnvironmentModel::getInstance()))
+        nRetVal = (static_cast<CEnvironmentModel*>(pData))->getNumberOfRootNodes();
+    else // must be of type CEnvironmentModelNode*
+    {
+        CEnvironmentModelNode *pNode = static_cast<CEnvironmentModelNode*>(pData);
+        nRetVal = pNode->getNumberOfChildren();
+    }
+    return nRetVal;
+}
+
+const char* getData(void *pData)
+{
+    if (pData == NULL)
+        return NULL;
+
+    return CEnvironmentModel::getInstance()->getData(static_cast<CEnvironmentModelNode*>(pData));
+}
+
+const char* getName(void *pData)
+{
+    if (pData == NULL)
+        return NULL;
+
+    return CEnvironmentModel::getInstance()->getInstanceName(static_cast<CEnvironmentModelNode*>(pData));
+}
+
+const char* getFileName(void *pData)
+{
+    if (pData == NULL)
+        return NULL;
+
+    return CEnvironmentModel::getInstance()->getXSDFileName(static_cast<CEnvironmentModelNode*>(pData));
+}
+
+void* getParent(void *pData)
+{
+    if (pData == NULL)
+        return NULL;
+
+    if (pData == (void*)(CEnvironmentModel::getInstance()->getRoot()))
+       return (void*)(CEnvironmentModel::getInstance());
+    else
+       return (void*)(CEnvironmentModel::getInstance()->getParent(static_cast<CEnvironmentModelNode*>(pData)));
+    }
+
+void* getChild(void *pData, int idx)
+{
+    if (pData == NULL || pData == CEnvironmentModel::getInstance())
+    {
+        if (idx == 0)
+            return (void*)(CEnvironmentModel::getInstance()->getRoot(0));
+        return NULL;
+    }
+    else
+        return (void*)(CEnvironmentModel::getInstance()->getChild(static_cast<CEnvironmentModelNode*>(pData), idx));
+}
+
+int getIndexFromParent(void *pData)
+{
+    CEnvironmentModelNode *pNode = static_cast<CEnvironmentModelNode*>(pData);
+
+    if (pNode->getParent() == NULL)
+        return 0; // Must be 'Environment' node
+
+    const CEnvironmentModelNode *pGrandParent = pNode->getParent();
+
+    int nChildren = pGrandParent->getNumberOfChildren();
+
+    for (int idx = 0; idx < nChildren; idx++)
+    {
+        if (pNode == pGrandParent->getChild(idx))
+            return idx;
+    }
+
+    assert(!"Should not reach here");
+    return 0;
+}
+
+void* getRootNode(int idx)
+{
+    return (void*)(CEnvironmentModel::getInstance()->getRoot(idx));
+}
+
+void* getModel()
+{
+    return (void*)(CEnvironmentModel::getInstance());
+}
+
+void getQML(void *pData, char **pOutput, int nIdx)
+{
+    CConfigSchemaHelper::getInstance()->printQML(CONFIGURATOR_API::getFileName(pData), pOutput, nIdx);
+}
+
+const char* getQMLFromFile(const char *pXSD, int idx)
+{
+    if (pXSD == NULL || *pXSD == 0)
+        return NULL;
+    return NULL;
+}
+
+void getQMLByIndex(int idx, char *pOutput)
+{
+    const char *pFileName = CBuildSetManager::getInstance()->getBuildSetComponentFileName(idx);
+    CConfigSchemaHelper::getInstance()->printQML(pFileName, &pOutput, 0);
+}
+
+const char* getDocBookByIndex(int idx)
+{
+    const char *pFileName = CBuildSetManager::getInstance()->getBuildSetComponentFileName(idx);
+    return CConfigSchemaHelper::getInstance()->printDocumentation(pFileName);
+}
+
+bool saveConfigurationFile()
+{
+    return CConfigSchemaHelper::getInstance()->saveConfigurationFile();
+}
+
+int getNumberOfNotificationTypes()
+{
+    return CNotificationManager::getInstance()->getNumberOfNotificationTypes();
+}
+
+const char* getNotificationTypeName(int type)
+{
+    return CNotificationManager::getInstance()->getNotificationTypeName(type);
+}
+
+int getNumberOfNotifications(int type)
+{
+    enum ENotificationType eType = static_cast<ENotificationType>(type);
+    return CNotificationManager::getInstance()->getNumberOfNotifications(eType);
+}
+
+const char* getNotification(int type, int idx)
+{
+    const char *pRet = NULL;
+    enum ENotificationType eType = static_cast<ENotificationType>(type);
+
+    return CNotificationManager::getInstance()->getNotification(eType, idx);
+}
+} // CONFIGURATOR_API namespace

--- a/configuration/configurator/ConfiguratorAPI.hpp
+++ b/configuration/configurator/ConfiguratorAPI.hpp
@@ -1,0 +1,77 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef _CONFIGURATOR_API_HPP_
+#define _CONFIGURATOR_API_HPP_
+
+#define MAX_ARRAY_X 100
+#define MAX_ARRAY_Y 128
+
+const char* getTableDataModelName(int index);
+void deleteTableModels();
+
+namespace CONFIGURATOR_API
+{
+#ifdef CONFIGURATOR_LIB
+    extern "C" int initialize();
+#endif // CONFIGURATOR_LIB
+
+extern "C" int getNumberOfAvailableComponents();
+extern "C" int getNumberOfAvailableServices();
+extern "C" const char* getServiceName(int idx, char *pName = 0);
+extern "C" const char* getComponentName(int idx, char *pName = 0);
+extern "C" int getValue(const char *pXPath, char *pValue);
+extern "C" void setValue(const char *pXPath, const char *pValue);
+extern "C" int getIndex(const char *pXPath);
+extern "C" void setIndex(const char *pXPath, int newIndex);
+extern "C" const char* getTableValue(const char *pXPath, int nRow);
+extern "C" void setTableValue(const char *pXPath, int index, const char *pValue);
+extern "C" int getNumberOfUniqueColumns();
+extern "C" const char* getColumnName(int idx);
+extern "C" int getNumberOfRows(const char* pXPath);
+extern "C" int getNumberOfTables();
+extern "C" int openConfigurationFile(const char* pFile);
+extern "C" int getNumberOfComponentsInConfiguration(void *pData);
+extern "C" void* getComponentInConfiguration(int idx);
+extern "C" void* getComponentInstance(int idx, void *pData);
+extern "C" const void* getPointerToComponentTypeInConfiguration(void *pData);
+extern "C" const char* getComponentNameInConfiguration(int idx, void *pData);
+extern "C" const void* getPointerToComponentInConfiguration(int idx, void *pData, int compIdx = -1);
+extern "C" const void* getPointerToComponents();
+extern "C" int getIndexOfParent(void *pData);
+extern "C" int getNumberOfChildren(void *pData);
+extern "C" const char* getData(void *pData);
+extern "C" const char* getName(void *pData);
+extern "C" const char* getFileName(void *pData);
+extern "C" void* getParent(void *pData);
+extern "C" void* getChild(void *pData, int idx);
+extern "C" int getIndexFromParent(void *pData);
+extern "C" void* getRootNode(int idx = 0);
+extern "C" void* getModel();
+extern "C" void reload(const char *pFile);
+extern "C" void getQML(void *pData, char **pOutput, int nIdx);
+extern "C" const char* getQMLFromFile(const char *pXSD, int idx);
+extern "C" void getQMLByIndex(int idx, char *pOutput);
+extern "C" const char* getDocBookByIndex(int idx);
+extern "C" bool saveConfigurationFile();
+extern "C" int getNumberOfNotificationTypes();
+extern "C" const char* getNotificationTypeName(int type);
+extern "C" int getNumberOfNotifications(int type);
+extern "C" const char* getNotification(int type, int idx);
+}
+
+#endif // _CONFIGURATOR_API_HPP_

--- a/configuration/configurator/ConfiguratorMain.cpp
+++ b/configuration/configurator/ConfiguratorMain.cpp
@@ -1,0 +1,372 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include "ConfiguratorMain.hpp"
+#include "EnvironmentConfiguration.hpp"
+#include "WizardBase.hpp"
+#include "ConfigSchemaHelper.hpp"
+#include "SchemaCommon.hpp"
+#include "ExceptionStrings.hpp"
+#include <iostream>
+#include "jfile.hpp"
+
+#ifdef CONFIGURATOR_LIB
+    #include "../configurator_ui/ConfiguratorUI.hpp"
+    #include "../configurator_app/MainWindowInterface.h"
+#endif // CONFIGURATOR_LIB
+
+#define BUFF_SIZE 1024
+
+const char *pDefaultDocExt =  ".mod.xml";
+const char *pDefaultQMLExt =  ".qml";
+
+void usage()
+{
+    std::cout << "configurator -use <xsd files>  -b <base dir path>" << std::endl;
+    std::cout << "Example Usage: ./configurator -use dali.xsd -b /opt/HPCCSystems/componentfiles/configxml -d -t /tmp " << std::endl;
+    std::cout << "-d -doc                           : generate docs" << std::endl;
+    std::cout << "-b -base <base dir path>          : base directory path to use with -use option and for xs:include references in xsd files" << std::endl;
+    std::cout << "-e -extension <file extension>    : write docs or qml to files with appended extension (default " <<  pDefaultDocExt << ")" << std::endl;
+    std::cout << "-t -target <target directory>     : directory to which to docs will be written. If not specified, then output will go to std::out" << std::endl;
+    std::cout << "-u -use <schema xsd>              : use specified xsd schema instead of buildset file" << std::endl;
+    std::cout << "-h -help                          : prints out this usage" << std::endl;
+
+    std::cout << std::endl;
+
+    std::cout << std::endl << "** Experimental **" << std::endl;
+    std::cout <<"Example Usage: ./configurator -use esp.xsd -b /opt/HPCCSystems/componentfiles/configxml/  -qml -t ./ -e qml -s1 ./esp.xsd.qml -env /etc/HPCCSystems/source/environment.xml" << std::endl;
+    std::cout << "-f -file <build set file>         : buildset file name (required if base directory is specfied" << std::endl;
+    std::cout << "-p -path <base dir path>          : base directory path (required if buildset file name is specified)" << std::endl;
+    std::cout << "-x -xsd  <xsd file name>          : xsd file name (can be more than one) - For use with buildset file" << std::endl;
+    std::cout << "-l -list                          : list available xsd files" << std::endl;
+    std::cout << "-m -xml                           : generate XML configuration file" << std::endl;
+    std::cout << "-q -qml                           : prints QML" << std::endl;
+    std::cout << "-c -env -config <path to env xml file> : load environment config xml file (e.g. environment.xml) " << std::endl;
+#ifdef CONFIGURATOR_LIB
+        std::cout << "-s1 -server1 <qml file>           : run server using qml file" << std::endl;
+        std::cout << "-s2 -server2                      : run QT application mode" << std::endl;
+#endif // CONFIGURATOR_LIB
+    std::cout << "-dump                             : dump out xsd internal structure and values" << std::endl;
+}
+
+#ifndef CONFIGURATOR_LIB
+    int main(int argc, char *argv[])
+#else
+    int ConfiguratorMain(int argc, char* argv[])
+#endif // CONFIGURATOR_LIB
+{
+    InitModuleObjects();
+
+    int idx = 1;
+
+    CConfigSchemaHelper *pSchemaHelper = NULL;
+
+    char pBuildSetFile[BUFF_SIZE];
+    char pBuildSetFileDir[BUFF_SIZE];
+    char pTargetDocDir[BUFF_SIZE];
+    char pTargetDocExt[BUFF_SIZE];
+    char pOverrideSchema[BUFF_SIZE];
+    char pBasePath[BUFF_SIZE];
+    char pEnvXMLPath[BUFF_SIZE];
+    char pQMLFile[BUFF_SIZE];
+
+    memset(pBuildSetFile, 0, sizeof(pBuildSetFile));
+    memset(pBuildSetFileDir, 0, sizeof(pBuildSetFileDir));
+    memset(pTargetDocDir, 0, sizeof(pTargetDocDir));
+    memset(pOverrideSchema, 0, sizeof(pOverrideSchema));
+    memset(pBasePath, 0, sizeof(pBasePath));
+    memset(pEnvXMLPath, 0, sizeof(pEnvXMLPath));
+    memset(pQMLFile,0, sizeof(pQMLFile));
+
+    strncpy(pTargetDocExt, pDefaultDocExt, sizeof(pTargetDocExt));
+
+    bool bListXSDs      = false;
+    bool bGenDocs       = false;
+    bool bGenQML        = false;
+    bool bDump          = false;
+    bool bLoadEnvXML    = false;
+    bool bQMLServer     = false;
+
+    StringArray arrXSDs;
+
+    if (argc == 1)
+    {
+        usage();
+        return 0;
+    }
+
+    while(idx < argc)
+    {
+        if (stricmp(argv[idx], "-help") == 0 || stricmp(argv[idx], "-h") == 0)
+        {
+            usage();
+            return 0;
+        }
+        if (stricmp(argv[idx], "-dump") == 0)
+            bDump = true;
+        if (stricmp(argv[idx], "-config") == 0 || stricmp(argv[idx], "-c") == 0 || stricmp(argv[idx], "-env") == 0)
+        {
+            idx++;
+            bLoadEnvXML = true;
+
+            if (argv[idx] == NULL)
+            {
+                std::cout << "Missing env xml file parameter!" << std::endl;
+                return 0;
+            }
+            strncpy(pEnvXMLPath, argv[idx], BUFF_SIZE);
+        }
+        else if (stricmp(argv[idx], "-file") == 0 || stricmp(argv[idx], "-f") == 0)
+        {
+            idx++;
+
+            assert(argv[idx]);
+            if (argv[idx] == NULL)
+            {
+                std::cout << "Missing file parameter!" << std::endl;
+                return 0;
+            }
+            strncpy(pBuildSetFile, argv[idx], BUFF_SIZE);
+        }
+        else if (stricmp(argv[idx], "-path") == 0 || stricmp(argv[idx], "-p") == 0)
+        {
+            idx++;
+
+            assert(argv[idx]);
+            if (argv[idx] == NULL)
+            {
+                std::cout << "Missing path parameter!" << std::endl;
+                return 0;
+            }
+            strncpy(pBuildSetFileDir, argv[idx], BUFF_SIZE);
+        }
+        else if (stricmp(argv[idx], "-base") == 0 || stricmp(argv[idx], "-b") == 0)
+        {
+            idx++;
+
+            assert(argv[idx]);
+            if (argv[idx] == NULL)
+            {
+                std::cout << "Missing base dir parameter!" << std::endl;
+                return 0;
+            }
+            strncpy(pBasePath, argv[idx], BUFF_SIZE);
+        }
+        else if (stricmp(argv[idx], "-xsd") == 0 || stricmp(argv[idx], "-x") == 0)
+        {
+            idx++;
+
+            assert(argv[idx]);
+            if (argv[idx] == NULL)
+            {
+                std::cout << "Missing XSD file!" << std::endl;
+                return 0;
+            }
+            arrXSDs.append(argv[idx]);
+        }
+#ifdef CONFIGURATOR_LIB
+        else if (stricmp(argv[idx], "-s1") == 0 || stricmp(argv[idx], "-server1") == 0)
+        {
+            idx++;
+
+            if (argv[idx] == NULL)
+            {
+                std::cout << "Missing qml file!" << std::endl;
+                return 0;
+            }
+            strncpy(pQMLFile, argv[idx], BUFF_SIZE);
+            bQMLServer = true;
+        }
+#endif // #ifdef CONFIGURATOR_LIB
+        else if (stricmp(argv[idx], "-list") == 0 || stricmp(argv[idx], "-l") == 0)
+            bListXSDs = true;
+        else if (stricmp(argv[idx], "-doc") == 0 || stricmp(argv[idx], "-d") == 0)
+            bGenDocs = true;
+        else if (stricmp(argv[idx], "-target") == 0 || stricmp(argv[idx], "-t") == 0)
+        {
+            idx++;
+
+            assert(argv[idx]);
+            if (argv[idx] == NULL)
+            {
+                std::cout << "Missing target!" << std::endl;
+                return 0;
+            }
+            strcpy(pTargetDocDir,argv[idx]);
+        }
+        else if (stricmp(argv[idx], "-extension") == 0 || stricmp(argv[idx], "-e") == 0)
+        {
+            idx++;
+
+            assert(argv[idx]);
+            if (argv[idx] == NULL)
+            {
+                std::cout << "Missing extension!" << std::endl;
+                return 0;
+            }
+            if (argv[idx][0] != '.')
+            {
+                strcat(pTargetDocExt, ".");
+                strcpy(&(pTargetDocExt[1]),argv[idx]);
+            }
+            else if (*pTargetDocExt == 0)
+                strcat(pTargetDocExt, "");
+            else
+                strcpy(pTargetDocExt,argv[idx]);
+        }
+        else if (stricmp(argv[idx], "-use") == 0 || stricmp(argv[idx], "-u") == 0)
+        {
+            idx++;
+
+            assert(argv[idx]);
+            if (argv[idx] == NULL)
+            {
+                std::cout << "Missing schema xsd!" << std::endl;
+                return 0;
+            }
+            else
+            {
+                strcpy(pOverrideSchema, argv[idx]);
+                arrXSDs.append(argv[idx]);
+            }
+        }
+        else if (stricmp(argv[idx], "-qml") == 0 || stricmp(argv[idx], "-q") == 0)
+            bGenQML = true;
+        idx++;
+    }
+
+    if ((pBuildSetFile[0] != 0) ^ (pBuildSetFileDir[0] != 0))
+    {
+        puts("-file and -path need to be both set or neither one!");
+        return 0;
+    }
+    if (bGenDocs == true && arrXSDs.length() == 0)
+    {
+        puts("No XSDs specified for doc generation!");
+        return 0;
+    }
+    if (pBuildSetFile[0] == 0 && pOverrideSchema[0] == 0)
+    {
+        pSchemaHelper = CConfigSchemaHelper::getInstance();
+    }
+    else if (pBuildSetFile[0] == 0)
+    {
+        pSchemaHelper = CConfigSchemaHelper::getInstance(pBasePath);
+    }
+    else
+    {
+        pSchemaHelper = CConfigSchemaHelper::getInstance(pBuildSetFile, pBuildSetFileDir);
+    }
+
+    assert(pSchemaHelper);
+    if (pOverrideSchema[0] != 0)
+        CBuildSetManager::getInstance()->setBuildSetArray(arrXSDs);
+
+    try
+    {
+        pSchemaHelper->populateSchema();
+    }
+    CATCH_EXCEPTION_AND_EXIT
+
+    if (bListXSDs == true)
+    {
+        StringArray arrXSDs;
+        CBuildSetManager::getInstance()->getBuildSetComponents(arrXSDs);
+
+        if (arrXSDs.length() > 0)
+            std::cout << "XSD files (" << arrXSDs.length() << ")" << std::endl;
+
+        for (int idx = 0; idx < arrXSDs.length(); idx++)
+            std::cout << "(" << idx+1 << ") " << arrXSDs.item(idx) << std::endl;
+    }
+
+    for (int idx =  0; bGenDocs == true && idx < arrXSDs.length(); idx++)
+    {
+        if (pTargetDocDir[0] == 0)
+            std::cout << pSchemaHelper->printDocumentation(arrXSDs.item(idx));
+        else
+        {
+            Owned<IFile>   pFile;
+            Owned<IFileIO> pFileIO;
+            StringBuffer strTargetPath;
+            const char *pXSDFile = strrchr(arrXSDs.item(idx), '/') == NULL ? arrXSDs.item(idx) : strrchr(arrXSDs.item(idx),'/');
+
+            strTargetPath.append(pTargetDocDir).append("/").append(pXSDFile).append(pTargetDocExt);
+            pFile.setown(createIFile(strTargetPath.str()));
+            pFileIO.setown(pFile->open(IFOcreaterw));
+
+            const char *pDoc = pSchemaHelper->printDocumentation(arrXSDs.item(idx));
+
+            if (pDoc == NULL)
+                continue;
+
+            pFileIO->write(0, strlen(pDoc), pDoc);
+        }
+    }
+
+    for (int idx =  0; bGenQML == true && idx < arrXSDs.length(); idx++)
+    {
+        if (pTargetDocDir[0] == 0)
+        {
+            char *pOutput = NULL;
+
+            pSchemaHelper->printQML(arrXSDs.item(idx), &pOutput);
+            std::cout << pOutput;
+
+            free(pOutput);
+        }
+        else
+        {
+            Owned<IFile>   pFile;
+            Owned<IFileIO> pFileIO;
+            StringBuffer strTargetPath;
+
+            const char *pXSDFile = strrchr(arrXSDs.item(idx), '/') == NULL ? arrXSDs.item(idx) : strrchr(arrXSDs.item(idx),'/');
+
+            strTargetPath.append(pTargetDocDir).append("/").append(pXSDFile).append(pDefaultQMLExt);
+            pFile.setown(createIFile(strTargetPath.str()));
+            pFileIO.setown(pFile->open(IFOcreaterw));
+
+            char *pQML = NULL;
+            pSchemaHelper->printQML(arrXSDs.item(idx), &pQML);
+
+            if (pQML == NULL)
+            {
+                free(pQML);
+                continue;
+            }
+            free(pQML);
+            pFileIO->write(0, strlen(pQML), pQML);
+        }
+    }
+
+    for (int idx =  0; (bDump == true || bLoadEnvXML == true) && idx < arrXSDs.length(); idx++)
+    {
+        if (bLoadEnvXML == true)
+            pSchemaHelper->loadEnvFromConfig(pEnvXMLPath);
+        if (bDump == true)
+            pSchemaHelper->printDump(arrXSDs.item(idx));
+    }
+
+    if (bQMLServer == true)
+    {
+#ifdef CONFIGURATOR_LIB
+        StartQMLUI(pQMLFile);
+#endif // CONFIGURATOR_LIB
+    }
+    return 0;
+}

--- a/configuration/configurator/ConfiguratorMain.hpp
+++ b/configuration/configurator/ConfiguratorMain.hpp
@@ -1,0 +1,26 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef _CONFIGURATOR_MAIN_HPP_
+#define _CONFIGURATOR_MAIN_HPP_
+
+#include "ConfiguratorAPI.hpp"
+void usage();
+#ifdef CONFIGURATOR_LIB
+    extern "C" int ConfiguratorMain(int argc, char* argv[]);
+#endif // CONFIGURATOR_LIB
+#endif // _CONFIGURATOR_MAIN_HPP_

--- a/configuration/configurator/DocumentationMarkup.hpp
+++ b/configuration/configurator/DocumentationMarkup.hpp
@@ -1,0 +1,52 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef _DOCUMENTATION_MARKUP_HPP
+#define _DOCUMENTATION_MARKUP_HPP
+
+static const char* DM_SECT2 = "sect2";
+static const char* DM_SECT2_END = "</sect2>\n";
+static const char* DM_SECT3_BEGIN = "";
+static const char* DM_SECT3_END = "";
+static const char* DM_SECT4_BEGIN = "";
+static const char* DM_SECT4_END = "";
+static const char* DM_ID = "id";
+static const char* DM_PARA = "para";
+static const char* DM_PARA_BEGIN = "<para><emphasis role=\"bold\">";
+static const char* DM_PARA_END = "</emphasis></para>\n";
+static const char* DM_LINE_BREAK = "<?linebreak?>";
+static const char* DM_LINE_BREAK2 = "_<?linebreak?>";
+static const char* DM_TITLE_BEGIN = DM_PARA_BEGIN;
+static const char* DM_TITLE_END = DM_PARA_END;
+static const char* DM_TITLE_LITERAL = "title";
+static const char* DM_TABLE_BEGIN = "<informaltable colsep=\"1\" rowsep=\"1\" ";
+static const char* DM_TABLE_ID_BEGIN = "id=\"";
+static const char* DM_TABLE_ID_UNDEFINED = "UNDEFINED";
+static const char* DM_TABLE_ID_END = "\">\n";
+static const char* DM_TABLE_END = "</informaltable>\n";
+static const char* DM_TABLE_ROW = "row";
+static const char* DM_TABLE_ENTRY = "entry";
+static const char* DM_TGROUP = "tgroup";
+static const char* DM_TGROUP4_BEGIN = "<tgroup cols=\"4\" align=\"left\">\n";
+static const char* DM_TGROUP4_END = "</tgroup>\n";
+static const char* DM_TGROUP_END = "</tgroup>\n";
+static const char* DM_TBODY_BEGIN = "<thead><row>\n<entry>attribute</entry>\n<entry>values</entry>\n<entry>default</entry>\n<entry>required</entry>\n</row>\n</thead><tbody>\n";
+static const char* DM_TBODY_END = "</tbody>\n";
+static const char* DM_COL_SPEC4  = "<colspec colwidth=\"155pt\" /><colspec colwidth=\"2*\" /><colspec colwidth=\"1*\" /><colspec colwidth=\"0.5*\" />\n";
+static const char* DM_HEADING = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE sect1 PUBLIC \"-//OASIS//DTD DocBook XML V4.5//EN\"\n\"http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd\">\n";
+
+#endif // _DOCUMENTATION_MARKUP_HPP

--- a/configuration/configurator/EnvironmentConfiguration.cpp
+++ b/configuration/configurator/EnvironmentConfiguration.cpp
@@ -1,0 +1,78 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include "EnvironmentConfiguration.hpp"
+#include "XMLTags.h"
+
+CEnvironmentConfiguration* CEnvironmentConfiguration::getInstance()
+{
+    static Owned<CEnvironmentConfiguration> s_ConfigurationSingleton;
+    static CSingletonLock slock;
+
+    if (slock.lock() == true)
+    {
+      if (s_ConfigurationSingleton.get() == NULL)
+      {
+        s_ConfigurationSingleton.setown(new CEnvironmentConfiguration());
+      }
+
+      slock.unlock();
+    }
+
+    return s_ConfigurationSingleton.get();
+}
+
+CEnvironmentConfiguration::CEnvironmentConfiguration()
+{
+
+}
+
+CEnvironmentConfiguration::~CEnvironmentConfiguration()
+{
+
+}
+
+enum CEnvironmentConfiguration::CEF_ERROR_CODES CEnvironmentConfiguration::generateBaseEnvironmentConfiguration()
+{
+    StringBuffer xpath;
+
+    xpath.clear().appendf("<%s><%s></%s>", XML_HEADER, XML_TAG_ENVIRONMENT, XML_TAG_ENVIRONMENT);
+
+    if (m_pEnv.get() != NULL)
+        m_pEnv.clear();
+
+    m_pEnv.setown(createPTreeFromXMLString(xpath.str()));
+
+    IPropertyTree* pSettings = m_pEnv->addPropTree(XML_TAG_ENVSETTINGS, createPTree());
+
+    return CEnvironmentConfiguration::CF_NO_ERROR;
+}
+
+enum CEnvironmentConfiguration::CEF_ERROR_CODES  CEnvironmentConfiguration::addComponent(const char* pCompType)
+{
+    return CEnvironmentConfiguration::CF_NO_ERROR;
+}
+
+enum CEnvironmentConfiguration::CEF_ERROR_CODES  CEnvironmentConfiguration::removeComponent(const char* pCompType, const char* pCompName)
+{
+    return CEnvironmentConfiguration::CF_NO_ERROR;
+}
+
+enum CEnvironmentConfiguration::CEF_ERROR_CODES  CEnvironmentConfiguration::addESPService(const char* espServiceType)
+{
+    return CEnvironmentConfiguration::CF_NO_ERROR;
+}

--- a/configuration/configurator/EnvironmentConfiguration.hpp
+++ b/configuration/configurator/EnvironmentConfiguration.hpp
@@ -1,0 +1,53 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef _ENVIRONMENT_CONFIGURATON_HPP_
+#define _ENVIRONMENT_CONFIGURATON_HPP_
+
+#include "jptree.hpp"
+#include "ConfigFileComponentUtils.hpp"
+
+
+class CEnvironmentConfiguration : public CConfigFileComponentUtils
+{
+public:
+
+    IMPLEMENT_IINTERFACE
+
+    enum CEF_ERROR_CODES{ CF_NO_ERROR = 0,
+                          CF_UNKNOWN_COMPONENT,
+                          CF_UNKNOWN_ESP_COMPONENT,
+                          CF_COMPONENT_INSTANCE_NOT_FOUND,
+                          CF_OTHER = 0xFF };
+
+    static CEnvironmentConfiguration* getInstance();
+
+    virtual ~CEnvironmentConfiguration();
+
+    enum CEF_ERROR_CODES generateBaseEnvironmentConfiguration();
+    enum CEF_ERROR_CODES addComponent(const char* pCompType);
+    enum CEF_ERROR_CODES removeComponent(const char* pCompType, const char* pCompName);
+    enum CEF_ERROR_CODES addESPService(const char* espServiceType);
+
+protected:
+
+    CEnvironmentConfiguration();
+    Owned<IPropertyTree> m_pEnv;
+private:
+};
+
+#endif // _ENVIRONMENT_CONFIGURATON_HPP_

--- a/configuration/configurator/EnvironmentModel.cpp
+++ b/configuration/configurator/EnvironmentModel.cpp
@@ -1,0 +1,235 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include "EnvironmentModel.hpp"
+#include "SchemaCommon.hpp"
+#include "ConfigSchemaHelper.hpp"
+#include "SchemaMapManager.hpp"
+#include "SchemaElement.hpp"
+#include "SchemaSchema.hpp"
+#include "jlib.hpp"
+#include "jlog.hpp"
+#include <cassert>
+
+#define LOG_CONSTRUCTOR
+
+CEnvironmentModelNode::CEnvironmentModelNode(const CEnvironmentModelNode *pParent, int index,  CXSDNodeBase *pNode) : m_pParent(NULL), m_pArrChildNodes(NULL)
+{
+    if (pParent == NULL && index == 0)  // if this is the 'Environment' Node
+    {
+        this->m_pXSDNode = NULL;
+        this->m_pArrChildNodes = new PointerArray();  // array of ptrs to each component
+
+        int nComps = CConfigSchemaHelper::getInstance()->getSchemaMapManager()->getNumberOfComponents();
+
+        for (int idx = 0; idx < nComps; idx++)
+        {
+            CXSDNodeBase *pNode = CConfigSchemaHelper::getInstance()->getSchemaMapManager()->getComponent(idx);
+
+            if (pNode == NULL)
+                continue;
+            assert(pNode != NULL);
+
+            CEnvironmentModelNode *pModelNode = new CEnvironmentModelNode(this, 0, pNode);
+            m_pArrChildNodes->append(pModelNode);
+        }
+    }
+    else if (pParent != NULL && pParent->getParent() == NULL)  // component tier
+    {
+        assert(pParent != NULL);
+        assert(pNode != NULL);
+
+        this->m_pParent = pParent;
+        this->m_pXSDNode = pNode;
+        this->m_pArrChildNodes = new PointerArray();
+
+        assert(m_pXSDNode->getNodeType() == XSD_ELEMENT);
+        assert(m_pXSDNode->getConstParentNode()->getNodeType() == XSD_ELEMENT_ARRAY);
+
+        const CElement *pElement =  static_cast<const CElement*>(m_pXSDNode->getNodeByTypeAndNameDescending(XSD_ELEMENT, NULL));
+        const CElementArray *pElementArray = pElement != NULL ? static_cast<const CElementArray*>(pElement->getParentNode()) : NULL;
+
+        for (int idx = 0; (pElementArray != NULL && idx < pElementArray->length()); idx++)
+        {
+            CEnvironmentModelNode *pModelNode = new CEnvironmentModelNode(this, idx, &(pElementArray->item(idx)));
+            m_pArrChildNodes->append(pModelNode);
+        }
+    }
+    else // instance tier
+    {
+        assert(pParent != NULL);
+        assert(pNode != NULL);
+
+        this->m_pParent = pParent;
+        this->m_pXSDNode = pNode;
+        this->m_pArrChildNodes = new PointerArray();
+    }
+}
+
+const CEnvironmentModelNode* CEnvironmentModelNode::getChild(int index) const
+{
+   assert(m_pArrChildNodes == NULL || m_pArrChildNodes->length() > index);
+
+   if (m_pArrChildNodes != NULL)
+   {
+        CEnvironmentModelNode *pNode = static_cast<CEnvironmentModelNode*>(m_pArrChildNodes->item(index));
+        return pNode;
+   }
+   return NULL;
+}
+
+CEnvironmentModelNode::~CEnvironmentModelNode()
+{
+    delete m_pArrChildNodes;
+}
+
+int CEnvironmentModelNode::getNumberOfChildren() const
+{
+    int nRetVal = 0;
+
+    if (m_pArrChildNodes != NULL)
+        nRetVal = m_pArrChildNodes->length();
+    else if (m_pArrChildNodes == NULL && m_pXSDNode != NULL && m_pParent != (CEnvironmentModel::getInstance()->getRoot()))
+        return 0;
+    else
+    {
+        assert(this->getXSDNode()->getNodeType() == XSD_ELEMENT);
+
+        const CElement *pElement = static_cast<const CElement*>(this->getXSDNode());
+        const CElementArray *pElementArray = static_cast<const CElementArray*>(pElement->getConstParentNode());
+        assert(pElementArray->getNodeType() == XSD_ELEMENT_ARRAY);
+
+        nRetVal = pElementArray->getCountOfSiblingElements(pElement->getXSDXPath());
+    }
+    return nRetVal;
+}
+
+CEnvironmentModel* CEnvironmentModel::getInstance()
+{
+    static CEnvironmentModel *s_pCEnvModel = NULL;
+
+    if (s_pCEnvModel == NULL)
+        s_pCEnvModel = new CEnvironmentModel();
+
+    return s_pCEnvModel;
+}
+
+CEnvironmentModel::CEnvironmentModel()
+{
+    m_pRootNode = new CEnvironmentModelNode(NULL);
+}
+
+CEnvironmentModel::~CEnvironmentModel()
+{
+    delete m_pRootNode;
+}
+
+const CEnvironmentModelNode* CEnvironmentModel::getParent(CEnvironmentModelNode *pChild)
+{
+    if (pChild != NULL)
+        return pChild->getParent();
+
+    assert(false);
+    return NULL;
+}
+
+const CEnvironmentModelNode* CEnvironmentModel::getChild(CEnvironmentModelNode *pParent, int index)
+{
+    assert(index >= 0);
+    assert(pParent != NULL);
+
+    if (pParent == NULL)
+    {
+        return m_pRootNode;
+    }
+
+    assert(pParent->getNumberOfChildren() > index);
+    return pParent->getChild(index);
+}
+
+const char* CEnvironmentModel::getData(const CEnvironmentModelNode *pChild) const
+{
+    assert(pChild != NULL);
+
+    if (pChild == reinterpret_cast<const CEnvironmentModelNode*>(this))
+        return NULL;
+
+    const CElement *pElement = static_cast<const CElement*>(pChild->getXSDNode());
+
+    if (pElement != NULL)
+    {
+        const char *pInstanceName = pElement->getInstanceName();
+
+        if (pChild->getParent() != CEnvironmentModel::getInstance()->getRoot())
+            return pInstanceName;
+        else
+            return pElement->getName();
+    }
+    else
+        return "Environment";
+}
+
+const char* CEnvironmentModel::getXSDFileName(const CEnvironmentModelNode *pChild) const
+{
+    assert(pChild != NULL);
+
+    const CElement *pElement = static_cast<const CElement*>(pChild->getXSDNode());
+
+    if (pElement != NULL && pElement->isTopLevelElement() == true)
+    {
+        const CSchema *pSchema = dynamic_cast<const CSchema*>(pElement->getConstAncestorNode(2));
+
+        if (pSchema == NULL)
+        {
+            assert(false);
+            return NULL;
+        }
+        else
+            return pSchema->getSchemaFileName();
+    }
+    else
+        return NULL;
+}
+
+const char* CEnvironmentModel::getInstanceName(const CEnvironmentModelNode *pChild) const
+{
+    assert(pChild != NULL);
+
+    const CElement *pElement = static_cast<const CElement*>(pChild->getXSDNode());
+
+    if (pElement != NULL && pElement->isTopLevelElement() == true)
+        return pElement->getInstanceName();
+    else
+        return pElement->getName();
+}
+
+
+int CEnvironmentModel::getNumberOfRootNodes() const
+{
+    return 1;
+}
+
+CEnvironmentModelNode* CEnvironmentModel::getRoot(int index)
+{
+    assert(m_pRootNode != 0);
+    assert(index == 0);
+
+    if (index != 0)
+        return NULL;
+    else
+        return m_pRootNode;
+}

--- a/configuration/configurator/EnvironmentModel.hpp
+++ b/configuration/configurator/EnvironmentModel.hpp
@@ -1,0 +1,80 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef _ENVIRONMENT_MODEL_HPP_
+#define _ENVIRONMENT_MODEL_HPP_
+
+#include <cassert>
+
+class CXSDNodeBase;
+class CEnvironmentModelNode;
+class PointerArray;
+
+template <class TYPE>
+class CIArrayOf;
+
+class CEnvironmentModelNode
+{
+public:
+
+    CEnvironmentModelNode(const CEnvironmentModelNode *pParent = 0, int index = 0, CXSDNodeBase *pNode = 0);
+    virtual ~CEnvironmentModelNode();
+
+    int getNumberOfChildren() const;
+
+    const CXSDNodeBase* getXSDNode() const
+    {
+        return m_pXSDNode;
+    }
+
+    const CEnvironmentModelNode* getParent() const
+    {
+        return m_pParent;
+    }
+
+    const CEnvironmentModelNode* getChild(int index) const;
+
+protected:
+
+    CXSDNodeBase *m_pXSDNode;
+    const CEnvironmentModelNode *m_pParent;
+    PointerArray *m_pArrChildNodes;
+} __attribute__((aligned (32)));
+
+class CEnvironmentModel
+{
+public:
+
+    static CEnvironmentModel* getInstance();
+
+    virtual ~CEnvironmentModel();
+
+    const CEnvironmentModelNode* getParent(CEnvironmentModelNode *pChild);
+    const CEnvironmentModelNode* getChild(CEnvironmentModelNode *pParent, int index);
+    int getNumberOfRootNodes() const;
+    CEnvironmentModelNode* getRoot(int index = 0);
+    const char* getData(const CEnvironmentModelNode *pChild) const;
+    const char* getInstanceName(const CEnvironmentModelNode *pChild) const;
+    const char* getXSDFileName(const CEnvironmentModelNode *pChild) const;
+
+protected:
+
+    CEnvironmentModel();
+    CEnvironmentModelNode *m_pRootNode;
+};
+
+#endif // _ENVIRONMENT_MODEL_HPP_

--- a/configuration/configurator/ExceptionStrings.cpp
+++ b/configuration/configurator/ExceptionStrings.cpp
@@ -1,0 +1,37 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include "jstring.hpp"
+#include "ExceptionStrings.hpp"
+
+const int nDefaultCode = 99;
+
+IException *MakeExceptionFromMap(int code, enum eExceptionCodes eCode, const char* pMsg)
+{
+    static StringBuffer strExceptionMessage;
+    strExceptionMessage.setf("Exception: %s\nPossible Action(s): %s\n",  pExceptionStringArray[eCode-1], pExceptionStringActionArray[eCode-1]);
+
+    if (pMsg != NULL)
+        strExceptionMessage.append("\nAdditonal Infomation: ").append(pMsg);
+
+    return MakeStringException(code, "%s", strExceptionMessage.str());
+}
+
+IException *MakeExceptionFromMap(enum eExceptionCodes eCode, const char* pMsg)
+{
+    return MakeExceptionFromMap(nDefaultCode, eCode, pMsg);
+}

--- a/configuration/configurator/ExceptionStrings.hpp
+++ b/configuration/configurator/ExceptionStrings.hpp
@@ -1,0 +1,102 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef _EXCEPTION_STRINGS_HPP_
+#define _EXCEPTION_STRINGS_HPP_
+
+#include "jexcept.hpp"
+#include <cstring>
+
+#define MAX_EXCEPTION_STRING_LENGTH 2048
+
+#define CATCH_EXCEPTION_AND_EXIT \
+catch (IException *except) \
+{\
+    StringBuffer strErrMsg;\
+    except->errorMessage(strErrMsg);\
+    std::cout << std::endl << strErrMsg.str() << std::endl << std::endl;\
+    exit(-1);\
+}
+
+enum eExceptionCodes
+{
+    EX_STR_CAN_NOT_OPEN_XSD  = 1,
+    EX_STR_SIMPLE_TYPE_ALREADY_DEFINED,
+    EX_STR_COMPLEX_TYPE_ALREADY_DEFINED,
+    EX_STR_ATTRIBUTE_GROUP_ALREADY_DEFINED,
+    EX_STR_CAN_NOT_PROCESS_ENV_XML,
+    EX_STR_XPATH_DOES_NOT_EXIST_IN_TREE,
+    EX_STR_MISSING_REQUIRED_ATTRIBUTE,
+    EX_STR_MISSING_VALUE_ATTRIBUTE_IN_LENGTH,
+    EX_STR_LENGTH_VALUE_MUST_BE_GREATER_THAN_OR_EQUAL_TO_ZERO,
+    EX_STR_PATTERN_HAS_INVALID_VALUE,
+    EX_STR_WHITE_SPACE_HAS_INVALID_VALUE,
+    EX_STR_MISSING_NAME_ATTRIBUTE,
+    EX_STR_UNKNOWN,
+    EX_STR_LAST_ENTRY
+};
+
+const char pExceptionStringArray[EX_STR_LAST_ENTRY][MAX_EXCEPTION_STRING_LENGTH] = { /*** ALWAYS ADD TO THE END OF THE ARRAY!!! ***/
+                                                                                     "can not open xsd file", //
+                                                                                     "simple type already defined",
+                                                                                     "complex type already defined",
+                                                                                     "attribute group already defined",
+                                                                                     "can not open/parse environment xml configuration",
+                                                                                     "xpath does not exist in supplied tree",
+                                                                                     "the xml file is missing a required attribute based on the xsd",
+                                                                                     "length type can not have an empty value attribute",
+                                                                                     "length value must be greater than or equal to zero",
+                                                                                     /*** ADD CORRESPONDING ENTRY TO pExceptionStringActionArray ***/
+                                                                                    };
+
+const char pExceptionStringActionArray[EX_STR_LAST_ENTRY*2][MAX_EXCEPTION_STRING_LENGTH] = {  /*** ALWAYS ADD TO THE END OF THE ARRAY!!! ***/
+                                                                                            /* 1 */ "Ensure that input xsd files exist and that it's permissions are set properly",
+                                                                                            /* 2 */ "Multiple xs:simpleType tags with the same name defined in xsd files. Try processing xsd files using -use parameter and only specify 1 xsd file for processing." ,
+                                                                                            /* 3 */ "Multiple xs:complexType tags with the same name defined in xsd files. Try processing xsd files using -use parameter and only specify 1 xsd file for processing.",
+                                                                                            /* 4 */ "Multiple xs:attributeGroup tags with the same name defined in xsd files. Try processing xsd files using -use parameter and only specify 1 xsd file for processing.",
+                                                                                            /* 5 */ "Failed to open/parss specified configuration file.  Verify file exits, permissions are set properly, and the file is valid.",
+                                                                                            /* 6 */ "The XML file may have errors.",
+                                                                                            /* 7 */ "The XML file may have errors.  An attribute marked as required in the XSD is missing in the xml file."
+                                                                                            /* 8 */ "The XSD has an node  xs:restriction type with an xs:length datatype that has not value; value is required",
+                                                                                            /* 9 */ "The XSD has an node xs:length @value is not greater than or equal to 0",
+                                                                                            /* 10 */ "The XSD has an node xs:fractionDigits that has a value that is not greater than or equl to 0",
+                                                                                            /* 11 */ "The XSD has an node xs:minLength value that is not greater than or equl to 0",
+                                                                                            /* 12 */ "The XSD has an node xs:minInclusive that has no value attribute",
+                                                                                            /* 13 */ "The XSD has an node xs:max:Exclusive that has no value attribute",
+                                                                                            /* 14 */ "The XSD has an node xs:max:Inclusive that has no value attribute",
+                                                                                            /* 15 */ "The XSD has a node xs:maxLength @value is not greater than or equal to 0",
+                                                                                            /* 16 */ "The XSD has a node xs:pattern @value is not set",
+                                                                                            /* 17 */ "The XSD has a node xs:totalDigits @value is not greater than or equal to 0",
+                                                                                            /* 17 */ "The XSD has a node xs:whitespace @value is not valid",
+                                                                                            /*** ADD CORRESPONDING ENTRY TO pExceptionStringActionArray ***/
+                                                                                        };
+
+enum eActionArray { EACTION_FRACTION_DIGITS_HAS_BAD_LENGTH = 10,
+                    EACTION_MIN_LENGTH_BAD_LENGTH = 11,
+                    EACTION_MIN_INCLUSIVE_NO_VALUE = 12,
+                    EACTION_MAX_EXCLUSIVE_NO_VALUE = 13,
+                    EACTION_MAX_INCLUSIVE_NO_VALUE = 14,
+                    EACTION_MAX_LENGTH_BAD_LENGTH = 15,
+                    EACTION_PATTERN_MISSING_VALUE = 16,
+                    EACTION_TOTAL_DIGITS_BAD_LENGTH = 17,
+                    EACTION_WHITE_SPACE_BAD_VALUE = 18
+                  };
+
+IException *MakeExceptionFromMap(int code, enum eExceptionCodes, const char* pMsg = NULL);
+IException *MakeExceptionFromMap(enum eExceptionCodes, const char* pMsg = NULL);
+
+#endif // _EXCEPTION_STRINGS_HPP_

--- a/configuration/configurator/QMLMarkup.cpp
+++ b/configuration/configurator/QMLMarkup.cpp
@@ -1,0 +1,251 @@
+﻿/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include "QMLMarkup.hpp"
+#include "SchemaCommon.hpp"
+#include "jstring.hpp"
+#include "jutil.hpp"
+#include "jarray.hpp"
+#include "jdebug.hpp"
+#include "SchemaAttributes.hpp"
+#include "SchemaElement.hpp"
+#include "SchemaAppInfo.hpp"
+#include "SchemaAnnotation.hpp"
+
+int CQMLMarkupHelper::glImplicitHeight = -1;
+
+void CQMLMarkupHelper::getTabQML(StringBuffer &strQML, const char *pName)
+{
+    assert(pName != NULL);
+
+    strQML.append(QML_TAB_BEGIN);
+    strQML.append(QML_TAB_TITLE_BEGIN).append(pName).append(QML_TAB_TITLE_END);
+    strQML.append(QML_FLICKABLE_BEGIN);
+    DEBUG_MARK_QML;
+}
+
+void CQMLMarkupHelper::getComboBoxListElement(const char* pLabel, StringBuffer &strID, const char* pDefault)
+{
+    static StringBuffer strBuf;
+    strBuf.append(QML_LIST_ELEMENT_BEGIN).append(pLabel);
+}
+
+void CQMLMarkupHelper::getToolTipQML(StringBuffer &strQML, const char *pToolTip, const char* pTextAreaID)
+{
+    assert(pToolTip != NULL);
+
+    StringBuffer strTimer1("timer1");
+    StringBuffer strTimer2("timer2");
+    StringBuffer strMouseArea("mousearea");
+    StringBuffer strRectangle("rectangle");
+    StringBuffer strTextArea(pTextAreaID);
+    StringBuffer strToolTip(pToolTip);
+
+    strToolTip.replace('\"','\'');
+
+    CQMLMarkupHelper::getRandomID(&strTimer1);
+    CQMLMarkupHelper::getRandomID(&strTimer2);
+    CQMLMarkupHelper::getRandomID(&strMouseArea);
+    CQMLMarkupHelper::getRandomID(&strRectangle);
+
+    CQMLMarkupHelper::getToolTipRectangle(strQML, strToolTip.str(), strRectangle.str());
+    DEBUG_MARK_QML;
+    CQMLMarkupHelper::getToolTipTimer(strQML, strToolTip.str(), strRectangle.str(), strTimer1.str(), strTimer2.str(), strMouseArea.str());
+    DEBUG_MARK_QML;
+    CQMLMarkupHelper::getToolMouseArea(strQML, strToolTip.str(), strRectangle.str(), strTimer1.str(), strTimer2.str(), strMouseArea.str(), strTextArea.str());
+    DEBUG_MARK_QML;
+}
+
+void CQMLMarkupHelper::getToolTipTimer(StringBuffer &strQML, const char *pToolTip, const char *pRectangleID, const char* pTimerID_1, const char* pTimerID_2, const char *pMouseAreaID)
+{
+
+    strQML.append(QML_TOOLTIP_TIMER_BEGIN)\
+            .append(QML_TOOLTIP_TIMER_ON_TRIGGERED_BEGIN)\
+                .append(QML_STYLE_INDENT).append(pRectangleID).append(QML_TOOLTIP_TIMER_RECTANGLE_APPEND_TRUE)\
+                .append(QML_STYLE_INDENT).append(pTimerID_2).append(QML_TOOLTIP_TIMER_TIMER_APPEND_START)\
+            .append(QML_TOOLTIP_TIMER_ON_TRIGGERED_END)\
+            .append(QML_TOOLTIP_TIMER_ID).append(pTimerID_1)\
+           .append(QML_TOOLTIP_TIMER_END);
+}
+
+void CQMLMarkupHelper::getToolTipRectangle(StringBuffer &strQML, const char *pToolTip, const char *pRectangleID)
+{
+    strQML.append(QML_TOOLTIP_TEXT_BEGIN).append(pRectangleID).append(QML_TOOLTIP_TEXT_PART_1).append(pToolTip).append(QML_TOOLTIP_TEXT_PART_2);
+}
+
+void CQMLMarkupHelper::getToolMouseArea(StringBuffer &strQML, const char *pToolTip, const char *pRectangleID, const char* pTimerID_1, const char* pTimerID_2, const char *pMouseAreaID, const char* pTextAreaID)
+{
+    strQML.append(QML_MOUSE_AREA_BEGIN)\
+            .append(pMouseAreaID).append(QML_MOUSE_AREA_ID_APPEND)\
+                .append(QML_MOUSE_AREA_ON_ENTERED_BEGIN)
+                    .append(QML_STYLE_INDENT).append(pTimerID_1).append(QML_TOOLTIP_TIMER_TIMER_APPEND_START)\
+                .append(QML_MOUSE_AREA_ON_ENTERED_END)\
+                .append(QML_MOUSE_AREA_ON_EXITED_BEGIN)\
+                    .append(QML_STYLE_INDENT).append(pTimerID_1).append(QML_TOOLTIP_TIMER_STOP)\
+                    .append(QML_STYLE_INDENT).append(pRectangleID).append(QML_MOUSE_AREA_RECTANGLE_VISIBLE_FALSE)\
+                .append(QML_MOUSE_AREA_ON_EXITED_END)\
+                .append(QML_MOUSE_AREA_ON_POSITION_CHANGED_BEGIN)\
+                        .append(QML_STYLE_INDENT).append(pTimerID_1).append(QML_TOOLTIP_TIMER_RESTART)\
+                        .append(QML_STYLE_INDENT).append(pRectangleID).append(QML_MOUSE_AREA_RECTANGLE_VISIBLE_FALSE)\
+                .append(QML_MOUSE_AREA_ON_POSITION_CHANGED_END).append(QML_STYLE_INDENT)\
+                .append(QML_MOUSE_AREA_ON_PRESSED_BEGIN)\
+                        .append(QML_STYLE_INDENT).append(pTextAreaID).append(QML_TEXT_AREA_FORCE_FOCUS)\
+                .append(QML_MOUSE_AREA_ON_PRESSED_END)\
+            .append(QML_MOUSE_AREA_END);
+}
+
+void CQMLMarkupHelper::getTableViewColumn(StringBuffer &strQML, const char* colTitle, const char *pRole)
+{
+    assert(colTitle != NULL);
+    assert(pRole != NULL);
+
+    if (colTitle != NULL && pRole != NULL)
+    {
+        strQML.append(QML_TABLE_VIEW_COLUMN_BEGIN).append(QML_TABLE_VIEW_COLUMN_TITLE_BEGIN).append(colTitle).append(QML_TABLE_VIEW_COLUMN_TITLE_END);
+        strQML.append(QML_ROLE_BEGIN).append(pRole).append(QML_ROLE_END);
+        strQML.append(QML_TABLE_VIEW_COLUMN_END);
+        DEBUG_MARK_QML;
+    }
+}
+
+unsigned CQMLMarkupHelper::getRandomID(StringBuffer *pID)
+{
+    Owned<IRandomNumberGenerator> random = createRandomNumberGenerator();
+    random->seed(get_cycles_now());
+
+    unsigned int retVal =  (random->next() % UINT_MAX);
+
+    if (pID != NULL)
+    {
+        pID->trim();
+        pID->append(retVal);
+    }
+
+    return retVal;
+}
+
+bool CQMLMarkupHelper::isTableRequired(const CAttribute *pAttrib)
+{
+    assert(pAttrib != NULL);
+
+    if (pAttrib == NULL)
+        return false;
+
+    const char* pViewType = NULL;
+    const char* pColumnIndex = NULL;
+    const char* pXPath = NULL;
+    const CXSDNodeBase *pGrandParentNode = pAttrib->getConstAncestorNode(2);
+    const CElement *pNextHighestElement = dynamic_cast<const CElement*>(pAttrib->getParentNodeByType(XSD_ELEMENT));
+
+    if (pAttrib->getAnnotation() != NULL && pAttrib->getAnnotation()->getAppInfo() != NULL)
+    {
+        const CAppInfo *pAppInfo = NULL;
+        pAppInfo = pAttrib->getAnnotation()->getAppInfo();
+        pViewType = pAppInfo->getViewType();
+        pColumnIndex = (pAppInfo->getColIndex() != NULL && pAppInfo->getColIndex()[0] != 0) ? pAppInfo->getColIndex() : NULL;
+        pXPath = (pAppInfo->getXPath() != NULL && pAppInfo->getXPath()[0] != 0) ? pAppInfo->getXPath() : NULL;
+    }
+
+    if ((pColumnIndex != NULL && pColumnIndex[0] != 0) || (pXPath != NULL && pXPath[0] != 0) || \
+            (pGrandParentNode != NULL && pGrandParentNode->getNodeType() != XSD_ATTRIBUTE_GROUP && pGrandParentNode->getNodeType() != XSD_COMPLEX_TYPE && pGrandParentNode->getNodeType() != XSD_ELEMENT) || \
+            (pGrandParentNode->getNodeType() == XSD_ELEMENT && stricmp( (dynamic_cast<const CElement*>(pGrandParentNode))->getMaxOccurs(), "unbounded") == 0) || \
+            (pNextHighestElement != NULL && pNextHighestElement->getMaxOccurs() != NULL && pNextHighestElement->getMaxOccurs()[0] != 0))
+        return true;
+    else
+        return false;
+}
+
+void CQMLMarkupHelper::buildAccordionStart(StringBuffer &strQML, const char * title, const char * altTitle, int idx)
+{
+    assert(title != NULL);
+
+    StringBuffer result;
+
+    result.append("AccordionItem {\n");
+    result.append(CQMLMarkupHelper::printProperty("title",title));
+
+    if(strlen(altTitle))
+        result.append(CQMLMarkupHelper::printProperty("altTitle",altTitle));
+
+    char * index = NULL;
+    result.append("contentModel: VisualItemModel {\n");
+
+    strQML.append(result);
+}
+void CQMLMarkupHelper::buildColumns(StringBuffer &strQML, StringArray &roles, StringArray &titles)
+{  
+    /*
+    Sample QML for Column Instance
+    columnNames: [{role:"key",title:"key"}, {role:"value",title:"value"},{role:"alphabet",title:"Alpha"}]
+     */
+    StringBuffer result;
+    assert(roles.length() == titles.length());
+    result.append("columnNames: [");
+    for(int i = 0; i < roles.length(); i++)
+    {
+        const StringBuffer temprole = CQMLMarkupHelper::printProperty("role", roles[i], false);
+        const StringBuffer temptitle = CQMLMarkupHelper::printProperty("title", titles[i], false);
+        result.appendf("{%s,%s}", temprole.str(), temptitle.str());
+
+        if(i != roles.length() - 1)
+            result.append(",");
+    }
+    result.append("]\n");
+
+    strQML.append(result);
+}
+
+void CQMLMarkupHelper::buildRole(StringBuffer &strQML, const char * role, StringArray &values, const char * type, const char * tooltip, const char * placeholder)
+{
+    StringBuffer result;
+    StringBuffer escapedToolTip = tooltip;
+
+    escapedToolTip.replaceString("\"","\\\"");
+
+    StringBuffer escapedPlaceholder = placeholder;
+
+    escapedPlaceholder.replaceString("\"","\\\"");
+    result.append(role).append(": ListElement { \n").append("value:[");
+
+    for(int i = 0; i < values.length(); i++)
+    {
+        result.append("ListElement {value: \"");
+        result.append(values[i]);
+        result.append("\"}");
+
+        if(i != values.length()-1)
+            result.append(",");
+    }
+
+    result.append("]\n");
+    result.append(CQMLMarkupHelper::printProperty("type",type));
+    result.append(CQMLMarkupHelper::printProperty("tooltip",escapedToolTip));
+    result.append(CQMLMarkupHelper::printProperty("placeholder",escapedPlaceholder));
+    result.append("}");
+    strQML.append(result);
+}
+
+const StringBuffer CQMLMarkupHelper::printProperty(const char * property, const char * value, const bool newline)
+{
+    StringBuffer result;
+    result.appendf("%s: \"%s\"",property,value);
+
+    if(newline)
+        result.append("\n");
+
+    return result;
+}

--- a/configuration/configurator/QMLMarkup.hpp
+++ b/configuration/configurator/QMLMarkup.hpp
@@ -1,0 +1,571 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef _QMLMARKUP_HPP_
+#define _QMLMARKUP_HPP_
+
+//#include "jarray.hpp"
+class StringBuffer;
+class CAttribute;
+class StringArray;
+class String;
+   
+
+static const char* QML_TABLE_DATA_MODEL(" tableDataModel\n");
+static const char* QML_PROPERTY_STRING_TABLE_BEGIN("\
+         property string table: ");//tableDataModel.setActiveTable(\"");
+static const char* QML_PROPERTY_STRING_TABLE_PART_1(".setActiveTable(\"");
+static const char* QML_PROPERTY_STRING_TABLE_END("\")\n");
+
+static const char* QML_APP_DATA_GET_VALUE_BEGIN(" ApplicationData.getValue(\"");
+static const char* QML_APP_DATA_GET_VALUE_END("\")\n");
+static const char* QML_APP_DATA_SET_VALUE_BEGIN(" ApplicationData.setValue(\"");
+static const char* QML_APP_DATA_SET_VALUE_END(".text)\n");
+static const char* QML_APP_DATA_GET_INDEX_BEGIN(" ApplicationData.getIndex(\"");
+static const char* QML_APP_DATA_GET_INDEX_END("\")\n");
+static const char* QML_APP_DATA_SET_INDEX_BEGIN(" ApplicationData.setIndex(\"");
+static const char* QML_APP_DATA_SET_INDEX_END(".currentIndex)\n");
+
+static const char* QML_ON_ACCEPTED("\n\
+        onAccepted: ");
+
+static const char* QML_MODEL("\n\
+       model: ");
+static const char* QML_ROLE_BEGIN("\
+            role: \"");
+static const char* QML_ROLE_END("\"\n");
+
+static const char* QML_ON_CURRENT_INDEX_CHANGED("\n\
+            onCurrentIndexChanged: ");
+
+static const char* QML_START("\
+ import QtQuick 2.1\n\
+ import QtQuick.Controls 1.2\n\
+ import QtQuick.Controls.Styles 1.0\n\
+ import QtQuick.Particles 2.0\n\
+ import QtQuick.Layouts 1.0\n\
+ \n\
+    Item {\n\
+     id: root\n\
+     width: 900\n\
+     height: 700\n\
+");
+
+static const char* QML_VERTICAL_SCROLL_BAR("\n\
+           ScrollBar {\n\
+               id: verticalScrollBar\n\
+               width: 12; height: view.height-12\n\
+               anchors.right: view.right\n\
+               opacity: 0\n\
+               orientation: Qt.Vertical\n\
+               position: view.visibleArea.yPosition\n\
+               pageSize: view.visibleArea.heightRatio\n\
+                    }\n");
+
+static const char* QML_HORIZONTAL_SCROLL_BAR("\n\
+           ScrollBar {\n\
+              id: horizontalScrollBar\n\
+              width: view.width-12; height: 12\n\
+              anchors.bottom: view.bottom\n\
+              opacity: 0\n\
+              orientation: Qt.Horizontal\n\
+              position: view.visibleArea.xPosition\n\
+              pageSize: view.visibleArea.widthRatio\n\
+                    }\n");
+
+static const char* QML_FLICKABLE_BEGIN("\n\
+           Flickable { id: view \n\
+                       anchors.fill: parent\n\
+                       contentWidth: 512\n\
+                       /*contentHeight: 24\n*/\
+                       ");
+
+static const char* QML_FLICKABLE_HEIGHT("\n\
+                       contentHeight: ");
+
+static const char* QML_FLICKABLE_END("\n\
+                        } // QML_FLICKABLE_END\n");
+
+static const char* QML_SCROLL_BAR_TRANSITIONS("\n\
+           states: State {\n\
+               name: \"ShowBars\"\n\
+               when: view.movingVertically || view.movingHorizontally\n\
+               PropertyChanges { target: verticalScrollBar; opacity: 1 }\n\
+               PropertyChanges { target: horizontalScrollBar; opacity: 1 }\n\
+           }\n\
+           transitions: Transition {\n\
+               NumberAnimation { properties: \"opacity\"; duration: 400 }\n\
+           }\n");
+
+//static const char* QML_HORIZONTAL_SCROLL_BAR_TRANSITION();
+
+static const char* QML_END("\
+}\n\
+");
+
+static const char* QML_TEXT_FIELD_STYLE("\
+property Component textfieldStyle: TextFieldStyle {\n\
+  background: Rectangle {\n\
+      implicitWidth: columnWidth\n\
+      implicitHeight: 22\n\
+      color: \"#f0f0f0\"\n\
+      antialiasing: true\n\
+      border.color: \"gray\"\n\
+      radius: height/2\n\
+      Rectangle {\n\
+          anchors.fill: parent\n\
+          anchors.margins: 1\n\
+          color: \"transparent\"\n\
+          antialiasing: true\n\
+          border.color: \"#aaffffff\"\n\
+          radius: height/2\n\
+      }\n\
+  }\n\
+}n\
+}\n\
+");
+
+static const char* QML_TAB_VIEW_BEGIN("\n\
+    TabView {\n\
+        Layout.row: 5\n\
+        Layout.columnSpan: 3\n\
+        Layout.fillWidth: true\n\
+        implicitWidth: 530\n\
+        /*implicitHeight: 1600*/\n\
+");
+static const char* QML_TAB_VIEW_HEIGHT("\
+        implicitHeight: ");
+
+static const char* QML_TAB_VIEW_END("\
+    } // QML_TAB_VIEW_END");
+
+
+static const char* QML_TAB_VIEW_STYLE("\
+    style: TabViewStyle {\n\
+                frameOverlap: 1\n\
+                tab: Rectangle {\n\
+//                    color: styleData.selected ? \"steelblue\" :\"lightsteelblue\"\n\
+                    color: styleData.selected ? \"#98A9B1\" :\"lightsteelblue\"\n\
+//                    border.color:  \"steelblue\"\n\
+                    border.color:  \"#0E3860\"\n\
+                    implicitWidth: Math.max(text.width + 4, 80)\n\
+                    implicitHeight: 20\n\
+                    radius: 2\n\
+                    Text {\n\
+                        id: text\n\
+                        anchors.centerIn: parent\n\
+                        text: styleData.title\n\
+//                        color: styleData.selected ? \"white\" : \"black\"\n\
+                          color: styleData.selected ? \"#0E3860\" : \"black\" \n\
+                    }\n\
+                }\n\
+//                frame: Rectangle { color: \"steelblue\" }\n\
+                frame: Rectangle { color: \"#98A9B1\" }\n\
+      }\n");
+
+static const char* QML_TAB_BEGIN("\
+    Tab {\n");
+
+static const char* QML_TAB_TITLE_BEGIN("\
+         title: \"");
+static const char* QML_TAB_TITLE_END("\"\n");
+static const char* QML_TAB_END("\
+    } // QML_TAB_END\n");
+
+static const char* QML_TAB_TEXT_STYLE("\
+\n\
+          property Component textfieldStyle: TextFieldStyle {\n\
+              background: Rectangle {\n\
+                  implicitWidth: columnWidth\n\
+                  implicitHeight: 22\n\
+                  color: \"#f0f0f0\"\n\
+                  antialiasing: true\n\
+                  border.color: \"gray\"\n\
+                  radius: height/2\n\
+                  Rectangle {\n\
+                      anchors.fill: parent\n\
+                      anchors.margins: 1\n\
+                      color: \"transparent\"\n\
+                      antialiasing: true\n\
+                      border.color: \"#aaffffff\"\n\
+                      radius: height/2\n\
+                  }\n\
+              }\n\
+          }\n\
+\n\
+");
+
+
+static const char* QML_COLOR_BEGIN("\
+        color: \"");
+
+static const char* QML_COLOR_END("\"");
+
+static const char* QML_ROW_BEGIN("\
+        Row {\n");
+
+static const char* QML_ROW_END("\n\
+        } // QML_ROW_END\n");
+
+static const char* QML_RECTANGLE_LIGHT_STEEEL_BLUE_BEGIN("\
+         Rectangle {\n\
+            color: \"lightsteelblue\"\n");
+
+static const char* QML_RECTANGLE_DEFAULT_MIGUEL_1_BEGIN("\
+         Rectangle {\n\
+            color: \"#0E3860\"\n");
+
+static const char* QML_RECTANGLE_DEFAULT_COLOR_SCHEME_1_BEGIN(QML_RECTANGLE_DEFAULT_MIGUEL_1_BEGIN);
+
+static const char* QML_RECTANGLE_BEGIN("\n\
+         Rectangle {\n\
+                     ");
+static const char* QML_RECTANGLE_END("\n\
+            width: childrenRect.width\n\
+            height: childrenRect.height\n\
+          } // QML_RECTANGLE_END \n");
+
+static const char* QML_RECTANGLE_LIGHT_STEEEL_BLUE_END(QML_RECTANGLE_END);
+
+static const char* QML_TEXT_BEGIN("\
+      Row {\n\
+        Rectangle {\n\
+          color: \"lightsteelblue\"\n\
+          Text {\n\
+               width: 275\n\
+               height: 25\n\
+               verticalAlignment: Text.AlignVCenter\n\
+               horizontalAlignment: Text.AlignHCenter\n\
+               text: \"");
+
+static const char* QML_TEXT_END("\"\n\
+            }\n\
+        width: childrenRect.width\n\
+        height: childrenRect.height\n\
+         } // QML_TEXT_END\n");
+
+static const char* QML_TEXT_BEGIN_2("\
+          Text {\n\
+//                 color: \"#98A9B1\"\n\
+                 color: \"lightgray\"\n\
+                 font.pointSize: 14\n\
+                 width: 275\n\
+                 height: 25\n\
+                 verticalAlignment: Text.AlignVCenter\n\
+                 horizontalAlignment: Text.AlignHLeft\n\
+                 text: ");
+
+static const char* QML_TEXT_END_2("\n\
+           } // QML_TEXT_END_2 \n");
+
+static const char* QML_TEXT_FIELD_PLACE_HOLDER_TEXT_BEGIN("\n\
+        placeholderText: ");
+
+static const char* QML_TEXT_FIELD_PLACE_HOLDER_TEXT_END("\n");
+
+static const char* QML_TEXT_FIELD_BEGIN("\
+        TextField {\n\
+        style: TextFieldStyle {\n\
+                textColor: \"black\"\n\
+//                textColor: \"#0E3860\"\n\
+        background: Rectangle {\n\
+             radius: 2\n\
+             implicitWidth: 250\n\
+             implicitHeight: 25\n\
+             border.color: \"#333\"\n\
+             border.width: 1\n\
+            }\n\
+        }\n\
+        horizontalAlignment: Text.AlignLeft\n\
+        implicitWidth: 250\n\
+        text: ");
+
+static const char* QML_TEXT_FIELD_ID_BEGIN("\
+        id: ");
+static const char* QML_TEXT_FIELD_ID_END("\n");
+
+static const char* QML_TEXT_FIELD_END("\n\
+          } // QML_TEXT_FIELD_END\n");
+
+static const char* QML_LIST_MODEL_BEGIN("\
+              model: ListModel {\n");
+
+
+static const char* QML_LIST_MODEL_END("\
+                }\n");
+
+static const char* QML_COMBO_BOX_BEGIN("\
+    ComboBox {\n\
+        implicitWidth: 250\n\
+        id:\
+");
+
+static const char* QML_COMBO_BOX_CURRENT_INDEX("\
+           currentIndex: ");
+
+static const char* QML_COMBO_BOX_END("\
+              }\n");
+
+static const char* QML_LIST_ELEMENT_BEGIN("\
+                ListElement { text: \"");
+
+static const char* QML_LIST_ELEMENT_END("\" }\n");
+
+static const char* QML_GRID_LAYOUT_BEGIN("\
+          GridLayout {\n\
+              rowSpacing: 1\n\
+              columnSpacing: 1\n\
+              columns: 1\n\
+              flow: GridLayout.LeftToRight\n");
+
+static const char* QML_GRID_LAYOUT_BEGIN_1("\
+         GridLayout {\n\
+             rowSpacing: 1\n\
+             columnSpacing: 1\n\
+             columns: 1\n\
+             flow: GridLayout.LeftToRight\n");
+
+static const char* QML_GRID_LAYOUT_END("\
+          } // QML_GRID_LAYOUT_END");
+
+static const char* QML_TOOLTIP_TEXT_BEGIN("\
+\n\
+        Rectangle {\n\
+          color: \"lightblue\"\n\
+          x: parent.x-275\n\
+          y: parent.y-50\n\
+          width: 250\n\
+          height: 50\n\
+          visible: false\n\
+          radius: 5\n\
+          smooth: true\n\
+          id: ");
+
+static const char* QML_TOOLTIP_TEXT_PART_1("\n\
+        \n\
+          Text {\n\
+            verticalAlignment: Text.AlignVCenter\n\
+            horizontalAlignment: Text.AlignHCenter\n\
+            visible: true\n\
+            width: 250\n\
+            height: 50\n\
+            wrapMode: Text.WordWrap\n\
+            font.pointSize: 8\n\
+            text: \"");
+
+static const char* QML_TOOLTIP_TEXT_PART_2("\"\n\
+                          }\n\
+                       }\n");
+
+static const char* QML_TOOLTIP_TIMER_BEGIN("\n\
+     Timer {\n\
+         interval: 2000\n\
+         repeat: false\n\
+         running: false\n");
+
+static const char* QML_TOOLTIP_TIMER_END("\n\
+     }");
+
+static const char* QML_TOOLTIP_TIMER_ON_TRIGGERED_BEGIN("\n\
+         onTriggered: {\n");
+
+static const char* QML_TOOLTIP_TIMER_ON_TRIGGERED_END("\
+          console.log(\"timer triggered\");\n\
+         }\n");
+
+
+static const char* QML_TOOLTIP_TIMER_RECTANGLE_APPEND_TRUE(".visible = true;\n");
+static const char* QML_TOOLTIP_TIMER_RECTANGLE_APPEND_FALSE(".visible = false;\n");
+static const char* QML_TOOLTIP_TIMER_MOUSE_AREA_APPEND_TRUE(".enabled = true;\n");
+static const char* QML_TOOLTIP_TIMER_MOUSE_AREA_APPEND_FALSE(".enabled = false;\n");
+static const char* QML_TOOLTIP_TIMER_TIMER_APPEND_START(".start();\n");
+static const char* QML_TOOLTIP_TIMER_ID("\
+        id: ");
+
+static const char* QML_TOOLTIP_TIMER_STOP(".stop();\n");
+static const char* QML_TOOLTIP_TIMER_RESTART(".restart();\n");
+
+static const char* QML_MOUSE_AREA_BEGIN("\n\
+     MouseArea {\n\
+        height: 25\n\
+        width: 250\n\
+        visible: true\n\
+        hoverEnabled: true;\n\
+        id: ");
+
+static const char* QML_MOUSE_AREA_END("\
+    }\n");
+
+static const char* QML_MOUSE_AREA_ID_APPEND("\n");
+
+static const char* QML_MOUSE_AREA_ON_ENTERED_BEGIN("\
+            onEntered: {\n\
+            //console.log(\"entered mouse area\");\
+                         \n");
+
+static const char* QML_MOUSE_AREA_ON_ENTERED_END("\
+             }\n");
+
+static const char* QML_MOUSE_AREA_ON_EXITED_BEGIN("\
+            onExited: {\n\
+            //console.log(\"exited mouse area\");\
+                        \n");
+
+static const char* QML_MOUSE_AREA_ON_EXITED_END("\
+            }\n");
+
+
+static const char* QML_MOUSE_AREA_TIMER_APPEND(".start();\n\
+            }\n\
+            onExited:  {\n\
+            //console.log(\"exited mouse area\");\n\
+                         ");
+
+static const char* QML_MOUSE_AREA_RECTANGLE_APPEND(".visible = false;\n\
+        }\n");
+
+static const char* QML_MOUSE_AREA_RECTANGLE_VISIBLE_FALSE(".visible = false;\n");
+
+static const char* QML_MOUSE_AREA_ON_POSITION_CHANGED_BEGIN("\
+            onPositionChanged: {\n");
+
+static const char* QML_MOUSE_AREA_ON_POSITION_CHANGED_END("\n\
+            //console.log(\"onPositionChanged\");\n\
+            }");
+
+
+static const char* QML_MOUSE_AREA_ON_PRESSED_BEGIN("\n\
+            onPressed: {\n");
+
+static const char* QML_MOUSE_AREA_ON_PRESSED_END("\
+                //console.log(\"mouse area pressed\");\n\
+            }\n");
+
+
+static const char* QML_MOUSE_AREA_ENABLE("enable = true\n");
+
+static const char* QML_TEXT_AREA_FORCE_FOCUS(".forceActiveFocus()\n");
+
+static const char* QML_STYLE_INDENT("\t\t\t");
+
+static const char* QML_STYLE_NEW_LINE("\n");
+
+static const char* QML_TOOLTIP_TEXT_END("\
+    }\n");
+
+static const char* QML_TABLE_VIEW_BEGIN("\
+    TableView {\n\
+        width: 800\n\
+        Layout.preferredHeight: 200\n\
+        Layout.preferredWidth: 800\n");
+
+static const char* QML_TABLE_VIEW_END("\n\
+    } // QML_TABLE_VIEW_END\n");
+
+static const char* QML_TABLE_VIEW_COLUMN_BEGIN("\
+        TableViewColumn {\n\
+            width: 120\n");
+
+static const char* QML_TABLE_VIEW_COLUMN_END("\
+        }// QML_TABLE_VIEW_COLUMN_END\n");
+
+static const char* QML_TABLE_VIEW_COLUMN_TITLE_BEGIN("\
+            title: \"");
+
+static const char* QML_TABLE_VIEW_COLUMN_TITLE_END("\"\n");
+
+// New Constants
+static const char* QML_FILE_START("\
+import QtQuick 2.1                                  \n\
+import QtQuick.Controls 1.2                         \n\
+import QtQuick.Controls.Styles 1.0                  \n\
+import QtQuick.Particles 2.0                        \n\
+import QtQuick.Layouts 1.0                          \n\
+Item {                                              \n\
+    id: gRoot                                       \n\
+    width: 900                                      \n\
+    height: 700                                     \n\
+    property alias root: gRoot                      \n\
+    ScrollView{                                     \n\
+        id: scrollRoot                              \n\
+        anchors.fill: parent                        \n\
+        ListView{                                   \n\
+            id: listRoot                            \n\
+            property int nest: 0                    \n\
+            property int visibility: 0              \n\
+            anchors.fill: parent                    \n\
+            spacing: 4                              \n\
+            model: configModel                      \n\
+            opacity: !visibility                    \n\
+            transitions: Transition {               \n\
+                NumberAnimation {                   \n\
+                    properties: 'opacity'           \n\
+                    easing.type: Easing.InOutQuad   \n\
+                    duration: 1000                  \n\
+                }                                   \n\
+            }                                       \n\
+        }                                           \n\
+    }                                               \n\
+    VisualItemModel {                               \n\
+        id: configModel");
+static const char * QML_DOUBLE_END_BRACKET("}\n}\n");
+// Always start content before column
+static const char * QML_TABLE_START("Table{                 \n");
+static const char * QML_TABLE_CONTENT_START("tableContent: ListModel {                      \n");
+static const char * QML_TABLE_ROW_START("ListElement {");
+static const char * QML_TABLE_ROW_END("}\n");
+static const char * QML_TABLE_CONTENT_END("}\n");
+static const char * QML_TABLE_END("}\n");
+// Table ends can be replaced with DOUBLE_END_BRACKET in appropriate situations (if buildColumns are done before Content)
+
+// NewConstants end;
+class CQMLMarkupHelper
+{
+public:
+    // New Helper Functions
+    static void buildAccordionStart(StringBuffer &strQML, const char * title, const char * altTitle = "", int idx = -1);
+    // End Accordion with QML_DOUBLE_END_BRACKET
+    static void buildColumns(StringBuffer &strQML, StringArray &roles, StringArray &titles);
+    static void buildRole(StringBuffer &strQML, const char * role, StringArray &values, const char * type = "text", const char * tooltip = "", const char * placeholder = "");
+    static const StringBuffer printProperty(const char * property, const char * value, const bool newline = true);
+    // NewHelperFunctions end;
+    static void getTabQML(StringBuffer &strQML, const char *pName);
+    static void getComboBoxListElement(const char* pLabel, StringBuffer &strID, const char* pDefault = "");
+    static void getToolTipQML(StringBuffer &strQML, const char *pToolTip, const char* pTextAreaID);
+    static void getToolTipRectangle(StringBuffer &strQML, const char *pToolTip, const char *pRectangleID);
+    static void getToolTipTimer(StringBuffer &strQML, const char *pToolTip, const char *pRectangleID, const char* pTimerID_1, const char* pTimerID_2, const char *pMouseAreaID);
+    static void getToolMouseArea(StringBuffer &strQML, const char *pToolTip, const char *pRectangleID, const char* pTimerID_1, const char* pTimerID_2, const char *pMouseAreaID, const char* pTextAreaID);
+    static void getTableViewColumn(StringBuffer &strQML, const char* colTitle, const char *pRole);
+    static unsigned getRandomID(StringBuffer *pID = 0);
+    static bool isTableRequired(const CAttribute *pAttrib);
+
+    static int getImplicitHeight()
+    {
+        return CQMLMarkupHelper::glImplicitHeight;
+    }
+
+    static void setImplicitHeight(int val)
+    {
+        CQMLMarkupHelper::glImplicitHeight = val;
+    }
+
+protected:
+
+    static int glImplicitHeight;
+};
+
+#endif // _QMLMARKUP_HPP_

--- a/configuration/configurator/SchemaAll.hpp
+++ b/configuration/configurator/SchemaAll.hpp
@@ -1,0 +1,50 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include "SchemaAnnotation.hpp"
+#include "SchemaAppInfo.hpp"
+#include "SchemaAttributes.hpp"
+#include "SchemaAttributeGroup.hpp"
+#include "SchemaChoice.hpp"
+#include "SchemaCommon.hpp"
+#include "SchemaComplexContent.hpp"
+#include "SchemaComplexType.hpp"
+#include "SchemaDocumentation.hpp"
+#include "SchemaElement.hpp"
+#include "SchemaExtension.hpp"
+#include "SchemaField.hpp"
+#include "SchemaFractionDigits.hpp"
+#include "SchemaInclude.hpp"
+#include "SchemaKey.hpp"
+#include "SchemaKeyRef.hpp"
+#include "SchemaLength.hpp"
+#include "SchemaMaxExclusive.hpp"
+#include "SchemaMinExclusive.hpp"
+#include "SchemaMaxInclusive.hpp"
+#include "SchemaMinInclusive.hpp"
+#include "SchemaMinLength.hpp"
+#include "SchemaMaxLength.hpp"
+#include "SchemaPattern.hpp"
+#include "SchemaRestriction.hpp"
+#include "SchemaSchema.hpp"
+#include "SchemaSelector.hpp"
+#include "SchemaSequence.hpp"
+#include "SchemaSimpleType.hpp"
+#include "SchemaTotalDigits.hpp"
+#include "SchemaUnique.hpp"
+#include "SchemaWhiteSpace.hpp"
+#include "SchemaSimpleContent.hpp"

--- a/configuration/configurator/SchemaAnnotation.cpp
+++ b/configuration/configurator/SchemaAnnotation.cpp
@@ -1,0 +1,89 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include <cassert>
+#include "XMLTags.h"
+#include "jptree.hpp"
+#include "SchemaAnnotation.hpp"
+#include "SchemaDocumentation.hpp"
+#include "SchemaAppInfo.hpp"
+
+CAnnotation* CAnnotation::load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath)
+{
+    assert(pSchemaRoot != NULL);
+
+    if (pSchemaRoot == NULL)
+        return NULL;
+
+    StringBuffer strXPathExt(xpath);
+
+    strXPathExt.append("/").append(XSD_TAG_DOCUMENTATION);
+    CDocumentation *pDocumentation = CDocumentation::load(NULL, pSchemaRoot, strXPathExt.str());
+
+    strXPathExt.clear().append(xpath).append("/").append(XSD_TAG_APP_INFO);
+    CAppInfo *pAnnInfo = CAppInfo::load(NULL, pSchemaRoot, strXPathExt.str());
+
+    CAnnotation *pAnnotation = new CAnnotation(pParentNode, pDocumentation, pAnnInfo);
+    pAnnotation->setXSDXPath(xpath);
+
+    SETPARENTNODE(pDocumentation, pAnnotation);
+    SETPARENTNODE(pAnnInfo, pAnnotation);
+
+    return pAnnotation;
+}
+
+void CAnnotation::dump(std::ostream& cout, unsigned int offset) const
+{
+    offset+= STANDARD_OFFSET_1;
+    QuickOutHeader(cout, XSD_ANNOTATION_STR, offset);
+
+    QUICK_OUT(cout, XSDXPath, offset);
+
+    if (m_pAppInfo != NULL)
+        m_pAppInfo->dump(cout, offset);
+
+    if (m_pDocumentation != NULL)
+        m_pDocumentation->dump(cout, offset);
+
+    QuickOutFooter(cout, XSD_ANNOTATION_STR, offset);
+}
+
+void CAnnotation::getDocumentation(StringBuffer &strDoc) const
+{
+    if (m_pAppInfo != NULL)
+        m_pAppInfo->getDocumentation(strDoc);
+    if (m_pDocumentation != NULL)
+        m_pDocumentation->getDocumentation(strDoc);
+}
+
+void CAnnotation::getQML(StringBuffer &strQML, int idx) const
+{
+    if (m_pAppInfo != NULL)
+        m_pAppInfo->getQML(strQML);
+
+    if (m_pDocumentation != NULL)
+        m_pDocumentation->getQML(strQML);
+}
+
+void CAnnotation::loadXMLFromEnvXml(const IPropertyTree *pEnvTree)
+{
+    if (m_pAppInfo != NULL)
+        m_pAppInfo->loadXMLFromEnvXml(pEnvTree);
+
+    if (m_pDocumentation != NULL)
+        m_pDocumentation->loadXMLFromEnvXml(pEnvTree);
+}

--- a/configuration/configurator/SchemaAnnotation.hpp
+++ b/configuration/configurator/SchemaAnnotation.hpp
@@ -1,0 +1,68 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef _SCHEMA_ANNOTATION_HPP_
+#define _SCHEMA_ANNOTATION_HPP_
+
+#include "SchemaCommon.hpp"
+
+class CDocumentation;
+class CAppInfo;
+class IPropertyTree;
+
+class CAnnotation : public CXSDNode
+{
+public:
+
+    virtual ~CAnnotation()
+    {
+    }
+
+    virtual void dump(std::ostream& cout, unsigned int offset = 0) const;
+
+    const CDocumentation* getDocumentation() const
+    {
+        return m_pDocumentation;
+    }
+
+    virtual void getDocumentation(StringBuffer &strDoc) const;
+    virtual void getQML(StringBuffer &strQML, int idx = -1) const;
+    virtual void loadXMLFromEnvXml(const IPropertyTree *pEnvTree);
+
+    const CAppInfo* getAppInfo() const
+    {
+        return m_pAppInfo;
+    }
+    static CAnnotation* load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath = NULL);
+
+protected:
+
+    CAnnotation(CXSDNodeBase* pParentNode, CDocumentation *pDocumenation = NULL, CAppInfo *pAppInfp = NULL) : CXSDNode::CXSDNode(pParentNode, XSD_ANNOTATION), m_pDocumentation(pDocumenation), m_pAppInfo(pAppInfp)
+    {
+    }
+
+    CDocumentation* m_pDocumentation;
+    CAppInfo* m_pAppInfo;
+
+private:
+
+    CAnnotation() : CXSDNode::CXSDNode(NULL, XSD_ANNOTATION)
+    {
+    }
+};
+
+#endif // _SCHEMA_ANNOTATION_HPP_

--- a/configuration/configurator/SchemaAppInfo.cpp
+++ b/configuration/configurator/SchemaAppInfo.cpp
@@ -1,0 +1,127 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include "jptree.hpp"
+#include "XMLTags.h"
+#include "SchemaAppInfo.hpp"
+#include "DocumentationMarkup.hpp"
+
+CAppInfo* CAppInfo::load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath)
+{
+    if (pSchemaRoot == NULL)
+        return NULL;
+
+    if (pSchemaRoot->queryPropTree(xpath) == NULL)
+        return NULL;   // No AppInfo node
+
+    StringBuffer strXPathViewType(xpath);
+    strXPathViewType.append("/").append(TAG_VIEWTYPE);
+    StringBuffer strXPathColIndex(xpath);
+    strXPathColIndex.append("/").append(TAG_COLINDEX);
+    StringBuffer strXPathToolTip(xpath);
+    strXPathToolTip.append("/").append(TAG_TOOLTIP);
+    StringBuffer strXPathTitle(xpath);
+    strXPathTitle.append("/").append(TAG_TITLE);
+    StringBuffer strXPathWidth(xpath);
+    strXPathWidth.append("/").append(TAG_WIDTH);
+    StringBuffer strXPathAutoGenDefaultValue(xpath);
+    strXPathAutoGenDefaultValue.append("/").append(TAG_AUTOGENWIZARD);
+    StringBuffer strXPathAutoGenForWizard(xpath);
+    strXPathAutoGenForWizard.append("/").append(TAG_AUTOGENDEFAULTVALUE);
+    StringBuffer strXPathAutoGenDefaultForMultiNode(xpath);
+    strXPathAutoGenDefaultForMultiNode.append("/").append(TAG_AUTOGENDEFAULTVALUEFORMULTINODE);
+    StringBuffer strXPathViewChildNodes(xpath);
+    strXPathViewChildNodes.append("/").append(TAG_VIEWCHILDNODES);
+    StringBuffer strXPathXPath(xpath);
+    strXPathXPath.append("/").append(TAG_XPATH);
+    StringBuffer strXPathDocID(xpath);
+    strXPathDocID.append("/").append(TAG_DOC_ID);
+    StringBuffer strXPathDocLineBreak(xpath);
+    strXPathDocLineBreak.append("/").append(TAG_DOC_USE_LINE_BREAK);
+
+    StringBuffer strViewType;
+    StringBuffer strColIndex;
+    StringBuffer strToolTip;
+    StringBuffer strTitle;
+    StringBuffer strWidth;
+    StringBuffer strAutoGenForWizard;
+    StringBuffer strAutoGenDefaultValue;
+    StringBuffer strAutoGenDefaultForMultiNode;
+    StringBuffer strViewChildNodes;
+    StringBuffer strXPath;
+    StringBuffer strDocTableID;
+    bool bDocLineBreak = false;
+
+    if (pSchemaRoot->queryPropTree(strXPathViewType.str()) != NULL)
+        strViewType.append(pSchemaRoot->queryPropTree(strXPathViewType.str())->queryProp(""));
+    if (pSchemaRoot->queryPropTree(strXPathColIndex.str()) != NULL)
+        strColIndex.append(pSchemaRoot->queryPropTree(strXPathColIndex.str())->queryProp(""));
+    if (pSchemaRoot->queryPropTree(strXPathToolTip.str()) != NULL)
+        strToolTip.append(pSchemaRoot->queryPropTree(strXPathToolTip.str())->queryProp(""));
+    if (pSchemaRoot->queryPropTree(strXPathTitle.str()) != NULL)
+        strTitle.append(pSchemaRoot->queryPropTree(strXPathTitle.str())->queryProp(""));
+    if (pSchemaRoot->queryPropTree(strXPathWidth.str()) != NULL)
+        strWidth.append(pSchemaRoot->queryPropTree(strXPathWidth.str())->queryProp(""));
+    if (pSchemaRoot->queryPropTree(strXPathAutoGenForWizard.str()) != NULL)
+        strAutoGenForWizard.append(pSchemaRoot->queryPropTree(strXPathAutoGenForWizard.str())->queryProp(""));
+    if (pSchemaRoot->queryPropTree(strXPathAutoGenDefaultValue.str()) != NULL)
+        strAutoGenDefaultValue.append(pSchemaRoot->queryPropTree(strXPathAutoGenDefaultValue.str())->queryProp(""));
+    if (pSchemaRoot->queryPropTree(strXPathAutoGenDefaultForMultiNode.str()) != NULL)
+        strAutoGenDefaultForMultiNode.append(pSchemaRoot->queryPropTree(strXPathAutoGenDefaultForMultiNode.str())->queryProp(""));
+    if (pSchemaRoot->queryPropTree(strXPathViewChildNodes.str()) != NULL)
+        strViewChildNodes.append(pSchemaRoot->queryPropTree(strXPathViewChildNodes.str())->queryProp(""));
+    if (pSchemaRoot->queryPropTree(strXPathXPath.str()) != NULL)
+        strXPath.append(pSchemaRoot->queryPropTree(strXPathXPath.str())->queryProp(""));
+    if (pSchemaRoot->queryPropTree(strXPathDocID.str()) != NULL)
+        strDocTableID.append(pSchemaRoot->queryPropTree(strXPathDocID.str())->queryProp(""));
+    if (pSchemaRoot->queryPropTree(strXPathDocLineBreak.str()) != NULL)
+        bDocLineBreak = true;
+
+    CAppInfo *pAppInfo = new CAppInfo(pParentNode, strViewType.str(),  strColIndex.str(), strToolTip.str(), strTitle.str(), strWidth.str(), strAutoGenForWizard.str(), strAutoGenDefaultValue.str(), NULL, strViewChildNodes.str(), strXPath.str(), strDocTableID.str(), bDocLineBreak);
+    pAppInfo->setXSDXPath(xpath);
+
+    return pAppInfo;
+}
+
+void CAppInfo::dump(std::ostream &cout, unsigned int offset) const
+{
+    offset += STANDARD_OFFSET_1;
+
+    QuickOutHeader(cout, XSD_APP_INFO_STR, offset);
+
+    QUICK_OUT(cout, Title, offset);
+    QUICK_OUT(cout, ViewType, offset);
+    QUICK_OUT(cout, ToolTip, offset);
+    QUICK_OUT(cout, ColIndex, offset);
+    QUICK_OUT(cout, Width, offset);
+    QUICK_OUT(cout, AutoGenForWizard, offset);
+    QUICK_OUT(cout, AutoGenDefaultValue, offset);
+    QUICK_OUT(cout, AutoGenDefaultValueForMultiNode, offset);
+    QUICK_OUT(cout, ViewChildNodes, offset);
+    QUICK_OUT(cout, XPath, offset);
+    QUICK_OUT(cout, XSDXPath, offset);
+
+    QuickOutFooter(cout, XSD_APP_INFO_STR, offset);
+}
+
+void CAppInfo::getDocumentation(StringBuffer &strDoc) const
+{
+}
+
+void CAppInfo::loadXMLFromEnvXml(const IPropertyTree *pEnvTree)
+{
+}

--- a/configuration/configurator/SchemaAppInfo.hpp
+++ b/configuration/configurator/SchemaAppInfo.hpp
@@ -1,0 +1,75 @@
+﻿/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef _SCHEMA_APP_INFO_HPP_
+#define _SCHEMA_APP_INFO_HPP_
+
+#include "SchemaCommon.hpp"
+#include "jstring.hpp"
+
+class IPropertyTree;
+
+class CAppInfo : public CXSDNodeBase
+{
+public:
+
+    virtual ~CAppInfo()
+    {
+    }
+
+    GETTERSETTER(ViewType)
+    GETTERSETTER(ColIndex)
+    GETTERSETTER(ToolTip)
+    GETTERSETTER(Title)
+    GETTERSETTER(AutoGenForWizard)
+    GETTERSETTER(AutoGenDefaultValue)
+    GETTERSETTER(Width)
+    GETTERSETTER(AutoGenDefaultValueForMultiNode)
+    GETTERSETTER(ViewChildNodes)
+    GETTERSETTER(XPath)
+    GETTERSETTER(DocTableID)
+
+    virtual void dump(std::ostream &cout, unsigned int offset = 0) const;
+    virtual void getDocumentation(StringBuffer &strDoc) const;
+    virtual void loadXMLFromEnvXml(const IPropertyTree *pEnvTree);
+
+    bool getDocLineBreak() const
+    {
+        return m_bDocLineBreak;
+    }
+    static CAppInfo* load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath);
+
+protected:
+
+    CAppInfo(CXSDNodeBase* pParentNode, const char *pViewType = NULL, const char *pColIndex = NULL, const char* pToolTip = NULL, const char* pTitle = NULL, const char* pWidth = NULL, const char* pAutoGenForWizard = NULL,\
+             const char* pAutoGenDefaultValue = NULL, const char* pAutoGenDefaultForMultiNode = NULL, const char* pViewChildNodes = NULL, const char* pXPath = NULL, const char* pDocTableID = NULL, bool bDocLineBreak = false)\
+        : CXSDNodeBase::CXSDNodeBase(pParentNode, XSD_APP_INFO), m_strViewType(pViewType), m_strColIndex(pColIndex), m_strToolTip(pToolTip), m_strTitle(pTitle), m_strWidth(pWidth), m_strAutoGenForWizard(pAutoGenForWizard),\
+          m_strAutoGenDefaultValue(pAutoGenDefaultValue), m_strAutoGenDefaultValueForMultiNode(pAutoGenDefaultForMultiNode), m_strViewChildNodes(pViewChildNodes), m_strXPath(pXPath), m_strDocTableID(pDocTableID),\
+          m_bDocLineBreak(bDocLineBreak)
+    {
+    }
+
+    bool m_bDocLineBreak;
+
+private:
+
+    CAppInfo(CXSDNodeBase* pParentNode = NULL) : CXSDNodeBase::CXSDNodeBase(pParentNode, XSD_APP_INFO)
+    {
+    }
+};
+
+#endif // _SCHEMA_APP_INFO_HPP_

--- a/configuration/configurator/SchemaAttributeGroup.cpp
+++ b/configuration/configurator/SchemaAttributeGroup.cpp
@@ -1,0 +1,355 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include "SchemaAttributeGroup.hpp"
+#include "DocumentationMarkup.hpp"
+#include "ConfigSchemaHelper.hpp"
+#include "jptree.hpp"
+#include "SchemaMapManager.hpp"
+#include "QMLMarkup.hpp"
+
+const CXSDNodeBase* CAttributeGroup::getNodeByTypeAndNameAscending(NODE_TYPES eNodeType, const char *pName) const
+{
+    const CXSDNodeBase* pMatchingNode = NULL;
+
+    if (eNodeType == this->getNodeType() && (pName != NULL ? !strcmp(pName, this->getNodeTypeStr()) : true))
+    {
+        assert(pName != NULL); // for now pName should always be populated
+        return this;
+    }
+
+    if (m_pAttributeArray != NULL)
+        pMatchingNode =  m_pAttributeArray->getNodeByTypeAndNameAscending(eNodeType, pName);
+    if (pMatchingNode == NULL && m_pAttributeArray != NULL)
+         pMatchingNode =  m_pAttributeArray->getNodeByTypeAndNameDescending(eNodeType, pName);
+    return pMatchingNode;
+}
+
+CAttributeGroup::~CAttributeGroup()
+{
+}
+
+const CXSDNodeBase* CAttributeGroup::getNodeByTypeAndNameDescending(NODE_TYPES eNodeType, const char *pName) const
+{
+    const CXSDNodeBase* pMatchingNode = NULL;
+
+    if (eNodeType == this->getNodeType() && (pName != NULL ? !strcmp(pName, this->getNodeTypeStr()) : true))
+    {
+        assert(pName != NULL); // for now pName should always be populated
+        return this;
+    }
+
+    if (m_pAttributeArray != NULL)
+        pMatchingNode =  m_pAttributeArray->getNodeByTypeAndNameDescending(eNodeType, pName);
+    return pMatchingNode;
+}
+
+void CAttributeGroup::dump(std::ostream &cout, unsigned int offset) const
+{
+    offset+= STANDARD_OFFSET_1;
+
+    QuickOutHeader(cout, XSD_ATTRIBUTE_GROUP_STR, offset);
+
+    QUICK_OUT(cout, Name,       offset);
+    QUICK_OUT(cout, Ref,        offset);
+    QUICK_OUT(cout, ID,         offset);
+    QUICK_OUT(cout, XSDXPath,   offset);
+    QUICK_OUT(cout, EnvXPath,   offset);
+
+    if (m_pAttributeArray != NULL)
+        m_pAttributeArray->dump(cout, offset);
+
+    QuickOutFooter(cout, XSD_ATTRIBUTE_GROUP_STR, offset);
+}
+
+void CAttributeGroup::getDocumentation(StringBuffer &strDoc) const
+{
+    if (this->getRef() != NULL && this->getRef()[0] != 0 && m_pRefAttributeGroup != NULL)
+    {
+        strDoc.appendf("%s%s%s", DM_TITLE_BEGIN, m_pRefAttributeGroup->getName(), DM_TITLE_END);
+        DEBUG_MARK_STRDOC;
+
+        if (m_pRefAttributeGroup->getConstAttributeArray() != NULL)
+            m_pRefAttributeGroup->getConstAttributeArray()->getDocumentation(strDoc);
+    }
+}
+
+void CAttributeGroup::getQML(StringBuffer &strQML, int idx) const
+{
+    assert(this->getRef() != NULL);
+    if (this->getRef() != NULL && this->getRef()[0] != 0 && m_pRefAttributeGroup != NULL)
+    {
+        if (m_pRefAttributeGroup->getConstAttributeArray() != NULL)
+            m_pRefAttributeGroup->getConstAttributeArray()->getQML(strQML);
+    }
+}
+
+void CAttributeGroup::getQML3(StringBuffer &strQML, int idx) const
+{
+    DEBUG_MARK_QML;
+    if (this->getRef() != NULL && this->getRef()[0] != 0 && m_pRefAttributeGroup != NULL && m_pRefAttributeGroup->getConstAttributeArray() != NULL)
+    {
+        DEBUG_MARK_QML;
+        CQMLMarkupHelper::buildAccordionStart(strQML, this->getRef(), "");
+        m_pRefAttributeGroup->getConstAttributeArray()->getQML3(strQML);
+        strQML.append(QML_DOUBLE_END_BRACKET);
+        DEBUG_MARK_QML;
+    }
+    DEBUG_MARK_QML;
+}
+
+void CAttributeGroup::populateEnvXPath(StringBuffer strXPath, unsigned int index)
+{
+    if (this->getRef() != NULL && this->getRef()[0] != 0 && m_pRefAttributeGroup != NULL)
+    {
+        if (m_pRefAttributeGroup->getConstAttributeArray() != NULL)
+            m_pRefAttributeGroup->getAttributeArray()->populateEnvXPath(strXPath);
+    }
+    this->setEnvXPath(strXPath);
+}
+
+void CAttributeGroup::loadXMLFromEnvXml(const IPropertyTree *pEnvTree)
+{
+    assert(pEnvTree != NULL);
+
+    if (m_pAttributeArray != NULL)
+    {
+        try
+        {
+            m_pAttributeArray->loadXMLFromEnvXml(pEnvTree);
+        }
+        catch (...)
+        {
+            // validation check needed here
+        }
+    }
+    if (m_pAnnotation != NULL)
+    {
+        try
+        {
+            m_pAnnotation->loadXMLFromEnvXml(pEnvTree);
+        }
+        catch (...)
+        {
+            // validation check needed here
+        }
+    }
+    if (m_pRefAttributeGroup != NULL)
+    {
+        try
+        {
+            m_pRefAttributeGroup->loadXMLFromEnvXml(pEnvTree);
+        }
+        catch (...)
+        {
+            // validation check needed here
+        }
+    }
+}
+
+const char* CAttributeGroup::getXML(const char* /*pComponent*/)
+{
+    if (m_strXML.length() == 0 && m_pAttributeArray != NULL)
+    {
+        for (int idx = 0; idx < m_pAttributeArray->length(); idx++)
+        {
+            m_strXML.append("\n").append(m_pAttributeArray->item(idx).getXML(NULL));
+        }
+    }
+    return m_strXML.str();
+}
+
+CAttributeGroup* CAttributeGroup::load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath)
+{
+    assert(pSchemaRoot != NULL);
+    if (pSchemaRoot == NULL || xpath == NULL)
+        return NULL;
+
+    assert(pParentNode->getNodeType() != XSD_ATTRIBUTE_GROUP);
+    CAttributeGroup *pAttributeGroup = new CAttributeGroup(pParentNode);
+
+    pAttributeGroup->setXSDXPath(xpath);
+    assert(pAttributeGroup);
+
+    if (pAttributeGroup == NULL)
+        return NULL;
+
+    IPropertyTree *pTree = pSchemaRoot->queryPropTree(xpath);
+    if (pTree == NULL)
+        return NULL;
+
+    pAttributeGroup->setName(pTree->queryProp(XML_ATTR_NAME));
+    pAttributeGroup->setID(pTree->queryProp(XML_ATTR_ID));
+    pAttributeGroup->setRef(pTree->queryProp(XML_ATTR_REF));
+
+    if (pAttributeGroup->getRef() != NULL && pAttributeGroup->getRef()[0] != 0)
+    {
+        if (pAttributeGroup->getName() != NULL && pAttributeGroup->getName()[0] != 0)
+        {
+            assert(false); //can't have both nameand ref set
+            return NULL;
+        }
+        else
+            CConfigSchemaHelper::getInstance()->addAttributeGroupToBeProcessed(pAttributeGroup);
+    }
+    else if (pAttributeGroup->getName() != NULL && pAttributeGroup->getName()[0] != 0)
+        CConfigSchemaHelper::getInstance()->getSchemaMapManager()->setAttributeGroupTypeWithName(pAttributeGroup->getName(), pAttributeGroup);
+
+    StringBuffer strXPath(xpath);
+    strXPath.append("/").append(XSD_TAG_ATTRIBUTE);
+
+    CAttributeArray *pAttribArray = CAttributeArray::load(pAttributeGroup, pSchemaRoot, strXPath.str());
+    if (pAttribArray != NULL)
+        pAttributeGroup->setAttributeArray(pAttribArray);
+
+    strXPath.setf("%s/%s",xpath, XSD_TAG_ANNOTATION);
+    pAttributeGroup->setAnnotation(CAnnotation::load(pAttributeGroup, pSchemaRoot, strXPath.str()));
+
+    return pAttributeGroup;
+}
+
+CAttributeGroupArray::~CAttributeGroupArray()
+{
+}
+
+CAttributeGroupArray* CAttributeGroupArray::load(const char* pSchemaFile)
+{
+    assert(false);  // Should never call this?
+
+    if (pSchemaFile == NULL)
+        return NULL;
+
+    Linked<IPropertyTree> pSchemaRoot;
+    StringBuffer schemaPath;
+
+    schemaPath.appendf("%s%s", DEFAULT_SCHEMA_DIRECTORY, pSchemaFile);
+    pSchemaRoot.setown(createPTreeFromXMLFile(schemaPath.str()));
+
+    return CAttributeGroupArray::load(NULL, pSchemaRoot, XSD_TAG_ATTRIBUTE_GROUP);
+}
+
+CAttributeGroupArray* CAttributeGroupArray::load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath)
+{
+    assert(pSchemaRoot != NULL);
+
+    if (pSchemaRoot == NULL || xpath == NULL)
+        return NULL;
+
+    CAttributeGroupArray *pAttribGroupArray = new CAttributeGroupArray(pParentNode);
+    pAttribGroupArray->setXSDXPath(xpath);
+
+    StringBuffer strXPathExt(xpath);
+
+    // to iterate over xs:attributeGroup nodes at same level in tree
+    Owned<IPropertyTreeIterator> attribGroupsIter = pSchemaRoot->getElements(strXPathExt.str());
+
+    int count = 1;
+    ForEach(*attribGroupsIter)
+    {
+        strXPathExt.clear().appendf("%s[%d]", xpath, count);
+
+        CAttributeGroup *pAttribGroup = CAttributeGroup::load(pAttribGroupArray, pSchemaRoot, strXPathExt.str());
+
+        if (pAttribGroup != NULL)
+            pAttribGroupArray->append(*pAttribGroup);
+
+        count++;
+    }
+
+    if (pAttribGroupArray->length() == 0)
+    {
+        delete pAttribGroupArray;
+        return NULL;
+    }
+    return pAttribGroupArray;
+}
+
+void CAttributeGroupArray::dump(std::ostream& cout, unsigned int offset) const
+{
+    offset+= STANDARD_OFFSET_1;
+
+    QuickOutHeader(cout,XSD_ATTRIBUTE_GROUP_ARRAY_STR, offset);
+
+    QUICK_OUT(cout, XSDXPath, offset);
+    QUICK_OUT(cout, EnvXPath,  offset);
+    QUICK_OUT_ARRAY(cout, offset);
+
+    QuickOutFooter(cout,XSD_ATTRIBUTE_GROUP_ARRAY_STR, offset);
+}
+
+void CAttributeGroupArray::getDocumentation(StringBuffer &strDoc) const
+{
+    StringBuffer strDocDupe1(strDoc);
+
+    QUICK_DOC_ARRAY(strDocDupe1);
+
+    if (strDocDupe1.length() == strDoc.length())  // hack
+       return;
+
+    for (int idx=0; idx < this->length(); idx++)
+    {
+        strDoc.append(DM_SECT3_BEGIN);
+        (this->item(idx)).getDocumentation(strDoc);
+        strDoc.append(DM_SECT3_END);
+    }
+}
+
+void CAttributeGroupArray::getQML(StringBuffer &strQML, int idx) const
+{
+    StringBuffer strQMLDupe1(strQML);
+
+    QUICK_QML_ARRAY(strQMLDupe1);
+
+    if (strQMLDupe1.length() == strQML.length())
+       return;
+
+    QUICK_QML_ARRAY(strQML);
+}
+
+void CAttributeGroupArray::getQML2(StringBuffer &strQML, int idx) const
+{
+    for (int idx=0; idx < this->length(); idx++)
+    {
+        (this->item(idx)).getQML2(strQML);
+    }
+}
+
+void CAttributeGroupArray::getQML3(StringBuffer &strQML, int idx) const
+{
+    DEBUG_MARK_QML;
+    for (int idx=0; idx < this->length(); idx++)
+    {
+        (this->item(idx)).getQML3(strQML);
+    }
+    DEBUG_MARK_QML;
+}
+
+void CAttributeGroupArray::populateEnvXPath(StringBuffer strXPath, unsigned int index)
+{
+    assert(index == 1);  // Only 1 array of elements per node
+
+    for (int idx=0; idx < this->length(); idx++)
+    {
+        (this->item(idx)).populateEnvXPath(strXPath, 1);
+    }
+    this->setEnvXPath(strXPath);
+}
+
+void CAttributeGroupArray::loadXMLFromEnvXml(const IPropertyTree *pEnvTree)
+{
+    QUICK_LOAD_ENV_XML(pEnvTree)
+}

--- a/configuration/configurator/SchemaAttributeGroup.hpp
+++ b/configuration/configurator/SchemaAttributeGroup.hpp
@@ -1,0 +1,118 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef _SCHEMA_ATTRIBUTE_GROUP_HPP_
+#define _SCHEMA_ATTRIBUTE_GROUP_HPP_
+
+#include "SchemaCommon.hpp"
+#include "SchemaAttributes.hpp"
+
+class CAttributeGroup : public CXSDNode
+{
+public:
+
+    virtual ~CAttributeGroup();
+
+    GETTERSETTER(Name)
+    GETTERSETTER(Ref)
+    GETTERSETTER(ID)
+
+    virtual const CXSDNodeBase* getNodeByTypeAndNameAscending(NODE_TYPES eNodeType, const char *pName) const;
+    virtual const CXSDNodeBase* getNodeByTypeAndNameDescending(NODE_TYPES eNodeType, const char *pName) const;
+
+    const CAttributeArray* getConstAttributeArray() const
+    {
+        return m_pAttributeArray;
+    }
+
+    void setAttributeArray(CAttributeArray *pAttribArray)
+    {
+        if (m_pAttributeArray != NULL)
+            m_pAttributeArray->Release();
+
+        m_pAttributeArray = pAttribArray;
+    }
+
+    void setRefNode(CAttributeGroup* pAttributeGroup)
+    {
+        assert(pAttributeGroup != NULL);
+        m_pRefAttributeGroup = pAttributeGroup;
+    }
+
+    virtual const char* getXML(const char* /*pComponent*/);
+    virtual void dump(std::ostream& cout, unsigned int offset = 0) const;
+    virtual void getDocumentation(StringBuffer &strDoc) const;
+    virtual void getQML(StringBuffer &strQML, int idx = -1) const;
+    virtual void getQML3(StringBuffer &strQML, int idx = -1) const;
+
+    virtual CAnnotation* getAnnotation() const
+    {
+        return m_pAnnotation;
+    }
+
+    virtual void populateEnvXPath(StringBuffer strXPath, unsigned int index = 1);
+    virtual void loadXMLFromEnvXml(const IPropertyTree *pEnvTree);
+
+    static CAttributeGroup* load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath);
+
+protected:
+
+   CAttributeGroup(CXSDNodeBase* pParentNode = NULL, CAttributeArray *pAttribArray = NULL, CAnnotation *pAnnotation = NULL) : CXSDNode::CXSDNode(pParentNode, XSD_ATTRIBUTE_GROUP), m_pAttributeArray(pAttribArray), m_pRefAttributeGroup(NULL), m_pAnnotation(pAnnotation)
+    {
+    }
+
+    virtual void setAnnotation(CAnnotation *pAnnotation)
+    {
+        m_pAnnotation = pAnnotation;
+    }
+
+    CAttributeArray* getAttributeArray() const
+    {
+        return m_pAttributeArray;
+    }
+
+    CAttributeGroup *m_pRefAttributeGroup;
+    CAttributeArray *m_pAttributeArray;
+    CAnnotation     *m_pAnnotation;
+
+private:
+};
+
+class CAttributeGroupArray : public CIArrayOf<CAttributeGroup>, public InterfaceImpl, public CXSDNodeBase
+{
+public:
+
+    CAttributeGroupArray(CXSDNodeBase* pParentNode = NULL) : CXSDNodeBase::CXSDNodeBase(pParentNode, XSD_ATTRIBUTE_GROUP_ARRAY)
+    {
+    }
+
+    virtual ~CAttributeGroupArray();
+    virtual void dump(std::ostream& cout, unsigned int offset = 0) const;
+    virtual void getDocumentation(StringBuffer &strDoc) const;
+    virtual void getQML(StringBuffer &strQML, int idx = -1) const;
+    virtual void getQML2(StringBuffer &strQML, int idx = -1) const;
+    virtual void getQML3(StringBuffer &strQML, int idx = -1) const;
+    virtual void populateEnvXPath(StringBuffer strXPath, unsigned int index = 1);
+    virtual void loadXMLFromEnvXml(const IPropertyTree *pEnvTree);
+    static CAttributeGroupArray* load(const char* pSchemaFile);
+    static CAttributeGroupArray* load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath);
+
+protected:
+private:
+};
+
+#endif // _SCHEMA_ATTRIBUTE_GROUP_HPP_

--- a/configuration/configurator/SchemaAttributes.cpp
+++ b/configuration/configurator/SchemaAttributes.cpp
@@ -1,0 +1,691 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include "jptree.hpp"
+#include "jarray.hpp"
+#include "SchemaCommon.hpp"
+#include "SchemaAttributes.hpp"
+#include "SchemaAppInfo.hpp"
+#include "SchemaSimpleType.hpp"
+#include "DocumentationMarkup.hpp"
+#include "ConfigSchemaHelper.hpp"
+#include "QMLMarkup.hpp"
+#include "ExceptionStrings.hpp"
+#include "SchemaMapManager.hpp"
+#include "ConfiguratorMain.hpp"
+#include "jlog.hpp"
+#include "SchemaKey.hpp"
+#include "SchemaKeyRef.hpp"
+#include "SchemaSimpleType.hpp"
+
+CAttribute::~CAttribute()
+{
+}
+
+bool CAttribute::isHidden()
+{
+    if(this->getAnnotation()->getAppInfo() != NULL && !stricmp(this->getAnnotation()->getAppInfo()->getViewType(),"hidden"))
+        return true;
+
+    return false;
+}
+
+const char* CAttribute::getTitle() const
+{
+    if (this->m_pAnnotation != NULL && this->m_pAnnotation->getAppInfo() != NULL && this->m_pAnnotation->getAppInfo()->getTitle() != NULL && this->m_pAnnotation->getAppInfo()->getTitle()[0] != 0)
+        return this->m_pAnnotation->getAppInfo()->getTitle();
+    else
+        return this->getName();
+}
+
+const char* CAttribute::getXML(const char* pComponent)
+{
+    if (m_strXML.length() == 0)
+        m_strXML.append(getName()).append("=\"").append(getDefault()).append("\"");
+    return m_strXML.str();
+}
+
+void CAttribute::dump(std::ostream& cout, unsigned int offset) const
+{
+    offset+= STANDARD_OFFSET_1;
+
+    QuickOutHeader(cout,XSD_ATTRIBUTE_STR, offset);
+
+    QUICK_OUT(cout, Name,   offset);
+    QUICK_OUT(cout, Type,   offset);
+    QUICK_OUT(cout, Default,offset);
+    QUICK_OUT(cout, Use,    offset);
+    QUICK_OUT(cout, XSDXPath,  offset);
+    QUICK_OUT(cout, EnvXPath,  offset);
+    QUICK_OUT(cout, EnvValueFromXML,  offset);
+
+    if (m_pAnnotation != NULL)
+        m_pAnnotation->dump(cout, offset);
+    if (m_pSimpleTypeArray != NULL)
+        m_pSimpleTypeArray->dump(cout, offset);
+
+    QuickOutFooter(cout,XSD_ATTRIBUTE_STR, offset);
+}
+
+void CAttribute::getDocumentation(StringBuffer &strDoc) const
+{
+    const char *pName = this->getTitle();
+    const char *pToolTip = NULL;
+    const char *pDefaultValue = this->getDefault();
+    const char *pRequired = this->getUse();
+
+    if (m_pAnnotation != NULL && m_pAnnotation->getAppInfo() != NULL)
+    {
+        const CAppInfo *pAppInfo = m_pAnnotation->getAppInfo();
+        const char* pViewType = pAppInfo->getViewType();
+
+        if (pViewType != NULL && stricmp("hidden", pViewType) == 0)
+            return; // HIDDEN
+        else
+            pToolTip = pAppInfo->getToolTip();
+    }
+
+    strDoc.appendf("<%s>\n", DM_TABLE_ROW);
+    strDoc.appendf("<%s>%s</%s>\n", DM_TABLE_ENTRY, pName, DM_TABLE_ENTRY);
+    strDoc.appendf("<%s>%s</%s>\n", DM_TABLE_ENTRY, pToolTip, DM_TABLE_ENTRY);
+
+    if (m_pSimpleTypeArray == NULL)
+        strDoc.appendf("<%s>%s</%s>\n", DM_TABLE_ENTRY, pDefaultValue, DM_TABLE_ENTRY);
+    else
+    {
+        StringBuffer strDocTemp(pDefaultValue);
+        m_pSimpleTypeArray->getDocumentation(strDocTemp);
+
+        strDoc.appendf("<%s>%s</%s>\n", DM_TABLE_ENTRY, strDocTemp.str(), DM_TABLE_ENTRY);
+    }
+
+    if (m_pAnnotation != NULL && m_pAnnotation->getAppInfo() != NULL && m_pAnnotation->getAppInfo()->getDocLineBreak() == true)
+        strDoc.appendf("<%s>%s%s</%s>\n", DM_TABLE_ENTRY, DM_LINE_BREAK2, pRequired, DM_TABLE_ENTRY);
+    else
+        strDoc.appendf("<%s>%s</%s>\n", DM_TABLE_ENTRY, pRequired, DM_TABLE_ENTRY);
+    strDoc.appendf("</%s>\n", DM_TABLE_ROW);
+}
+
+void CAttribute::getQML2(StringBuffer &strQML, int idx) const
+{
+    if (this->getParentNode()->getUIType() == QML_UI_TABLE_CONTENTS)
+    {
+        this->setUIType(QML_UI_TABLE_CONTENTS);
+        CQMLMarkupHelper::getTableViewColumn(strQML, this->getTitle(), this->getEnvXPath());
+        DEBUG_MARK_QML;
+    }
+    else if (this->getParentNode()->getUIType() == QML_UI_TAB_CONTENTS)
+    {
+        this->setUIType(QML_UI_TEXT_FIELD);
+        strQML.append(QML_ROW_BEGIN).append(QML_RECTANGLE_DEFAULT_COLOR_SCHEME_1_BEGIN);
+        DEBUG_MARK_QML;
+        strQML.append(QML_TEXT_BEGIN_2).append("\"  ").append(this->getTitle()).append("\"").append(QML_TEXT_END_2);
+        DEBUG_MARK_QML;
+        strQML.append(QML_RECTANGLE_LIGHT_STEEEL_BLUE_END);
+        DEBUG_MARK_QML;
+        strQML.append(QML_TEXT_FIELD_BEGIN);
+
+        StringBuffer strTextArea("textarea");
+        CQMLMarkupHelper::getRandomID(&strTextArea);
+
+        strQML.append(QML_APP_DATA_GET_VALUE_BEGIN).append(this->getEnvXPath()).append(QML_APP_DATA_GET_VALUE_END);
+        strQML.append(QML_ON_ACCEPTED);
+        strQML.append(QML_APP_DATA_SET_VALUE_BEGIN).append(this->getEnvXPath()).append("\", ").append(strTextArea.str()).append(QML_APP_DATA_SET_VALUE_END);
+        strQML.append(QML_TEXT_FIELD_ID_BEGIN).append(strTextArea).append(QML_TEXT_FIELD_ID_END);
+        DEBUG_MARK_QML;
+
+        strQML.append(QML_TEXT_FIELD_PLACE_HOLDER_TEXT_BEGIN);
+        strQML.append("\"").append(this->getDefault()).append("\"");
+        strQML.append(QML_TEXT_FIELD_PLACE_HOLDER_TEXT_END);
+        DEBUG_MARK_QML;
+
+        if (this->getAnnotation()->getAppInfo() != NULL) // check for tooltip
+            CQMLMarkupHelper::getToolTipQML(strQML, this->getAnnotation()->getAppInfo()->getToolTip(), strTextArea.str());
+
+        strQML.append(QML_TEXT_FIELD_END);
+        DEBUG_MARK_QML;
+        strQML.append(QML_ROW_END);
+        DEBUG_MARK_QML;
+    }
+    else
+        assert(!"what am i?");
+}
+
+void CAttribute::getQML3(StringBuffer &strQML, const char * role, int idx) const
+{
+    /*
+    Sample QML Returned by Attribute
+        value: ListElement {
+            value: [ListElement{value: "A Masterpiece"}] // Or multiple for ComboBoxes
+            type: "field" 
+            tooltip:"Hey"
+            placeholder: "kay" 
+        }
+     */
+    DEBUG_MARK_QML;
+
+    StringBuffer name(role == NULL || role[0] == '\0' ? this->getName() : role);
+    StringArray values;
+
+    values.append(this->getEnvXPath());
+
+    if(this->getAnnotation()->getAppInfo() != NULL)
+    {
+        const char * viewType = this->getAnnotation()->getAppInfo()->getViewType();
+        if( viewType != NULL)
+        {
+            if(!stricmp(viewType,"readonly"))
+                viewType = "text";
+            else
+                viewType = "field";
+        }
+        else
+            viewType = "field";
+        CQMLMarkupHelper::buildRole(strQML, name, values, viewType, this->getAnnotation()->getAppInfo()->getToolTip(), this->getDefault());
+    }
+    else
+        CQMLMarkupHelper::buildRole(strQML, name, values, "field");
+    DEBUG_MARK_QML
+}
+
+void CAttribute::populateEnvXPath(StringBuffer strXPath, unsigned int index)
+{
+    assert(this->getName() != NULL);
+
+    const char *pChar = strrchr(strXPath.str(),'[');
+    assert(pChar != NULL && strlen(pChar) >= 3);
+
+    strXPath.setLength(strXPath.length()-strlen(pChar));  // remove [N] from XPath;
+    strXPath.appendf("[%d]", index);
+    strXPath.append("/").append("[@").append(this->getName()).append("]");
+    this->setEnvXPath(strXPath.str());
+
+    PROGLOG("Mapping attribute with XPATH of %s to %p", this->getEnvXPath(), this);
+
+    CConfigSchemaHelper::getInstance()->getSchemaMapManager()->addMapOfXPathToAttribute(this->getEnvXPath(), this);
+    CConfigSchemaHelper::getInstance()->appendAttributeXPath(this->getEnvXPath());
+
+    if (this->m_pSimpleTypeArray != NULL)
+        m_pSimpleTypeArray->populateEnvXPath(strXPath);
+}
+
+void CAttribute::loadXMLFromEnvXml(const IPropertyTree *pEnvTree)
+{
+    assert(this->getEnvXPath() != NULL);
+    assert(this->getConstParentNode()->getEnvXPath() != NULL);
+
+    StringBuffer strXPath(this->getConstParentNode()->getEnvXPath());
+
+    if (pEnvTree->hasProp(strXPath.str()) == true)
+    {
+        StringBuffer strAttribName("@");
+
+        strAttribName.append(this->getName());
+        this->setEnvValueFromXML(pEnvTree->queryPropTree(strXPath.str())->queryProp(strAttribName.str()));
+        setInstanceAsValid();
+
+        if (this->m_pSimpleTypeArray != NULL)
+            m_pSimpleTypeArray->loadXMLFromEnvXml(pEnvTree);
+    }
+    else if (stricmp(this->getUse(), XML_ENV_VALUE_REQUIRED) == 0) // check if this a required attribute
+    {
+        assert(false);  // required value missing
+        throw MakeExceptionFromMap(EX_STR_MISSING_REQUIRED_ATTRIBUTE);
+    }
+}
+
+void CAttribute::setEnvValueFromXML(const char *p)
+{
+    if (p == NULL)
+    {
+        if (this->getDefault() != NULL && *(this->getDefault()) != 0)
+        {
+            this->setInstanceValue(this->getDefault());
+            this->setInstanceAsValid(true);
+            return;
+        }
+
+        if (this->getUse() != NULL && stricmp(this->getUse(), TAG_REQUIRED) != 0)
+            return;
+        else
+        {
+            this->setInstanceAsValid(false);
+            assert (!"Missing attribute property, property not marked as optional");
+
+            return;
+        }
+    }
+
+    if (this->getTypeNode() != NULL)
+    {
+        const CXSDBuiltInDataType *pNodeBuiltInType = dynamic_cast<const CXSDBuiltInDataType*>(this->getTypeNode());
+
+        if (pNodeBuiltInType != NULL && pNodeBuiltInType->checkConstraint(p) == false)
+        {
+            this->setInstanceAsValid(false);
+            assert (!"Invalid value for data type");
+
+            return;
+        }
+
+        if (this->getTypeNode()->getNodeType() == XSD_SIMPLE_TYPE)
+            const CSimpleType *pNodeSimpleType = dynamic_cast<const CSimpleType*>(this->getTypeNode());
+    }
+    if (this->m_ReverseKeyRefArray.length() > 0)
+    {
+        for (int idx = 0; this->m_ReverseKeyRefArray.length(); idx++)
+        {
+           CKeyRef *pKeyRef = static_cast<CKeyRef*>((this->m_ReverseKeyRefArray.item(idx)));
+            assert(pKeyRef != NULL);
+
+            if (pKeyRef->checkConstraint(p) == false)
+            {
+                this->setInstanceAsValid(false);
+                assert (!"Constraint Violated");
+
+                return;
+            }
+        }
+    }
+    this->setInstanceValue(p);
+    this->setInstanceAsValid(true);
+}
+
+void CAttribute::appendReverseKeyRef(const CKeyRef *pKeyRef)
+{
+    assert(pKeyRef != NULL);
+
+    if (pKeyRef != NULL)
+        this->m_ReverseKeyRefArray.append(static_cast<void*>(const_cast<CKeyRef*>(pKeyRef)));
+}
+
+void CAttribute::appendReverseKey(const CKey *pKey)
+{
+    assert(pKey != NULL);
+
+    if (pKey != NULL)
+        this->m_ReverseKeyArray.append(static_cast<void*>(const_cast<CKey*>(pKey)));
+}
+
+CAttribute* CAttribute::load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath)
+{
+    assert(pSchemaRoot != NULL);
+
+    if (pSchemaRoot == NULL)
+        return NULL;
+
+    CAttribute *pAttribute = new CAttribute(pParentNode);
+
+    pAttribute->setXSDXPath(xpath);
+
+    Owned<IAttributeIterator> iterAttrib = pSchemaRoot->queryPropTree(xpath)->getAttributes(true);
+
+    ForEach(*iterAttrib)
+    {
+        if (strcmp(iterAttrib->queryName(), XML_ATTR_NAME) == 0)
+            pAttribute->setName(iterAttrib->queryValue());
+        else if (strcmp(iterAttrib->queryName(), XML_ATTR_DEFAULT) == 0)
+            pAttribute->setDefault(iterAttrib->queryValue());
+        else if (strcmp(iterAttrib->queryName(), XML_ATTR_USE) == 0)
+            pAttribute->setUse(iterAttrib->queryValue());
+        else if (strcmp(iterAttrib->queryName(), XML_ATTR_TYPE) == 0)
+        {
+            const char *pType = iterAttrib->queryValue();
+            assert(pType != NULL && *pType != 0);
+
+            if (pType != NULL && *pType != 0)
+            {
+                pAttribute->setType(pType);
+                CConfigSchemaHelper::getInstance()->addNodeForTypeProcessing(pAttribute);
+            }
+        }
+    }
+
+
+    StringBuffer strXPathExt(xpath);
+    strXPathExt.append("/").append(XSD_TAG_ANNOTATION);
+
+    CAnnotation *pAnnotation = CAnnotation::load(pAttribute, pSchemaRoot, strXPathExt.str());
+    if (pAnnotation != NULL)
+        pAttribute->setAnnotation(pAnnotation);
+
+    strXPathExt.clear().append(xpath);
+    strXPathExt.append("/").append(XSD_TAG_SIMPLE_TYPE);
+
+    CSimpleTypeArray *pSimpleTypeArray = CSimpleTypeArray::load(pAttribute, pSchemaRoot, strXPathExt.str());
+    if (pSimpleTypeArray != NULL)
+        pAttribute->setSimpleTypeArray(pSimpleTypeArray);
+
+    return pAttribute;
+}
+
+const char* CAttributeArray::getXML(const char* /*pComponent*/)
+{
+    if (m_strXML.length() == 0)
+    {
+        int length = this->length();
+
+        for (int idx = 0; idx < length; idx++)
+        {
+            CAttribute &Attribute = this->item(idx);
+            m_strXML.append(" ").append(Attribute.getXML(NULL));
+
+            if (idx+1 < length)
+                m_strXML.append("\n");
+        }
+    }
+    return m_strXML.str();
+}
+
+CAttributeArray* CAttributeArray::load(const char* pSchemaFile)
+{
+    assert(pSchemaFile != NULL);
+
+    if (pSchemaFile == NULL)
+        return NULL;
+
+    Linked<IPropertyTree> pSchemaRoot;
+
+    StringBuffer schemaPath;
+    schemaPath.appendf("%s%s", DEFAULT_SCHEMA_DIRECTORY, pSchemaFile);
+    pSchemaRoot.setown(createPTreeFromXMLFile(schemaPath.str()));
+
+    StringBuffer strXPathExt("./");
+    strXPathExt.append(XSD_TAG_ATTRIBUTE);
+
+    return CAttributeArray::load(NULL, pSchemaRoot, strXPathExt.str());
+}
+
+CAttributeArray* CAttributeArray::load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath)
+{
+    assert(pSchemaRoot != NULL);
+
+    if (pSchemaRoot == NULL || xpath == NULL)
+        return NULL;
+
+    StringBuffer strXPathExt(xpath);
+    CAttributeArray *pAttribArray = new CAttributeArray(pParentNode);
+    pAttribArray->setXSDXPath(xpath);
+
+    Owned<IPropertyTreeIterator> attributeIter = pSchemaRoot->getElements(xpath, ipt_ordered);
+
+    int count = 1;
+    ForEach(*attributeIter)
+    {
+        strXPathExt.clear().append(xpath).appendf("[%d]",count);
+
+        CAttribute *pAttrib = CAttribute::load(pAttribArray, pSchemaRoot, strXPathExt.str());
+
+        if (pAttrib != NULL)
+            pAttribArray->append(*pAttrib);
+        count++;
+    }
+
+    if (pAttribArray->length() == 0)
+    {
+        delete pAttribArray;
+        return NULL;
+    }
+    return pAttribArray;
+}
+
+void CAttributeArray::dump(std::ostream &cout, unsigned int offset) const
+{
+    offset+= STANDARD_OFFSET_1;
+
+    QuickOutHeader(cout, XSD_ATTRIBUTE_ARRAY_STR, offset);
+
+    QUICK_OUT(cout, XSDXPath,  offset);
+    QUICK_OUT(cout, EnvXPath,  offset);
+    QUICK_OUT_ARRAY(cout, offset);
+
+    QuickOutFooter(cout, XSD_ATTRIBUTE_ARRAY_STR, offset);
+}
+
+
+void CAttributeArray::getDocumentation(StringBuffer &strDoc) const
+{
+    assert(this->getConstParentNode() != NULL);
+
+    strDoc.append(DM_SECT4_BEGIN);
+
+    if (this->getConstParentNode()->getNodeType() == XSD_COMPLEX_TYPE && this->getConstParentNode()->getConstParentNode()->getNodeType() != XSD_COMPLEX_TYPE)
+    {
+        strDoc.appendf("%s%s%s", DM_TITLE_BEGIN, "Attributes", DM_TITLE_END);  // Attributes is hard coded default
+        DEBUG_MARK_STRDOC;
+    }
+    else
+    {
+        strDoc.append(DM_TITLE_BEGIN).append(DM_TITLE_END);
+        DEBUG_MARK_STRDOC;
+    }
+
+    const CComplexType *pParentComplexType = dynamic_cast<const CComplexType*>(this->getConstParentNode());
+    const CAttributeGroup *pParentAttributeGroup = dynamic_cast<const CAttributeGroup*>(this->getConstParentNode());
+
+    strDoc.append(DM_TABLE_BEGIN);
+    DEBUG_MARK_STRDOC;
+    strDoc.append(DM_TABLE_ID_BEGIN);
+    DEBUG_MARK_STRDOC;
+
+    if (pParentComplexType != NULL && pParentComplexType->getAnnotation() != NULL && pParentComplexType->getAnnotation()->getAppInfo() != NULL && pParentComplexType->getAnnotation()->getAppInfo()->getDocTableID() != NULL)
+    {
+        strDoc.append(pParentComplexType->getAnnotation()->getAppInfo()->getDocTableID());
+        DEBUG_MARK_STRDOC;
+    }
+    else if  (pParentAttributeGroup != NULL && pParentAttributeGroup->getAnnotation() != NULL && pParentAttributeGroup->getAnnotation()->getAppInfo() != NULL && pParentAttributeGroup->getAnnotation()->getAppInfo()->getDocTableID() != NULL)
+    {
+        strDoc.append(pParentAttributeGroup->getAnnotation()->getAppInfo()->getDocTableID());
+        DEBUG_MARK_STRDOC;
+    }
+    else
+    {
+        static unsigned undefined_counter = 1;
+        strDoc.append(DM_TABLE_ID_UNDEFINED).append("-").append(undefined_counter++);
+        DEBUG_MARK_STRDOC;
+    }
+
+    strDoc.append(DM_TABLE_ID_END);
+    DEBUG_MARK_STRDOC;
+
+    strDoc.append(DM_TGROUP4_BEGIN);
+    strDoc.append(DM_COL_SPEC4);
+    strDoc.append(DM_TBODY_BEGIN);
+
+    DEBUG_MARK_STRDOC;
+    QUICK_DOC_ARRAY(strDoc);
+    DEBUG_MARK_STRDOC;
+
+    strDoc.append(DM_TBODY_END);
+    strDoc.append(DM_TGROUP4_END);
+    strDoc.append(DM_TABLE_END);
+
+    strDoc.append(DM_SECT4_END);
+}
+
+void CAttributeArray::getQML2(StringBuffer &strQML, int idx) const
+{
+    if (this->getParentNode()->getUIType() == QML_UI_TABLE)
+    {
+        this->setUIType(QML_UI_TABLE_CONTENTS);
+
+        for (int i = 0; i < this->length(); i++)
+        {
+            DEBUG_MARK_QML2(this);
+            (this->item(i)).getQML2(strQML);
+        }
+        DEBUG_MARK_QML2(this);
+    }
+    else if (this->getParentNode()->getUIType() == QML_UI_TAB)
+    {
+        this->setUIType(QML_UI_TAB_CONTENTS);
+
+        const CElement* pElem = dynamic_cast<const CElement*>(this->getParentNodeByType(XSD_ELEMENT));
+
+        assert(pElem != NULL);
+
+        if (pElem->isTopLevelElement() == true)
+        {
+            CQMLMarkupHelper::getTabQML(strQML, "Attributes");
+            DEBUG_MARK_QML;
+            strQML.append(QML_GRID_LAYOUT_BEGIN_1);
+            DEBUG_MARK_QML;
+        }
+
+        for (int i = 0; i < this->length(); i++)
+        {
+            DEBUG_MARK_QML2(this);
+            (this->item(i)).getQML2(strQML);
+        }
+
+        if (pElem->isTopLevelElement() == true)
+        {
+            strQML.append(QML_GRID_LAYOUT_END);
+            DEBUG_MARK_QML;
+            strQML.append(QML_FLICKABLE_HEIGHT).append(CQMLMarkupHelper::getImplicitHeight() * 1.5);
+            DEBUG_MARK_QML;
+            strQML.append(QML_FLICKABLE_END);
+            DEBUG_MARK_QML;
+            strQML.append(QML_TAB_END);
+            DEBUG_MARK_QML;
+        }
+
+        DEBUG_MARK_QML2(this);
+    }
+    else
+        assert(!"what am i?");
+}
+
+void CAttributeArray::getQML3(StringBuffer &strQML, int idx) const
+{
+    /*
+        Sample QML returned by AttributeArray
+        ListElement {
+            value: ListElement {value: [ListElement{value: "A Masterpiece"}] type: "field"; tooltip:"Hey" }
+            key: ListElement {value: [ListElement{value: "Gabriel"}]}
+        }
+     */
+    DEBUG_MARK_QML;
+    // If UI is LIST, each AttributeArray.getQML3() call needs to effectively return a row
+    if(this->getUIType() == QML_UI_TABLE_LIST)
+    {
+        strQML.append(QML_TABLE_ROW_START);
+        for(int i = 0; i < this->length(); i++)
+        {
+            (this->item(i)).getQML3(strQML);
+        }
+        strQML.append(QML_TABLE_ROW_END);
+    // Otherwise, assume Key/Val and generate your own table
+    } 
+    else 
+    {
+        StringArray roles;
+        StringArray titles;
+        strQML.append(QML_TABLE_START);
+        
+        // Builds Columns
+        roles.append("key");
+        titles.append("key");
+        roles.append("value");
+        titles.append("value");
+
+        CQMLMarkupHelper::buildColumns(strQML, roles, titles);
+        strQML.append(QML_TABLE_CONTENT_START);
+
+        // build Rows
+        for (int i = 0; i < this->length(); i++)
+        {
+            if((this->item(i)).isHidden()) 
+                continue;
+
+            strQML.append(QML_TABLE_ROW_START);
+            StringArray key;
+            key.append(this->item(i).getTitle());
+
+            CQMLMarkupHelper::buildRole(strQML, "key", key);
+            (this->item(i)).getQML3(strQML, "value");
+
+            strQML.append(QML_TABLE_ROW_END);
+        }
+        strQML.append(QML_DOUBLE_END_BRACKET);
+    }
+    DEBUG_MARK_QML;
+}
+
+void CAttributeArray::populateEnvXPath(StringBuffer strXPath, unsigned int index)
+{
+    this->setEnvXPath(strXPath);
+    QUICK_ENV_XPATH_WITH_INDEX(strXPath, index)
+}
+
+void CAttributeArray::loadXMLFromEnvXml(const IPropertyTree *pEnvTree)
+{
+    assert(pEnvTree != NULL);
+
+    if (pEnvTree->hasProp(this->getEnvXPath()) == false)
+        throw MakeExceptionFromMap(EX_STR_XPATH_DOES_NOT_EXIST_IN_TREE);
+    else
+    {
+        try
+        {
+            QUICK_LOAD_ENV_XML(pEnvTree)
+        }
+        catch (IException *e)
+        {
+            if (e->errorCode() == EX_STR_MISSING_REQUIRED_ATTRIBUTE)
+                throw e;
+        }
+    }
+}
+
+const CAttribute* CAttributeArray::findAttributeWithName(const char *pName, bool bCaseInsensitive) const
+{
+    assert (pName != NULL && pName[0] != 0);
+    if (pName == NULL || pName[0] == 0 || this->length() == 0)
+        return NULL;
+
+    for (int idx = 0; idx < this->length(); idx++)
+    {
+        if (bCaseInsensitive == true)
+        {
+            if (stricmp(this->item(idx).getName(), pName) == 0)
+                return &(this->item(idx));
+        }
+        else
+        {
+            if (strcmp(this->item(idx).getName(), pName) == 0)
+                return &(this->item(idx));
+        }
+    }
+    return NULL;
+}
+const void CAttributeArray::getAttributeNames(StringArray &names, StringArray &titles) const
+{
+    for(int i = 0; i < this->length(); i++)
+    {
+        if(!this->item(i).isHidden())
+        {
+            names.append(this->item(i).getName());
+            titles.append(this->item(i).getTitle());
+        }
+    }
+}
+
+bool CAttributeArray::getCountOfValueMatches(const char *pValue) const
+{
+    return false;
+}

--- a/configuration/configurator/SchemaAttributes.hpp
+++ b/configuration/configurator/SchemaAttributes.hpp
@@ -1,0 +1,140 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef _SCHEMA_ATTRIBUTES_HPP_
+#define _SCHEMA_ATTRIBUTES_HPP_
+
+#include "jarray.hpp"
+#include "jatomic.hpp"
+#include "XMLTags.h"
+#include "SchemaCommon.hpp"
+#include "SchemaAnnotation.hpp"
+
+class CSimpleTypeArray;
+class CKeyRefArray;
+class CKeyArray;
+class CKey;
+class CKeyRef;
+
+class CAttribute : public CXSDNodeWithType
+{
+public:
+
+    CAttribute(CXSDNodeBase* pParentNode, const char* pName = NULL) : CXSDNodeWithType::CXSDNodeWithType(pParentNode, XSD_ATTRIBUTE), m_strName(pName),
+            m_strDefault(""), m_strUse(""), m_pAnnotation(NULL), m_pSimpleTypeArray(NULL), m_bInstanceValueValid(false)
+    {
+    }
+
+    CAttribute(CXSDNodeBase* pParentNode, const char* pName, const char* pType, const char* pDefault, const char* pUse) : CXSDNodeWithType::CXSDNodeWithType(pParentNode, XSD_ATTRIBUTE), m_strName(pName), m_pAnnotation(NULL),
+            m_strDefault(pDefault), m_strUse(pUse), m_pSimpleTypeArray(NULL), m_bInstanceValueValid(false)
+    {
+    }
+
+    virtual ~CAttribute();
+
+    GETTERSETTER(Name)
+    GETTERSETTER(Default)
+    GETTERSETTER(Use)
+    GETTERSETTER(InstanceValue)
+
+    const CAnnotation* getAnnotation() const
+    {
+        return m_pAnnotation;
+    }
+
+    const char* getTitle() const;
+    virtual const char* getXML(const char* pComponent);
+    virtual void dump(std::ostream& cout, unsigned int offset = 0) const;
+    virtual void getDocumentation(StringBuffer &strDoc) const;
+    virtual void getQML2(StringBuffer &strQML, int idx = -1) const;
+    virtual void getQML3(StringBuffer &strQML, const char * role = NULL, int idx = -1) const;
+    virtual void populateEnvXPath(StringBuffer strXPath, unsigned int index = 1);
+    virtual void loadXMLFromEnvXml(const IPropertyTree *pEnvTree);
+
+    static CAttribute* load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath = NULL);
+
+    bool isInstanceValueValid()
+    {
+        return m_bInstanceValueValid;
+    }
+
+    bool isHidden();
+    virtual void setEnvValueFromXML(const char *p);
+    void appendReverseKey(const CKey *pKey);
+    void appendReverseKeyRef(const CKeyRef *pKeyRef);
+
+protected:
+
+    void setInstanceAsValid(bool bValid = true)
+    {
+        m_bInstanceValueValid = bValid;
+    }
+
+    void setAnnotation(CAnnotation *pAnnotation)
+    {
+        assert(pAnnotation != NULL);  // why would this ever be NULL?
+        m_pAnnotation = pAnnotation;
+    }
+
+    void setSimpleTypeArray(CSimpleTypeArray *pSimpleTypeArray)
+    {
+        assert(pSimpleTypeArray != NULL);  // why would this ever be NULL?
+        m_pSimpleTypeArray = pSimpleTypeArray;
+    }
+
+    CAnnotation *m_pAnnotation;
+    CSimpleTypeArray *m_pSimpleTypeArray;
+    PointerArray m_ReverseKeyArray;
+    PointerArray m_ReverseKeyRefArray;
+    bool m_bInstanceValueValid;
+
+private:
+
+};
+
+class CAttributeArray : public CIArrayOf<CAttribute>, public InterfaceImpl, public CXSDNodeBase
+{
+public:
+
+    CAttributeArray(CXSDNodeBase* pParentNode = NULL) : CXSDNodeBase::CXSDNodeBase(pParentNode, XSD_ATTRIBUTE_ARRAY)
+    {
+    }
+
+    virtual ~CAttributeArray()
+    {
+    }
+
+    virtual void dump(std::ostream& cout, unsigned int offset = 0) const;
+    virtual void getDocumentation(StringBuffer &strDoc) const;
+    virtual void getQML2(StringBuffer &strQML, int idx = -1) const;
+    virtual void getQML3(StringBuffer &strQML, int idx = -1) const;
+    virtual void populateEnvXPath(StringBuffer strXPath, unsigned int index = 1);
+    virtual void loadXMLFromEnvXml(const IPropertyTree *pEnvTree);
+    virtual const char* getXML(const char* /*pComponent*/);
+    const CAttribute* findAttributeWithName(const char *pName, bool bCaseInsensitive = true) const;
+    const void getAttributeNames(StringArray &names, StringArray &titles) const;
+    static CAttributeArray* load(const char* pSchemaFile);
+    static CAttributeArray* load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath);
+
+protected:
+
+    bool getCountOfValueMatches(const char *pValue) const;
+
+private:
+};
+
+#endif // _SCHEMA_ATTRIBUTES_HPP_

--- a/configuration/configurator/SchemaChoice.cpp
+++ b/configuration/configurator/SchemaChoice.cpp
@@ -1,0 +1,118 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include "jptree.hpp"
+#include "XMLTags.h"
+#include "SchemaChoice.hpp"
+#include "SchemaElement.hpp"
+#include "DocumentationMarkup.hpp"
+
+
+CChoice* CChoice::load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath)
+{
+    assert(pSchemaRoot != NULL);
+
+    if (pSchemaRoot == NULL || xpath == NULL)
+         return NULL;
+
+    if (pSchemaRoot->queryPropTree(xpath) == NULL)
+        return NULL; // no xs:choice node found
+
+    StringBuffer strXPathExt(xpath);
+    strXPathExt.append("/").append(XSD_TAG_ELEMENT);
+
+    CElementArray *pElemArray = CElementArray::load(NULL, pSchemaRoot, strXPathExt.str());
+    assert(pElemArray);
+
+    if (pElemArray == NULL)
+        return NULL;
+
+    CChoice *pChoice  = new CChoice(pParentNode, pElemArray);
+    assert(pChoice);
+
+    if (pChoice == NULL)
+        return NULL;
+
+    pChoice->setXSDXPath(xpath);
+
+    SETPARENTNODE(pElemArray, pChoice);
+
+    return pChoice;
+}
+
+const char* CChoice::getXML(const char* /*pComponent*/)
+{
+    if (m_strXML.length() == 0)
+        if (m_pElementArray != NULL)
+            m_strXML.append(m_pElementArray->getXML(NULL));
+
+    return m_strXML.str();
+}
+
+void CChoice::dump(std::ostream &cout, unsigned int offset) const
+{
+    offset += STANDARD_OFFSET_1;
+
+    QuickOutHeader(cout, XSD_CHOICE_STR, offset);
+
+    QUICK_OUT(cout, ID,         offset);
+    QUICK_OUT(cout ,MinOccurs,  offset);
+    QUICK_OUT(cout, MaxOccurs,  offset);
+    QUICK_OUT(cout, XSDXPath,   offset);
+
+    if (m_pElementArray != NULL)
+        m_pElementArray->dump(cout, offset);
+
+    QuickOutFooter(cout, XSD_CHOICE_STR, offset);
+}
+
+void CChoice::getDocumentation(StringBuffer &strDoc) const
+{
+    if (m_pElementArray != NULL)
+        m_pElementArray->getDocumentation(strDoc);
+}
+
+void CChoice::getQML(StringBuffer &strQML, int idx) const
+{
+    if (m_pElementArray != NULL)
+        m_pElementArray->getQML(strQML);
+}
+
+
+void CChoice::populateEnvXPath(StringBuffer strXPath, unsigned int index)
+{
+    this->setEnvXPath(strXPath);
+
+    if (m_pElementArray != NULL)
+        m_pElementArray->populateEnvXPath(strXPath);
+}
+
+void CChoice::loadXMLFromEnvXml(const IPropertyTree *pEnvTree)
+{
+    assert (pEnvTree != NULL);
+
+    if (m_pElementArray != NULL)
+    {
+        try
+        {
+            m_pElementArray->loadXMLFromEnvXml(pEnvTree);
+        }
+        catch (...)
+        {
+        }
+    }
+}

--- a/configuration/configurator/SchemaChoice.hpp
+++ b/configuration/configurator/SchemaChoice.hpp
@@ -1,0 +1,62 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef _SCHEMA_CHOICE_HPP_
+#define _SCHEMA_CHOICE_HPP_
+
+#include "SchemaCommon.hpp"
+#include "jstring.hpp"
+
+class CElementArray;
+
+class CChoice : public CXSDNode
+{
+public:
+
+    virtual ~CChoice()
+    {
+    }
+
+    GETTERSETTER(MaxOccurs)
+    GETTERSETTER(MinOccurs)
+    GETTERSETTER(ID)
+
+    virtual void dump(std::ostream &cout, unsigned int offset = 0) const;
+    virtual void getDocumentation(StringBuffer &strDoc) const;
+    virtual void getQML(StringBuffer &strQML, int idx = -1) const;
+    virtual const char* getXML(const char* /*pComponent*/);
+    virtual void populateEnvXPath(StringBuffer strXPath, unsigned int index = 1);
+    virtual void loadXMLFromEnvXml(const IPropertyTree *pEnvTree);
+
+    static CChoice* load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath);
+
+protected:
+
+    CChoice(CXSDNodeBase* pParentNode, CElementArray *pElemArray = NULL) : CXSDNode::CXSDNode(pParentNode, XSD_CHOICE), m_pElementArray(pElemArray)
+    {
+    }
+
+    CElementArray *m_pElementArray;
+
+private:
+
+    CChoice() : CXSDNode::CXSDNode(NULL, XSD_CHOICE)
+    {
+    }
+};
+
+#endif // _SCHEMA_CHOICE_HPP_

--- a/configuration/configurator/SchemaCommon.cpp
+++ b/configuration/configurator/SchemaCommon.cpp
@@ -1,0 +1,419 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include "SchemaCommon.hpp"
+#include "ConfigSchemaHelper.hpp"
+#include "SchemaMapManager.hpp"
+#include "jregexp.hpp"
+#include <cstring>
+
+CXSDNodeBase::CXSDNodeBase(CXSDNodeBase* pParentNode, NODE_TYPES eNodeType) : m_pParentNode(pParentNode),  m_eNodeType(eNodeType), m_eUIType(QML_UI_UNKNOWN)
+{
+   assert(eNodeType != XSD_ERROR);
+
+   switch (eNodeType)
+   {
+   case(XSD_ERROR):
+       strcpy(m_pNodeType, XSD_ERROR_STR);
+       break;
+   case(XSD_ANNOTATION):
+       strcpy(m_pNodeType, XSD_ANNOTATION_STR);
+       break;
+   case(XSD_APP_INFO):
+       strcpy(m_pNodeType, XSD_APP_INFO_STR);
+       break;
+   case(XSD_ATTRIBUTE):
+       strcpy(m_pNodeType, XSD_ATTRIBUTE_STR);
+       break;
+   case(XSD_ATTRIBUTE_ARRAY):
+       strcpy(m_pNodeType, XSD_ATTRIBUTE_ARRAY_STR);
+       break;
+   case(XSD_ATTRIBUTE_GROUP):
+       strcpy(m_pNodeType, XSD_ATTRIBUTE_GROUP_STR);
+       break;
+   case(XSD_ATTRIBUTE_GROUP_ARRAY):
+       strcpy(m_pNodeType, XSD_ATTRIBUTE_GROUP_ARRAY_STR);
+       break;
+   case(XSD_CHOICE):
+       strcpy(m_pNodeType, XSD_CHOICE_STR);
+       break;
+   case(XSD_COMPLEX_CONTENT):
+       strcpy(m_pNodeType, XSD_COMPLEX_CONTENT_STR);
+       break;
+   case(XSD_COMPLEX_TYPE):
+       strcpy(m_pNodeType, XSD_COMPLEX_TYPE_STR);
+       break;
+   case(XSD_COMPLEX_TYPE_ARRAY):
+       strcpy(m_pNodeType, XSD_COMPLEX_TYPE_ARRAY_STR);
+       break;
+   case(XSD_DOCUMENTATION):
+       strcpy(m_pNodeType, XSD_DOCUMENTATION_STR);
+       break;
+   case(XSD_ELEMENT):
+       strcpy(m_pNodeType, XSD_ELEMENT_STR);
+       break;
+   case(XSD_ELEMENT_ARRAY):
+       strcpy(m_pNodeType, XSD_ELEMENT_ARRAY_STR);
+       break;
+   case(XSD_EXTENSION):
+       strcpy(m_pNodeType, XSD_EXTENSION_STR);
+       break;
+   case(XSD_FIELD):
+       strcpy(m_pNodeType, XSD_FIELD_STR);
+       break;
+   case(XSD_FIELD_ARRAY):
+       strcpy(m_pNodeType, XSD_FIELD_ARRAY_STR);
+       break;
+   case(XSD_KEY):
+       strcpy(m_pNodeType, XSD_KEY_STR);
+       break;
+   case(XSD_KEY_ARRAY):
+       strcpy(m_pNodeType, XSD_KEY_ARRAY_STR);
+       break;
+   case(XSD_KEYREF):
+       strcpy(m_pNodeType, XSD_KEYREF_STR);
+       break;
+   case(XSD_KEYREF_ARRAY):
+       strcpy(m_pNodeType, XSD_KEYREF_ARRAY_STR);
+       break;
+   case(XSD_INCLUDE):
+       strcpy(m_pNodeType, XSD_INCLUDE_STR);
+       break;
+   case(XSD_INCLUDE_ARRAY):
+       strcpy(m_pNodeType, XSD_INCLUDE_ARRAY_STR);
+       break;
+   case(XSD_RESTRICTION):
+       strcpy(m_pNodeType, XSD_RESTRICTION_STR);
+       break;
+   case(XSD_SCHEMA):
+       strcpy(m_pNodeType, XSD_SCHEMA_STR);
+       break;
+   case(XSD_SEQUENCE):
+       strcpy(m_pNodeType, XSD_SEQUENCE_STR);
+       break;
+   case(XSD_SIMPLE_TYPE):
+       strcpy(m_pNodeType, XSD_SIMPLE_TYPE_STR);
+       break;
+   case(XSD_SIMPLE_TYPE_ARRAY):
+       strcpy(m_pNodeType, XSD_SIMPLE_TYPE_ARRAY_STR);
+       break;
+   case(XSD_ENUMERATION):
+       strcpy(m_pNodeType, XSD_ENUMERATION_STR);
+       break;
+   case(XSD_ENUMERATION_ARRAY):
+       strcpy(m_pNodeType, XSD_ENUMERATION_ARRAY_STR);
+       break;
+   case(XSD_LENGTH):
+       strcpy(m_pNodeType, XSD_LENGTH_STR);
+       break;
+   case(XSD_FRACTION_DIGITS):
+       strcpy(m_pNodeType, XSD_FRACTION_DIGITS_STR);
+       break;
+   case(XSD_MAX_EXCLUSIVE):
+       strcpy(m_pNodeType, XSD_MAX_EXCLUSIVE_STR);
+       break;
+   case(XSD_MAX_INCLUSIVE):
+       strcpy(m_pNodeType, XSD_MAX_INCLUSIVE_STR);
+       break;
+   case(XSD_MIN_EXCLUSIVE):
+       strcpy(m_pNodeType, XSD_MIN_INCLUSIVE_STR);
+       break;
+   case(XSD_MIN_LENGTH):
+       strcpy(m_pNodeType, XSD_MIN_LENGTH_STR);
+       break;
+   case(XSD_MAX_LENGTH):
+       strcpy(m_pNodeType, XSD_MAX_LENGTH_STR);
+       break;
+   case(XSD_PATTERN):
+       strcpy(m_pNodeType, XSD_PATTERN_STR);
+       break;
+   case(XSD_SELECTOR):
+       strcpy(m_pNodeType, XSD_SELECTOR_STR);
+       break;
+   case(XSD_TOTAL_DIGITS):
+       strcpy(m_pNodeType, XSD_TOTAL_DIGITS_STR);
+       break;
+   case(XSD_WHITE_SPACE):
+       strcpy(m_pNodeType, XSD_WHITE_SPACE_STR);
+       break;
+   case(XSD_DT_NORMALIZED_STRING):
+       strcpy(m_pNodeType, XSD_DATA_TYPE_NORMALIZED_STRING);
+       break;
+   case(XSD_DT_STRING):
+       strcpy(m_pNodeType, XSD_DATA_TYPE_STRING);
+       break;
+   case(XSD_DT_TOKEN):
+       strcpy(m_pNodeType, XSD_DATA_TYPE_TOKEN);
+       break;
+   case(XSD_DT_DATE):
+       strcpy(m_pNodeType, XSD_DATA_TYPE_DATE);
+       break;
+   case(XSD_DT_TIME):
+       strcpy(m_pNodeType, XSD_DATA_TYPE_TIME);
+       break;
+   case(XSD_DT_DATE_TIME):
+       strcpy(m_pNodeType, XSD_DATA_TYPE_DATE_TIME);
+       break;
+   case(XSD_DT_DECIMAL):
+       strcpy(m_pNodeType, XSD_DATA_TYPE_DECIMAL);
+       break;
+   case(XSD_DT_INT):
+       strcpy(m_pNodeType, XSD_DATA_TYPE_INT);
+       break;
+   case(XSD_DT_INTEGER):
+       strcpy(m_pNodeType, XSD_DATA_TYPE_INTEGER);
+       break;
+   case(XSD_DT_LONG):
+       strcpy(m_pNodeType, XSD_DATA_TYPE_LONG);
+       break;
+   case(XSD_DT_NON_NEG_INTEGER):
+       strcpy(m_pNodeType, XSD_DATA_TYPE_NON_NEGATIVE_INTEGER);
+       break;
+   case(XSD_DT_NON_POS_INTEGER):
+       strcpy(m_pNodeType, XSD_DATA_TYPE_NON_POSITIVE_INTEGER);
+       break;
+   case(XSD_DT_NEG_INTEGER):
+       strcpy(m_pNodeType, XSD_DATA_TYPE_NEGATIVE_INTEGER);
+       break;
+   case(XSD_DT_POS_INTEGER):
+       strcpy(m_pNodeType, XSD_DATA_TYPE_POSITIVE_INTEGER);
+       break;
+   case(XSD_DT_BOOLEAN):
+       strcpy(m_pNodeType, XSD_DATA_TYPE_BOOLEAN);
+       break;
+   default:
+       assert(!"Unknown XSD Type"); // should never get here
+       strcpy(m_pNodeType, XSD_ERROR_STR);
+       break;
+   }
+}
+
+CXSDNodeBase::~CXSDNodeBase()
+{
+}
+
+void CXSDNodeBase::dumpStdOut() const
+{
+   dump(std::cout);
+}
+
+const CXSDNodeBase* CXSDNodeBase::getConstAncestorNode(unsigned iLevel) const
+{
+   CXSDNodeBase *pAncestorNode = const_cast<CXSDNodeBase*>(this);
+
+   if (iLevel == 0)
+       return this;
+
+   do
+   {
+       pAncestorNode = const_cast<CXSDNodeBase*>(pAncestorNode->getConstParentNode());
+       iLevel--;
+   } while (iLevel > 0 && pAncestorNode != NULL);
+
+   return pAncestorNode;
+}
+
+const CXSDNodeBase* CXSDNodeBase::getParentNodeByType(NODE_TYPES eNodeType[], const CXSDNodeBase *pParent, int length) const
+{
+   for (int i = 0; i < length; i++)
+   {
+       if (this->m_eNodeType == eNodeType[i] && pParent != NULL)
+           return this;
+   }
+   if (this->getConstParentNode() != NULL)
+       return this->getConstParentNode()->getParentNodeByType(eNodeType, this, length);
+
+   return NULL;
+}
+
+CXSDNode::CXSDNode(CXSDNodeBase *pParentNode, NODE_TYPES pNodeType) : CXSDNodeBase::CXSDNodeBase(pParentNode, pNodeType)
+{
+}
+
+bool CXSDNode::checkSelf(NODE_TYPES eNodeType, const char *pName, const char* pCompName) const
+{
+  if (eNodeType & this->getNodeType() && (pName != NULL ? !strcmp(pName, this->getNodeTypeStr()) : true))
+  {
+      assert(pName != NULL); // for now pName should always be populated
+      return this;
+  }
+  return NULL;
+}
+
+const CXSDNodeBase* CXSDNode::getParentNodeByType(NODE_TYPES eNodeType) const
+{
+  if (this->m_eNodeType == eNodeType)
+      return this;
+  if (this->getConstParentNode() != NULL)
+      return this->getConstParentNode()->getParentNodeByType(eNodeType);
+  return NULL;
+}
+
+const CXSDNodeBase* CXSDNodeBase::getNodeByTypeAndNameAscending(NODE_TYPES eNodeType[], const char *pName, int length) const
+{
+  for (int i = 0; i < length; i++)
+  {
+    assert(this->m_eNodeType != eNodeType[i]);
+
+    if (this->getConstParentNode() != NULL)
+        return this->getConstParentNode()->getNodeByTypeAndNameAscending(eNodeType[i], pName);
+  }
+  return NULL;
+}
+
+const CXSDNodeBase* CXSDNodeBase::getNodeByTypeAndNameDescending(NODE_TYPES eNodeType[], const char *pName, int length) const
+{
+    assert(false);  // Derived classes need to hande this
+    return NULL;
+}
+
+const CXSDNodeBase* CXSDNodeBase::getParentNodeByType(NODE_TYPES eNodeType, const CXSDNodeBase *pParent) const
+{
+    if (this->getConstParentNode() == NULL)
+        return NULL;
+    else if (this->getConstParentNode()->getNodeType() == eNodeType)
+        return this->getConstParentNode();
+    else
+        return this->getConstParentNode()->getParentNodeByType(eNodeType, pParent);
+}
+
+CXSDBuiltInDataType* CXSDBuiltInDataType::create(CXSDNodeBase* pParentNode, const char* pNodeType)
+{
+    assert(pParentNode != NULL);
+
+    enum NODE_TYPES eNodeType = CConfigSchemaHelper::getInstance()->getSchemaMapManager()->getEnumFromTypeName(pNodeType);
+
+    if (eNodeType != XSD_ERROR)
+        return new CXSDBuiltInDataType(pParentNode, eNodeType);
+    else
+        return NULL;
+}
+
+CXSDBuiltInDataType::CXSDBuiltInDataType(CXSDNodeBase* pParentNode, enum NODE_TYPES eNodeType) : CXSDNode::CXSDNode(pParentNode, eNodeType)
+{
+    assert(eNodeType != XSD_ERROR);
+}
+
+CXSDBuiltInDataType::~CXSDBuiltInDataType()
+{
+}
+
+void CXSDBuiltInDataType::dump(std::ostream& cout, unsigned int offset) const
+{
+    offset += STANDARD_OFFSET_1;
+
+    const char *pTypeNameString = CConfigSchemaHelper::getInstance()->getSchemaMapManager()->getTypeNameFromEnum(this->getNodeType(), true);
+
+    QuickOutHeader(cout, pTypeNameString, offset);
+    QuickOutFooter(cout, pTypeNameString, offset);
+}
+
+void CXSDBuiltInDataType::getDocumentation(StringBuffer &strDoc) const
+{
+    UNIMPLEMENTED;
+}
+
+bool CXSDBuiltInDataType::checkConstraint(const char *pValue) const
+{
+    if (pValue == NULL || *pValue == 0)
+        return true;
+
+    enum NODE_TYPES eNodeType = this->getNodeType();
+
+    if (eNodeType >= XSD_DT_NORMALIZED_STRING && eNodeType < XSD_ERROR)
+    {
+        if (XSD_DT_NORMALIZED_STRING == eNodeType)
+        {
+            const char key[] = "\n\r\t";
+            if (strpbrk(pValue, key) != NULL)
+                return false;
+        }
+        else if (XSD_DT_STRING == eNodeType)
+        {
+            // all allowed
+        }
+        else if(XSD_DT_TOKEN == eNodeType)
+        {
+            const char key[] = "\n\r\t";
+            if (strpbrk(pValue, key) != NULL)
+                return false;
+            if (pValue[0] == ' ' || pValue[strlen(pValue)-1] == ' ' || strstr(pValue, "  ")); // leading/trailing space multiple spaces
+                return false;
+        }
+        else if(XSD_DT_DATE == eNodeType)
+        {
+            UNIMPLEMENTED;
+        }
+        else if(XSD_DT_TIME == eNodeType)
+        {
+            UNIMPLEMENTED;
+        }
+        else if(XSD_DT_DATE_TIME == eNodeType)
+        {
+            UNIMPLEMENTED;
+        }
+        else if(XSD_DT_DECIMAL == eNodeType)
+        {
+            UNIMPLEMENTED;
+        }
+        else if(XSD_DT_INT == eNodeType)
+        {
+            UNIMPLEMENTED;
+        }
+        else if(XSD_DT_INTEGER == eNodeType)
+        {
+            RegExpr expr("^(\\+|-)?\\d+$");
+
+            if ((expr.find(pValue)) && (expr.findlen(0) == strlen(pValue)) == false)
+                return false;
+        }
+        else if(XSD_DT_LONG == eNodeType)
+        {
+            UNIMPLEMENTED;
+        }
+        else if(XSD_DT_NON_NEG_INTEGER == eNodeType)
+        {
+            RegExpr expr("^\\d+$");
+
+            if ((expr.find(pValue)) && (expr.findlen(0) == strlen(pValue)) == false)
+                return false;
+        }
+        else if(XSD_DT_NON_POS_INTEGER == eNodeType)
+        {
+            RegExpr expr("^\\d-$");
+
+            if ((expr.find(pValue)) && (expr.findlen(0) == strlen(pValue)) == false)
+                return false;
+        }
+        else if(XSD_DT_NEG_INTEGER == eNodeType)
+        {
+            UNIMPLEMENTED;
+        }
+        else if(XSD_DT_POS_INTEGER == eNodeType)
+        {
+            UNIMPLEMENTED;
+        }
+        else if(XSD_DT_BOOLEAN == eNodeType)
+        {
+            if (stricmp(pValue,"true") != 0 && stricmp(pValue,"false") != 0)
+                return false;
+            else
+                assert("!Unknown datatype");
+        }
+    }
+    return true;
+}

--- a/configuration/configurator/SchemaCommon.hpp
+++ b/configuration/configurator/SchemaCommon.hpp
@@ -1,0 +1,685 @@
+﻿/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef _SCHEMA_COMMON_HPP_
+#define _SCHEMA_COMMON_HPP_
+
+#include <iostream>
+#include "jiface.hpp"
+#include "jstring.hpp"
+#include "jlib.hpp"
+#include "jlog.hpp"
+#include "jarray.hpp"
+#include "ExceptionStrings.hpp"
+#include "XMLTags.h"
+
+#define MINIMUM_STRICTNESS  0
+#define DEFAULT_STRICTNESS  5
+#define MAXIMUM_STRICTNESS  10
+#define STRICTNESS_LEVEL MINIMUM_STRICTNESS
+
+#define QUICK_OUT(X,Y,Z) QuickOut(X,#Y,get##Y(),Z);
+#define QUICK_OUT_2(Y) QuickOut(cout, #Y, get##Y(), offset);
+#define QUICK_OUT_3(X) if (m_p##X != NULL) m_p##X->dump(cout, offset);
+#define QUICK_OUT_ARRAY(X,Z) for (int idx=0; idx < this->length(); idx++)               \
+                             {                                                          \
+                                QuickOutPad(X,Z+STANDARD_OFFSET_1);                     \
+                                X << idx+1 << "]" << std::endl;                         \
+                                (this->item(idx)).dump(cout,Z);                         \
+                             }
+
+#define QUICK_DOC_ARRAY(X) for (int idx=0; idx < this->length(); idx++)                 \
+                           {                                                            \
+                                (this->item(idx)).getDocumentation(X);                  \
+                           }
+
+#define QUICK_QML_ARRAY(X) for (int idx=0; idx < this->length(); idx++)                 \
+                           {                                                            \
+                                (this->item(idx)).getQML(X);                            \
+                           }
+
+#define QUICK_QML_ARRAY4(X,Y) for (int idx=0; idx < this->length(); idx++)                 \
+                           {\
+                                (this->item(idx)).setUIType(Y);                         \
+                                (this->item(idx)).getQML(X);                            \
+                           }
+#define LAST_ONLY -1
+#define LAST_AND_FIRST  -2
+/*#define QUICK_QML_ARRAY2(X)     for (int idx=0; idx < this->length(); idx++)            \
+                                {                                                       \
+                                    (this->item(idx)).getQML(X, idx == this->length()-1 && idx == 0 ? LAST_AND_FIRST : (idx == this->length()-1 ? LAST_ONLY : idx));                   \
+                                }*/
+
+#define QUICK_QML_ARRAY2(X)     for (int idx=0; idx < this->length(); idx++)            \
+                                {                                                       \
+                                    (this->item(idx)).getQML2(X, idx == this->length()-1 && idx == 0 ? LAST_AND_FIRST : (idx == this->length()-1 ? LAST_ONLY : idx));                   \
+                                }
+
+#define QUICK_QML_ARRAY3(X)     for (int idx=0; idx < this->length(); idx++)            \
+                                {                                                       \
+                                    DEBUG_MARK_QML;                                     \
+                                    (this->item(idx)).getQML(X, idx);                   \
+                                }
+
+#define QUICK_ENV_XPATH(X) for (int idx=0; idx < this->length(); idx++)                 \
+                            {                                                           \
+                                 (this->item(idx)).populateEnvXPath(X.str(), idx+1);          \
+                            }
+#define QUICK_ENV_XPATH_WITH_INDEX(X,Y) for (int idx=0; idx < this->length(); idx++)                 \
+                            {                                                           \
+                                 (this->item(idx)).populateEnvXPath(X.str(), Y);          \
+                            }
+
+#define QUICK_LOAD_ENV_XML(X)   assert(X != NULL);                                        \
+                                for (int idx=0; idx < this->length(); idx++)              \
+                                {                                                         \
+                                     (this->item(idx)).loadXMLFromEnvXml(X);              \
+                                }
+
+#define GETTER(X) virtual const char* get##X() const { return m_str##X.str(); }
+#define SETTER(X) virtual void set##X(const char* p) { m_str##X.clear().append(p); }
+#define GETTERSETTER(X) protected: StringBuffer m_str##X; public: GETTER(X) SETTER(X) public:
+
+#define GETTERINT(X) virtual const long get##X() const { return m_n##X; }
+#define SETTERINT(X) virtual void set##X(long p) { m_n##X = p; } virtual void set##X(const char *p) { assert(p != NULL); if (p != 0 && *p != 0) m_n##X = atol(p); }
+#define GETTERSETTERINT(X) protected: long m_n##X; public: GETTERINT(X) SETTERINT(X) private:
+
+#define SETPARENTNODE(X, Y) if (X!= NULL && Y != NULL) X->setParentNode(Y);
+//#define DEBUG_MARK_STRDOC strDoc.append(__FILE__).append(":").append(__LINE__).append("\n");
+#define DEBUG_MARK_STRDOC
+#define DEBUG_MARK_COMMENT(X) X.append("//  ").append(__FILE__).append(":").append(__LINE__).append("\n");
+#define DEBUG_MARK_COMMENT2(X,Y) X.append("//  UIType=").append(Y->getUIType()).append("  ").append(__FILE__).append(":").append(__LINE__).append("\n");
+#define DEBUG_MARK_STRJS DEBUG_MARK_COMMENT(strJS)
+#define DEBUG_MARK_QML DEBUG_MARK_COMMENT(strQML)
+#define DEBUG_MARK_QML2(X) DEBUG_MARK_COMMENT2(strQML, X)
+//#define DEBUG_MARK_QML
+//#define DEBUG_MARK_STRJS
+
+#define GETTERTYPE(X) C##X* get##X() { return m_p##X; }
+#define SETTERTYPE(X) void set##X( C##X *p ) { assert(p != NULL); if (p != NULL) m_p##X = p; }
+#define GETTERSETTERTYPE(X) public: C##X *m_p##X; GETTERTYPE(X) SETTERTYPE(X) private:
+
+enum NODE_TYPES
+{
+    XSD_ANNOTATION = 0x0,
+    XSD_APP_INFO,
+    XSD_ATTRIBUTE,
+    XSD_ATTRIBUTE_ARRAY,
+    XSD_ATTRIBUTE_GROUP,
+    XSD_ATTRIBUTE_GROUP_ARRAY,
+    XSD_CHOICE,
+    XSD_COMPLEX_CONTENT,
+    XSD_COMPLEX_TYPE,
+    XSD_COMPLEX_TYPE_ARRAY,
+    XSD_DOCUMENTATION,
+    XSD_ELEMENT,
+    XSD_ELEMENT_ARRAY,
+    XSD_EXTENSION,
+    XSD_FIELD,
+    XSD_FIELD_ARRAY,
+    XSD_KEY,
+    XSD_KEY_ARRAY,
+    XSD_KEYREF,
+    XSD_KEYREF_ARRAY,
+    XSD_INCLUDE,
+    XSD_INCLUDE_ARRAY,
+    XSD_RESTRICTION,
+    XSD_SCHEMA,
+    XSD_SEQUENCE,
+    XSD_SIMPLE_TYPE,
+    XSD_SIMPLE_TYPE_ARRAY,
+    XSD_ENUMERATION,
+    XSD_ENUMERATION_ARRAY,
+    XSD_LENGTH,
+    XSD_FRACTION_DIGITS,
+    XSD_MAX_EXCLUSIVE,
+    XSD_MAX_INCLUSIVE,
+    XSD_MIN_EXCLUSIVE,
+    XSD_MIN_INCLUSIVE,
+    XSD_MIN_LENGTH,
+    XSD_MAX_LENGTH,
+    XSD_PATTERN,
+    XSD_SELECTOR,
+    XSD_SIMPLE_CONTENT,
+    XSD_TOTAL_DIGITS,
+    XSD_UNIQUE,
+    XSD_UNIQUE_ARRAY,
+    XSD_WHITE_SPACE,
+    XSD_DT_NORMALIZED_STRING,  // keep this as the first DT type for array index purposes
+    XSD_DT_STRING,
+    XSD_DT_TOKEN,
+    XSD_DT_DATE,
+    XSD_DT_TIME,
+    XSD_DT_DATE_TIME,
+    XSD_DT_DECIMAL,
+    XSD_DT_INT,
+    XSD_DT_INTEGER,
+    XSD_DT_LONG,
+    XSD_DT_NON_NEG_INTEGER,
+    XSD_DT_NON_POS_INTEGER,
+    XSD_DT_NEG_INTEGER,
+    XSD_DT_POS_INTEGER,
+    XSD_DT_BOOLEAN,
+    XSD_ERROR
+};
+
+enum QML_UI_TYPE
+{
+    QML_UI_UNKNOWN = 0,
+    QML_UI_TEXT_FIELD,
+    QML_UI_DROP_DOWN,
+    QML_UI_TABLE,
+    QML_UI_TABLE_CONTENTS,
+    QML_UI_TAB,
+    QML_UI_TAB_CONTENTS,
+    QML_UI_LABEL,
+    QML_UI_EMPTY,
+    QML_UI_TABLE_LIST,
+    QML_UI_TABLE_KEYVAL
+};
+
+static const char* DEFAULT_SCHEMA_DIRECTORY("/opt/HPCCSystems/componentfiles/configxml/");
+
+#define NAME_SPACE_FOR_XSD_SCHEMA   "xs:"
+
+static const char* XSD_TAG_ANNOTATION(NAME_SPACE_FOR_XSD_SCHEMA"annotation");
+static const char* XSD_TAG_APP_INFO(NAME_SPACE_FOR_XSD_SCHEMA"appinfo");
+//static const char* XSD_TAG_ATTRIBUTE(NAME_SPACE_FOR_XSD_SCHEMA"attribute");
+//static const char* XSD_TAG_ATTRIBUTE_GROUP(NAME_SPACE_FOR_XSD_SCHEMA"attributeGroup");
+//static const char* XSD_TAG_CHOICE(NAME_SPACE_FOR_XSD_SCHEMA"choice");
+//static const char* XSD_TAG_COMPLEX_CONTENT(NAME_SPACE_FOR_XSD_SCHEMA"complexContent");
+//static const char* XSD_TAG_COMPLEX_TYPE(NAME_SPACE_FOR_XSD_SCHEMA"complexType");
+static const char* XSD_TAG_DOCUMENTATION(NAME_SPACE_FOR_XSD_SCHEMA"documentation");
+//static const char* XSD_TAG_ELEMENT(NAME_SPACE_FOR_XSD_SCHEMA"element");
+static const char* XSD_TAG_EXTENSION(NAME_SPACE_FOR_XSD_SCHEMA"extension");
+static const char* XSD_TAG_KEY(NAME_SPACE_FOR_XSD_SCHEMA"key");
+static const char* XSD_TAG_KEYREF(NAME_SPACE_FOR_XSD_SCHEMA"keyref");
+static const char* XSD_TAG_SELECTOR(NAME_SPACE_FOR_XSD_SCHEMA"selector");
+static const char* XSD_TAG_FIELD(NAME_SPACE_FOR_XSD_SCHEMA"field");
+static const char* XSD_TAG_INCLUDE(NAME_SPACE_FOR_XSD_SCHEMA"include");
+static const char* XSD_TAG_RESTRICTION(NAME_SPACE_FOR_XSD_SCHEMA"restriction");
+static const char* XSD_TAG_SCHEMA("");
+static const char* XSD_TAG_SIMPLE_CONTENT(NAME_SPACE_FOR_XSD_SCHEMA"simpleContent");
+//static const char* XSD_TAG_SEQUENCE(NAME_SPACE_FOR_XSD_SCHEMA"sequence");
+static const char* XSD_TAG_SIMPLE_TYPE(NAME_SPACE_FOR_XSD_SCHEMA"simpleType");
+static const char* XSD_TAG_ENUMERATION(NAME_SPACE_FOR_XSD_SCHEMA"enumeration");
+static const char* XSD_TAG_FRACTION_DIGITS(NAME_SPACE_FOR_XSD_SCHEMA"fractionDigits");
+static const char* XSD_TAG_LENGTH(NAME_SPACE_FOR_XSD_SCHEMA"length");
+static const char* XSD_TAG_MAX_EXCLUSIVE(NAME_SPACE_FOR_XSD_SCHEMA"maxExclusive");
+static const char* XSD_TAG_MAX_INCLUSIVE(NAME_SPACE_FOR_XSD_SCHEMA"maxInclusive");
+static const char* XSD_TAG_MIN_EXCLUSIVE(NAME_SPACE_FOR_XSD_SCHEMA"minExlusive");
+static const char* XSD_TAG_MIN_INCLUSIVE(NAME_SPACE_FOR_XSD_SCHEMA"minExclusive");
+static const char* XSD_TAG_MAX_LENGTH(NAME_SPACE_FOR_XSD_SCHEMA"maxLength");
+static const char* XSD_TAG_MIN_LENGTH(NAME_SPACE_FOR_XSD_SCHEMA"minLength");
+static const char* XSD_TAG_PATTERN(NAME_SPACE_FOR_XSD_SCHEMA"pattern");
+static const char* XSD_TAG_TOTAL_DIGITS(NAME_SPACE_FOR_XSD_SCHEMA"totalDigits");
+static const char* XSD_TAG_UNQIUE(NAME_SPACE_FOR_XSD_SCHEMA"unique");
+static const char* XSD_TAG_WHITE_SPACE(NAME_SPACE_FOR_XSD_SCHEMA"whiteSpace");
+
+static const char* XSD_DATA_TYPE_NORMALIZED_STRING(NAME_SPACE_FOR_XSD_SCHEMA"normalizedString");
+static const char* XSD_DATA_TYPE_STRING(NAME_SPACE_FOR_XSD_SCHEMA"string");
+static const char* XSD_DATA_TYPE_TOKEN(NAME_SPACE_FOR_XSD_SCHEMA"token");
+static const char* XSD_DATA_TYPE_DATE(NAME_SPACE_FOR_XSD_SCHEMA"date");
+static const char* XSD_DATA_TYPE_TIME(NAME_SPACE_FOR_XSD_SCHEMA"time");
+static const char* XSD_DATA_TYPE_DATE_TIME(NAME_SPACE_FOR_XSD_SCHEMA"dateTime");
+static const char* XSD_DATA_TYPE_DECIMAL(NAME_SPACE_FOR_XSD_SCHEMA"decimal"); // A decimal value
+static const char* XSD_DATA_TYPE_INTEGER(NAME_SPACE_FOR_XSD_SCHEMA"integer"); // An integer value
+static const char* XSD_DATA_TYPE_INT(NAME_SPACE_FOR_XSD_SCHEMA"int"); // A signed 32-bit integer
+static const char* XSD_DATA_TYPE_LONG(NAME_SPACE_FOR_XSD_SCHEMA"long"); // A signed 64-bit integer
+static const char* XSD_DATA_TYPE_NON_NEGATIVE_INTEGER(NAME_SPACE_FOR_XSD_SCHEMA"nonNegativeInteger");
+static const char* XSD_DATA_TYPE_NON_POSITIVE_INTEGER(NAME_SPACE_FOR_XSD_SCHEMA"nonPositiveInteger");
+static const char* XSD_DATA_TYPE_NEGATIVE_INTEGER(NAME_SPACE_FOR_XSD_SCHEMA"negativeInteger");
+static const char* XSD_DATA_TYPE_POSITIVE_INTEGER(NAME_SPACE_FOR_XSD_SCHEMA"positiveInteger");
+static const char* XSD_DATA_TYPE_BOOLEAN(NAME_SPACE_FOR_XSD_SCHEMA"boolean");
+
+static const char* XSD_ANNOTATION_STR("Annotation");
+static const char* XSD_APP_INFO_STR("AppInfo");
+static const char* XSD_ATTRIBUTE_STR("Attribute");
+static const char* XSD_ATTRIBUTE_ARRAY_STR("AttributeArray");
+static const char* XSD_ATTRIBUTE_GROUP_STR("AttributeGroup");
+static const char* XSD_ATTRIBUTE_GROUP_ARRAY_STR("AttributeGroupArray");
+static const char* XSD_CHOICE_STR("Choice");
+static const char* XSD_COMPLEX_CONTENT_STR("ComplexContent");
+static const char* XSD_COMPLEX_TYPE_STR("ComplexType");
+static const char* XSD_COMPLEX_TYPE_ARRAY_STR("ComplexTypeArray");
+static const char* XSD_DOCUMENTATION_STR("Documentation");
+static const char* XSD_ELEMENT_STR("Element");
+static const char* XSD_ELEMENT_ARRAY_STR("ElementArray");
+static const char* XSD_ERROR_STR("ERROR");
+static const char* XSD_ENUMERATION_STR("Enumeration");
+static const char* XSD_ENUMERATION_ARRAY_STR("EnumerationArray");
+static const char* XSD_EXTENSION_STR("Extension");
+static const char* XSD_FIELD_STR("Field");
+static const char* XSD_FIELD_ARRAY_STR("FieldArray");
+static const char* XSD_FRACTION_DIGITS_STR("FractionDigits");
+static const char* XSD_INCLUDE_STR("Include");
+static const char* XSD_INCLUDE_ARRAY_STR("IncludeArray");
+static const char* XSD_KEY_STR("Key");
+static const char* XSD_KEY_ARRAY_STR("KeyArray");
+static const char* XSD_KEYREF_STR("KeyRef");
+static const char* XSD_KEYREF_ARRAY_STR("KeyRefArray");
+static const char* XSD_LENGTH_STR("Length");
+static const char* XSD_MIN_INCLUSIVE_STR("MinInclusive");
+static const char* XSD_MAX_INCLUSIVE_STR("MaxInclusive");
+static const char* XSD_MIN_EXCLUSIVE_STR("MinExclusive");
+static const char* XSD_MAX_EXCLUSIVE_STR("MaxExclusive");
+static const char* XSD_MIN_LENGTH_STR("MinLength");
+static const char* XSD_MAX_LENGTH_STR("MaxLength");
+static const char* XSD_PATTERN_STR("Pattern");
+static const char* XSD_RESTRICTION_STR("Restriction");
+static const char* XSD_SCHEMA_STR("Schema");
+static const char* XSD_SELECTOR_STR("Selector");
+static const char* XSD_SEQUENCE_STR("Sequence");
+static const char* XSD_SIMPLE_CONTENT_STR("SimpleContent");
+static const char* XSD_SIMPLE_TYPE_STR("SimpleType");
+static const char* XSD_SIMPLE_TYPE_ARRAY_STR("SimpleTypeArray");
+static const char* XSD_TOTAL_DIGITS_STR("TotalDigits");
+static const char* XSD_UNIQUE_STR("Unique");
+static const char* XSD_UNIQUE_ARRAY_STR("UniqueArray");
+static const char* XSD_WHITE_SPACE_STR("WhiteSpace");
+static const char* XSD_DT_NORMALIZED_STRING_STR("NormalizedString");
+static const char* XSD_DT_STRING_STR("String");
+static const char* XSD_DT_TOKEN_STR("Token");
+static const char* XSD_DT_DATE_STR("Date");
+static const char* XSD_DT_TIME_STR("Time");
+static const char* XSD_DT_DATE_TIME_STR("DateTime");
+static const char* XSD_DT_DECIMAL_STR("Decimal");
+static const char* XSD_DT_INTEGER_STR("Integer");
+static const char* XSD_DT_INT_STR("Int");
+static const char* XSD_DT_LONG_STR("Long");
+static const char* XSD_DT_NON_NEG_INTEGER_STR("NonNegativeInteger");
+static const char* XSD_DT_NON_POS_INTEGER_STR("NonPositiveInteger");
+static const char* XSD_DT_POS_INTEGER_STR("PositiveInteger");
+static const char* XSD_DT_NEG_INTEGER_STR("NegativeInteger");
+static const char* XSD_DT_BOOLEAN_STR("Boolean");
+
+static const char* XML_ENV_VALUE_OPTIONAL("optional");
+static const char* XML_ENV_VALUE_REQUIRED("required");
+
+static const char* XML_ATTR_DEFAULT("@default");
+static const char* XML_ATTR_USE("@use");
+static const char* XML_ATTR_MINOCCURS("@minOccurs");
+static const char* XML_ATTR_BASE("@base");
+static const char* XML_ATTR_XPATH("@xpath");
+static const char* XML_ATTR_REFER("@refer");
+
+static const char* TAG_VIEWCHILDNODES("viewChildNodes");
+static const char* TAG_VIEWTYPE("viewType");
+static const char* TAG_TOOLTIP("tooltip");
+static const char* TAG_COLINDEX("colIndex");
+static const char* TAG_TITLE("title");
+static const char* TAG_WIDTH("width");
+//static const char* TAG_TOOLTIP("tooltip");
+static const char* TAG_AUTOGENWIZARD("autogenforwizard");
+static const char* TAG_AUTOGENDEFAULTVALUE("autogendefaultvalue");
+static const char* TAG_AUTOGENDEFAULTVALUEFORMULTINODE("autogendefaultformultinode");
+static const char* TAG_XPATH("xpath");
+static const char* TAG_DOC_ID("docid");
+static const char* TAG_DOC_USE_LINE_BREAK("docuselinebreak");
+static const char* TAG_UNBOUNDED("unbounded");
+
+#define TAG_OPTIONAL                    "optional"
+#define TAG_REQUIRED                    "required"
+#define XML_ATTR_ATTRIBUTEFORMDEFAULT  "@attributeFormDefault"
+#define XML_ATTR_ELEMENTFORMDEFAULT    "@elementFormDefault"
+#define XML_ATTR_ID                    "@id"
+#define XML_ATTR_REF                   "@ref"
+#define XML_ATTR_XMLNS_XS              "@xmlns:xs"
+#define XML_ATTR_SCHEMA_LOCATION       "@schemaLocation"
+#define XML_ATTR_VALUE                 "@value"
+#define XML_ATTR_OVERIDE               "@overide"
+#define XML_ATTR_DEPLOYABLE            "@deployable"
+
+static unsigned int STANDARD_OFFSET_1 = 3;
+static unsigned int STANDARD_OFFSET_2 = 6;
+
+static void QuickOutPad(std::ostream& cout, unsigned int offset)
+{
+    while(offset > 0)
+    {
+        cout << " ";
+        offset--;
+    }
+}
+
+static void QuickOutHeader(std::ostream &cout, const char* pLabel, unsigned int offset = 0)
+{
+    QuickOutPad(cout,offset);
+    cout << "\033[32m-- " << pLabel << " START" << " --" << "\033[0m" << std::endl;
+}
+
+static void QuickOutFooter(std::ostream &cout, const char* pLabel, unsigned int offset = 0)
+{
+    QuickOutPad(cout,offset);
+    //cout << "<--- FINISH " << pLabel << std::endl;
+    cout << "\033[31m" << "-- " << pLabel << " FINISH" << " --" << "\033[0m" << std::endl;
+}
+
+static void QuickOut(std::ostream &cout, const char* pLabel, const char* pValue, unsigned int offset = 0)
+{
+    if (pLabel && strlen(pValue) > 0)
+    {
+        QuickOutPad(cout,offset+STANDARD_OFFSET_2);
+        cout << "\033[34m" << pLabel << ":\t\033[0m" << "\033[34m'\033[0m" << pValue << "\033[34m'" << "\033[0m" << std::endl;
+    }
+}
+
+static void QuickOut(std::ostream &cout, const char* pLabel, int value, unsigned int offset = 0)
+{
+    QuickOutPad(cout,offset);
+    cout << pLabel << ": " << value << std::endl;
+}
+
+class InterfaceImpl : public IInterface
+{
+public:
+
+    InterfaceImpl()
+    {
+        atomic_set(&xxcount, 1);
+    }
+
+    virtual void Link() const
+    {
+        atomic_inc(&xxcount);
+    }
+
+    virtual bool Release() const
+    {
+        if (atomic_dec_and_test(&xxcount))
+        {
+           delete this;
+           return true;
+        }
+
+        return false;
+    }
+
+    int getLinkCount() const
+    {
+        return xxcount.counter;
+    }
+
+private:
+
+    mutable atomic_t xxcount;
+};
+
+class CXSDNodeBase
+{
+public:
+
+    CXSDNodeBase(CXSDNodeBase* pParentNode = NULL, NODE_TYPES eNodeType = XSD_ERROR);
+
+    virtual ~CXSDNodeBase();
+
+    GETTERSETTER(XSDXPath)
+    GETTERSETTER(EnvXPath)
+    GETTERSETTER(EnvValueFromXML)
+
+    void dumpStdOut() const;
+
+    virtual CXSDNodeBase* getParentNode() const
+    {
+        return m_pParentNode;
+    }
+
+    virtual const CXSDNodeBase* getConstAncestorNode(unsigned iLevel) const;
+    virtual const CXSDNodeBase* getConstParentNode() const
+    {
+        return m_pParentNode;
+    }
+
+    virtual const CXSDNodeBase* getParentNodeByType(NODE_TYPES eNodeType[], const CXSDNodeBase *pParent = NULL, int length = 1) const;
+    virtual const CXSDNodeBase* getParentNodeByType(NODE_TYPES eNodeType, const CXSDNodeBase *pParent = NULL) const;
+    virtual const CXSDNodeBase* getNodeByTypeAndNameAscending(NODE_TYPES eNodeType[], const char *pName, int length = 1) const;
+    virtual const CXSDNodeBase* getNodeByTypeAndNameAscending(NODE_TYPES eNodeType, const char *pName) const
+    {
+        return getNodeByTypeAndNameAscending(&eNodeType, pName);
+    }
+    virtual const CXSDNodeBase* getNodeByTypeAndNameDescending(NODE_TYPES eNodeType[], const char *pName, int length = 1) const;
+    virtual const CXSDNodeBase* getNodeByTypeAndNameDescending(NODE_TYPES eNodeType, const char *pName) const
+    {
+        return getNodeByTypeAndNameDescending(&eNodeType, pName);
+    }
+    void setParentNode(CXSDNodeBase *pParentNode)
+    {
+        if (m_pParentNode == NULL)  // Should only be set once, otherwise it's an external schema and should have parent set
+        {
+            m_pParentNode = pParentNode;
+        }
+    }
+    const char* getNodeTypeStr() const
+    {
+        return m_pNodeType;
+    }
+    virtual NODE_TYPES getNodeType() const
+    {
+        return m_eNodeType;
+    }
+    virtual void dump(std::ostream& cout, unsigned int offset = 0) const = 0;
+
+    virtual const char* getXML(const char* /*pComponent*/)
+    {
+        return NULL;
+    }
+
+    virtual void getDocumentation(StringBuffer &strDoc) const = 0;
+    virtual void getQML(StringBuffer &strQML, int idx = -1) const
+    {
+    }
+    virtual void getQML2(StringBuffer &strQML, int idx = -1) const
+    {
+    }
+
+    virtual void getQML3(StringBuffer &strQML, int idx = -1) const
+    {
+    }
+
+    virtual void populateEnvXPath(StringBuffer strXPath, unsigned int index = 1)
+    {
+    }
+
+    virtual void loadXMLFromEnvXml(const IPropertyTree *pEnvTree)
+    {
+    }
+
+    virtual QML_UI_TYPE getUIType() const
+    {
+        return m_eUIType;
+    }
+
+    virtual void setUIType(QML_UI_TYPE eUI_Type) const
+    {
+        m_eUIType = eUI_Type;
+    }
+
+protected:
+
+    CXSDNodeBase*               m_pParentNode;
+    StringBuffer                m_strXML;
+    NODE_TYPES                  m_eNodeType;
+    char                        m_pNodeType[1024];
+    mutable QML_UI_TYPE                     m_eUIType;
+
+private:
+
+} __attribute__((aligned (32)));
+
+class CXSDNode : public CInterface, public CXSDNodeBase
+{
+public:
+
+    IMPLEMENT_IINTERFACE
+
+    CXSDNode(CXSDNodeBase *pParentNode, NODE_TYPES pNodeType = XSD_ERROR );
+
+    virtual bool checkSelf(NODE_TYPES eNodeType, const char *pName, const char* pCompName) const;
+    virtual const CXSDNodeBase* getParentNodeByType(NODE_TYPES eNodeType) const;
+
+private:
+};
+
+template<class T>
+class CXSDNodeWithRestrictions : public CXSDNode
+{
+
+public:
+
+    CXSDNodeWithRestrictions(CXSDNodeBase* pParentNode, enum NODE_TYPES eNodeType) : CXSDNode::CXSDNode(pParentNode)
+    {
+    }
+
+    static T* load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath)
+    {
+        assert(pSchemaRoot != NULL);
+
+        if (pSchemaRoot == NULL)
+            return NULL;
+
+        T *pT = NULL;
+
+        if (xpath != NULL && *xpath != 0)
+        {
+            IPropertyTree* pTree = pSchemaRoot->queryPropTree(xpath);
+
+            if (pTree == NULL)
+                return NULL;
+
+            pT = new T(pParentNode);
+
+            const char* pValue = pTree->queryProp(XML_ATTR_VALUE);
+
+            if (pValue != NULL && *pValue != 0)
+                pT->setValue(pValue);
+            else
+            {
+                assert(!"No Value set");
+                //TODO: throw? and delete?
+            }
+            pT->setXSDXPath(xpath);
+        }
+        return pT;
+    }
+
+    void dump(std::ostream& cout, unsigned int offset) const
+    {
+        offset += STANDARD_OFFSET_1;
+
+        QuickOutHeader(cout, XSD_MIN_INCLUSIVE_STR, offset);
+        QUICK_OUT(cout, Value, offset);
+        QuickOutFooter(cout, XSD_MIN_INCLUSIVE_STR, offset);
+    }
+
+    virtual void getDocumentation(StringBuffer &strDoc) const
+    {
+        UNIMPLEMENTED;
+    }
+
+    void getQML(StringBuffer &strQML, int idx = -1) const
+    {
+        UNIMPLEMENTED;
+    }
+
+    virtual const char* getXML(const char* /*pComponent*/)
+    {
+        UNIMPLEMENTED;
+        return NULL;
+    }
+
+    virtual void populateEnvXPath(StringBuffer strXPath, unsigned int index = 1)
+    {
+        UNIMPLEMENTED;
+    }
+
+    virtual void loadXMLFromEnvXml(const IPropertyTree *pEnvTree)
+    {
+        UNIMPLEMENTED;
+    }
+
+    GETTERSETTER(Value)
+};
+
+class CXSDNodeWithType : public CXSDNode
+{
+    GETTERSETTER(Type)
+
+public:
+
+    CXSDNodeWithType(CXSDNodeBase* pParentNode, enum NODE_TYPES eNodeType) : CXSDNode::CXSDNode(pParentNode, eNodeType), m_pXSDNode(NULL)
+    {
+    }
+
+    void setTypeNode(CXSDNode* pCXSDNode)
+    {
+        m_pXSDNode = pCXSDNode;
+    }
+
+    const CXSDNode* getTypeNode() const
+    {
+        return m_pXSDNode;
+    }
+
+protected:
+
+    CXSDNode *m_pXSDNode;
+};
+
+class CXSDNodeWithBase : public CXSDNode
+{
+    GETTERSETTER(Base)
+
+public:
+
+    CXSDNodeWithBase(CXSDNodeBase* pParentNode, enum NODE_TYPES eNodeType) : CXSDNode::CXSDNode(pParentNode, eNodeType), m_pXSDNode(NULL)
+    {
+    }
+
+    void setBaseNode(CXSDNodeBase* pCXSDNode)
+    {
+        m_pXSDNode = pCXSDNode;
+    }
+
+    const CXSDNodeBase* getBaseNode() const
+    {
+        return m_pXSDNode;
+    }
+
+protected:
+
+    CXSDNodeBase *m_pXSDNode;
+};
+
+class CXSDBuiltInDataType : public CXSDNode
+{
+public:
+
+    static CXSDBuiltInDataType* create(CXSDNodeBase* pParentNode, const char* pNodeType);
+
+    virtual ~CXSDBuiltInDataType();
+
+    virtual void dump(std::ostream& cout, unsigned int offset = 0) const;
+    virtual void getDocumentation(StringBuffer &strDoc) const;
+    virtual bool checkConstraint(const char *pValue) const;
+
+private:
+
+    CXSDBuiltInDataType(CXSDNodeBase* pParentNode = NULL, NODE_TYPES eNodeType = XSD_ERROR);
+    CXSDBuiltInDataType(CXSDNodeBase* pParentNode, const char* pNodeType);
+};
+
+#endif // _SCHEMA_COMMON_HPP_

--- a/configuration/configurator/SchemaComplexContent.cpp
+++ b/configuration/configurator/SchemaComplexContent.cpp
@@ -1,0 +1,80 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include "jptree.hpp"
+#include "XMLTags.h"
+#include "SchemaComplexContent.hpp"
+#include "SchemaExtension.hpp"
+
+CComplexContent* CComplexContent::load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath)
+{
+    assert(pSchemaRoot);
+
+    if (pSchemaRoot == NULL)
+        return NULL;
+
+    StringBuffer strXPathExt(xpath);
+    strXPathExt.append("/").append(XSD_TAG_EXTENSION);
+
+    if (pSchemaRoot->queryPropTree(strXPathExt.str()) == NULL)
+        return NULL;
+
+    CExtension* pExtension = CExtension::load(NULL, pSchemaRoot, strXPathExt.str());
+    CComplexContent *pComplexContent = new CComplexContent(pParentNode, pExtension);
+
+    pComplexContent->setXSDXPath(xpath);
+    assert(pExtension != NULL);
+
+    assert(pComplexContent != NULL);
+    if (pExtension != NULL && pComplexContent != NULL)
+    {
+        SETPARENTNODE(pExtension, pComplexContent);
+        pExtension->initExtension();
+    }
+    return pComplexContent;
+}
+
+void CComplexContent::dump(std::ostream& cout, unsigned int offset) const
+{
+    offset+= STANDARD_OFFSET_1;
+
+    QuickOutHeader(cout, XSD_COMPLEX_CONTENT_STR, offset);
+    QUICK_OUT(cout, XSDXPath,  offset);
+
+    if (m_pExtension != NULL)
+        m_pExtension->dump(cout, offset);
+
+    QuickOutFooter(cout, XSD_COMPLEX_CONTENT_STR, offset);
+}
+
+
+void CComplexContent::getDocumentation(StringBuffer &strDoc) const
+{
+    return;
+}
+
+void CComplexContent::getQML(StringBuffer &strQML, int idx) const
+{
+}
+
+const char* CComplexContent::getXML(const char* /*pComponent*/)
+{
+    if (m_strXML.length() == 0 && m_pExtension != NULL)
+        m_strXML.append(m_pExtension->getXML(NULL));
+
+    return m_strXML.str();
+}

--- a/configuration/configurator/SchemaComplexContent.hpp
+++ b/configuration/configurator/SchemaComplexContent.hpp
@@ -1,0 +1,56 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef _SCHEMA_COMPLEX_CONTENT_HPP_
+#define _SCHEMA_COMPLEX_CONTENT_HPP_
+
+#include "SchemaCommon.hpp"
+
+class IPropertyTree;
+class CExtension;
+
+class CComplexContent : public CXSDNode
+{
+public:
+
+    virtual ~CComplexContent()
+    {
+    }
+
+    virtual void dump(std::ostream& cout, unsigned int offset = 0) const;
+    virtual void getDocumentation(StringBuffer &strDoc) const;
+    virtual void getQML(StringBuffer &strQML, int idx = -1) const;
+    virtual const char* getXML(const char* /*pComponent*/);
+
+    static CComplexContent* load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath = NULL);
+
+protected:
+
+    CComplexContent(CXSDNodeBase* pParentNode, CExtension *pExtension = NULL) : CXSDNode::CXSDNode(pParentNode, XSD_COMPLEX_CONTENT), m_pExtension(pExtension)
+    {
+    }
+
+    CExtension *m_pExtension;
+
+private:
+
+    CComplexContent(CXSDNodeBase* pParentNode = NULL) : CXSDNode::CXSDNode(pParentNode, XSD_COMPLEX_CONTENT)
+    {
+    }
+};
+
+#endif // _SCHEMA_COMPLEX_CONTENT_HPP_

--- a/configuration/configurator/SchemaComplexType.cpp
+++ b/configuration/configurator/SchemaComplexType.cpp
@@ -1,0 +1,489 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include <cassert>
+#include "jstring.hpp"
+#include "jptree.hpp"
+#include "XMLTags.h"
+#include "SchemaComplexType.hpp"
+#include "SchemaSequence.hpp"
+#include "SchemaComplexContent.hpp"
+#include "SchemaAttributes.hpp"
+#include "SchemaChoice.hpp"
+#include "SchemaComplexType.hpp"
+#include "SchemaSchema.hpp"
+#include "ConfigSchemaHelper.hpp"
+#include "DocumentationMarkup.hpp"
+#include "ExceptionStrings.hpp"
+#include "SchemaMapManager.hpp"
+#include "QMLMarkup.hpp"
+
+const CXSDNodeBase* CComplexType::getNodeByTypeAndNameAscending(NODE_TYPES eNodeType, const char *pName) const
+{
+    const CXSDNodeBase* pMatchingNode = NULL;
+
+    if (eNodeType == this->getNodeType() && (pName != NULL ? !strcmp(pName, this->getNodeTypeStr()) : true))
+        return this;
+
+    if (m_pSequence != NULL)
+        pMatchingNode =  m_pSequence->getNodeByTypeAndNameAscending(eNodeType, pName);
+
+    return pMatchingNode;
+}
+
+const CXSDNodeBase* CComplexType::getNodeByTypeAndNameDescending(NODE_TYPES eNodeType, const char *pName) const
+{
+    const CXSDNodeBase* pMatchingNode = NULL;
+
+    if (eNodeType == this->getNodeType() && (pName != NULL ? !strcmp(pName, this->getNodeTypeStr()) : true))
+        return this;
+
+    if (m_pSequence != NULL)
+        pMatchingNode = m_pSequence->getNodeByTypeAndNameDescending(eNodeType, pName);
+    if (pMatchingNode == NULL && m_pSequence != NULL)
+        pMatchingNode = m_pComplexContent->getNodeByTypeAndNameDescending(eNodeType, pName);
+    if (pMatchingNode == NULL && m_pAttributeArray != NULL)
+        pMatchingNode = m_pSequence->getNodeByTypeAndNameDescending(eNodeType, pName);
+    if (pMatchingNode == NULL && m_pChoice != NULL)
+        pMatchingNode = m_pSequence->getNodeByTypeAndNameDescending(eNodeType, pName);
+
+    return pMatchingNode;
+}
+
+void CComplexType::dump(std::ostream& cout, unsigned int offset) const
+{
+    offset+= STANDARD_OFFSET_1;
+    QuickOutHeader(cout, XSD_COMPLEX_TYPE_STR, offset);
+
+    QUICK_OUT_2(Name)
+    QUICK_OUT(cout, XSDXPath,   offset);
+
+    if (m_pSequence != NULL)
+        m_pSequence->dump(cout, offset);
+    if (m_pComplexContent != NULL)
+        m_pComplexContent->dump(cout, offset);
+    if (m_pAttributeArray != NULL)
+        m_pAttributeArray->dump(cout, offset);
+    if (m_pChoice != NULL)
+        m_pChoice->dump(cout, offset);
+    if (m_pAttributeGroupArray != NULL)
+        m_pAttributeGroupArray->dump(cout, offset);
+    if (m_pAnnotation != NULL)
+        m_pAnnotation->dump(cout, offset);
+
+    QuickOutFooter(cout, XSD_COMPLEX_TYPE_STR, offset);
+}
+
+void CComplexType::getDocumentation(StringBuffer &strDoc) const
+{
+    if (m_pSequence != NULL)
+        m_pSequence->getDocumentation(strDoc);
+
+    if (m_pComplexContent != NULL)
+        strDoc.append(DM_SECT3_BEGIN);
+        DEBUG_MARK_STRDOC
+        m_pComplexContent->getDocumentation(strDoc);
+        strDoc.append(DM_SECT3_END);
+
+    if (m_pAttributeArray != NULL)
+    {
+        if (this->getConstParentNode()->getConstParentNode()->getNodeType() == XSD_SCHEMA)
+            strDoc.appendf("<%s>\n", DM_TABLE_ROW);
+
+        m_pAttributeArray->getDocumentation(strDoc);
+
+        if (this->getConstParentNode()->getConstParentNode()->getNodeType() == XSD_SCHEMA)
+            strDoc.appendf("</%s>\n", DM_TABLE_ROW);
+    }
+
+    if (m_pChoice != NULL)
+        m_pChoice->getDocumentation(strDoc);
+    if (m_pAttributeGroupArray != NULL)
+        m_pAttributeGroupArray->getDocumentation(strDoc);
+}
+
+void CComplexType::getQML(StringBuffer &strQML, int idx) const
+{
+    if (m_pSequence != NULL)
+        m_pSequence->getQML(strQML);
+    if (m_pComplexContent != NULL)
+        m_pComplexContent->getQML(strQML);
+    if (m_pAttributeArray != NULL)
+    {
+        if (this->getUIType() == QML_UI_TABLE)
+        {
+            DEBUG_MARK_QML;
+            m_pAttributeArray->setUIType(QML_UI_TABLE_CONTENTS);
+            DEBUG_MARK_QML;
+        }
+        m_pAttributeArray->getQML(strQML);
+
+        if (this->getUIType() == QML_UI_TABLE)
+        {
+            DEBUG_MARK_QML;
+            strQML.append(QML_TABLE_VIEW_END);
+            DEBUG_MARK_QML;
+        }
+    }
+    if (m_pChoice != NULL)
+        m_pChoice->getQML(strQML);
+}
+
+void CComplexType::getQML2(StringBuffer &strQML, int idx) const
+{
+    if (this->getParentNode()->getUIType() == QML_UI_TABLE)
+    {
+        DEBUG_MARK_QML2(this);
+        this->setUIType(QML_UI_TABLE);
+
+        if (m_pAttributeArray != NULL && m_pAttributeArray->length() > 0)
+        {
+            DEBUG_MARK_QML;
+            m_pAttributeArray->getQML2(strQML);
+            DEBUG_MARK_QML;
+        }
+    }
+    else if (this->getParentNode()->getUIType() == QML_UI_TAB)
+    {
+        DEBUG_MARK_QML2(this);
+        this->setUIType(QML_UI_TAB);
+
+        if (m_pSequence != NULL)
+        {
+            DEBUG_MARK_QML2(this);
+            m_pSequence->getQML2(strQML);
+            DEBUG_MARK_QML2(this);
+        }
+        DEBUG_MARK_QML2(this);
+
+        if (m_pAttributeArray != NULL && m_pAttributeArray->length() > 0)
+        {
+            DEBUG_MARK_QML;
+            m_pAttributeArray->getQML2(strQML);
+            DEBUG_MARK_QML;
+        }
+        DEBUG_MARK_QML2(this);
+    }
+    else
+        assert(!"what am i?");
+}
+void CComplexType::getQML3(StringBuffer &strQML, int idx) const
+{
+    if (m_pAttributeArray != NULL && m_pAttributeArray->length() > 0)
+    {
+        DEBUG_MARK_QML;
+        if( m_pSequence == NULL && m_pAttributeGroupArray  == NULL)
+        {
+            m_pAttributeArray->setUIType(this->getUIType());
+            m_pAttributeArray->getQML3(strQML);
+        } 
+        else 
+        {
+            CQMLMarkupHelper::buildAccordionStart(strQML, "Attributes");
+            m_pAttributeArray->setUIType(this->getUIType());
+            m_pAttributeArray->getQML3(strQML);
+            strQML.append(QML_DOUBLE_END_BRACKET);
+        }
+        DEBUG_MARK_QML;
+    }
+    if (m_pSequence != NULL)
+    {
+        DEBUG_MARK_QML;
+        m_pSequence->getQML3(strQML);
+        DEBUG_MARK_QML;
+    }
+    if(m_pAttributeGroupArray != NULL)
+    {
+        DEBUG_MARK_QML;
+        m_pAttributeGroupArray->getQML3(strQML);
+        DEBUG_MARK_QML;
+    }
+    
+}
+
+void CComplexType::populateEnvXPath(StringBuffer strXPath, unsigned int index)
+{
+    this->setEnvXPath(strXPath);
+
+    if (m_pSequence != NULL)
+        m_pSequence->populateEnvXPath(strXPath, index);
+    if (m_pComplexContent != NULL)
+        m_pComplexContent->populateEnvXPath(strXPath, index);
+    if (m_pAttributeArray != NULL)
+        m_pAttributeArray->populateEnvXPath(strXPath, index);
+    if (m_pChoice != NULL)
+        m_pChoice->populateEnvXPath(strXPath, index);
+    if (m_pAttributeGroupArray != NULL)
+        m_pAttributeGroupArray->populateEnvXPath(strXPath, index);
+}
+
+void CComplexType::loadXMLFromEnvXml(const IPropertyTree *pEnvTree)
+{
+    if (m_pSequence != NULL)
+        m_pSequence->loadXMLFromEnvXml(pEnvTree);
+    if (m_pComplexContent != NULL)
+        m_pComplexContent->loadXMLFromEnvXml(pEnvTree);
+    if (m_pAttributeArray != NULL)
+        m_pAttributeArray->loadXMLFromEnvXml(pEnvTree);
+    if (m_pChoice != NULL)
+        m_pChoice->loadXMLFromEnvXml(pEnvTree);
+    if (m_pAttributeGroupArray != NULL)
+        m_pAttributeGroupArray->loadXMLFromEnvXml(pEnvTree);
+}
+
+const char* CComplexType::getXML(const char* /*pComponent*/)
+{
+    if (m_strXML.length() == 0)
+    {
+        if (m_pComplexContent != NULL)
+            m_strXML.append(m_pComplexContent->getXML(NULL));
+        if (m_pAttributeArray != NULL)
+            m_strXML.append(m_pAttributeArray->getXML(NULL));
+        if (m_pChoice != NULL)
+            m_strXML.append(m_pChoice->getXML(NULL));
+    }
+    return m_strXML.str();
+}
+
+bool CComplexType::hasChildElements() const
+{
+    if (this->m_pSequence != NULL)
+        return m_pSequence->hasChildElements();
+
+    return false;
+}
+
+CComplexType* CComplexType::load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath)
+{
+    assert(pSchemaRoot != NULL);
+
+    CComplexContent *pComplexContent = NULL;
+    CAttributeArray *pAttributeArray =  NULL;
+    CChoice *pChoice = NULL;
+    CElementArray *pElementArray = NULL;
+    CSequence *pSequence  = NULL;
+    CAttributeGroupArray *pAttributeGroupArray = NULL;
+    CAnnotation *pAnnotation = NULL;
+
+    if (pSchemaRoot == NULL)
+        return NULL;
+
+    IPropertyTree *pTree = pSchemaRoot->queryPropTree(xpath);
+    const char* pName = pTree->queryProp(XML_ATTR_NAME);
+    StringBuffer strXPathExt(xpath);
+
+    StringBuffer strXPathExt2(strXPathExt);
+    strXPathExt2.append("*");
+
+    Owned<IPropertyTreeIterator> iter = pSchemaRoot->getElements(strXPathExt2.str());
+
+    strXPathExt.clear().append(xpath).append("/").append(XSD_TAG_SEQUENCE);
+    pSequence = CSequence::load(NULL, pSchemaRoot, strXPathExt.str());
+
+    strXPathExt.clear().append(xpath).append("/").append(XSD_TAG_ANNOTATION);
+    pAnnotation = CAnnotation::load(NULL, pSchemaRoot, strXPathExt.str());
+
+    strXPathExt.clear().append(xpath).append("/").append(XSD_TAG_COMPLEX_CONTENT);
+    pComplexContent = CComplexContent::load(NULL, pSchemaRoot, strXPathExt.str());
+
+    strXPathExt.clear().append(xpath).append("/").append(XSD_TAG_ATTRIBUTE);
+    pAttributeArray = CAttributeArray::load(NULL, pSchemaRoot, strXPathExt.str());
+
+    strXPathExt.clear().append(xpath).append("/").append(XSD_TAG_CHOICE);
+    pChoice = CChoice::load(NULL, pSchemaRoot, strXPathExt.str());
+
+    strXPathExt.clear().append(xpath).append("/").append(XSD_TAG_ATTRIBUTE_GROUP);
+    pAttributeGroupArray = CAttributeGroupArray::load(NULL, pSchemaRoot, strXPathExt.str());
+
+    CComplexType *pComplexType = new CComplexType(pParentNode, pName, pSequence, pComplexContent, pAttributeArray, pChoice, pAttributeGroupArray, pAnnotation);
+    pComplexType->setXSDXPath(xpath);
+
+    assert(pComplexType != NULL);
+
+    if (pComplexType != NULL)
+    {
+        SETPARENTNODE(pSequence, pComplexType)
+        SETPARENTNODE(pComplexContent, pComplexType)
+        SETPARENTNODE(pAttributeArray, pComplexType)
+        SETPARENTNODE(pChoice, pComplexType)
+        SETPARENTNODE(pAttributeGroupArray, pComplexType)
+        SETPARENTNODE(pAnnotation, pComplexType);
+
+        if (pName != NULL)
+            CConfigSchemaHelper::getInstance()->getSchemaMapManager()->setComplexTypeWithName(pName, pComplexType);
+    }
+    return pComplexType;
+}
+
+void CComplexTypeArray::dump(std::ostream& cout, unsigned int offset) const
+{
+    offset+= STANDARD_OFFSET_1;
+
+    QuickOutHeader(cout, XSD_COMPLEX_TYPE_ARRAY_STR, offset);
+
+    QUICK_OUT(cout, XSDXPath,   offset);
+    QUICK_OUT_ARRAY(cout, offset);
+
+    QuickOutFooter(cout, XSD_COMPLEX_TYPE_ARRAY_STR, offset);
+}
+
+void CComplexTypeArray::getDocumentation(StringBuffer &strDoc) const
+{
+    QUICK_DOC_ARRAY(strDoc);
+}
+
+void CComplexTypeArray::getQML(StringBuffer &strQML, int idx) const
+{
+   QUICK_QML_ARRAY(strQML);
+}
+
+void CComplexTypeArray::getQML2(StringBuffer &strQML, int idx) const
+{
+    if (this->getParentNode()->getUIType() == QML_UI_TAB)
+    {
+        DEBUG_MARK_QML;
+        this->setUIType(QML_UI_TAB);
+    }
+    else if (this->getParentNode()->getUIType() == QML_UI_TABLE)
+    {
+        this->setUIType(QML_UI_TABLE);
+        DEBUG_MARK_QML;
+    }
+    else
+        assert(!"what am i?");
+
+    DEBUG_MARK_QML;
+
+    for (int idx=0; idx < this->length(); idx++)
+    {
+        DEBUG_MARK_QML;
+        (this->item(idx)).getQML2(strQML);
+        DEBUG_MARK_QML;
+    }
+}
+void CComplexTypeArray::getQML3(StringBuffer &strQML, int idx) const
+{
+    for (int idx=0; idx < this->length(); idx++)
+    {
+        DEBUG_MARK_QML;
+        (this->item(idx)).setUIType(this->getUIType());
+        (this->item(idx)).getQML3(strQML);
+        DEBUG_MARK_QML;
+    }
+}
+
+const char* CComplexTypeArray::getXML(const char* /*pComponent*/)
+{
+    if (m_strXML.length() == 0)
+    {
+        int length = this->length();
+
+        for (int idx = 0; idx < length; idx++)
+        {
+            CComplexType &ComplexType = this->item(idx);
+
+            m_strXML.append(ComplexType.getXML(NULL));
+
+            if (idx+1 < length)
+                m_strXML.append("\n");
+        }
+    }
+    return m_strXML.str();
+}
+
+void CComplexTypeArray::populateEnvXPath(StringBuffer strXPath, unsigned int index)
+{
+    this->setEnvXPath(strXPath);
+    QUICK_ENV_XPATH_WITH_INDEX(strXPath, index)
+}
+
+void CComplexTypeArray::loadXMLFromEnvXml(const IPropertyTree *pEnvTree)
+{
+    assert(pEnvTree != NULL);
+    if (pEnvTree->hasProp(this->getEnvXPath()) == false)
+        throw MakeExceptionFromMap(EX_STR_XPATH_DOES_NOT_EXIST_IN_TREE);
+    else
+        QUICK_LOAD_ENV_XML(pEnvTree);
+}
+
+CComplexTypeArray* CComplexTypeArray::load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath)
+{
+    assert(pSchemaRoot != NULL);
+
+    if (pSchemaRoot == NULL)
+        return NULL;
+
+    CComplexTypeArray *pComplexTypeArray = new CComplexTypeArray(pParentNode);
+
+    pComplexTypeArray->setXSDXPath(xpath);
+
+    Owned<IPropertyTreeIterator> complexTypeIter = pSchemaRoot->getElements(xpath);
+
+    int count = 1;
+
+    ForEach(*complexTypeIter)
+    {
+        StringBuffer strXPathExt(xpath);
+        strXPathExt.appendf("[%d]", count);
+
+        CComplexType *pComplexType = CComplexType::load(pComplexTypeArray, pSchemaRoot, strXPathExt.str());
+
+        assert(pComplexType != NULL);
+
+        if (pComplexType != NULL)
+            pComplexTypeArray->append(*pComplexType);
+
+        count++;
+    }
+
+    if (pComplexTypeArray->length() == 0)
+    {
+        delete pComplexTypeArray;
+        pComplexTypeArray = NULL;
+    }
+
+    return pComplexTypeArray;
+}
+
+CComplexTypeArray* CComplexTypeArray::load(CXSDNodeBase* pParentNode, const char* pSchemaFile)
+{
+    assert(false);  // why do still need to call this?
+    assert(pSchemaFile != NULL);
+
+    if (pSchemaFile == NULL)
+        return NULL;
+
+    if (pParentNode == NULL)
+    {
+        Linked<IPropertyTree> pSchemaRoot;
+
+        StringBuffer schemaPath;
+
+        schemaPath.appendf("%s%s", DEFAULT_SCHEMA_DIRECTORY, pSchemaFile);
+        pSchemaRoot.setown(createPTreeFromXMLFile(schemaPath.str()));
+
+        return CComplexTypeArray::load(pParentNode, pSchemaRoot, XSD_TAG_COMPLEX_TYPE);
+    }
+    else
+    {
+        CSchema *pSchema = (dynamic_cast<CSchema*>(pParentNode));
+
+        if (pSchema != NULL)
+            return pSchema->getComplexTypeArray();
+    }
+    return NULL;
+}

--- a/configuration/configurator/SchemaComplexType.hpp
+++ b/configuration/configurator/SchemaComplexType.hpp
@@ -1,0 +1,131 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef _SCHEMA_COMPLEX_TYPE_HPP
+#define _SCHEMA_COMPLEX_TYPE_HPP
+
+#include "SchemaCommon.hpp"
+#include "jarray.hpp"
+
+class CSequence;
+class CComplexContent;
+class CAttributeArray;
+class IPropertyTree;
+class CChoice;
+class CComplexType;
+class CAttributeGroupArray;
+class CAnnotation;
+
+class CComplexType : public CXSDNode
+{
+public:
+
+    virtual ~CComplexType()
+    {
+    }
+
+    GETTERSETTER(Name)
+
+    virtual const CXSDNodeBase* getNodeByTypeAndNameDescending(NODE_TYPES eNodeType, const char *pName) const;
+    virtual const CXSDNodeBase* getNodeByTypeAndNameAscending(NODE_TYPES eNodeType, const char *pName) const;
+
+    virtual void dump(std::ostream& cout, unsigned int offset = 0) const;
+    virtual void getDocumentation(StringBuffer &strDoc) const;
+    virtual void getQML(StringBuffer &strQML, int idx = -1) const;
+    virtual void getQML2(StringBuffer &strQML, int idx = -1) const;
+    virtual void getQML3(StringBuffer &strQML, int idx = -1) const;
+    virtual void populateEnvXPath(StringBuffer strXPath, unsigned int index = 1);
+    virtual void loadXMLFromEnvXml(const IPropertyTree *pEnvTree);
+    virtual const char* getXML(const char* /*pComponent*/);
+
+    virtual const CAttributeArray* getAttributeArray() const
+    {
+        return m_pAttributeArray;
+    }
+
+    virtual const CAttributeGroupArray* getAttributeGroupArray() const
+    {
+        return m_pAttributeGroupArray;
+    }
+
+    virtual const CSequence* getSequence() const
+    {
+        return m_pSequence;
+    }
+
+    virtual CAnnotation* getAnnotation() const
+    {
+        return m_pAnnotation;
+    }
+
+    bool hasChildElements() const;
+
+    static CComplexType* load(CXSDNodeBase* pRootNode, const IPropertyTree *pSchemaRoot, const char* xpath = NULL);
+
+protected:
+
+    CComplexType(CXSDNodeBase* pParentNode, const char* pName = NULL, CSequence *pSequence = NULL, CComplexContent *pComplexContent = NULL, CAttributeArray *pAttributeArray = NULL, \
+        CChoice *pChoice = NULL, CAttributeGroupArray *pAttributeGroupArray = NULL, CAnnotation *pAnnotation = NULL) : CXSDNode::CXSDNode(pParentNode, XSD_COMPLEX_TYPE), \
+        m_strName(pName), m_pSequence(pSequence), m_pComplexContent(pComplexContent), m_pAttributeArray(pAttributeArray), m_pChoice(pChoice), \
+        m_pAttributeGroupArray(pAttributeGroupArray), m_pAnnotation(pAnnotation)
+    {
+    }
+
+    CSequence*              m_pSequence;
+    CComplexContent*        m_pComplexContent;
+    CAttributeArray*        m_pAttributeArray;
+    CChoice*                m_pChoice;
+    CAttributeGroupArray*   m_pAttributeGroupArray;
+    CAnnotation*            m_pAnnotation;
+
+private:
+
+    CComplexType() : CXSDNode::CXSDNode(NULL)
+    {
+    }
+
+};
+
+class CComplexTypeArray : public CIArrayOf<CComplexType>, public InterfaceImpl, public CXSDNodeBase
+{
+public:
+
+    CComplexTypeArray(CXSDNodeBase* pParentNode = NULL) : CXSDNodeBase::CXSDNodeBase(pParentNode, XSD_COMPLEX_TYPE_ARRAY)
+    {
+    }
+
+    virtual ~CComplexTypeArray()
+    {
+    }
+
+    virtual void dump(std::ostream& cout, unsigned int offset = 0) const;
+    virtual void getDocumentation(StringBuffer &strDoc) const;
+    virtual void getQML(StringBuffer &strQML, int idx = -1) const;
+    virtual void getQML2(StringBuffer &strQML, int idx = -1) const;
+    virtual void getQML3(StringBuffer &strQML, int idx = -1) const;
+    virtual void populateEnvXPath(StringBuffer strXPath, unsigned int index = 1);
+    virtual void loadXMLFromEnvXml(const IPropertyTree *pEnvTree);
+    virtual const char* getXML(const char* /*pComponent*/);
+
+    static CComplexTypeArray* load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath = NULL);
+    static CComplexTypeArray* load(CXSDNodeBase* pParentNode, const char* pSchemaFile);
+
+protected:
+private:
+};
+
+#endif // _SCHEMA_COMPLEX_TYPE_HPP

--- a/configuration/configurator/SchemaDocumentation.cpp
+++ b/configuration/configurator/SchemaDocumentation.cpp
@@ -1,0 +1,54 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include "jptree.hpp"
+#include "jstring.hpp"
+#include "SchemaDocumentation.hpp"
+#include "DocumentationMarkup.hpp"
+
+void CDocumentation::dump(std::ostream& cout, unsigned int offset) const
+{
+    offset+= STANDARD_OFFSET_1;
+
+    QuickOutHeader(cout, XSD_DOCUMENTATION_STR, offset);
+    QUICK_OUT(cout, XSDXPath,  offset);
+    QUICK_OUT(cout,Documentation, offset);
+    QuickOutFooter(cout, XSD_DOCUMENTATION_STR, offset);
+}
+
+CDocumentation* CDocumentation::load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath)
+{
+    if (pSchemaRoot == NULL)
+        return NULL;
+    if (pSchemaRoot->queryPropTree(xpath) == NULL)
+        return NULL; // no documentation node
+
+    StringBuffer strDoc;
+
+    if (xpath && *xpath)
+        strDoc.append(pSchemaRoot->queryPropTree(xpath)->queryProp(""));
+
+    CDocumentation *pDocumentation = new CDocumentation(pParentNode, strDoc.str());
+    pDocumentation->setXSDXPath(xpath);
+
+    return pDocumentation;
+}
+
+void  CDocumentation::getDocumentation(StringBuffer &strDoc) const
+{
+    strDoc.appendf("%s%s%s", DM_PARA_BEGIN, this->getDocString(), DM_PARA_END);
+}

--- a/configuration/configurator/SchemaDocumentation.hpp
+++ b/configuration/configurator/SchemaDocumentation.hpp
@@ -1,0 +1,58 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef _SCHEMA_DOCUMENATION_HPP_
+#define _SCHEMA_DOCUMENATION_HPP_
+
+#include "jiface.hpp"
+#include "jstring.hpp"
+#include "SchemaCommon.hpp"
+
+class CDocumentation : public CXSDNode
+{
+public:
+
+    virtual ~CDocumentation()
+    {
+    }
+
+    GETTERSETTER(DocString)
+
+    const char* getDocumentation() const
+    {
+        return m_strDocString.str();
+    }
+
+    virtual void dump(std::ostream& cout, unsigned int offset = 0) const;
+    virtual void getDocumentation(StringBuffer &strDoc) const;
+
+    static CDocumentation* load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath = NULL);
+
+protected:
+
+    CDocumentation(CXSDNodeBase* pParentNode, const char *pDocs = NULL) : CXSDNode::CXSDNode(pParentNode, XSD_DOCUMENTATION), m_strDocString(pDocs)
+    {
+    }
+
+private:
+
+    CDocumentation() : CXSDNode::CXSDNode(NULL, XSD_DOCUMENTATION)
+    {
+    }
+};
+
+#endif // _SCHEMA_DOCUMENATION_HPP_

--- a/configuration/configurator/SchemaElement.cpp
+++ b/configuration/configurator/SchemaElement.cpp
@@ -1,0 +1,1118 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include <cassert>
+#include "jptree.hpp"
+#include "jstring.hpp"
+#include "jarray.hpp"
+#include "jhash.hpp"
+#include "XMLTags.h"
+#include "SchemaAnnotation.hpp"
+#include "SchemaCommon.hpp"
+#include "SchemaElement.hpp"
+#include "SchemaComplexType.hpp"
+#include "SchemaElement.hpp"
+#include "SchemaAttributes.hpp"
+#include "SchemaAppInfo.hpp"
+#include "SchemaDocumentation.hpp"
+#include "DocumentationMarkup.hpp"
+#include "ConfigSchemaHelper.hpp"
+#include "ConfigSchemaHelper.hpp"
+#include "QMLMarkup.hpp"
+#include "SchemaMapManager.hpp"
+#include "ConfiguratorMain.hpp"
+
+const CXSDNodeBase* CElement::getNodeByTypeAndNameAscending(NODE_TYPES eNodeType, const char *pName) const
+{
+    const CXSDNodeBase* pMatchingNode = NULL;
+
+    if (eNodeType == this->getNodeType() && (pName != NULL ? !strcmp(pName, this->getNodeTypeStr()) : true))
+        return this;
+
+    if (eNodeType == XSD_ELEMENT)
+        pMatchingNode = (dynamic_cast<CElement*>(this->getParentNode()))->getNodeByTypeAndNameAscending(XSD_ELEMENT, pName);
+    if (pMatchingNode == NULL)
+        pMatchingNode = (dynamic_cast<CElementArray*>(this->getParentNode()))->getNodeByTypeAndNameAscending(eNodeType, pName);
+
+    return pMatchingNode;
+}
+
+const CXSDNodeBase* CElement::getNodeByTypeAndNameDescending(NODE_TYPES eNodeType, const char *pName) const
+{
+    const CXSDNodeBase* pMatchingNode = NULL;
+
+    if (eNodeType == this->getNodeType() && (pName != NULL ? !strcmp(pName, this->getNodeTypeStr()) : true))
+        return this;
+    if (m_pComplexTypeArray != NULL)
+        pMatchingNode = m_pComplexTypeArray->getNodeByTypeAndNameDescending(eNodeType, pName);
+
+    return pMatchingNode;
+}
+
+CElement* CElement::load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath, bool bIsInXSD)
+{
+    assert(pSchemaRoot != NULL);
+    assert(pParentNode != NULL);
+
+    if (pSchemaRoot == NULL || pParentNode == NULL)
+        return NULL;
+
+    CElement *pElement = new CElement(pParentNode);
+
+    pElement->setIsInXSD(bIsInXSD);
+    pElement->setXSDXPath(xpath);
+
+    IPropertyTree *pTree = pSchemaRoot->queryPropTree(xpath);
+
+    if (pElement != NULL && pTree != NULL)
+        pElement->setName(pTree->queryProp(XML_ATTR_NAME));
+
+    Owned<IAttributeIterator> iterAttrib = pTree->getAttributes(true);
+
+    ForEach(*iterAttrib)
+    {
+        if (strcmp(iterAttrib->queryName(), XML_ATTR_NAME) == 0)
+        {
+            const char *pName = iterAttrib->queryValue();
+
+            if (pName != NULL && *pName != 0)
+                pElement->setName(pName);
+        }
+        else if (strcmp(iterAttrib->queryName(), XML_ATTR_MAXOCCURS) == 0)
+            pElement->setMaxOccurs(iterAttrib->queryValue());
+        else if (strcmp(iterAttrib->queryName(), XML_ATTR_MINOCCURS) == 0)
+            pElement->setMinOccurs(iterAttrib->queryValue());
+        else if (strcmp(iterAttrib->queryName(), XML_ATTR_TYPE) == 0)
+        {
+            const char *pType = iterAttrib->queryValue();
+
+            assert(pType != NULL && *pType != 0);
+
+            if (pType != NULL && *pType != 0)
+            {
+                pElement->setType(pType);
+                CConfigSchemaHelper::getInstance()->addNodeForTypeProcessing(pElement);
+            }
+        }
+        else if (strcmp(iterAttrib->queryName(), XML_ATTR_REF) == 0)
+        {
+            const char *pRef = iterAttrib->queryValue();
+
+            assert (pRef != NULL && *pRef != 0 && pElement->getConstAncestorNode(2)->getNodeType() != XSD_SCHEMA);
+
+            if (pRef != NULL && *pRef != 0 && pElement->getConstAncestorNode(2)->getNodeType() != XSD_SCHEMA)
+            {
+                pElement->setRef(pRef);
+                CConfigSchemaHelper::getInstance()->addElementForRefProcessing(pElement);
+            }
+            else
+            {
+                // TODO:  throw exception
+            }
+        }
+        assert(iterAttrib->queryValue() != NULL);
+    }
+    assert(strlen(pElement->getName()) > 0);
+
+    StringBuffer strXPathExt(xpath);
+
+    strXPathExt.append("/").append(XSD_TAG_ANNOTATION);
+    pElement->m_pAnnotation = CAnnotation::load(pElement, pSchemaRoot, strXPathExt.str());
+
+    strXPathExt.clear().append(xpath).append("/").append(XSD_TAG_COMPLEX_TYPE);
+    pElement->m_pComplexTypeArray = CComplexTypeArray::load(pElement, pSchemaRoot, strXPathExt.str());
+
+    if (pElement->m_pAnnotation != NULL && pElement->m_pAnnotation->getAppInfo() != NULL && strlen(pElement->m_pAnnotation->getAppInfo()->getTitle()) > 0)
+    {
+        /****  MUST FIX TO HAVE CORRECT UI TAB LABELS (but getName is expected to return the XPATH name *****/
+        //pElement->setName(pElement->m_pAnnotation->getAppInfo()->getTitle());
+        pElement->setTitle(pElement->m_pAnnotation->getAppInfo()->getTitle());
+    }
+    else
+        pElement->setTitle(pElement->getName());
+
+    strXPathExt.clear().append(xpath).append("/").append(XSD_TAG_KEY);
+    pElement->m_pKeyArray = CKeyArray::load(pElement, pSchemaRoot, strXPathExt.str());
+
+    strXPathExt.clear().append(xpath).append("/").append(XSD_TAG_KEYREF);
+    pElement->m_pKeyRefArray = CKeyRefArray::load(pElement, pSchemaRoot, strXPathExt.str());
+
+    strXPathExt.clear().append(xpath).append("/").append(XSD_TAG_SIMPLE_TYPE);
+    pElement->m_pSimpleType = CSimpleType::load(pElement, pSchemaRoot, strXPathExt.str());
+
+    SETPARENTNODE(pElement, pParentNode);
+
+    return pElement;
+}
+
+const CElement* CElement::getTopMostElement(const CXSDNodeBase *pNode)
+{
+    if (pNode == NULL)
+        return NULL;
+    else if (pNode->getNodeType() == XSD_ELEMENT)
+    {
+        if (pNode->getParentNodeByType(XSD_ELEMENT) == NULL)
+        {
+            assert(dynamic_cast<const CElement*>(pNode) != NULL);
+            return dynamic_cast<const CElement*>(pNode);
+        }
+    }
+    return getTopMostElement(pNode->getParentNodeByType(XSD_ELEMENT));
+}
+
+const CSchema* CElement::getConstSchemaNode() const
+{
+    const CSchema *pSchema = dynamic_cast<const CSchema*>(CElement::getTopMostElement(this)->getParentNodeByType(XSD_SCHEMA));
+    return pSchema;
+}
+
+const char* CElement::getXML(const char* /*pComponent*/)
+{
+    if (m_strXML.length () == 0)
+    {
+        m_strXML.append("\n<").append(getName()).append(" ");
+
+        if (m_pAnnotation != NULL)
+            m_strXML.append(m_pAnnotation->getXML(NULL));
+        if (m_pComplexTypeArray != NULL)
+            m_strXML.append(m_pComplexTypeArray->getXML(NULL));
+        if (m_pKeyArray != NULL)
+            m_strXML.append(m_pKeyArray->getXML(NULL));
+        if (m_pKeyRefArray != NULL)
+            m_strXML.append(m_pKeyRefArray->getXML(NULL));
+    }
+    return m_strXML.str();
+}
+
+void CElement::dump(std::ostream &cout, unsigned int offset) const
+{
+    offset += STANDARD_OFFSET_1;
+
+    QuickOutHeader(cout, XSD_ELEMENT_STR, offset);
+    QUICK_OUT(cout, Name, offset);
+    QUICK_OUT(cout, Type, offset);
+    QUICK_OUT(cout, MinOccurs, offset);
+    QUICK_OUT(cout, MaxOccurs, offset);
+    QUICK_OUT(cout, Title,  offset);
+    QUICK_OUT(cout, XSDXPath,  offset);
+    QUICK_OUT(cout, EnvXPath,  offset);
+    QUICK_OUT(cout, EnvValueFromXML,  offset);
+    QUICK_OUT(cout, Ref, offset);
+
+    if (this->getTypeNode() != NULL)
+        this->getTypeNode()->dump(cout, offset);
+    if (m_pAnnotation != NULL)
+        m_pAnnotation->dump(cout, offset);
+    if (m_pComplexTypeArray != NULL)
+        m_pComplexTypeArray->dump(cout, offset);
+    if (m_pKeyArray != NULL)
+        m_pKeyArray->dump(cout, offset);
+    if (m_pKeyRefArray != NULL)
+        m_pKeyRefArray->dump(cout, offset);
+    if (m_pSimpleType != NULL)
+        m_pSimpleType->dump(cout, offset);
+
+    if (this->getRef() != NULL)
+    {
+        CElement *pElement = CConfigSchemaHelper::getInstance()->getSchemaMapManager()->getElementWithName(this->getRef());
+
+        assert(pElement != NULL);
+        if (pElement != NULL)
+            pElement->dump(cout, offset);
+    }
+    QuickOutFooter(cout, XSD_ELEMENT_STR, offset);
+}
+
+void CElement::getDocumentation(StringBuffer &strDoc) const
+{
+    const CXSDNodeBase *pGrandParentNode = this->getConstParentNode()->getConstParentNode();
+
+    assert(pGrandParentNode != NULL);
+    if (pGrandParentNode == NULL)
+        return;
+
+    if (m_pAnnotation != NULL && m_pAnnotation->getAppInfo() != NULL && m_pAnnotation->getAppInfo()->getViewType() != NULL && stricmp(m_pAnnotation->getAppInfo()->getViewType(), "none") == 0)
+        return;
+
+    if (this->getName() != NULL && (stricmp(this->getName(), "Instance") == 0 || stricmp(this->getName(), "Note") == 0 || stricmp(this->getName(), "Notes") == 0 ||  stricmp(this->getName(), "Topology") == 0 ))
+        return; // don't document instance
+
+    assert(strlen(this->getName()) > 0);
+
+    if (pGrandParentNode->getNodeType() == XSD_SCHEMA)
+    {
+        StringBuffer strName(this->getName());
+
+        strName.replace(' ', '_');
+        strDoc.append(DM_HEADING);
+
+        // component name would be here
+        strDoc.appendf("<%s %s=\"%s%s\">\n", DM_SECT2, DM_ID, strName.str(),"_mod");
+        strDoc.appendf("<%s>%s</%s>\n", DM_TITLE_LITERAL, this->getName(), DM_TITLE_LITERAL);
+
+        if (m_pAnnotation!= NULL)
+        {
+            m_pAnnotation->getDocumentation(strDoc);
+            DEBUG_MARK_STRDOC;
+        }
+
+        strDoc.append(DM_SECT3_BEGIN);
+        DEBUG_MARK_STRDOC;
+        strDoc.append(DM_TITLE_BEGIN).append(DM_TITLE_END);
+
+        if (m_pComplexTypeArray != NULL)
+            m_pComplexTypeArray->getDocumentation(strDoc);
+
+        strDoc.append(DM_SECT3_END);
+        return;
+    }
+    else if (m_pComplexTypeArray != NULL)
+    {
+        if (m_pAnnotation!= NULL)
+        {
+            m_pAnnotation->getDocumentation(strDoc);
+            DEBUG_MARK_STRDOC;
+        }
+
+        if (pGrandParentNode->getNodeType() == XSD_CHOICE)
+            strDoc.appendf("%s%s%s", DM_PARA_BEGIN, this->getTitle(), DM_PARA_END);
+        else
+            strDoc.appendf("%s%s%s", DM_TITLE_BEGIN, this->getTitle(), DM_TITLE_END);
+
+        DEBUG_MARK_STRDOC;
+        m_pComplexTypeArray->getDocumentation(strDoc);
+    }
+    else if (m_pComplexTypeArray == NULL)
+    {
+        if (m_pAnnotation!= NULL)
+        {
+            m_pAnnotation->getDocumentation(strDoc);
+            DEBUG_MARK_STRDOC;
+        }
+
+        strDoc.appendf("%s%s%s", DM_PARA_BEGIN, this->getName(), DM_PARA_END);
+        DEBUG_MARK_STRDOC;
+
+        if (m_pAnnotation != NULL && m_pAnnotation->getDocumentation() != NULL)
+        {
+            m_pAnnotation->getDocumentation(strDoc);
+            DEBUG_MARK_STRDOC;
+        }
+    }
+}
+
+
+void CElement::getQML(StringBuffer &strQML, int idx) const
+{
+    // Handle HPCC Specific tag
+    if (m_pAnnotation != NULL && m_pAnnotation->getAppInfo() != NULL && m_pAnnotation->getAppInfo()->getViewType() != NULL)
+    {
+        if (stricmp(m_pAnnotation->getAppInfo()->getViewType(), "none") == 0)
+            return;
+    }
+    if (this->isATab())/// || this->isTopLevelElement() == true)  // Tabs will be made for all elements in a sequence
+    {
+        if (idx == 0)
+        {
+            strQML.append(QML_TAB_VIEW_BEGIN);
+            DEBUG_MARK_QML;
+            //strQML.append(QML_GRID_LAYOUT_BEGIN_1);
+            //DEBUG_MARK_QML;
+        }
+        CQMLMarkupHelper::getTabQML(strQML, /*this->isTopLevelElement() == true ? "Attributes" : */this->getTitle());
+        DEBUG_MARK_QML;
+        strQML.append(QML_GRID_LAYOUT_BEGIN_1);
+        DEBUG_MARK_QML;
+
+        if (m_pAnnotation != NULL)
+            m_pAnnotation->getQML(strQML);
+        if (m_pComplexTypeArray != NULL)
+            m_pComplexTypeArray->getQML(strQML,idx);
+
+        strQML.append(QML_GRID_LAYOUT_END);
+        DEBUG_MARK_QML;
+        strQML.append(QML_FLICKABLE_HEIGHT).append(CQMLMarkupHelper::getImplicitHeight() * 1.5);
+        DEBUG_MARK_QML;
+        strQML.append(QML_FLICKABLE_END);
+        DEBUG_MARK_QML;
+        strQML.append(QML_TAB_END);
+        DEBUG_MARK_QML;
+
+        if (static_cast<CElementArray*>(this->getParentNode())->getCountOfElementsInXSD()-1 == idx)
+        {
+            //strQML.append(QML_GRID_LAYOUT_END);
+            //DEBUG_MARK_QML;
+            strQML.append(QML_TAB_VIEW_HEIGHT).append(CQMLMarkupHelper::getImplicitHeight());
+            DEBUG_MARK_QML;
+            strQML.append(QML_TAB_VIEW_STYLE);
+            DEBUG_MARK_QML;
+
+            const CComplexType *pComplexType = dynamic_cast<const CComplexType*>(this->getConstAncestorNode(3));
+
+            if (pComplexType != NULL)
+            {
+                if ((pComplexType->getAttributeArray() != NULL && pComplexType->getAttributeArray()->length() > 0) ||\
+                        (pComplexType->getAttributeGroupArray() != NULL && pComplexType->getAttributeGroupArray()->length() > 0))
+                {
+                    DEBUG_MARK_QML;
+                }
+            }
+            else
+            {
+                strQML.append(QML_TAB_VIEW_END);
+                DEBUG_MARK_QML;
+            }
+            //strQML.append(QML_TAB_TEXT_STYLE);
+            //DEBUG_MARK_QML;
+            //strQML.append(QML_TAB_VIEW_END);
+            //DEBUG_MARK_QML;
+        }
+    }
+    else
+    {
+        if (0 == idx)
+        {
+            //strQML.append(QML_GRID_LAYOUT_BEGIN_1);
+            //DEBUG_MARK_QML;
+        }
+        if (m_pAnnotation != NULL)
+            m_pAnnotation->getQML(strQML);
+        if (m_pComplexTypeArray != NULL)
+            m_pComplexTypeArray->getQML(strQML,idx);
+
+        if (static_cast<CElementArray*>(this->getParentNode())->getCountOfElementsInXSD()-1 == idx)
+        {
+            //strQML.append(QML_GRID_LAYOUT_END);
+            //DEBUG_MARK_QML;
+        }
+    }
+
+}
+
+void CElement::getQML2(StringBuffer &strQML, int idx) const
+{
+    // Handle HPCC Specific tag
+    if (m_pAnnotation != NULL && m_pAnnotation->getAppInfo() != NULL && m_pAnnotation->getAppInfo()->getViewType() != NULL)
+    {
+        if (stricmp(m_pAnnotation->getAppInfo()->getViewType(), "none") == 0)
+            return;
+    }
+
+    if (this->getParentNode()->getUIType() == QML_UI_EMPTY)
+    {
+        this->setUIType(QML_UI_TAB);
+        if (m_pComplexTypeArray != NULL && m_pComplexTypeArray->length() > 0)
+        {
+            DEBUG_MARK_QML2(this);
+            m_pComplexTypeArray->getQML2(strQML);
+            DEBUG_MARK_QML2(this);
+        }
+    }
+    else if (this->getMaxOccursInt() > 1 && this->hasChildElements() == false) // must be a table
+    {
+        this->setUIType(QML_UI_TABLE);
+
+        strQML.append(QML_TABLE_VIEW_BEGIN);
+        DEBUG_MARK_QML;
+
+        strQML.append(QML_MODEL).append(getTableDataModelName(CConfigSchemaHelper::getInstance(0)->getNumberOfTables())).append(QML_STYLE_NEW_LINE);
+        DEBUG_MARK_QML;
+
+        strQML.append(QML_PROPERTY_STRING_TABLE_BEGIN).append(getTableDataModelName(CConfigSchemaHelper::getInstance(0)->getNumberOfTables())).append(QML_PROPERTY_STRING_TABLE_PART_1).append(this->getXSDXPath()).append(QML_PROPERTY_STRING_TABLE_END);
+        DEBUG_MARK_QML;
+
+        CConfigSchemaHelper::getInstance(0)->incTables();
+
+        if (m_pComplexTypeArray != NULL)
+        {
+            DEBUG_MARK_QML;
+            m_pComplexTypeArray->getQML2(strQML);
+            DEBUG_MARK_QML;
+        }
+
+        DEBUG_MARK_QML;
+        strQML.append(QML_TABLE_VIEW_END);
+        DEBUG_MARK_QML;
+
+    }
+    else if (this->hasChildElements() == false && this->getConstParentNode()->getUIType() == QML_UI_TAB && this->getMaxOccursInt() > 1) // must be table
+    {
+        this->setUIType(QML_UI_TABLE);
+
+        strQML.append(QML_TABLE_VIEW_BEGIN);
+        DEBUG_MARK_QML;
+
+        strQML.append(QML_MODEL).append(getTableDataModelName(CConfigSchemaHelper::getInstance(0)->getNumberOfTables())).append(QML_STYLE_NEW_LINE);
+        DEBUG_MARK_QML;
+
+        strQML.append(QML_PROPERTY_STRING_TABLE_BEGIN).append(getTableDataModelName(CConfigSchemaHelper::getInstance(0)->getNumberOfTables())).append(QML_PROPERTY_STRING_TABLE_PART_1).append(this->getXSDXPath()).append(QML_PROPERTY_STRING_TABLE_END);
+        DEBUG_MARK_QML;
+
+        CConfigSchemaHelper::getInstance(0)->incTables();
+
+        if (m_pComplexTypeArray != NULL)
+        {
+            DEBUG_MARK_QML;
+            m_pComplexTypeArray->getQML2(strQML);
+            DEBUG_MARK_QML;
+        }
+
+        DEBUG_MARK_QML;
+        strQML.append(QML_TABLE_VIEW_END);
+        DEBUG_MARK_QML;
+    }
+    else // must be a tab
+    {
+        const CElement *pElem = dynamic_cast<const CElement*>(this->getAncestorElement(this));
+
+        if (pElem->isTopLevelElement() == false)
+        {
+            //strQML.append(QML_ROW_BEGIN);
+            DEBUG_MARK_QML;
+
+            if (idx == 0)
+            {
+                strQML.append(QML_TAB_VIEW_BEGIN);
+                DEBUG_MARK_QML;
+            }
+        }
+
+        this->setUIType(QML_UI_TAB);
+
+        CQMLMarkupHelper::getTabQML(strQML, this->getTitle());
+        DEBUG_MARK_QML;
+
+        strQML.append(QML_GRID_LAYOUT_BEGIN);
+        DEBUG_MARK_QML;
+
+        strQML.append(QML_ROW_BEGIN);
+        DEBUG_MARK_QML;
+
+        if (m_pComplexTypeArray != NULL && m_pComplexTypeArray->length() > 0)
+        {
+            m_pComplexTypeArray->getQML2(strQML);
+            DEBUG_MARK_QML2(this);
+        }
+
+        strQML.append(QML_ROW_END);
+        DEBUG_MARK_QML;
+        strQML.append(QML_GRID_LAYOUT_END);
+        DEBUG_MARK_QML;
+        strQML.append(QML_FLICKABLE_END);
+        DEBUG_MARK_QML;
+        strQML.append(QML_TAB_END);
+        DEBUG_MARK_QML;
+
+        const CElementArray *pElementArray = dynamic_cast<const CElementArray*>(this->getConstParentNode());
+        assert(pElementArray != NULL);
+
+        if (pElementArray != NULL && pElementArray->length()-1 == idx && pElem->isTopLevelElement() == false)
+        {
+            strQML.append(QML_TAB_VIEW_STYLE);
+            DEBUG_MARK_QML;
+
+            strQML.append(QML_TAB_VIEW_END);
+            DEBUG_MARK_QML;
+
+            if (pElem->isTopLevelElement() == false)
+            {
+                //strQML.append(QML_ROW_END);
+                DEBUG_MARK_QML;
+            }
+
+            strQML.append(QML_TAB_TEXT_STYLE);
+            DEBUG_MARK_QML;
+        }
+        else
+        {
+            //strQML.append(QML_ROW_END);
+            DEBUG_MARK_QML;
+        }
+    }
+}
+void CElement::getQML3(StringBuffer &strQML, int idx) const
+{
+    DEBUG_MARK_QML;
+    if (m_pComplexTypeArray != NULL)
+    {
+        if(this->getUIType() == QML_UI_TABLE_LIST)
+        {
+            DEBUG_MARK_QML;
+            m_pComplexTypeArray->setUIType(this->getUIType());
+            m_pComplexTypeArray->getQML3(strQML);
+        }
+        else 
+        {
+            const char * altTitle = "";
+            if((m_pComplexTypeArray->item(0)).getAttributeArray() != NULL && (m_pComplexTypeArray->item(0)).getAttributeArray()->findAttributeWithName("name") != NULL)
+                altTitle = (m_pComplexTypeArray->item(0)).getAttributeArray()->findAttributeWithName("name")->getEnvXPath();
+    
+            DEBUG_MARK_QML;
+            CQMLMarkupHelper::buildAccordionStart(strQML, this->getTitle(), altTitle);
+            DEBUG_MARK_QML;
+            m_pComplexTypeArray->getQML3(strQML);
+            strQML.append(QML_DOUBLE_END_BRACKET);
+            DEBUG_MARK_QML;
+        }
+    }
+    DEBUG_MARK_QML;
+}
+
+bool CElement::isATab() const
+{
+    const CComplexTypeArray *pComplexTypArray = this->getComplexTypeArray();
+    const CAttributeGroupArray *pAttributeGroupArray = (pComplexTypArray != NULL && pComplexTypArray->length() > 0) ? pComplexTypArray->item(0).getAttributeGroupArray() : NULL;
+    const CAttributeArray *pAttributeArray = (pComplexTypArray != NULL && pComplexTypArray->length() > 0) ? pComplexTypArray->item(0).getAttributeArray() : NULL;
+
+    if (this->getConstAncestorNode(2)->getNodeType() != XSD_SCHEMA && \
+            (this->hasChildElements() == true || \
+             (this->hasChildElements() == false && (static_cast<const CElementArray*>(this->getConstParentNode()))->anyElementsHaveMaxOccursGreaterThanOne() == false)/* || \
+             (this->isTopLevelElement() == true && (pAttributeGroupArray != NULL || pAttributeArray != NULL))*/))
+
+    {
+        return true;
+    }
+    else
+    {
+        return false;
+    }
+/*    if (stricmp(this->getMaxOccurs(), TAG_UNBOUNDED) == 0)
+    {
+        return false;
+    }
+    // Any element that is in sequence of complex type will be a tab
+    else*/ if (this->getConstAncestorNode(2)->getNodeType() == XSD_SEQUENCE && this->getConstAncestorNode(3)->getNodeType() == XSD_COMPLEX_TYPE)
+    {
+        return true;
+    }
+    else if (/*this->getConstAncestorNode(2)->getNodeType == XSD_COMPLEX_TYPE &&*/ this->getConstAncestorNode(3)->getNodeType() == XSD_ELEMENT)
+    {
+        const CElement *pElement = dynamic_cast<const CElement*>(this->getConstAncestorNode(3));
+
+        assert(pElement != NULL);
+        if (pElement != NULL)
+            return pElement->isATab();
+    }
+    return false;
+}
+
+bool CElement::isLastTab(const int idx) const
+{
+    assert(this->isATab() == true);
+
+    const CElementArray *pElementArray = dynamic_cast<const CElementArray*>(this->getConstParentNode());
+
+    if (pElementArray == NULL)
+    {
+        assert(!"Corrupt XSD??");
+        return false;
+    }
+    if (pElementArray->length()-1 == idx)
+        return true;
+
+    return false;
+}
+
+
+void CElement::populateEnvXPath(StringBuffer strXPath, unsigned int index)
+{
+    assert(strXPath.length() > 0);
+
+    strXPath.append("/").append(this->getName()).append("[").append(index).append("]");
+
+    PROGLOG("Setting element to envpath of %s, previous path: %s", strXPath.str(), this->getEnvXPath());
+    this->setEnvXPath(strXPath);
+
+    if (m_pComplexTypeArray != NULL)
+        m_pComplexTypeArray->populateEnvXPath(strXPath, index);
+    if (m_pSimpleType != NULL)
+        m_pSimpleType->populateEnvXPath(strXPath, index);
+    if (m_pKeyArray != NULL)
+        m_pKeyArray->populateEnvXPath(strXPath, index);
+}
+
+void CElement::loadXMLFromEnvXml(const IPropertyTree *pEnvTree)
+{
+    //PROGLOG("Mapping element with XPATH of %s to %p", this->getEnvXPath(), this);
+    CConfigSchemaHelper::getInstance()->getSchemaMapManager()->addMapOfXPathToElement(this->getEnvXPath(), this);
+
+    if (m_pComplexTypeArray != NULL)
+    {
+        try
+        {
+            m_pComplexTypeArray->loadXMLFromEnvXml(pEnvTree);
+        }
+        catch (...)
+        {
+            // node described in XSD doesn't exist in XML
+            // time to do validation?
+        }
+    }
+    if (m_pSimpleType != NULL)
+    {
+        try
+        {
+            m_pSimpleType->loadXMLFromEnvXml(pEnvTree);
+        }
+        catch(...)
+        {
+        }
+    }
+
+    if (m_pComplexTypeArray == NULL)
+    {
+        const char* pValue =  pEnvTree->queryPropTree(this->getEnvXPath())->queryProp("");
+
+        if (pValue != NULL)
+        {
+            this->setEnvValueFromXML(pValue);
+            CConfigSchemaHelper::getInstance()->appendElementXPath(this->getEnvXPath());
+        }
+    }
+
+    const char* pInstanceName =  pEnvTree->queryPropTree(this->getEnvXPath())->queryProp(XML_ATTR_NAME);
+
+    if (pInstanceName != NULL && *pInstanceName != 0)
+        this->setInstanceName(pInstanceName);
+}
+
+bool CElement::isTopLevelElement() const
+{
+    return m_bTopLevelElement;
+}
+
+const char * CElement::getViewType() const
+{
+    if(m_pAnnotation != NULL && m_pAnnotation->getAppInfo() != NULL)
+        return m_pAnnotation->getAppInfo()->getViewType();
+    return NULL;
+}
+
+void CElementArray::dump(std::ostream &cout, unsigned int offset) const
+{
+    offset+= STANDARD_OFFSET_1;
+
+    QuickOutHeader(cout, XSD_ELEMENT_ARRAY_STR, offset);
+    QUICK_OUT(cout, XSDXPath,  offset);
+    QUICK_OUT(cout, EnvXPath,  offset);
+    QUICK_OUT_ARRAY(cout, offset);
+    QuickOutFooter(cout, XSD_ELEMENT_ARRAY_STR, offset);
+}
+
+void CElementArray::getDocumentation(StringBuffer &strDoc) const
+{
+    QUICK_DOC_ARRAY(strDoc);
+}
+
+void CElementArray::getQML(StringBuffer &strQML, int idx) const
+{
+    for (int idx=0; idx < this->length(); idx++)
+    {
+        if ((this->item(idx)).getIsInXSD() == true)
+            (this->item(idx)).getQML(strQML, idx);
+    }
+}
+
+void CElementArray::getQML2(StringBuffer &strQML, int idx) const
+{
+    DEBUG_MARK_QML;
+    if (this->getParentNode()->getUIType() == QML_UI_TAB)
+    {
+        DEBUG_MARK_QML;
+        this->setUIType(QML_UI_TAB);
+        //strQML.append(QML_TAB_VIEW_BEGIN);
+        //DEBUG_MARK_QML;
+        for (int i = 0; i < this->length(); i++)
+        {
+            if ((this->item(i)).hasChildElements() == true)
+            {
+                DEBUG_MARK_QML;
+                //(this->item(i)).setUIType(QML_UI_TAB);
+            }
+            else if ((this->item(i)).getMaxOccursInt() > 1)
+            {
+                DEBUG_MARK_QML;
+                //(this->item(i)).setUIType(QML_UI_TABLE);
+            }
+            else
+            {
+                DEBUG_MARK_QML;
+                //(this->item(i)).setUIType(QML_UI_TEXT_FIELD);
+            }
+            DEBUG_MARK_QML;
+            (this->item(i)).getQML2(strQML,i);
+        }
+    }
+    else if (this->getUIType() == QML_UI_EMPTY)
+    {
+        DEBUG_MARK_QML;
+        this->item(0).getQML2(strQML,0);
+        DEBUG_MARK_QML;
+    }
+}
+
+void CElementArray::getQML3(StringBuffer &strQML, int idx) const
+{
+    DEBUG_MARK_QML;
+    if(this->length() > 1)
+    {
+        StringArray keyspace;
+        MapStringTo<bool,bool> isList;
+        MapStringTo<StringBuffer,const char *> elementGroups;
+
+        for (int i = 0; i < this->length(); i++) // Go through Element Array to initialize elementGroups
+        {            
+            if(elementGroups.getValue((this->item(i)).getName()) == NULL) // If this is a unique element name
+            {
+                StringBuffer temp("");
+                CQMLMarkupHelper::buildAccordionStart(temp,(this->item(i)).getTitle()); // Build Accordion
+
+                // If list or instance, append table boilerplate, make mapping for later
+                if( (this->item(i)).getViewType() != NULL && 
+                    (!stricmp((this->item(i)).getViewType(),"list") || !stricmp((this->item(i)).getViewType(),"instance")) &&
+                    (this->item(i)).getComplexTypeArray() != NULL &&
+                    ((this->item(i)).getComplexTypeArray()->item(0)).getSequence() == NULL &&
+                    ((this->item(i)).getComplexTypeArray()->item(0)).getAttributeGroupArray() == NULL && 
+                    ((this->item(i)).getComplexTypeArray()->item(0)).getAttributeArray() != NULL && 
+                    ((this->item(i)).getComplexTypeArray()->item(0)).getAttributeArray()->length() > 0
+                    )
+                {
+                    StringArray names;
+                    StringArray titles;
+
+                    isList.setValue((this->item(i)).getName(),true);
+                    temp.append(QML_TABLE_START);
+
+                    ((this->item(i)).getComplexTypeArray()->item(0)).getAttributeArray()->getAttributeNames(names,titles);
+                    CQMLMarkupHelper::buildColumns(temp, names, titles);
+
+                    temp.append(QML_TABLE_CONTENT_START);
+                }
+                else
+                    isList.setValue((this->item(i)).getName(),false);
+
+                // Save grouping, save keyspace for reference
+                elementGroups.setValue((this->item(i)).getName(),temp.str());
+                keyspace.append((this->item(i)).getName());
+            }
+        }
+        for (int i = 0; i < this->length(); i++)
+        {
+            assert(*elementGroups.getValue((this->item(i)).getName()) != NULL);
+            if(*elementGroups.getValue((this->item(i)).getName()) != NULL)
+            {
+                StringBuffer temp = *elementGroups.getValue((this->item(i)).getName());
+
+                if(*isList.getValue((this->item(i)).getName()) == true)
+                    (this->item(i)).setUIType(QML_UI_TABLE_LIST);
+
+                (this->item(i)).getQML3(temp,i);
+                elementGroups.setValue((this->item(i)).getName(),temp.str());
+            }
+        }
+        for(int i = 0; i < keyspace.length(); i++)
+        {
+            strQML.append(*elementGroups.getValue(keyspace[i]));
+            DEBUG_MARK_QML;
+
+            if(*isList.getValue(keyspace[i]) == true)
+                strQML.append(QML_DOUBLE_END_BRACKET);
+
+            strQML.append(QML_DOUBLE_END_BRACKET);
+            DEBUG_MARK_QML;
+        }
+    }
+    else
+        (this->item(0)).getQML3(strQML,0);
+}
+
+void CElementArray::populateEnvXPath(StringBuffer strXPath, unsigned int index)
+{
+    int elemCount = 1;
+
+    this->setEnvXPath(strXPath);
+
+    for (int idx=0; idx < this->length(); idx++)
+    {
+        if (this->item(idx).getIsInXSD() == true)
+            elemCount == 1;
+        else
+            elemCount++;
+
+        this->item(idx).populateEnvXPath(strXPath, elemCount);
+    }
+}
+
+const char* CElementArray::getXML(const char* /*pComponent*/)
+{
+    if (m_strXML.length() == 0)
+    {
+        int length = this->length();
+
+        for (int idx = 0; idx < length; idx++)
+        {
+            CElement &Element = this->item(idx);
+            m_strXML.append(Element.getXML(NULL));
+
+            if (idx+1 < length)
+                m_strXML.append("\n");
+        }
+    }
+    return m_strXML.str();
+}
+
+void CElementArray::loadXMLFromEnvXml(const IPropertyTree *pEnvTree)
+{
+    int nUniqueElements = this->length();
+
+    for (int idx = 0; idx < nUniqueElements; idx++)
+    {
+        StringBuffer strXPath(this->item(idx).getEnvXPath());
+
+        if (pEnvTree->hasProp(strXPath.str()) == false)
+            continue;
+
+        int subIndex = 1;
+
+        do
+        {
+            StringBuffer strEnvXPath(this->item(idx).getEnvXPath());
+            CConfigSchemaHelper::stripXPathIndex(strEnvXPath);
+
+            strEnvXPath.appendf("[%d]",subIndex);
+
+            if (pEnvTree->queryPropTree(strEnvXPath.str()) == NULL)
+                break;
+
+            CElement *pElement = NULL;
+            if (subIndex > 1)
+            {
+                pElement = CElement::load(this, this->getSchemaRoot(), this->item(idx).getXSDXPath(), false);
+
+                int nIndexOfElement =  (static_cast<CElementArray*>(pElement->getParentNode()))->getCountOfSiblingElements(pElement->getXSDXPath())+1;
+                pElement->populateEnvXPath(this->getEnvXPath(), subIndex);
+
+                PROGLOG("XSD Xpath to non-native element to %s", pElement->getXSDXPath());
+                PROGLOG("XML Xpath to non-native element to %s", pElement->getEnvXPath());
+
+                pElement->setTopLevelElement(false);
+
+                CConfigSchemaHelper::getInstance()->getSchemaMapManager()->addMapOfXPathToElement(pElement->getEnvXPath(), pElement);
+                CConfigSchemaHelper::getInstance()->getSchemaMapManager()->addMapOfXSDXPathToElementArray(pElement/*->getConstParentNode()*/->getXSDXPath(), (static_cast<CElementArray*>(pElement->getParentNode())));
+
+                this->append(*pElement);
+                PROGLOG("Added element %p with xsd xpath=%s array is size=%d with xpath of %s", pElement, pElement->getXSDXPath(),this->length(), this->getXSDXPath());
+            }
+            else
+            {
+                pElement = &(this->item(idx));
+
+                if (pElement->getConstAncestorNode(2)->getNodeType() == XSD_SCHEMA)
+                    pElement->setTopLevelElement(true);
+
+                CConfigSchemaHelper::getInstance()->getSchemaMapManager()->addMapOfXSDXPathToElementArray(pElement/*->getConstParentNode()*/->getXSDXPath(), (static_cast<CElementArray*>(pElement->getParentNode())));
+                PROGLOG("Added element %p with xsd xpath=%s array is size=%d with xpath of %s", pElement, pElement->getXSDXPath(),this->length(), this->getXSDXPath());
+            }
+            pElement->loadXMLFromEnvXml(pEnvTree);
+
+            subIndex++;
+        }
+        while (true);
+    }
+}
+
+CElementArray* CElementArray::load(const char* pSchemaFile)
+{
+    assert(pSchemaFile != NULL);
+    if (pSchemaFile == NULL)
+        return NULL;
+
+    Linked<IPropertyTree> pSchemaRoot;
+    StringBuffer schemaPath;
+
+    schemaPath.appendf("%s%s", DEFAULT_SCHEMA_DIRECTORY, pSchemaFile);
+    pSchemaRoot.setown(createPTreeFromXMLFile(schemaPath.str()));
+
+    CElementArray *pElemArray = CElementArray::load(NULL, pSchemaRoot, XSD_TAG_ELEMENT);
+
+    PROGLOG("Function: %s() at %s:%d", __func__, __FILE__, __LINE__);
+    PROGLOG("pElemArray = %p", pElemArray);
+
+    return pElemArray;
+}
+
+CElementArray* CElementArray::load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath)
+{
+    assert(pSchemaRoot != NULL);
+    if (pSchemaRoot == NULL)
+        return NULL;
+
+    CElementArray *pElemArray = new CElementArray(pParentNode);
+    assert(pElemArray != NULL);
+
+    pSchemaRoot->Link();
+    pElemArray->setSchemaRoot(pSchemaRoot);
+
+    StringBuffer strXPathExt(xpath);
+    pElemArray->setXSDXPath(xpath);
+
+    Owned<IPropertyTreeIterator> elemIter = pSchemaRoot->getElements(xpath);
+
+    int count = 1;
+
+    ForEach(*elemIter)
+    {
+        strXPathExt.set(xpath);
+        strXPathExt.appendf("[%d]", count);
+
+        CElement *pElem = CElement::load(pElemArray, pSchemaRoot, strXPathExt.str());
+
+        assert(pElem);
+        pElemArray->append(*pElem);
+
+        count++;
+    }
+
+    if (pElemArray->length() == 0)
+    {
+        delete pElemArray;
+        return NULL;
+    }
+
+    SETPARENTNODE(pElemArray, pParentNode);
+
+    return pElemArray;
+}
+
+int CElementArray::getCountOfSiblingElements(const char *pXPath) const
+{
+    assert(pXPath != NULL && *pXPath != 0);
+
+    int count = 0;
+
+    for (int idx=0; idx < this->length(); idx++)
+    {
+        if (strcmp(this->item(idx).getXSDXPath(), pXPath) == 0)
+            count++;
+    }
+    return count;
+}
+
+const CXSDNodeBase* CElementArray::getNodeByTypeAndNameAscending(NODE_TYPES eNodeType, const char *pName) const
+{
+    assert(pName != NULL);
+
+    for (int idx = 1; idx < this->length() && eNodeType == XSD_ELEMENT; idx++)
+    {
+        if (strcmp ((static_cast<CElement>(this->item(idx))).getName(), pName) == 0)
+            return &(this->item(idx));
+    }
+    return (this->getParentNode()->getNodeByTypeAndNameAscending(eNodeType, pName));
+}
+
+const CXSDNodeBase* CElementArray::getNodeByTypeAndNameDescending(NODE_TYPES eNodeType, const char *pName) const
+{
+    assert(pName != NULL);
+
+    if (eNodeType == this->getNodeType())
+        return this;
+
+    return (this->getParentNode()->getNodeByTypeAndNameDescending(eNodeType, pName));
+}
+
+const CElement* CElementArray::getElementByNameAscending(const char *pName) const
+{
+    for (int idx = 1; idx < this->length() ;idx++)
+    {
+        if (strcmp ((static_cast<CElement>(this->item(idx))).getName(), pName) == 0)
+            return &(this->item(idx));
+    }
+
+    assert(!("Control should not reach here, unknown pName?"));
+    return NULL;
+}
+
+const CElement* CElementArray::getElementByNameDescending(const char *pName) const
+{
+    for (int idx = 1; idx < this->length(); idx++)
+    {
+        if (strcmp ((static_cast<CElement>(this->item(idx))).getName(), pName) == 0)
+            return &(this->item(idx));
+    }
+    return NULL;
+}
+
+int CElementArray::getSiblingIndex(const char* pXSDXPath, const CElement* pElement)
+{
+    assert(pXSDXPath != NULL && *pXSDXPath != 0 && pElement != NULL);
+
+    int nSiblingIndex = 0;
+
+    for (int idx=0; idx < this->length(); idx++)
+    {
+        if (strcmp(this->item(idx).getXSDXPath(), pXSDXPath) == 0)
+        {
+            if (&(this->item(idx)) == pElement)
+                break;
+
+            nSiblingIndex++;
+        }
+    }
+    return nSiblingIndex;
+}
+
+bool CElementArray::anyElementsHaveMaxOccursGreaterThanOne() const
+{
+    int len = this->length();
+
+    for (int i = 0; i < len; i++)
+    {
+        if ((this->item(i)).getMaxOccursInt() > 1 || this->item(i).getMaxOccursInt() == -1)
+            return true;
+    }
+    return false;
+}
+void CElement::setIsInXSD(bool b)
+{
+    m_bIsInXSD = b;
+
+    if (m_bIsInXSD == true)
+    {
+        CElementArray *pElemArray = dynamic_cast<CElementArray*>(this->getParentNode());
+        assert(pElemArray != NULL);
+
+        if (pElemArray != NULL)
+            pElemArray->incCountOfElementsInXSD();
+    }
+}
+
+bool CElement::hasChildElements() const
+{
+    const CComplexTypeArray* pComplexTypeArray = this->getComplexTypeArray();
+
+    if (pComplexTypeArray != NULL && pComplexTypeArray->length() != 0)
+    {
+        int nLen = pComplexTypeArray->length();
+
+        for (int i = 0; i < nLen; i++)
+        {
+            if (pComplexTypeArray->item(i).hasChildElements() == true)
+                return true;
+        }
+    }
+    return false;
+}

--- a/configuration/configurator/SchemaElement.hpp
+++ b/configuration/configurator/SchemaElement.hpp
@@ -1,0 +1,231 @@
+﻿/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef _SCHEMA_ELEMENT_HPP_
+#define _SCHEMA_ELEMENT_HPP_
+
+#include "jiface.hpp"
+#include "jstring.hpp"
+#include "jlib.hpp"
+#include "jarray.hpp"
+#include "SchemaCommon.hpp"
+#include "SchemaComplexType.hpp"
+#include <climits>
+
+class CAnnotation;
+class CComplexTypeArray;
+class IPropertyTree;
+class CKeyArray;
+class CKeyRefArray;
+class CKeyRef;
+class CSchema;
+class CElementArray;
+class CSimpleType;
+
+static const char* DEFAULT_ELEMENT_ARRAY_XPATH(".");
+
+class CElement : public CXSDNodeWithType
+{
+public:
+
+    virtual ~CElement()
+    {
+        assert(false);
+    }
+
+    virtual const CXSDNodeBase* getNodeByTypeAndNameAscending(NODE_TYPES eNodeType, const char *pName) const;
+    virtual const CXSDNodeBase* getNodeByTypeAndNameDescending(NODE_TYPES eNodeType, const char *pName) const;
+    virtual const char* getXML(const char* /*pComponent*/);
+    virtual void dump(std::ostream &cout, unsigned int offset = 0) const;
+    virtual void getDocumentation(StringBuffer &strJS) const;
+    virtual void getQML(StringBuffer &strQML, int idx = -1) const;
+    virtual void getQML2(StringBuffer &strQML, int idx = -1) const;
+    virtual void getQML3(StringBuffer &strQML, int idx = -1) const;
+    virtual void populateEnvXPath(StringBuffer strXPath, unsigned int index = 1);
+    virtual void loadXMLFromEnvXml(const IPropertyTree *pEnvTree);
+    virtual bool isTopLevelElement() const;
+    const CSchema* getConstSchemaNode() const;
+
+    void setTopLevelElement(bool b = true)
+    {
+        m_bTopLevelElement =  b;
+    }
+    void setParentIndex(int index)
+    {
+        m_nParentIndex = index;
+    }
+    int getParentIndex() const
+    {
+        return m_nParentIndex;
+    }
+    const CAnnotation* getAnnotation() const
+    {
+        return m_pAnnotation;
+    }
+    const CSimpleType* getSimpleType() const
+    {
+        return m_pSimpleType;
+    }
+    const CComplexTypeArray* getComplexTypeArray() const
+    {
+        return m_pComplexTypeArray;
+    }
+
+    static const CXSDNodeBase* getAncestorElement(const CXSDNodeBase *pNode)
+    {
+         return pNode->getParentNodeByType(XSD_ELEMENT);
+    }
+    static const CElement* getTopMostElement(const CXSDNodeBase *pNode);
+    static bool isAncestorTopElement(const CXSDNodeBase *pNode)
+    {
+        return (pNode != NULL && pNode->getParentNodeByType(XSD_ELEMENT) == getTopMostElement(pNode));
+    }
+    void setRefElementNode(CElement *pElement)
+    {
+        assert (pElement != NULL && this->getRefElementNode() != NULL);
+        if (pElement != NULL)
+            this->m_pElementRefNode = pElement;
+    }
+    CElement* getRefElementNode() const
+    {
+        return this->m_pElementRefNode;
+    }
+
+    bool isATab() const;
+    bool isLastTab(const int idx) const;
+    bool getIsInXSD() const
+    {
+        return m_bIsInXSD;
+    }
+
+    bool hasChildElements() const;
+
+    int getMaxOccursInt() const
+    {
+        if (strcmp(m_strMaxOccurs.str(), TAG_UNBOUNDED) == 0)
+            return __SHRT_MAX__;
+        else
+            return atoi(m_strMaxOccurs.str());
+    }
+
+    int getMinOccursInt() const
+    {
+        return atoi(m_strMinOccurs.str());
+    }
+
+    static CElement* load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath, bool bIsInXSD = true);
+
+    const char * getViewType() const;
+
+    GETTERSETTER(Name)
+    GETTERSETTER(MaxOccurs)
+    GETTERSETTER(MinOccurs)
+    GETTERSETTER(Title)
+    GETTERSETTER(InstanceName)
+    GETTERSETTER(Ref)
+
+protected:
+
+    CElement(CXSDNodeBase* pParentNode, const char* pName = "") : CXSDNodeWithType::CXSDNodeWithType(pParentNode, XSD_ELEMENT), m_strMinOccurs("1"), m_strMaxOccurs("1"), m_strName(pName), m_pAnnotation(NULL),
+        m_pComplexTypeArray(NULL), m_pKeyArray(NULL), m_pKeyRefArray(NULL), m_pReverseKeyRefArray(NULL), m_pElementRefNode(NULL), m_pSimpleType(NULL),\
+        m_bTopLevelElement(false), m_nParentIndex(-1), m_bIsInXSD(true)
+    {
+    }
+
+    void setIsInXSD(bool b);
+
+    CAnnotation * m_pAnnotation;
+    CComplexTypeArray* m_pComplexTypeArray;
+    CKeyArray *m_pKeyArray;
+    CKeyRefArray *m_pKeyRefArray;
+    CKeyRefArray *m_pReverseKeyRefArray;
+    CElement *m_pElementRefNode;
+    CSimpleType *m_pSimpleType;
+
+    bool m_bTopLevelElement;
+    int m_nParentIndex;
+    bool m_bIsInXSD;
+
+private:
+};
+
+class CElementArray : public CIArrayOf<CElement>, public InterfaceImpl, public CXSDNodeBase
+{
+    friend class CElement;
+public:
+    CElementArray(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot = NULL) : CXSDNodeBase::CXSDNodeBase(pParentNode, XSD_ELEMENT_ARRAY),\
+        m_pSchemaRoot(pSchemaRoot), m_nCountOfElementsInXSD(0)
+    {
+    }
+
+    virtual ~CElementArray()
+    {
+    }
+
+    virtual const CXSDNodeBase* getNodeByTypeAndNameAscending(NODE_TYPES eNodeType, const char *pName) const;
+    virtual const CXSDNodeBase* getNodeByTypeAndNameDescending(NODE_TYPES eNodeType, const char *pName) const;
+
+    const CElement* getElementByNameAscending(const char *pName) const;
+    const CElement* getElementByNameDescending(const char *pName) const;
+    virtual void dump(std::ostream &cout, unsigned int offset = 0) const;
+    virtual void getDocumentation(StringBuffer &strDoc) const;
+    virtual void getQML(StringBuffer &strQML, int idx = -1) const;
+    virtual void getQML2(StringBuffer &strQML, int idx = -1) const;
+    virtual void getQML3(StringBuffer &strQML, int idx = -1) const;
+    virtual void populateEnvXPath(StringBuffer strXPath, unsigned int index = 1);
+    virtual void loadXMLFromEnvXml(const IPropertyTree *pEnvTree);
+    virtual const char* getXML(const char* /*pComponent*/);
+    virtual int getCountOfSiblingElements(const char *pXPath) const;
+    bool anyElementsHaveMaxOccursGreaterThanOne() const;
+
+    virtual void setSchemaRoot(const IPropertyTree *pSchemaRoot)
+    {
+        assert(m_pSchemaRoot == NULL);
+        assert(pSchemaRoot);
+
+        m_pSchemaRoot = pSchemaRoot;
+    }
+    const IPropertyTree* getSchemaRoot() const
+    {
+        return m_pSchemaRoot;
+    }
+    int getCountOfElementsInXSD() const
+    {
+        return m_nCountOfElementsInXSD;
+    }
+    void incCountOfElementsInXSD()
+    {
+        m_nCountOfElementsInXSD++;
+    }
+
+    static CElementArray* load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath = DEFAULT_ELEMENT_ARRAY_XPATH);
+    static CElementArray* load(const char *pSchemaFile);
+
+protected:
+
+    const IPropertyTree *m_pSchemaRoot;
+    int m_nCountOfElementsInXSD;
+    int getSiblingIndex(const char* pXSDXPath, const CElement* pElement);
+
+private:
+
+    CElementArray() : CXSDNodeBase::CXSDNodeBase(NULL, XSD_ELEMENT_ARRAY)
+    {
+    }
+};
+
+#endif // _SCHEMA_ELEMENT_HPP_

--- a/configuration/configurator/SchemaEnumeration.cpp
+++ b/configuration/configurator/SchemaEnumeration.cpp
@@ -1,0 +1,205 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include "SchemaCommon.hpp"
+#include "SchemaAttributes.hpp"
+#include "SchemaEnumeration.hpp"
+#include "SchemaRestriction.hpp"
+#include "XMLTags.h"
+#include "jptree.hpp"
+#include "DocumentationMarkup.hpp"
+#include "QMLMarkup.hpp"
+
+CEnumeration* CEnumeration::load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath)
+{
+    assert(pSchemaRoot != NULL);
+    if (pSchemaRoot == NULL)
+        return NULL;
+
+    CEnumeration *pEnumeration = new CEnumeration(pParentNode);
+    pEnumeration->setXSDXPath(xpath);
+
+    if (xpath && *xpath)
+    {
+        IPropertyTree* pTree = pSchemaRoot->queryPropTree(xpath);
+
+        if (pTree == NULL)
+            return pEnumeration;
+
+        const char* pValue = pTree->queryProp(XML_ATTR_VALUE);
+
+        if (pValue != NULL)
+            pEnumeration->setValue(pValue);
+    }
+    return pEnumeration;
+}
+
+void CEnumeration::dump(std::ostream &cout, unsigned int offset) const
+{
+    offset += STANDARD_OFFSET_1;
+
+    QuickOutHeader(cout, XSD_ENUMERATION_STR, offset);
+    QUICK_OUT(cout, Value, offset);
+    QUICK_OUT(cout, XSDXPath,  offset);
+    QUICK_OUT(cout, EnvXPath,  offset);
+    QUICK_OUT(cout, EnvValueFromXML,  offset);
+    QuickOutFooter(cout, XSD_ENUMERATION_STR, offset);
+}
+
+void CEnumeration::getDocumentation(StringBuffer &strDoc) const
+{
+    strDoc.appendf("* %s %s\n", this->getValue(), DM_LINE_BREAK);
+}
+
+void CEnumeration::getQML(StringBuffer &strQML, int idx) const
+{
+    strQML.append(QML_LIST_ELEMENT_BEGIN).append(this->getValue()).append(QML_LIST_ELEMENT_END);
+    DEBUG_MARK_QML;
+}
+
+const char* CEnumeration::getXML(const char* /*pComponent*/)
+{
+    UNIMPLEMENTED;
+    return NULL;
+}
+
+void CEnumeration::populateEnvXPath(StringBuffer strXPath, unsigned int index)
+{
+    assert(this->getValue() != NULL);
+    const CAttribute *pAttribute = dynamic_cast<const CAttribute*>(this->getParentNodeByType(XSD_ATTRIBUTE));
+
+    assert(pAttribute != NULL);
+    this->setEnvXPath(strXPath.str());
+}
+
+void CEnumeration::loadXMLFromEnvXml(const IPropertyTree *pEnvTree)
+{
+    assert(this->getEnvXPath() != NULL);
+    const CAttribute *pAttribute = dynamic_cast<const CAttribute*>(this->getParentNodeByType(XSD_ATTRIBUTE) );
+    assert(pAttribute != NULL);
+
+    StringBuffer strXPath(this->getEnvXPath());
+    strXPath.append("[@").append(pAttribute->getName()).append("=\"").append(this->getValue()).append("\"]");
+
+    if (pEnvTree->hasProp(strXPath.str()) == true)
+        this->setInstanceValueValid(true);
+    else
+        this->setInstanceValueValid(false);
+}
+
+void CEnumerationArray::dump(std::ostream &cout, unsigned int offset) const
+{
+    offset+= STANDARD_OFFSET_1;
+
+    QuickOutHeader(cout, XSD_ENUMERATION_ARRAY_STR, offset);
+    QUICK_OUT_ARRAY(cout, offset);
+    QUICK_OUT(cout, XSDXPath,  offset);
+    QUICK_OUT(cout, EnvXPath,  offset);
+    QuickOutFooter(cout, XSD_ENUMERATION_ARRAY_STR, offset);
+}
+
+void CEnumerationArray::getDocumentation(StringBuffer &strDoc) const
+{
+    strDoc.append("\nChoices are: \n").append(DM_LINE_BREAK);
+    QUICK_DOC_ARRAY(strDoc);
+}
+
+void CEnumerationArray::getQML(StringBuffer &strQML, int idx) const
+{
+    QUICK_QML_ARRAY(strQML);
+}
+
+const char* CEnumerationArray::getXML(const char* /*pComponent*/)
+{
+    UNIMPLEMENTED;
+    return NULL;
+}
+
+void CEnumerationArray::populateEnvXPath(StringBuffer strXPath, unsigned int index)
+{
+    assert(index == 1);  // Only 1 array of elements per node
+    QUICK_ENV_XPATH(strXPath)
+    this->setEnvXPath(strXPath);
+}
+
+void CEnumerationArray::loadXMLFromEnvXml(const IPropertyTree *pEnvTree)
+{
+    assert(pEnvTree != NULL);
+    if (pEnvTree->hasProp(this->getEnvXPath()) == false)
+        throw MakeExceptionFromMap(EX_STR_XPATH_DOES_NOT_EXIST_IN_TREE);
+    else
+        QUICK_LOAD_ENV_XML(pEnvTree)
+}
+
+int CEnumerationArray::getEnvValueNodeIndex() const
+{
+    int len = this->length();
+
+    for (int idx = 0; idx < len; idx++)
+    {
+        if (this->item(idx).isInstanceValueValid() == true)
+            return idx;
+    }
+    return 1;
+}
+
+void CEnumerationArray::setEnvValueNodeIndex(int index)
+{
+    assert(index >= 0);
+    assert(index < this->length());
+
+    for (int idx = 0; idx < this->length(); idx++)
+    {
+        if (this->item(idx).isInstanceValueValid() == true)
+            this->item(idx).setInstanceValueValid(false);
+    }
+    this->item(index).setInstanceValueValid(true);
+}
+
+CEnumerationArray* CEnumerationArray::load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath)
+{
+    assert(pSchemaRoot != NULL);
+    if (pSchemaRoot == NULL)
+        return NULL;
+
+    CEnumerationArray *pEnumerationArray = new CEnumerationArray(pParentNode);
+    pEnumerationArray->setXSDXPath(xpath);
+
+    Owned<IPropertyTreeIterator> elemIter = pSchemaRoot->getElements(xpath);
+
+    int count = 1;
+
+    ForEach(*elemIter)
+    {
+        StringBuffer strXPathExt(xpath);
+        strXPathExt.appendf("[%d]", count);
+
+        CEnumeration *pEnumeration = CEnumeration::load(pEnumerationArray, pSchemaRoot, strXPathExt.str());
+        pEnumerationArray->append(*pEnumeration);
+
+        count++;
+    }
+
+    if (pEnumerationArray->length() == 0)
+    {
+        delete pEnumerationArray;
+        return NULL;
+    }
+
+    SETPARENTNODE(pEnumerationArray, pParentNode);
+    return pEnumerationArray;
+}

--- a/configuration/configurator/SchemaEnumeration.hpp
+++ b/configuration/configurator/SchemaEnumeration.hpp
@@ -1,0 +1,96 @@
+﻿/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef _SCHEMA_ENUMERATION_HPP_
+#define _SCHEMA_ENUMERATION_HPP_
+
+#include "SchemaCommon.hpp"
+
+class CEnumeration : public CXSDNode
+{
+public:
+    friend class CEnumerationArray;
+
+    virtual ~CEnumeration()
+    {
+    }
+
+    GETTERSETTER(Value)
+
+    virtual void dump(std::ostream &cout, unsigned int offset = 0) const;
+    virtual void getDocumentation(StringBuffer &strDoc) const;
+    void getQML(StringBuffer &strQML, int idx = -1) const;
+    virtual const char* getXML(const char* /*pComponent*/);
+    virtual void populateEnvXPath(StringBuffer strXPath, unsigned int index = 1);
+    virtual void loadXMLFromEnvXml(const IPropertyTree *pEnvTree);
+    bool isInstanceValueValid() const
+    {
+        return m_bInstanceValueValid;
+    }
+    static CEnumeration* load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath);
+
+protected:
+
+    CEnumeration(CXSDNodeBase* pParentNode) : CXSDNode::CXSDNode(pParentNode, XSD_ENUMERATION), m_strValue(""), m_bInstanceValueValid(false)
+    {
+    }
+    void setInstanceValueValid(bool b)
+    {
+        m_bInstanceValueValid = b;
+    }
+
+    bool m_bInstanceValueValid;
+
+private:
+
+    CEnumeration() : CXSDNode::CXSDNode(NULL, XSD_ENUMERATION)
+    {
+    }
+};
+
+class CEnumerationArray : public CIArrayOf<CEnumeration>, public InterfaceImpl, public CXSDNodeBase
+{
+public:
+
+    CEnumerationArray(CXSDNodeBase* pParentNode, IPropertyTree *pSchemaRoot = NULL) : CXSDNodeBase::CXSDNodeBase(pParentNode, XSD_ENUMERATION_ARRAY), m_pSchemaRoot(pSchemaRoot)
+    {
+    }
+    virtual ~CEnumerationArray()
+    {
+    }
+    virtual void dump(std::ostream &cout, unsigned int offset = 0) const;
+    virtual void getDocumentation(StringBuffer &strDoc) const;
+    void getQML(StringBuffer &strQML, int idx = -1) const;
+    virtual const char* getXML(const char* /*pComponent*/);
+    virtual void populateEnvXPath(StringBuffer strXPath, unsigned int index = 1);
+    virtual void loadXMLFromEnvXml(const IPropertyTree *pEnvTree);
+    int getEnvValueNodeIndex() const;
+    void setEnvValueNodeIndex(int index);
+    static CEnumerationArray* load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath = NULL);
+
+protected:
+
+    IPropertyTree *m_pSchemaRoot;
+
+private:
+
+    CEnumerationArray() : CXSDNodeBase::CXSDNodeBase(NULL, XSD_ENUMERATION_ARRAY)
+    {
+    }
+};
+
+#endif // _SCHEMA_ENUMERATION_HPP_

--- a/configuration/configurator/SchemaExtension.cpp
+++ b/configuration/configurator/SchemaExtension.cpp
@@ -1,0 +1,92 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include "XMLTags.h"
+#include "jptree.hpp"
+#include "SchemaExtension.hpp"
+#include "SchemaComplexType.hpp"
+#include "SchemaSchema.hpp"
+#include "ConfigSchemaHelper.hpp"
+
+static const char* DEFAULT_ENVIRONMENT_XSD("Environment.xsd");
+
+void CExtension::dump(std::ostream& cout, unsigned int offset) const
+{
+    offset+= STANDARD_OFFSET_1;
+
+    QuickOutHeader(cout, XSD_EXTENSION_STR, offset);
+    QUICK_OUT(cout, Base, offset);
+    QUICK_OUT(cout, XSDXPath,  offset);
+
+    if (this->getBaseNode() != NULL)
+        this->getBaseNode()->dump(cout, offset);
+
+    QuickOutFooter(cout, XSD_EXTENSION_STR, offset);
+}
+
+const char* CExtension::getXML(const char* /*pComponent*/)
+{
+    if (m_strXML.length() == 0 && m_pXSDNode != NULL)
+        m_pXSDNode->getXML(NULL);
+
+    return NULL;
+}
+
+void CExtension::initExtension()
+{
+    NODE_TYPES eNodeType[] = { XSD_SIMPLE_TYPE, XSD_SIMPLE_CONTENT };
+
+    const CXSDNodeBase *pBaseNode = (dynamic_cast<const CXSDNodeBase*>(this));
+
+    if (pBaseNode != NULL)
+    {
+        pBaseNode->getNodeByTypeAndNameAscending( eNodeType, this->getBase());
+        this->setBaseNode(const_cast<CXSDNodeBase*>(pBaseNode));
+    }
+}
+
+CExtension* CExtension::load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath)
+{
+    assert(pSchemaRoot != NULL);
+
+    if (pSchemaRoot == NULL)
+        return NULL;
+
+    CExtension *pExtension = NULL;
+
+    if (xpath && *xpath)
+    {
+        IPropertyTree* pTree = pSchemaRoot->queryPropTree(xpath);
+
+        if (pTree == NULL)
+            return NULL; // no xs:extension node
+
+        const char* pBase = pSchemaRoot->getPropTree(xpath)->queryProp(XML_ATTR_BASE);
+
+        if (pBase != NULL)
+        {
+            pExtension = new CExtension(pParentNode);
+            pExtension->setXSDXPath(xpath);
+            pExtension->setBase(pBase);
+        }
+    }
+
+    if (pExtension != NULL)
+        CConfigSchemaHelper::getInstance()->addExtensionToBeProcessed(pExtension);
+
+    return pExtension;
+}

--- a/configuration/configurator/SchemaExtension.hpp
+++ b/configuration/configurator/SchemaExtension.hpp
@@ -1,0 +1,58 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef _SCHEMA_EXTENSION_HPP_
+#define _SCHEMA_EXTENSION_HPP_
+
+#include "SchemaCommon.hpp"
+#include "jstring.hpp"
+
+class IPropertyTree;
+
+class CExtension : public CXSDNodeWithBase
+{
+public:
+
+    virtual ~CExtension()
+    {
+    }
+
+    virtual const char* getXML(const char* /*pComponent*/);
+    virtual void initExtension();
+    virtual void dump(std::ostream& cout, unsigned int offset = 0) const;
+
+    virtual void getDocumentation(StringBuffer &strDoc) const
+    {
+       throwUnexpected(); // Should not be called directly
+    }
+
+    static CExtension* load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath = NULL);
+
+protected:
+
+    CExtension(CXSDNodeBase* pParentNode, const char* pBase = NULL, CXSDNode *pXSDNode = NULL) : CXSDNodeWithBase::CXSDNodeWithBase(pParentNode, XSD_EXTENSION)
+    {
+    }
+
+private:
+
+    CExtension() : CXSDNodeWithBase::CXSDNodeWithBase(NULL, XSD_EXTENSION)
+    {
+    }
+};
+
+#endif // _SCHEMA_EXTENSION_HPP_

--- a/configuration/configurator/SchemaField.cpp
+++ b/configuration/configurator/SchemaField.cpp
@@ -1,0 +1,133 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include "SchemaField.hpp"
+
+CField* CField::load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath)
+{
+    assert(pSchemaRoot != NULL);
+    assert(pParentNode != NULL);
+    assert(pParentNode->getNodeType() == XSD_FIELD_ARRAY);
+
+    if (pSchemaRoot == NULL || pParentNode == NULL)
+    {
+        // TODO: Throw Exception
+        return NULL;
+    }
+
+    CField *pField = NULL;
+
+    if (xpath != NULL && *xpath != 0)
+    {
+        IPropertyTree* pTree = pSchemaRoot->queryPropTree(xpath);
+
+        if (pTree == NULL)
+            return NULL;
+
+        const char* pXPath = pSchemaRoot->getPropTree(xpath)->queryProp(XML_ATTR_XPATH);
+        assert(pXPath != NULL && *pXPath != 0);
+
+        if (pXPath == NULL || *pXPath == 0)
+        {
+            assert(!"Throw Exception");
+            // TODO: throw exception
+        }
+
+        if (pXPath != NULL)
+        {
+            pField = new CField(pParentNode);
+            pField->setXSDXPath(xpath);
+            pField->setXPath(pXPath);
+        }
+        else
+        {
+            assert(!"xpath can not be be empty!");
+            // TODO: throw MakeExceptionFromMap(EX_STR_MISSING_XPATH_IN_FIELD);
+        }
+
+        const char *pID = pSchemaRoot->getPropTree(xpath)->queryProp(XML_ATTR_ID);
+
+        if (pID != NULL)
+            pField->setID(pID);
+   }
+   return pField;
+}
+
+void CField::dump(std::ostream& cout, unsigned int offset) const
+{
+    offset += STANDARD_OFFSET_1;
+
+    QuickOutHeader(cout, XSD_FIELD_STR, offset);
+    QUICK_OUT(cout, XPath, offset);
+    QUICK_OUT(cout, ID, offset);
+    QUICK_OUT(cout, XSDXPath,  offset);
+    QuickOutFooter(cout, XSD_FIELD_STR, offset);
+}
+
+CFieldArray* CFieldArray::load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath)
+{
+    assert(xpath != NULL);
+    assert(pParentNode != NULL);
+    assert(pSchemaRoot != NULL);
+    assert(pParentNode->getNodeType() == XSD_KEY || pParentNode->getNodeType() == XSD_KEYREF || pParentNode->getNodeType() == XSD_UNIQUE);
+
+    if (pSchemaRoot == NULL || xpath == NULL || pParentNode == NULL)
+    {
+        // TODO: exceptions
+        //throw
+        return NULL;
+    }
+
+    StringBuffer strXPathExt(xpath);
+    CFieldArray *pFieldArray = new CFieldArray(pParentNode);
+    pFieldArray->setXSDXPath(xpath);
+
+    Owned<IPropertyTreeIterator> attributeIter = pSchemaRoot->getElements(xpath, ipt_ordered);
+
+    int count = 1;
+    ForEach(*attributeIter)
+    {
+        strXPathExt.clear().append(xpath).appendf("[%d]",count);
+
+        CField *pField = CField::load(pFieldArray, pSchemaRoot, strXPathExt.str());
+
+        if (pField != NULL)
+                pFieldArray->append(*pField);
+
+        count++;
+    }
+
+    if (pFieldArray->length() == 0)
+    {
+        delete pFieldArray;
+        pFieldArray = NULL;
+    }
+    return pFieldArray;
+}
+
+void CFieldArray::dump(std::ostream &cout, unsigned int offset) const
+{
+    offset+= STANDARD_OFFSET_1;
+
+    QuickOutHeader(cout, XSD_FIELD_ARRAY_STR, offset);
+    QUICK_OUT(cout, XSDXPath,  offset);
+    QUICK_OUT(cout, EnvXPath,  offset);
+    QUICK_OUT_ARRAY(cout, offset);
+    QuickOutFooter(cout, XSD_FIELD_ARRAY_STR, offset);
+}
+
+

--- a/configuration/configurator/SchemaField.hpp
+++ b/configuration/configurator/SchemaField.hpp
@@ -1,0 +1,113 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef _SCHEMA_FIELD_HPP_
+#define _SCHEMA_FIELD_HPP_
+
+#include "SchemaCommon.hpp"
+#include "jstring.hpp"
+
+class CSchemaField;
+class CKey;
+
+class CField : public CXSDNode
+{
+public:
+
+    virtual ~CField()
+    {
+    }
+
+    virtual void dump(std::ostream &cout, unsigned int offset = 0) const;
+    virtual void getDocumentation(StringBuffer &strDoc) const
+    {
+        UNIMPLEMENTED;
+    }
+    virtual void getQML(StringBuffer &strQML, int idx = -1) const
+    {
+        UNIMPLEMENTED;
+    }
+    virtual void populateEnvXPath(StringBuffer strXPath, unsigned int index = 1)
+    {
+        UNIMPLEMENTED;
+    }
+
+    static CField* load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath);
+
+    GETTERSETTER(ID)
+    SETTER(XPath)
+
+    const char* getXPath(bool bRemoveAmpersand = true) const
+    {
+        if (bRemoveAmpersand == true)
+        {
+            static StringBuffer strRetString(m_strXPath);
+            static bool bOnce = true;
+
+            if (bOnce == true)
+                strRetString.remove(0,1);
+
+            return strRetString;
+        }
+        else
+            return m_strXPath.str();
+    }
+
+
+protected:
+
+    CField(CXSDNodeBase *pParentNode) : CXSDNode::CXSDNode(pParentNode, XSD_FIELD)
+    {
+    }
+
+    StringBuffer m_strXPath;
+};
+
+class CFieldArray : public CIArrayOf<CField>, public InterfaceImpl, public CXSDNodeBase
+{
+public:
+    virtual ~CFieldArray()
+    {
+    }
+
+    virtual void dump(std::ostream& cout, unsigned int offset = 0) const;
+    virtual void getDocumentation(StringBuffer &strDoc) const
+    {
+        UNIMPLEMENTED;
+    }
+    virtual void getQML(StringBuffer &strQML, int idx = -1) const
+    {
+        UNIMPLEMENTED;
+    }
+    virtual void populateEnvXPath(StringBuffer strXPath, unsigned int index = 1)
+    {
+        UNIMPLEMENTED;
+    }
+    virtual void loadXMLFromEnvXml(const IPropertyTree *pEnvTree)
+    {
+        UNIMPLEMENTED;
+    }
+
+    static CFieldArray* load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath);
+
+protected:
+
+    CFieldArray(CXSDNodeBase* pParentNode = NULL) : CXSDNodeBase::CXSDNodeBase(pParentNode, XSD_FIELD_ARRAY)
+    {
+    }
+};
+#endif // _SCHEMA_FIELD_HPP_

--- a/configuration/configurator/SchemaFractionDigits.cpp
+++ b/configuration/configurator/SchemaFractionDigits.cpp
@@ -1,0 +1,69 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include "SchemaFractionDigits.hpp"
+#include "XMLTags.h"
+#include "jptree.hpp"
+#include <cstdlib>
+
+CFractionDigits* CFractionDigits::load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath)
+{
+    assert(pSchemaRoot != NULL);
+    if (pSchemaRoot == NULL)
+        return NULL;
+
+    CFractionDigits *pFractionDigits = new CFractionDigits(pParentNode);
+    pFractionDigits->setXSDXPath(xpath);
+
+    if (xpath != NULL && *xpath != 0)
+    {
+        IPropertyTree* pTree = pSchemaRoot->queryPropTree(xpath);
+
+        if (pTree == NULL)
+            return pFractionDigits;
+
+        const char* pValue = pTree->queryProp(XML_ATTR_VALUE);
+
+        if (pValue != NULL && *pValue != 0)
+        {
+            pFractionDigits->setFractionDigits(pValue);
+            pFractionDigits->setValue(pValue);
+        }
+
+        if (pFractionDigits->getFractionDigits() < 0)  // not set or bad length value
+        {
+            delete pFractionDigits;
+            pFractionDigits = NULL;
+
+            //throw MakeExceptionFromMap(EX_STR_LENGTH_VALUE_MUST_BE_GREATER_THAN_OR_EQUAL_TO_ZERO, EACTION_FRACTION_DIGITS_HAS_BAD_LENGTH);
+            assert(false);
+        }
+    }
+    return pFractionDigits;
+}
+
+void CFractionDigits::dump(std::ostream& cout, unsigned int offset) const
+{
+    offset+= STANDARD_OFFSET_1;
+
+    QuickOutHeader(cout, XSD_FRACTION_DIGITS_STR, offset);
+    QUICK_OUT(cout, XSDXPath,  offset);
+    QUICK_OUT(cout, EnvXPath,  offset);
+    QUICK_OUT(cout, Value, offset);
+    QUICK_OUT(cout, FractionDigits, offset);
+    QuickOutFooter(cout, XSD_FRACTION_DIGITS_STR, offset);
+}

--- a/configuration/configurator/SchemaFractionDigits.hpp
+++ b/configuration/configurator/SchemaFractionDigits.hpp
@@ -1,0 +1,60 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef _SCHEMA_FRACTION_DIGITS_HPP_
+#define _SCHEMA_FRACTION_DIGITS_HPP_
+
+#include "SchemaCommon.hpp"
+
+class CFractionDigits : public CXSDNode
+{
+public:
+
+    virtual ~CFractionDigits()
+    {
+    }
+
+    static CFractionDigits* load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath);
+
+    virtual void dump(std::ostream& cout, unsigned int offset = 0) const;
+    virtual void getDocumentation(StringBuffer &strDoc) const
+    {
+        UNIMPLEMENTED;
+    }
+    void getQML(StringBuffer &strQML, int idx = -1) const
+    {
+        UNIMPLEMENTED;
+    }
+    virtual const char* getXML(const char* /*pComponent*/)
+    {
+        UNIMPLEMENTED;
+        return NULL;
+    }
+    virtual void populateEnvXPath(StringBuffer strXPath, unsigned int index = 1)
+    {
+        UNIMPLEMENTED;
+    }
+    GETTERSETTER(Value)
+    GETTERSETTERINT(FractionDigits)
+
+private:
+
+    CFractionDigits(CXSDNodeBase* pParentNode = NULL) : CXSDNode::CXSDNode(pParentNode, XSD_FRACTION_DIGITS), m_strValue(""), m_nFractionDigits(-1)
+    {
+    }
+};
+#endif

--- a/configuration/configurator/SchemaInclude.cpp
+++ b/configuration/configurator/SchemaInclude.cpp
@@ -1,0 +1,155 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include "jptree.hpp"
+#include "XMLTags.h"
+#include "SchemaInclude.hpp"
+#include "SchemaSchema.hpp"
+#include "ConfigSchemaHelper.hpp"
+
+void CInclude::dump(std::ostream& cout, unsigned int offset) const
+{
+    offset+= STANDARD_OFFSET_1;
+
+    QuickOutHeader(cout, XSD_INCLUDE_STR, offset);
+    QUICK_OUT(cout, SchemaLocation, offset);
+    QUICK_OUT(cout, XSDXPath,  offset);
+
+    if (this->getIncludeSchema() != NULL)
+        this->getIncludeSchema()->dump(cout, offset);
+
+    QuickOutFooter(cout, XSD_INCLUDE_STR, offset);
+}
+
+void CInclude::getDocumentation(StringBuffer &strDoc) const
+{
+}
+
+void CInclude::getQML(StringBuffer &strQML, int idx) const
+{
+}
+
+const char* CInclude::getXML(const char* /*pComponent*/)
+{
+    return m_strXML.str();
+}
+
+CInclude* CInclude::load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath)
+{
+    if (pParentNode == NULL || pSchemaRoot == NULL || xpath == NULL)
+        return NULL;
+
+    CInclude *pInclude = NULL;
+    IPropertyTree *pTree = pSchemaRoot->queryPropTree(xpath);
+
+    if (pTree != NULL)
+    {
+        const char *pSchemaLocation = pSchemaRoot->queryPropTree(xpath)->queryProp(XML_ATTR_SCHEMA_LOCATION);
+
+        if (pSchemaLocation != NULL)
+        {
+            CSchema* pSchema = CSchema::load(pSchemaLocation, NULL); // no parent across XSD files
+
+            pInclude = new CInclude(NULL, pSchemaLocation);
+            pInclude->setXSDXPath(xpath);
+            pInclude->setIncludedSchema(pSchema);
+        }
+    }
+    return pInclude;
+}
+
+void CInclude::populateEnvXPath(StringBuffer strXPath, unsigned int index)
+{
+    assert(this->m_pIncludedSchema != NULL);
+    this->m_pIncludedSchema->populateEnvXPath(strXPath.str());
+}
+
+
+void CIncludeArray::populateEnvXPath(StringBuffer strXPath, unsigned int index)
+{
+    //this->setEnvXPath(strXPath);
+    //strXPath.clear();
+    //QUICK_ENV_XPATH_WITH_INDEX(strXPath, index);
+}
+
+CIncludeArray* CIncludeArray::load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char *xpath)
+{
+    if (pSchemaRoot == NULL)
+        return NULL;
+
+    CIncludeArray *pIncludeArray = new CIncludeArray(pParentNode);
+    pIncludeArray->setXSDXPath(xpath);
+
+    Owned<IPropertyTreeIterator> elemIter = pSchemaRoot->getElements(xpath);
+
+    int count = 1;
+
+    ForEach(*elemIter)
+    {
+        StringBuffer strXPathExt(xpath);
+        strXPathExt.appendf("[%d]", count);
+
+        CInclude *pInclude = CInclude::load(pIncludeArray, pSchemaRoot, strXPathExt.str());
+
+        if (pInclude != NULL)
+            pIncludeArray->append(*pInclude);
+
+        count++;
+    }
+
+    if (pIncludeArray->length() == 0)
+        return NULL;
+
+    return pIncludeArray;
+}
+
+const char* CIncludeArray::getXML(const char* /*pComponent*/)
+{
+    if (m_strXML.length() == 0)
+    {
+        int length = this->length();
+
+        for (int idx = 0; idx < length; idx++)
+        {
+            CInclude &Include = this->item(idx);
+            m_strXML.append(Include.getXML(NULL));
+
+            if (idx+1 < length)
+                m_strXML.append("\n");
+        }
+    }
+    return m_strXML.str();
+}
+
+void CIncludeArray::dump(std::ostream &cout, unsigned int offset) const
+{
+    offset+= STANDARD_OFFSET_1;
+
+    QuickOutHeader(cout, XSD_INCLUDE_ARRAY_STR, offset);
+    QUICK_OUT_ARRAY(cout, offset);
+    QuickOutFooter(cout, XSD_INCLUDE_ARRAY_STR, offset);
+}
+
+void CIncludeArray::getDocumentation(StringBuffer &strDoc) const
+{
+    QUICK_DOC_ARRAY(strDoc);
+}
+
+void CIncludeArray::getQML(StringBuffer &strQML, int idx) const
+{
+    QUICK_QML_ARRAY(strQML);
+}

--- a/configuration/configurator/SchemaInclude.hpp
+++ b/configuration/configurator/SchemaInclude.hpp
@@ -1,0 +1,102 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef _SCHEMA_INCLUDE_HPP_
+#define _SCHEMA_INCLUDE_HPP_
+
+#include "jstring.hpp"
+#include "jarray.hpp"
+#include "SchemaCommon.hpp"
+
+class CSchema;
+
+class CInclude : public CXSDNode
+{
+public:
+
+    virtual ~CInclude()
+    {
+    }
+
+    virtual void dump(std::ostream& cout, unsigned int offset = 0) const;
+    virtual void getDocumentation(StringBuffer &strDoc) const;
+    virtual void getQML(StringBuffer &strQML, int idx = -1) const;
+    virtual const char* getXML(const char* /*pComponent*/);
+    virtual void populateEnvXPath(StringBuffer strXPath, unsigned int index = 1);
+
+    GETTERSETTER(SchemaLocation)
+
+    const CSchema* getIncludeSchema() const
+    {
+        return m_pIncludedSchema;
+    }
+
+    static CInclude* load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath = NULL);
+
+protected:
+
+    CInclude(CXSDNodeBase* pParentNode, const char* pSchemaLocation = NULL) : CXSDNode::CXSDNode(pParentNode, XSD_INCLUDE), m_strSchemaLocation(pSchemaLocation)
+    {
+    }
+
+    CSchema *m_pIncludedSchema;
+
+    void setIncludedSchema(CSchema *pSchema)
+    {
+        m_pIncludedSchema = pSchema;
+    }
+
+private:
+
+    CInclude(CXSDNodeBase* pParentNode = NULL) : CXSDNode::CXSDNode(pParentNode, XSD_INCLUDE), m_pIncludedSchema(NULL)
+    {
+    }
+
+};
+
+class CIncludeArray : public CIArrayOf<CInclude>, public InterfaceImpl, public CXSDNodeBase
+{
+public:
+
+    CIncludeArray(CXSDNodeBase* pParentNode, IPropertyTree *pSchemaRoot) : CXSDNodeBase::CXSDNodeBase(pParentNode, XSD_INCLUDE_ARRAY), m_pSchemaRoot(pSchemaRoot)
+    {
+    }
+
+    virtual ~CIncludeArray()
+    {
+    }
+
+    virtual void dump(std::ostream &cout, unsigned int offset = 0) const;
+    virtual void getDocumentation(StringBuffer &strDoc) const;
+    virtual void getQML(StringBuffer &strQML, int idx = -1) const;
+    virtual void populateEnvXPath(StringBuffer strXPath, unsigned int index = 1);
+    virtual const char* getXML(const char* /*pComponent*/);
+
+    static CIncludeArray* load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath);
+
+protected:
+
+    IPropertyTree *m_pSchemaRoot;
+
+private:
+
+    CIncludeArray(CXSDNodeBase* pParentNode = NULL) : CXSDNodeBase::CXSDNodeBase(pParentNode, XSD_INCLUDE_ARRAY)
+    {
+    }
+};
+
+#endif // _SCHEMA_INCLUDE_HPP_

--- a/configuration/configurator/SchemaKey.cpp
+++ b/configuration/configurator/SchemaKey.cpp
@@ -1,0 +1,217 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include "SchemaKey.hpp"
+#include "SchemaSelector.hpp"
+#include "SchemaField.hpp"
+#include "SchemaAnnotation.hpp"
+#include "SchemaCommon.hpp"
+#include "ConfigSchemaHelper.hpp"
+#include "SchemaMapManager.hpp"
+#include "SchemaAttributes.hpp"
+#include "jptree.hpp"
+
+CKey* CKey::load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath)
+{
+    assert(pSchemaRoot != NULL);
+    assert(pParentNode != NULL);
+    assert(pParentNode->getNodeType() == XSD_KEY_ARRAY);
+
+    if (pSchemaRoot == NULL || pParentNode == NULL)
+    {
+        // TODO: Throw Exception
+        return NULL;
+    }
+
+    CKey *pKey = new CKey(pParentNode);
+
+    if (xpath != NULL && *xpath != 0)
+    {
+        IPropertyTree* pTree = pSchemaRoot->queryPropTree(xpath);
+
+        if (pTree == NULL)
+            return NULL; // no xs:key
+
+        const char* pName = pSchemaRoot->getPropTree(xpath)->queryProp(XML_ATTR_NAME);
+        if (pName != NULL)
+         {
+             pKey = new CKey(pParentNode);
+             pKey->setXSDXPath(xpath);
+             pKey->setName(pName);
+         }
+         else
+         {
+             assert(!"value attribute can be empty!");
+             // TODO: throw MakeExceptionFromMap(EX_STR_MISSING_VALUE_ATTRIBUTE_IN_LENGTH);
+             return NULL;
+         }
+
+         const char *pID = pSchemaRoot->getPropTree(xpath)->queryProp(XML_ATTR_ID);
+         if (pID != NULL)
+             pKey->setID(pID);
+
+         StringBuffer strXPathExt(xpath);
+         strXPathExt.append("/").append(XSD_TAG_FIELD);
+
+         if (strXPathExt.charAt(0) == '@')
+             strXPathExt.remove(0,1); // remove '@'
+
+         pKey->m_pFieldArray = CFieldArray::load(pKey, pSchemaRoot, strXPathExt.str());
+
+         strXPathExt.clear().set(xpath);
+         strXPathExt.append("/").append(XSD_TAG_SELECTOR);
+
+         if (strXPathExt.charAt(0) == '.')
+             strXPathExt.remove(0,2); // remove leading ./
+
+         pKey->m_pSelector = CSelector::load(pKey, pSchemaRoot, strXPathExt.str());
+         assert(pKey->m_pFieldArray != NULL && pKey->m_pSelector != NULL);
+
+         strXPathExt.append("/").append(XSD_TAG_ANNOTATION);
+         pKey->m_pAnnotation = CAnnotation::load(pKey, pSchemaRoot, strXPathExt.str());
+    }
+    return pKey;
+}
+
+void CKey::populateEnvXPath(StringBuffer strXPath, unsigned int index)
+{
+    assert(this->m_pSelector != NULL);
+
+    this->setEnvXPath(strXPath.str());
+
+    if (this->m_pSelector != NULL)
+    {
+        this->m_pSelector->populateEnvXPath(strXPath.str());
+        CConfigSchemaHelper::getInstance()->addKeyForReverseAssociation(this);
+    }
+}
+
+bool CKey::checkConstraint(const char *pValue) const
+{
+    bool bRetVal = true;
+
+    if (m_pSelector != NULL && m_pFieldArray->length() != 0)
+    {
+        for (int idx = 0; idx < m_pFieldArray->length(); idx++)
+        {
+            assert(!"Multiple fields not implemented");
+            CField *m_pField = &(m_pFieldArray->item(idx));
+
+            assert(m_pField != NULL);
+            if (m_pField == NULL)
+                return false;
+
+            StringBuffer strXPathForConstraintCheck(this->getEnvXPath());
+            strXPathForConstraintCheck.appendf("/%s", this->m_pSelector->getXPath());
+
+            const CElement *pElement = CConfigSchemaHelper::getInstance()->getSchemaMapManager()->getElementFromXPath(strXPathForConstraintCheck.str());
+            if (pElement == NULL)
+                return false;
+
+            const CAttribute *pAttribute = dynamic_cast<const CAttribute*>(pElement->getNodeByTypeAndNameDescending(XSD_ATTRIBUTE, m_pField->getXPath()));  // needs to be first possible descendent
+            if (pAttribute != NULL && pAttribute->getParentNodeByType(XSD_ELEMENT) != pElement)
+            {
+                assert(!"Could not find match for key");
+            }
+        }
+    }
+    return bRetVal;
+}
+
+void CKey::dump(std::ostream& cout, unsigned int offset) const
+{
+    offset += STANDARD_OFFSET_1;
+
+    QuickOutHeader(cout, XSD_KEY_STR, offset);
+    QUICK_OUT(cout, Name, offset);
+    QUICK_OUT(cout, ID, offset);
+    QUICK_OUT(cout, XSDXPath,  offset);
+
+    if (m_pFieldArray != NULL)
+        m_pFieldArray->dump(cout, offset);
+    if (m_pSelector != NULL)
+        m_pSelector->dump(cout, offset);
+
+    QuickOutFooter(cout, XSD_KEY_STR, offset);
+}
+
+CKeyArray* CKeyArray::load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath)
+{
+    assert(pSchemaRoot != NULL);
+    assert(pParentNode->getNodeType() == XSD_ELEMENT);
+
+    if (pSchemaRoot == NULL || xpath == NULL)
+        return NULL;
+
+    StringBuffer strXPathExt(xpath);
+
+    CKeyArray *pKeyArray = new CKeyArray(pParentNode);
+    pKeyArray->setXSDXPath(xpath);
+
+    Owned<IPropertyTreeIterator> attributeIter = pSchemaRoot->getElements(xpath, ipt_ordered);
+
+    int count = 1;
+    ForEach(*attributeIter)
+    {
+        strXPathExt.clear().append(xpath).appendf("[%d]",count);
+
+        CKey *pKey = CKey::load(pKeyArray, pSchemaRoot, strXPathExt.str());
+        if (pKey != NULL)
+            pKeyArray->append(*pKey);
+
+        count++;
+    }
+
+    if (pKeyArray->length() == 0)
+    {
+        delete pKeyArray;
+        pKeyArray = NULL;
+    }
+    return pKeyArray;
+}
+
+bool CKeyArray::checkConstraint(const char *pValue) const
+{
+    assert(pValue != NULL);
+
+    if (pValue == NULL)
+        return false;
+
+    for (int idx = 0; idx < this->length(); idx++)
+    {
+        if ((this->item(idx)).checkConstraint(pValue) == false)
+            return false;
+    }
+    return true;
+}
+
+void CKeyArray::dump(std::ostream &cout, unsigned int offset) const
+{
+    offset+= STANDARD_OFFSET_1;
+
+    QuickOutHeader(cout, XSD_KEY_ARRAY_STR, offset);
+    QUICK_OUT(cout, XSDXPath,  offset);
+    QUICK_OUT(cout, EnvXPath,  offset);
+    QUICK_OUT_ARRAY(cout, offset);
+    QuickOutFooter(cout, XSD_KEY_ARRAY_STR, offset);
+}
+
+void CKeyArray::populateEnvXPath(StringBuffer strXPath, unsigned int index)
+{
+    this->setEnvXPath(strXPath);
+    QUICK_ENV_XPATH_WITH_INDEX(strXPath, index)
+}

--- a/configuration/configurator/SchemaKey.hpp
+++ b/configuration/configurator/SchemaKey.hpp
@@ -1,0 +1,106 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef _SCHEMA_KEY_HPP_
+#define _SCHEMA_KEY_HPP_
+
+#include "SchemaCommon.hpp"
+#include "jstring.hpp"
+
+class CSelector;
+class CFieldArray;
+class CAnnotation;
+
+class CKey : public CXSDNode
+{
+    friend class CKeyArray;
+    friend class CKeyRef;
+
+public:
+
+    virtual ~CKey()
+    {
+    }
+
+    virtual void dump(std::ostream &cout, unsigned int offset = 0) const;
+    virtual void populateEnvXPath(StringBuffer strXPath, unsigned int index = 1);
+    virtual void getDocumentation(StringBuffer &strDoc) const
+    {
+        UNIMPLEMENTED;
+    }
+    virtual void getQML(StringBuffer &strQML, int idx = -1) const
+    {
+        UNIMPLEMENTED;
+    }
+
+    const CAnnotation* getAnnotation() const
+    {
+        return m_pAnnotation;
+    }
+    static CKey* load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath);
+
+    GETTERSETTER(Name)
+    GETTERSETTER(ID)
+
+protected:
+
+    CKey(CXSDNodeBase* pParentNode) : CXSDNode::CXSDNode(pParentNode, XSD_KEY), m_pFieldArray(NULL), m_pSelector(NULL), m_pAnnotation(NULL)
+    {
+    }
+
+    virtual bool checkConstraint(const char *pValue) const;
+
+    CFieldArray *m_pFieldArray;
+    CSelector *m_pSelector;
+    CAnnotation *m_pAnnotation;
+};
+
+class CKeyArray : public CIArrayOf<CKey>, public InterfaceImpl, public CXSDNodeBase
+{
+public:
+
+    virtual ~CKeyArray()
+    {
+    }
+
+    virtual void dump(std::ostream& cout, unsigned int offset = 0) const;
+    virtual void populateEnvXPath(StringBuffer strXPath, unsigned int index = 1);
+
+    virtual void getDocumentation(StringBuffer &strDoc) const
+    {
+        UNIMPLEMENTED;
+    }
+    virtual void getQML(StringBuffer &strQML, int idx = -1) const
+    {
+        UNIMPLEMENTED;
+    }
+    virtual void loadXMLFromEnvXml(const IPropertyTree *pEnvTree)
+    {
+        UNIMPLEMENTED;
+    }
+    virtual bool checkConstraint(const char *pValue) const;
+
+    static CKeyArray* load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath);
+
+protected:
+
+    CKeyArray(CXSDNodeBase* pParentNode = NULL) : CXSDNodeBase::CXSDNodeBase(pParentNode, XSD_KEY_ARRAY)
+    {
+    }
+};
+
+#endif // _SCHEMA_KEY_HPP_

--- a/configuration/configurator/SchemaKeyRef.cpp
+++ b/configuration/configurator/SchemaKeyRef.cpp
@@ -1,0 +1,173 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include "SchemaKeyRef.hpp"
+#include "SchemaSelector.hpp"
+#include "SchemaCommon.hpp"
+#include "ConfigSchemaHelper.hpp"
+#include "SchemaMapManager.hpp"
+
+CKeyRef* CKeyRef::load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath)
+{
+    assert(pSchemaRoot != NULL);
+    assert(pParentNode != NULL);
+    assert(pParentNode->getNodeType() == XSD_KEYREF_ARRAY);
+
+    if (pSchemaRoot == NULL || pParentNode == NULL)
+    {
+        // TODO: Throw Exception
+        return NULL;
+    }
+
+    CKeyRef *pKeyRef = new CKeyRef(pParentNode);
+
+    if (xpath != NULL && *xpath != 0)
+    {
+        IPropertyTree* pTree = pSchemaRoot->queryPropTree(xpath);
+        if (pTree == NULL)
+            return NULL; // no xs:KeyRef
+
+        const char* pName = pSchemaRoot->getPropTree(xpath)->queryProp(XML_ATTR_NAME);
+        const char* pRefer = pSchemaRoot->getPropTree(xpath)->queryProp(XML_ATTR_REFER);
+
+        if (pName != NULL && pRefer != NULL)
+        {
+            pKeyRef = new CKeyRef(pParentNode);
+            pKeyRef->setXSDXPath(xpath);
+            pKeyRef->setName(pName);
+        }
+        else
+        {
+            assert(!"value attribute can be empty!");
+            // TODO: throw MakeExceptionFromMap(EX_STR_MISSING_VALUE_ATTRIBUTE_IN_LENGTH);
+        }
+
+        const char *pID = pSchemaRoot->getPropTree(xpath)->queryProp(XML_ATTR_ID);
+        if (pID != NULL)
+            pKeyRef->setID(pID);
+
+        StringBuffer strXPathExt(xpath);
+        strXPathExt.append("/").append(XSD_TAG_FIELD);
+        pKeyRef->m_pFieldArray = CFieldArray::load(pKeyRef, pSchemaRoot, strXPathExt.str());
+
+        strXPathExt.clear().set(xpath);
+        strXPathExt.append("/").append(XSD_TAG_SELECTOR);
+        pKeyRef->m_pSelector = CSelector::load(pKeyRef, pSchemaRoot, strXPathExt.str());
+    }
+    return pKeyRef;
+}
+
+void CKeyRef::dump(std::ostream& cout, unsigned int offset) const
+{
+    offset += STANDARD_OFFSET_1;
+
+    QuickOutHeader(cout, XSD_KEYREF_STR, offset);
+    QUICK_OUT(cout, Name, offset);
+    QUICK_OUT(cout, ID, offset);
+    QUICK_OUT(cout, Refer, offset);
+    QUICK_OUT(cout, XSDXPath,  offset);
+
+    if (m_pFieldArray != NULL)
+        m_pFieldArray->dump(cout, offset);
+
+    if (m_pSelector != NULL)
+        m_pSelector->dump(cout, offset);
+
+    QuickOutFooter(cout, XSD_KEYREF_STR, offset);
+}
+
+bool CKeyRef::checkConstraint(const char *pValue) const
+{
+    assert (pValue != NULL);
+
+    if (pValue == NULL)
+        return true;
+    else
+    {
+        StringBuffer strQName(this->getXSDXPath());
+        strQName.append("/").append(this->getRefer());
+
+        CKey *pKey = CConfigSchemaHelper::getInstance()->getSchemaMapManager()->getKeyFromXSDXPath(strQName.str());
+        return pKey->checkConstraint(pValue);
+    }
+}
+
+void CKeyRef::populateEnvXPath(StringBuffer strXPath, unsigned int index)
+{
+    assert(this->m_pSelector != NULL);
+
+    this->setEnvXPath(strXPath.str());
+
+    if (this->m_pSelector != NULL)
+    {
+        this->m_pSelector->populateEnvXPath(strXPath.str());
+        CConfigSchemaHelper::getInstance()->addKeyRefForReverseAssociation(this);
+    }
+}
+
+CKeyRefArray* CKeyRefArray::load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath)
+{
+    assert(pSchemaRoot != NULL);
+    assert(pParentNode->getNodeType() == XSD_ELEMENT);
+
+    if (pSchemaRoot == NULL || xpath == NULL)
+        return NULL;
+
+    StringBuffer strXPathExt(xpath);
+
+    CKeyRefArray *pKeyRefArray = new CKeyRefArray(pParentNode);
+    pKeyRefArray->setXSDXPath(xpath);
+
+    Owned<IPropertyTreeIterator> attributeIter = pSchemaRoot->getElements(xpath, ipt_ordered);
+
+    int count = 1;
+    ForEach(*attributeIter)
+    {
+        strXPathExt.clear().append(xpath).appendf("[%d]",count);
+
+        CKeyRef *pKeyRef = CKeyRef::load(pKeyRefArray, pSchemaRoot, strXPathExt.str());
+
+        if (pKeyRef != NULL)
+            pKeyRefArray->append(*pKeyRef);
+
+        count++;
+    }
+
+    if (pKeyRefArray->length() == 0)
+    {
+        delete pKeyRefArray;
+        pKeyRefArray = NULL;
+    }
+    return pKeyRefArray;
+}
+
+void CKeyRefArray::dump(std::ostream &cout, unsigned int offset) const
+{
+    offset+= STANDARD_OFFSET_1;
+
+    QuickOutHeader(cout, XSD_KEYREF_ARRAY_STR, offset);
+    QUICK_OUT(cout, XSDXPath,  offset);
+    QUICK_OUT(cout, EnvXPath,  offset);
+    QUICK_OUT_ARRAY(cout, offset);
+    QuickOutFooter(cout, XSD_KEYREF_ARRAY_STR, offset);
+}
+
+void CKeyRefArray::populateEnvXPath(StringBuffer strXPath, unsigned int index)
+{
+    this->setEnvXPath(strXPath);
+    QUICK_ENV_XPATH_WITH_INDEX(strXPath, index)
+}

--- a/configuration/configurator/SchemaKeyRef.hpp
+++ b/configuration/configurator/SchemaKeyRef.hpp
@@ -1,0 +1,95 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef _SCHEMA_KEYREF_HPP_
+#define _SCHEMA_KEYREF_HPP_
+
+#include "SchemaCommon.hpp"
+#include "jstring.hpp"
+
+class CSelector;
+class CFieldArray;
+
+class CKeyRef : public CXSDNode
+{
+public:
+
+    virtual ~CKeyRef()
+    {
+    }
+
+    virtual void dump(std::ostream &cout, unsigned int offset = 0) const;
+    virtual void populateEnvXPath(StringBuffer strXPath, unsigned int index = 1);
+    bool checkConstraint(const char *pValue) const;
+
+    virtual void getDocumentation(StringBuffer &strDoc) const
+    {
+        UNIMPLEMENTED;
+    }
+    virtual void getQML(StringBuffer &strQML, int idx = -1) const
+    {
+        UNIMPLEMENTED;
+    }
+
+    static CKeyRef* load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath);
+
+    GETTERSETTER(Name)
+    GETTERSETTER(ID)
+    GETTERSETTER(Refer)
+
+protected:
+
+    CKeyRef(CXSDNodeBase* pParentNode) : CXSDNode::CXSDNode(pParentNode, XSD_KEYREF), m_pFieldArray(NULL), m_pSelector(NULL)
+    {
+    }
+
+    CFieldArray *m_pFieldArray;
+    CSelector *m_pSelector;
+};
+
+class CKeyRefArray : public CIArrayOf<CKeyRef>, public InterfaceImpl, public CXSDNodeBase
+{
+public:
+    virtual ~CKeyRefArray()
+    {
+    }
+
+    virtual void dump(std::ostream& cout, unsigned int offset = 0) const;
+    virtual void populateEnvXPath(StringBuffer strXPath, unsigned int index = 1);
+
+    virtual void getDocumentation(StringBuffer &strDoc) const
+    {
+        UNIMPLEMENTED;
+    }
+    virtual void getQML(StringBuffer &strQML, int idx = -1) const
+    {
+        UNIMPLEMENTED;
+    }
+    virtual void loadXMLFromEnvXml(const IPropertyTree *pEnvTree)
+    {
+        UNIMPLEMENTED;
+    }
+    static CKeyRefArray* load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath);
+
+protected:
+
+    CKeyRefArray(CXSDNodeBase* pParentNode = NULL) : CXSDNodeBase::CXSDNodeBase(pParentNode, XSD_KEYREF_ARRAY)
+    {
+    }
+};
+
+#endif // _SCHEMA_KeyRef_HPP_

--- a/configuration/configurator/SchemaLength.cpp
+++ b/configuration/configurator/SchemaLength.cpp
@@ -1,0 +1,63 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include "jptree.hpp"
+#include "SchemaLength.hpp"
+#include "ConfigSchemaHelper.hpp"
+
+CLength* CLength::load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath)
+{
+    assert(pSchemaRoot != NULL);
+    if (pSchemaRoot == NULL)
+        return NULL;
+
+    CLength *pLength = NULL;
+
+    if (xpath && *xpath)
+    {
+        IPropertyTree* pTree = pSchemaRoot->queryPropTree(xpath);
+        if (pTree == NULL)
+            return NULL; // no xs:length node
+
+        const char* pValue = pSchemaRoot->getPropTree(xpath)->queryProp(XML_ATTR_VALUE);
+        if (pValue != NULL)
+        {
+            if (atoi(pValue) < 0)
+                 throw MakeExceptionFromMap(EX_STR_MISSING_VALUE_ATTRIBUTE_IN_LENGTH);
+
+            pLength = new CLength(pParentNode);
+            pLength->setXSDXPath(xpath);
+            pLength->setValue(pValue);
+        }
+        else
+        {
+            assert(!"value attribute can be empty!");
+            throw MakeExceptionFromMap(EX_STR_MISSING_VALUE_ATTRIBUTE_IN_LENGTH);
+        }
+    }
+    return pLength;
+}
+
+void CLength::dump(std::ostream& cout, unsigned int offset) const
+{
+    offset += STANDARD_OFFSET_1;
+
+    QuickOutHeader(cout, XSD_LENGTH_STR, offset);
+    QUICK_OUT(cout, Value, offset);
+    QuickOutFooter(cout, XSD_LENGTH_STR, offset);
+}
+

--- a/configuration/configurator/SchemaLength.hpp
+++ b/configuration/configurator/SchemaLength.hpp
@@ -1,0 +1,59 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef _SCHEMA_LENGTH_HPP_
+#define _SCHEMA_LENGTH_HPP_
+
+#include "SchemaCommon.hpp"
+
+class CLength : public CXSDNode
+{
+public:
+
+    virtual ~CLength()
+    {
+    }
+    static CLength* load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath);
+    virtual void dump(std::ostream& cout, unsigned int offset = 0) const;
+    virtual void getDocumentation(StringBuffer &strDoc) const
+    {
+        UNIMPLEMENTED;
+    }
+    void getQML(StringBuffer &strQML, int idx = -1) const
+    {
+        UNIMPLEMENTED;
+    }
+    virtual const char* getXML(const char* /*pComponent*/)
+    {
+        UNIMPLEMENTED;
+        return NULL;
+    }
+    virtual void populateEnvXPath(StringBuffer strXPath, unsigned int index = 1)
+    {
+        UNIMPLEMENTED;
+    }
+    GETTERSETTER(Value)
+    GETTERSETTERINT(Length)
+
+private:
+
+    CLength(CXSDNodeBase* pParentNode = NULL) : CXSDNode::CXSDNode(pParentNode, XSD_LENGTH), m_nLength(-1)
+    {
+    }
+};
+
+#endif // _SCHEMA_LENGTH_HPP_

--- a/configuration/configurator/SchemaMapManager.cpp
+++ b/configuration/configurator/SchemaMapManager.cpp
@@ -1,0 +1,522 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include "SchemaMapManager.hpp"
+#include "SchemaAll.hpp"
+
+CSchemaMapManager::CSchemaMapManager()
+{
+    m_pSchemaPtrMap.setown(new MapStringToCSchema());
+    m_pSimpleTypePtrMap.setown(new MapStringToCSimpleType());
+    m_pComplexTypePtrsMap.setown (new MapStringToCComplexType);
+    m_pAttributeGroupTypePtrsMap.setown(new MapStringToCAttributeGroup);
+    m_pAttributePtrsMap.setown(new MapStringToCAttribute);
+    m_pRestrictionPtrsMap.setown(new MapStringToCRestriction);
+    m_pElementPtrsMap.setown(new MapStringToCElement);
+    m_pElementNamePtrsMap.setown(new MapStringToCElement);
+    m_pXSDToElementPtrsMap.setown(new MapStringToCElement);
+    m_pElementArrayPtrsMap.setown(new MapStringToCElementArray);
+    m_pStringToEnumMap.setown(new MapStringToNodeTypeEnum);
+    m_pStringToKeyPtrsMap.setown(new MapStringToCKey);
+    m_pStringToNodeBaseMap.setown(new MapStringToCNodeBase);
+
+    m_enumArray[XSD_DT_NORMALIZED_STRING][0] = XSD_DATA_TYPE_NORMALIZED_STRING;
+    m_enumArray[XSD_DT_NORMALIZED_STRING][1] = XSD_DT_NORMALIZED_STRING_STR;
+
+    m_enumArray[XSD_DT_STRING-XSD_DT_NORMALIZED_STRING][0] = XSD_DATA_TYPE_STRING;
+    m_enumArray[XSD_DT_STRING-XSD_DT_NORMALIZED_STRING][1] = XSD_DT_STRING_STR;
+
+    m_enumArray[XSD_DT_TOKEN-XSD_DT_NORMALIZED_STRING][0] = XSD_DATA_TYPE_TOKEN;
+    m_enumArray[XSD_DT_TOKEN-XSD_DT_NORMALIZED_STRING][1] = XSD_DT_TOKEN_STR;
+
+    m_enumArray[XSD_DT_DATE-XSD_DT_NORMALIZED_STRING][0] = XSD_DATA_TYPE_DATE;
+    m_enumArray[XSD_DT_DATE-XSD_DT_NORMALIZED_STRING][1] = XSD_DT_DATE_STR;
+
+    m_enumArray[XSD_DT_TIME-XSD_DT_NORMALIZED_STRING][0] = XSD_DATA_TYPE_TIME;
+    m_enumArray[XSD_DT_TIME-XSD_DT_NORMALIZED_STRING][1] = XSD_DT_TIME_STR;
+
+    m_enumArray[XSD_DT_DATE_TIME-XSD_DT_NORMALIZED_STRING][0] = XSD_DATA_TYPE_DATE_TIME;
+    m_enumArray[XSD_DT_DATE_TIME-XSD_DT_NORMALIZED_STRING][1] = XSD_DT_DATE_TIME_STR;
+
+    m_enumArray[XSD_DT_DECIMAL-XSD_DT_NORMALIZED_STRING][0] = XSD_DATA_TYPE_DECIMAL;
+    m_enumArray[XSD_DT_DECIMAL-XSD_DT_NORMALIZED_STRING][1] = XSD_DT_DECIMAL_STR;
+
+    m_enumArray[XSD_DT_INTEGER-XSD_DT_NORMALIZED_STRING][0] = XSD_DATA_TYPE_INTEGER;
+    m_enumArray[XSD_DT_INTEGER-XSD_DT_NORMALIZED_STRING][1] = XSD_DT_INTEGER_STR;
+
+    m_enumArray[XSD_DT_INT-XSD_DT_NORMALIZED_STRING][0] = XSD_DATA_TYPE_INT;
+    m_enumArray[XSD_DT_INT-XSD_DT_NORMALIZED_STRING][1] = XSD_DT_INT_STR;
+
+    m_enumArray[XSD_DT_LONG-XSD_DT_NORMALIZED_STRING][0] = XSD_DATA_TYPE_NORMALIZED_STRING;
+    m_enumArray[XSD_DT_LONG-XSD_DT_NORMALIZED_STRING][1] = XSD_DT_LONG_STR;
+
+    m_enumArray[XSD_DT_NON_NEG_INTEGER-XSD_DT_NORMALIZED_STRING][0] = XSD_DATA_TYPE_NORMALIZED_STRING;
+    m_enumArray[XSD_DT_NON_NEG_INTEGER-XSD_DT_NORMALIZED_STRING][1] = XSD_DT_NON_NEG_INTEGER_STR;
+
+    m_enumArray[XSD_DT_NON_POS_INTEGER-XSD_DT_NORMALIZED_STRING][0] = XSD_DATA_TYPE_NORMALIZED_STRING;
+    m_enumArray[XSD_DT_NON_POS_INTEGER-XSD_DT_NORMALIZED_STRING][1] = XSD_DT_NON_POS_INTEGER_STR;
+
+    m_enumArray[XSD_DT_POS_INTEGER-XSD_DT_NORMALIZED_STRING][0] = XSD_DATA_TYPE_NORMALIZED_STRING;
+    m_enumArray[XSD_DT_POS_INTEGER-XSD_DT_NORMALIZED_STRING][1] = XSD_DT_POS_INTEGER_STR;
+
+    m_enumArray[XSD_DT_NEG_INTEGER-XSD_DT_NORMALIZED_STRING][0] = XSD_DATA_TYPE_NORMALIZED_STRING;
+    m_enumArray[XSD_DT_NEG_INTEGER-XSD_DT_NORMALIZED_STRING][1] = XSD_DT_NEG_INTEGER_STR;
+
+    m_enumArray[XSD_DT_BOOLEAN-XSD_DT_NORMALIZED_STRING][0] = XSD_DATA_TYPE_BOOLEAN;
+    m_enumArray[XSD_DT_BOOLEAN-XSD_DT_NORMALIZED_STRING][1] = XSD_DT_BOOLEAN_STR;
+
+    m_pStringToEnumMap->setValue(XSD_DATA_TYPE_NORMALIZED_STRING, XSD_DT_NORMALIZED_STRING);
+    m_pStringToEnumMap->setValue(XSD_DATA_TYPE_STRING, XSD_DT_STRING);
+    m_pStringToEnumMap->setValue(XSD_DATA_TYPE_TOKEN, XSD_DT_TOKEN);
+    m_pStringToEnumMap->setValue(XSD_DATA_TYPE_DATE, XSD_DT_DATE);
+    m_pStringToEnumMap->setValue(XSD_DATA_TYPE_TIME, XSD_DT_TIME);
+    m_pStringToEnumMap->setValue(XSD_DATA_TYPE_DATE_TIME, XSD_DT_DATE_TIME);
+    m_pStringToEnumMap->setValue(XSD_DATA_TYPE_DECIMAL, XSD_DT_INTEGER);
+    m_pStringToEnumMap->setValue(XSD_DATA_TYPE_DECIMAL, XSD_DT_DECIMAL);
+    m_pStringToEnumMap->setValue(XSD_DATA_TYPE_LONG, XSD_DT_LONG);
+    m_pStringToEnumMap->setValue(XSD_DATA_TYPE_NON_NEGATIVE_INTEGER, XSD_DT_NON_NEG_INTEGER);
+    m_pStringToEnumMap->setValue(XSD_DATA_TYPE_NON_POSITIVE_INTEGER, XSD_DT_NON_POS_INTEGER);
+    m_pStringToEnumMap->setValue(XSD_DATA_TYPE_NEGATIVE_INTEGER, XSD_DT_POS_INTEGER);
+    m_pStringToEnumMap->setValue(XSD_DATA_TYPE_POSITIVE_INTEGER, XSD_DT_NEG_INTEGER);
+    m_pStringToEnumMap->setValue(XSD_DATA_TYPE_BOOLEAN, XSD_DT_BOOLEAN);
+}
+
+CSchemaMapManager::~CSchemaMapManager()
+{
+}
+
+CSchema* CSchemaMapManager::getSchemaForXSD(const char* pComponent)
+{
+    CSchema **pSchema = m_pSchemaPtrMap->getValue(pComponent);
+
+    if (pSchema != NULL )
+    {
+        assert ((*pSchema)->getLinkCount() == 1);
+        return *pSchema;
+    }
+    else
+        return NULL;
+}
+
+void CSchemaMapManager::setSchemaForXSD(const char* pComponent, CSchema *pSchema)
+{
+    assert(pSchema != NULL);
+    assert(pComponent != NULL);
+    assert(*pComponent != 0);
+
+    assert(pSchema->getLinkCount() == 1);
+
+    if (pSchema != NULL && pComponent != NULL && *pComponent != 0)
+    {
+        if (m_pSchemaPtrMap->getValue(pComponent) == NULL)
+            m_pSchemaPtrMap->setValue(pComponent, (pSchema));
+    }
+}
+
+CSimpleType* CSchemaMapManager::getSimpleTypeWithName(const char* pName)
+{
+    assert(pName != NULL);
+    if (pName == NULL)
+        return NULL;
+
+    CSimpleType **ppSimpleType = NULL;
+    ppSimpleType = m_pSimpleTypePtrMap->getValue(pName);
+
+    if (ppSimpleType != NULL)
+        return *ppSimpleType;
+    else
+        return NULL;
+}
+
+void CSchemaMapManager::setSimpleTypeWithName(const char* pName, CSimpleType *pSimpleType)
+{
+    assert (pSimpleType != NULL);
+    if (pName == NULL || pSimpleType == NULL)
+        return;
+    if (m_pSimpleTypePtrMap->getValue(pName) != NULL)
+        throw MakeExceptionFromMap(EX_STR_SIMPLE_TYPE_ALREADY_DEFINED);
+
+    assert(pSimpleType->getLinkCount() == 1);
+    m_pSimpleTypePtrMap->setValue(pName, pSimpleType);
+}
+
+CComplexType* CSchemaMapManager::getComplexTypeWithName(const char* pName)
+{
+    assert(pName != NULL);
+    if (pName == NULL)
+        return NULL;
+
+    CComplexType **ppComplexType = NULL;
+    ppComplexType = (m_pComplexTypePtrsMap->getValue(pName));
+
+    return (ppComplexType != NULL ? *ppComplexType : NULL);
+}
+
+void CSchemaMapManager::setComplexTypeWithName(const char* pName, CComplexType *pComplexType)
+{
+    assert (pComplexType != NULL);
+    if (pName == NULL || pComplexType == NULL)
+        return;
+
+    if (m_pComplexTypePtrsMap->getValue(pName) != NULL)
+        throw MakeExceptionFromMap(EX_STR_COMPLEX_TYPE_ALREADY_DEFINED);
+
+    assert(pComplexType->getLinkCount() == 1);
+    m_pComplexTypePtrsMap->setValue(pName, pComplexType);
+}
+
+CComplexType* CSchemaMapManager::getComplexTypeFromXPath(const char *pXPath)
+{
+    assert(pXPath != NULL && *pXPath != 0);
+
+    CComplexType** ppComplexType =  m_pComplexTypePtrsMap->getValue(pXPath);
+    if (ppComplexType != NULL)
+        return *ppComplexType;
+    else
+        return NULL;
+}
+
+CAttributeGroup* CSchemaMapManager::getAttributeGroup(const char* pName)
+{
+    assert(pName != NULL);
+    if (pName == NULL)
+        return NULL;
+
+    CAttributeGroup *pAttributeGroup = NULL;
+    pAttributeGroup = *(m_pAttributeGroupTypePtrsMap->getValue(pName));
+
+    assert(pAttributeGroup != NULL);
+    return pAttributeGroup;
+}
+
+void CSchemaMapManager::setAttributeGroupTypeWithName(const char* pName, CAttributeGroup *pAttributeGroup)
+{
+    assert (pAttributeGroup != NULL);
+    if (pName == NULL || pAttributeGroup == NULL)
+        return;
+
+    if (m_pAttributeGroupTypePtrsMap->getValue(pName) != NULL)
+    {
+        m_pAttributeGroupTypePtrsMap->remove(pName);
+        //throw MakeExceptionFromMap(EX_STR_ATTRIBUTE_GROUP_ALREADY_DEFINED);
+    }
+
+    assert(pAttributeGroup->getLinkCount() == 1);
+    m_pAttributeGroupTypePtrsMap->setValue(pName, pAttributeGroup);
+}
+
+CAttributeGroup* CSchemaMapManager::getAttributeGroupFromXPath(const char *pXPath)
+{
+    assert(pXPath != NULL && *pXPath != 0);
+    if (pXPath == NULL || *pXPath == 0)
+        return NULL;
+
+    CAttributeGroup **ppAttributeGroup = m_pAttributeGroupTypePtrsMap->getValue(pXPath);
+    assert(ppAttributeGroup != NULL);
+
+    if (ppAttributeGroup != NULL)
+        return *ppAttributeGroup;
+    else
+        return NULL;
+}
+
+CElement* CSchemaMapManager::getElementWithName(const char* pName)
+{
+    assert (pName != NULL && *pName != 0);
+    if (pName != NULL && *pName != 0)
+    {
+        CElement **ppElement = m_pElementNamePtrsMap->getValue(pName);
+        assert(ppElement != NULL);
+
+        if (ppElement != NULL)
+            return *ppElement;
+        else
+            return NULL;
+    }
+    else
+        return NULL;
+}
+
+void CSchemaMapManager::setElementWithName(const char* pName, CElement *pElement)
+{
+    assert (pName != NULL && *pName != 0 && pElement != NULL);
+
+    if (pName != NULL && *pName != 0 && pElement != NULL)
+    {
+        assert (pElement != NULL);
+        if (pName == NULL || *pName == 0 || pElement == NULL)
+            return;
+        if (m_pElementNamePtrsMap->getValue(pName) != NULL)
+        {
+            if (STRICTNESS_LEVEL >= DEFAULT_STRICTNESS)
+                assert(!"Redefintion");
+            else
+                PROGLOG("Symbol redefinition.  Possible misprocessing xsd file. Ignoring..");
+        }
+        assert(m_pElementNamePtrsMap->getLinkCount() == 1);
+        m_pElementNamePtrsMap->setValue(pName, pElement);
+    }
+}
+
+void CSchemaMapManager::addMapOfXPathToAttribute(const char*pXPath, CAttribute *pAttribute)
+{
+    assert (pAttribute != NULL);
+    assert(pXPath != NULL && *pXPath != 0);
+
+    // TODO:: throw exception if problems here
+    CAttribute **ppAttribute = m_pAttributePtrsMap->getValue(pXPath);
+
+    if (ppAttribute != NULL && *ppAttribute != pAttribute)
+        assert(!"Assigning different node with same xpath! delete it first!");
+
+    // should I remove automatically?
+    assert(pAttribute->getLinkCount() == 1);
+    m_pAttributePtrsMap->setValue(pXPath, pAttribute);
+}
+
+void CSchemaMapManager::removeMapOfXPathToAttribute(const char*pXPath)
+{
+    assert (m_pAttributePtrsMap->find(pXPath) != NULL);
+    m_pAttributePtrsMap->remove(pXPath);
+}
+
+CAttribute* CSchemaMapManager::getAttributeFromXPath(const char* pXPath)
+{
+    assert(pXPath != NULL && *pXPath != 0);
+    CAttribute **pAttribute = m_pAttributePtrsMap->getValue(pXPath);
+
+    if (STRICTNESS_LEVEL >= DEFAULT_STRICTNESS)
+        assert(pAttribute != NULL);
+    if (pAttribute == NULL)
+        return NULL;
+
+    return *pAttribute;
+}
+
+void CSchemaMapManager::addMapOfXSDXPathToElementArray(const char*pXPath, CElementArray *pElementArray)
+{
+    assert (pElementArray != NULL);
+    assert(pXPath != NULL && *pXPath != 0);
+    assert(pElementArray->getLinkCount() == 1);
+
+    if (m_pElementArrayPtrsMap->find(pXPath) != NULL)
+        return;  // already mapped, we must be dealing with live data
+
+    PROGLOG("Mapping XSD XPath %s to %p elementarray", pXPath, pElementArray);
+    m_pElementArrayPtrsMap->setValue(pXPath, pElementArray);
+}
+
+void CSchemaMapManager::removeMapOfXSDXPathToElementArray(const char*pXPath)
+{
+    assert (m_pElementArrayPtrsMap->find(pXPath) != NULL);
+    m_pElementArrayPtrsMap->remove(pXPath);
+}
+
+CElementArray* CSchemaMapManager::getElementArrayFromXSDXPath(const char* pXPath)
+{
+    assert(pXPath != NULL && *pXPath != 0);
+    if (pXPath == NULL)
+        return NULL;
+
+    CElementArray** ppElementArray = m_pElementArrayPtrsMap->getValue(pXPath);
+    if (ppElementArray != NULL)
+        return *ppElementArray;
+    else
+        return NULL;
+}
+
+void CSchemaMapManager::addMapOfXPathToElement(const char* pXPath, CElement *pElement,  bool bIsTopLevelElement)
+{
+    assert (pElement != NULL);
+    assert(pXPath != NULL && *pXPath != 0);
+    PROGLOG("Mapping XPath %s to %p element", pXPath, pElement);
+    assert(pElement->getLinkCount() == 1);
+
+    m_pElementPtrsMap->setValue(pXPath, pElement);
+}
+
+void CSchemaMapManager::removeMapOfXPathToElement(const char*pXPath)
+{
+    assert (m_pElementPtrsMap->find(pXPath) != NULL);
+    m_pElementPtrsMap->remove(pXPath);
+}
+
+CElement* CSchemaMapManager::getElementFromXPath(const char *pXPath)
+{
+    assert(pXPath != NULL && *pXPath != 0);
+    CElement **ppElement = m_pElementPtrsMap->getValue(pXPath);
+
+    assert(ppElement != NULL);
+    if (ppElement != NULL)
+        return *ppElement;
+    else
+        return NULL;
+}
+
+void CSchemaMapManager::addMapOfXSDXPathToElement(const char* pXPath, CElement *pElement)
+{
+    assert (pElement != NULL);
+    assert(pXPath != NULL && *pXPath != 0);
+
+    if (pElement != NULL && pXPath != NULL && *pXPath != 0)
+    {
+        StringBuffer strFullXPath;
+        strFullXPath.appendf("%s-%s",pElement->getConstSchemaNode()->getXSDXPath(), pXPath);
+        m_pXSDToElementPtrsMap->setValue(strFullXPath.str(), pElement);
+    }
+}
+
+CElement* CSchemaMapManager::getElementFromXSDXPath(const char *pXPath) const
+{
+    UNIMPLEMENTED;
+    //return NULL;
+}
+
+void CSchemaMapManager::addMapOfXSDXPathToKey(const char* pXPath, CKey *pKey)
+{
+    assert (pKey != NULL);
+    assert (pXPath != NULL && *pXPath != 0);
+
+    if (pKey != NULL && pXPath != NULL && *pXPath != 0)
+        m_pStringToKeyPtrsMap->setValue(pXPath, pKey);
+}
+
+CKey* CSchemaMapManager::getKeyFromXSDXPath(const char *pXPath) const
+{
+    assert(pXPath != NULL && *pXPath != 0);
+    if (pXPath != NULL && *pXPath != 0)
+    {
+        CKey **ppKey = m_pStringToKeyPtrsMap->getValue(pXPath);
+        assert(ppKey != NULL);
+
+        if (ppKey != NULL)
+            return *ppKey;
+        else
+            return NULL;
+    }
+    assert(!"Control should reach here.  xpath invalid?");
+    return NULL;
+}
+
+void CSchemaMapManager::addMapOfXPathToRestriction(const char*pXPath, CRestriction *pRestriction)
+{
+    assert (pRestriction != NULL);
+    assert(pXPath != NULL && *pXPath != 0);
+    assert(m_pRestrictionPtrsMap->find(pXPath) == NULL);
+    assert(pRestriction->getLinkCount() == 1);
+
+    m_pRestrictionPtrsMap->setValue(pXPath, pRestriction);
+}
+
+void CSchemaMapManager::removeMapOfXPathToRestriction(const char*pXPath)
+{
+    assert(pXPath != NULL && *pXPath != 0);
+    m_pRestrictionPtrsMap->remove(pXPath);
+}
+
+CRestriction* CSchemaMapManager::getRestrictionFromXPath(const char* pXPath)
+{
+    assert(pXPath != NULL && *pXPath != 0);
+
+    CRestriction **ppRestriction = m_pRestrictionPtrsMap->getValue(pXPath);
+    assert(ppRestriction != NULL);
+
+    if (ppRestriction != NULL)
+        return *ppRestriction;
+    else
+        return NULL;
+}
+
+int CSchemaMapManager::getNumberOfComponents() const
+{
+    int nCount = 0;
+    HashIterator iter(*(m_pElementPtrsMap.get()));
+
+    ForEach(iter)
+    {
+        CElement *pElement = *(m_pElementPtrsMap->mapToValue(&iter.query()));
+        if (pElement->isTopLevelElement() == true)
+            nCount++;
+    }
+    return nCount;
+}
+
+CElement* CSchemaMapManager::getComponent(int index)
+{
+    assert(index >= 0 && index < getNumberOfComponents());
+    HashIterator iter(*(m_pElementPtrsMap.get()));
+
+    int nCount = 0;
+
+    ForEach(iter)
+    {
+        CElement *pElement = *(m_pElementPtrsMap->mapToValue(&iter.query()));
+        if (pElement->isTopLevelElement() == true)
+        {
+            if (nCount == index)
+                return pElement;
+            nCount++;
+        }        
+    }
+    return NULL;
+}
+
+int CSchemaMapManager::getIndexOfElement(const CElement *pElem)
+{
+    int nCount = 0;
+    HashIterator iter(*(m_pElementPtrsMap.get()));
+
+    ForEach(iter)
+    {
+        CElement *pElement = *(m_pElementPtrsMap->mapToValue(&iter.query()));
+
+        if (pElement == pElem)
+            return nCount;
+        if (pElement->isTopLevelElement() == true)
+            nCount++;
+    }
+    assert(false);
+    return -1;
+}
+
+enum NODE_TYPES CSchemaMapManager::getEnumFromTypeName(const char *pTypeName) const
+{
+    if (pTypeName == NULL || *pTypeName == 0)
+        return XSD_ERROR;
+
+    enum NODE_TYPES *eRet = (m_pStringToEnumMap->getValue(pTypeName));
+
+    if (eRet == NULL || *eRet == XSD_ERROR)
+    {
+        if (STRICTNESS_LEVEL >= MAXIMUM_STRICTNESS)
+            assert(!"Unknown XSD built in data type");
+
+        PROGLOG("Unknown XSD built in data type");
+        return XSD_ERROR;
+    }
+    return *eRet;
+}
+
+const char* CSchemaMapManager::getTypeNameFromEnum(enum NODE_TYPES eType, bool bForDump) const
+{
+    if (eType-XSD_DT_NORMALIZED_STRING > 0 && eType-XSD_DT_NORMALIZED_STRING < XSD_ERROR)
+        return m_enumArray[eType-XSD_DT_NORMALIZED_STRING][bForDump ? 1 : 0];
+
+    assert(!"Unknown XSD built-in type");
+    PROGLOG("Unknown XSD built-in type");
+    return NULL;
+}

--- a/configuration/configurator/SchemaMapManager.hpp
+++ b/configuration/configurator/SchemaMapManager.hpp
@@ -1,0 +1,139 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include "jhash.hpp"
+#include "jhash.ipp"
+#include "jlog.hpp"
+#include "SchemaCommon.hpp"
+
+#ifndef _SCHEMA_MAP_MANAGER_HPP_
+#define _SCHEMA_MAP_MANAGER_HPP_
+
+class CSchema;
+class CAttribute;
+class CAttributeGroup;
+class CSimpleType;
+class CComplexType;
+class CAttributeGroup;
+class CAttribute;
+class CRestriction;
+class CElementArray;
+class CElement;
+class CKey;
+
+class CSchemaMapManager
+{
+public:
+
+    CSchemaMapManager();
+    virtual ~CSchemaMapManager();
+
+    CSchema* getSchemaForXSD(const char* pComponent);
+    void setSchemaForXSD(const char* pComponent, CSchema *pSchema);
+
+    CSimpleType* getSimpleTypeWithName(const char* pName);
+    void setSimpleTypeWithName(const char* pName, CSimpleType *pSimpleType);
+
+    CComplexType* getComplexTypeWithName(const char* pName);
+    void setComplexTypeWithName(const char* pName, CComplexType *pComplexType);
+    CComplexType* getComplexTypeFromXPath(const char *pXPath);
+
+    CAttributeGroup *getAttributeGroup(const char* pName);
+    void setAttributeGroupTypeWithName(const char* pName, CAttributeGroup *pAttributeGroup);
+    CAttributeGroup* getAttributeGroupFromXPath(const char *pXPath);
+
+    CElement* getElementWithName(const char* pName);
+    void setElementWithName(const char* pName, CElement *pElement);
+
+    void addMapOfXPathToAttribute(const char* pXPath, CAttribute *pAttribute);
+    void removeMapOfXPathToAttribute(const char* pXPath);
+    CAttribute* getAttributeFromXPath(const char* pXPath);
+
+    void addMapOfXPathToRestriction(const char*pXPath, CRestriction *pRestriction);
+    void removeMapOfXPathToRestriction(const char*pXPath);
+    CRestriction* getRestrictionFromXPath(const char* pXPath);
+
+    void addMapOfXSDXPathToElementArray(const char* pXPath, CElementArray *pElementArray);
+    void removeMapOfXSDXPathToElementArray(const char* pXPath);
+    CElementArray* getElementArrayFromXSDXPath(const char* pXPath);
+
+    void addMapOfXPathToElement(const char* pXPath, CElement *pElement, bool bIsTopLevelElement = false);
+    void removeMapOfXPathToElement(const char* pXPath);
+    CElement* getElementFromXPath(const char *pXPath);
+
+    void addMapOfXSDXPathToElement(const char* pXPath, CElement *pElement);
+    CElement* getElementFromXSDXPath(const char *pXPath) const;
+
+    void addMapOfXSDXPathToKey(const char* pXPath, CKey *pKey);
+    CKey* getKeyFromXSDXPath(const char *pXPath) const;
+
+    int getNumberOfComponents() const;
+    CElement* getComponent(int index);
+    int getIndexOfElement(const CElement *pElem);
+
+    enum NODE_TYPES getEnumFromTypeName(const char *pTypeName) const;
+    const char* getTypeNameFromEnum(enum NODE_TYPES, bool bForDump = false) const;
+
+protected:
+
+    typedef MapStringTo<CSchema*> MapStringToCSchema;
+    Owned<MapStringToCSchema> m_pSchemaPtrMap;
+
+    typedef MapStringTo<CSimpleType*> MapStringToCSimpleType;
+    Owned<MapStringToCSimpleType> m_pSimpleTypePtrMap;
+
+    typedef MapStringTo<CComplexType*> MapStringToCComplexType;
+    Owned<MapStringToCComplexType> m_pComplexTypePtrsMap;
+
+    typedef MapStringTo<CAttributeGroup*> MapStringToCAttributeGroup;
+    Owned<MapStringToCAttributeGroup> m_pAttributeGroupTypePtrsMap;
+
+    typedef MapStringTo<CAttribute*> MapStringToCAttribute;
+    Owned<MapStringToCAttribute> m_pAttributePtrsMap;
+
+    typedef MapStringTo<CRestriction*> MapStringToCRestriction;
+    Owned<MapStringToCRestriction> m_pRestrictionPtrsMap;
+
+    typedef MapStringTo<CElement*> MapStringToCElement;
+    Owned<MapStringToCElement> m_pElementPtrsMap;
+    Owned<MapStringToCElement> m_pElementNamePtrsMap;
+    Owned<MapStringToCElement> m_pXSDToElementPtrsMap;
+
+    typedef MapStringTo<CElementArray*> MapStringToCElementArray;
+    Owned<MapStringToCElementArray> m_pElementArrayPtrsMap;
+
+    const char* m_enumArray[XSD_ERROR][2];
+
+    typedef MapStringTo<enum NODE_TYPES> MapStringToNodeTypeEnum;
+    Owned<MapStringToNodeTypeEnum> m_pStringToEnumMap;
+
+    typedef MapStringTo<CKey*> MapStringToCKey;
+    Owned<MapStringToCKey> m_pStringToKeyPtrsMap;
+
+    typedef MapStringTo<CXSDNodeBase*> MapStringToCNodeBase;
+    Owned<MapStringToCNodeBase> m_pStringToNodeBaseMap;
+
+    struct STypeStrings
+    {
+        const char *pXSDTypeString;
+        const char *pDumpTypeString;
+    };
+
+private:
+};
+
+#endif // _SCHEMA_MAP_MANAGER_HPP_

--- a/configuration/configurator/SchemaMaxExclusive.cpp
+++ b/configuration/configurator/SchemaMaxExclusive.cpp
@@ -1,0 +1,28 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include "SchemaMaxExclusive.hpp"
+
+CMaxExclusive* CMaxExclusive::load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath)
+{
+    CMaxExclusive *pMaxExclusive = CXSDNodeWithRestrictions<CMaxExclusive>::load(pParentNode, pSchemaRoot, xpath);
+    if (pMaxExclusive == NULL)
+        return NULL;
+
+    pMaxExclusive->setMaxExclusive(pMaxExclusive->getValue());
+    return pMaxExclusive;
+}

--- a/configuration/configurator/SchemaMaxExclusive.hpp
+++ b/configuration/configurator/SchemaMaxExclusive.hpp
@@ -1,0 +1,42 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef _SCHEMA_MAX_EXCLUSIVE_HPP_
+#define _SCHEMA_MAX_EXCLUSIVE_HPP_
+
+#include "SchemaCommon.hpp"
+
+class CMaxExclusive : public CXSDNodeWithRestrictions<CMaxExclusive>
+{
+    friend class CXSDNodeWithRestrictions<CMaxExclusive>;
+public:
+
+    virtual ~CMaxExclusive()
+    {
+    }
+    static CMaxExclusive* load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath);
+
+protected:
+
+    CMaxExclusive(CXSDNodeBase* pParentNode = NULL) : CXSDNodeWithRestrictions<CMaxExclusive>::CXSDNodeWithRestrictions(pParentNode, XSD_MAX_EXCLUSIVE), m_nMaxExclusive(-1)
+    {
+    }
+    GETTERSETTER(Value)
+    GETTERSETTERINT(MaxExclusive)
+};
+
+#endif // _SCHEMA_MAX_EXCLUSIVE_HPP_

--- a/configuration/configurator/SchemaMaxInclusive.cpp
+++ b/configuration/configurator/SchemaMaxInclusive.cpp
@@ -1,0 +1,28 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include "SchemaMaxInclusive.hpp"
+
+CMaxInclusive* CMaxInclusive::load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath)
+{
+    CMaxInclusive *pMaxInclusive = CXSDNodeWithRestrictions<CMaxInclusive>::load(pParentNode, pSchemaRoot, xpath);
+    if (pMaxInclusive == NULL)
+        return NULL;
+
+    pMaxInclusive->setMaxInclusive(pMaxInclusive->getValue());
+    return pMaxInclusive;
+}

--- a/configuration/configurator/SchemaMaxInclusive.hpp
+++ b/configuration/configurator/SchemaMaxInclusive.hpp
@@ -1,0 +1,42 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef _SCHEMA_MAX_INCLUSIVE_HPP_
+#define _SCHEMA_MAX_INCLUSIVE_HPP_
+
+#include "SchemaCommon.hpp"
+
+class CMaxInclusive : public CXSDNodeWithRestrictions<CMaxInclusive>
+{
+    friend class CXSDNodeWithRestrictions<CMaxInclusive>;
+public:
+
+    virtual ~CMaxInclusive()
+    {
+    }
+
+    static CMaxInclusive* load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath);
+    GETTERSETTERINT(MaxInclusive)
+
+protected:
+
+    CMaxInclusive(CXSDNodeBase* pParentNode = NULL) : CXSDNodeWithRestrictions<CMaxInclusive>::CXSDNodeWithRestrictions(pParentNode, XSD_MAX_INCLUSIVE), m_nMaxInclusive(-1)
+    {
+    }
+};
+
+#endif // _SCHEMA_MAX_INCLUSIVE_HPP_

--- a/configuration/configurator/SchemaMaxLength.cpp
+++ b/configuration/configurator/SchemaMaxLength.cpp
@@ -1,0 +1,28 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include "SchemaMaxLength.hpp"
+
+CMaxLength* CMaxLength::load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath)
+{
+    CMaxLength *pMaxLength = CXSDNodeWithRestrictions<CMaxLength>::load(pParentNode, pSchemaRoot, xpath);
+    if (pMaxLength == NULL)
+        return NULL;
+
+    pMaxLength->setMaxLength(pMaxLength->getValue());
+    return pMaxLength;
+}

--- a/configuration/configurator/SchemaMaxLength.hpp
+++ b/configuration/configurator/SchemaMaxLength.hpp
@@ -1,0 +1,42 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef _SCHEMA_MAX_LENGTH_HPP_
+#define _SCHEMA_MAX_LENGTH_HPP_
+
+#include "SchemaCommon.hpp"
+
+class CMaxLength : public CXSDNodeWithRestrictions<CMaxLength>
+{
+    friend class CXSDNodeWithRestrictions<CMaxLength>;
+public:
+
+    virtual ~CMaxLength()
+    {
+    }
+    static CMaxLength* load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath);
+
+    GETTERSETTERINT(MaxLength)
+
+protected:
+
+    CMaxLength(CXSDNodeBase* pParentNode = NULL) : CXSDNodeWithRestrictions<CMaxLength>::CXSDNodeWithRestrictions(pParentNode, XSD_MAX_LENGTH), m_nMaxLength(-1)
+    {
+    }
+};
+
+#endif // _SCHEMA_MAX_LENGTH_HPP_

--- a/configuration/configurator/SchemaMinExclusive.cpp
+++ b/configuration/configurator/SchemaMinExclusive.cpp
@@ -1,0 +1,29 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include "SchemaMinExclusive.hpp"
+
+CMinExclusive* CMinExclusive::load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath)
+{
+    CMinExclusive *pMinExclusive = CXSDNodeWithRestrictions<CMinExclusive>::load(pParentNode, pSchemaRoot, xpath);
+
+    if (pMinExclusive == NULL)
+        return NULL;
+
+    pMinExclusive->setMinExclusive(pMinExclusive->getValue());
+    return pMinExclusive;
+}

--- a/configuration/configurator/SchemaMinExclusive.hpp
+++ b/configuration/configurator/SchemaMinExclusive.hpp
@@ -1,0 +1,41 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef _SCHEMA_MIN_EXCLUSIVE_HPP_
+#define _SCHEMA_MIN_EXCLUSIVE_HPP_
+
+#include "SchemaCommon.hpp"
+
+class CMinExclusive : public CXSDNodeWithRestrictions<CMinExclusive>
+{
+    friend class CXSDNodeWithRestrictions<CMinExclusive>;
+public:
+
+    virtual ~CMinExclusive()
+    {
+    }
+    static CMinExclusive* load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath);
+    GETTERSETTERINT(MinExclusive)
+
+protected:
+
+    CMinExclusive(CXSDNodeBase* pParentNode = NULL) : CXSDNodeWithRestrictions<CMinExclusive>::CXSDNodeWithRestrictions<CMinExclusive>(pParentNode, XSD_MIN_EXCLUSIVE), m_nMinExclusive(-1)
+    {
+    }
+};
+
+#endif // _SCHEMA_MIN_EXCLUSIVE_HPP_

--- a/configuration/configurator/SchemaMinInclusive.cpp
+++ b/configuration/configurator/SchemaMinInclusive.cpp
@@ -1,0 +1,28 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include "SchemaMinInclusive.hpp"
+
+CMinInclusive* CMinInclusive::load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath)
+{
+    CMinInclusive *pMinInclusive = CXSDNodeWithRestrictions<CMinInclusive>::load(pParentNode, pSchemaRoot, xpath);
+    if (pMinInclusive == NULL)
+        return NULL;
+
+    pMinInclusive->setMinInclusive(pMinInclusive->getValue());
+    return pMinInclusive; 
+}

--- a/configuration/configurator/SchemaMinInclusive.hpp
+++ b/configuration/configurator/SchemaMinInclusive.hpp
@@ -1,0 +1,42 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef _SCHEMA_MIN_INCLUSIVE_HPP_
+#define _SCHEMA_MIN_INCLUSIVE_HPP_
+
+#include "SchemaCommon.hpp"
+
+class CMinInclusive : public CXSDNodeWithRestrictions<CMinInclusive>
+{
+    friend class CXSDNodeWithRestrictions<CMinInclusive>;
+public:
+
+    virtual ~CMinInclusive()
+    {
+    }
+    static CMinInclusive* load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath);
+
+    GETTERSETTERINT(MinInclusive)
+
+protected:
+
+    CMinInclusive(CXSDNodeBase* pParentNode = NULL) : CXSDNodeWithRestrictions<CMinInclusive>::CXSDNodeWithRestrictions(pParentNode, XSD_MIN_INCLUSIVE), m_nMinInclusive(-1)
+    {
+    }
+};
+
+#endif // _SCHEMA_MIN_INCLUSIVE_HPP_

--- a/configuration/configurator/SchemaMinLength.cpp
+++ b/configuration/configurator/SchemaMinLength.cpp
@@ -1,0 +1,28 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include "SchemaMinLength.hpp"
+
+CMinLength* CMinLength::load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath)
+{
+    CMinLength *pMinLength = CXSDNodeWithRestrictions<CMinLength>::load(pParentNode, pSchemaRoot, xpath);
+    if (pMinLength == NULL)
+        return NULL;
+
+    pMinLength->setMinLength(pMinLength->getValue());
+    return pMinLength;
+}

--- a/configuration/configurator/SchemaMinLength.hpp
+++ b/configuration/configurator/SchemaMinLength.hpp
@@ -1,0 +1,42 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef _SCHEMA_MIN_LENGTH_HPP_
+#define _SCHEMA_MIN_LENGTH_HPP_
+
+#include "SchemaCommon.hpp"
+
+class CMinLength : public CXSDNodeWithRestrictions<CMinLength>
+{
+    friend class CXSDNodeWithRestrictions<CMinLength>;
+public:
+
+    virtual ~CMinLength()
+    {
+    }
+    static CMinLength* load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath);
+
+    GETTERSETTERINT(MinLength)
+
+protected:
+
+    CMinLength(CXSDNodeBase* pParentNode = NULL) : CXSDNodeWithRestrictions<CMinLength>::CXSDNodeWithRestrictions(pParentNode, XSD_MIN_LENGTH), m_nMinLength(-1)
+    {
+    }
+};
+
+#endif // _SCHEMA_MIN_LENGTH_HPP_

--- a/configuration/configurator/SchemaPattern.cpp
+++ b/configuration/configurator/SchemaPattern.cpp
@@ -1,0 +1,28 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include "SchemaPattern.hpp"
+
+CPattern* CPattern::load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath)
+{
+    CPattern *pPattern = CXSDNodeWithRestrictions<CPattern>::load(pParentNode, pSchemaRoot, xpath);
+    if (pPattern == NULL)
+        return NULL;
+
+    pPattern->setPattern(pPattern->getValue());
+    return pPattern;
+}

--- a/configuration/configurator/SchemaPattern.hpp
+++ b/configuration/configurator/SchemaPattern.hpp
@@ -1,0 +1,42 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef _SCHEMA_PATTERN_HPP_
+#define _SCHEMA_PATTERN_HPP_
+
+#include "SchemaCommon.hpp"
+
+class CPattern : public CXSDNodeWithRestrictions<CPattern>
+{
+    friend class CXSDNodeWithRestrictions<CPattern>;
+public:
+
+    virtual ~CPattern()
+    {
+    }
+    static CPattern* load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath);
+
+    GETTERSETTER(Pattern)
+
+private:
+
+    CPattern(CXSDNodeBase* pParentNode = NULL) : CXSDNodeWithRestrictions<CPattern>::CXSDNodeWithRestrictions(pParentNode, XSD_PATTERN)
+    {
+    }
+};
+
+#endif // _SCHEMA_PATTERN_HPP_

--- a/configuration/configurator/SchemaRestriction.cpp
+++ b/configuration/configurator/SchemaRestriction.cpp
@@ -1,0 +1,210 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include "jptree.hpp"
+#include "SchemaRestriction.hpp"
+#include "SchemaEnumeration.hpp"
+#include "SchemaAttributes.hpp"
+#include "XMLTags.h"
+#include "ConfigSchemaHelper.hpp"
+#include "QMLMarkup.hpp"
+#include "DocumentationMarkup.hpp"
+#include "SchemaMapManager.hpp"
+#include "SchemaFractionDigits.hpp"
+#include "SchemaLength.hpp"
+#include "SchemaTotalDigits.hpp"
+#include "SchemaWhiteSpace.hpp"
+#include "SchemaSimpleContent.hpp"
+
+#define QUICK_LOAD_XSD_RESTRICTIONS(X, Y)       \
+    strXPathExt.set(xpath);                     \
+    strXPathExt.append("/").append(Y);          \
+    C##X *p##X = C##X::load(pRestriction, pSchemaRoot, strXPathExt.str());    \
+    if (p##X != NULL) pRestriction->set##X(p##X);
+    //if (p##X != NULL) pRestriction->C##X(p##X);
+
+CRestriction::~CRestriction()
+{
+    CConfigSchemaHelper::getInstance()->getSchemaMapManager()->removeMapOfXPathToRestriction(this->getEnvXPath());
+}
+
+void CRestriction::dump(std::ostream& cout, unsigned int offset) const
+{
+    offset+= STANDARD_OFFSET_1;
+
+    QuickOutHeader(cout, XSD_RESTRICTION_STR, offset);
+    QUICK_OUT_2(Base);
+    QUICK_OUT_2(ID);
+    QUICK_OUT(cout, XSDXPath,  offset);
+    QUICK_OUT(cout, EnvXPath,  offset);
+    QUICK_OUT(cout, EnvValueFromXML,  offset);
+    QUICK_OUT_3(EnumerationArray)
+    QUICK_OUT_3(FractionDigits)
+    QUICK_OUT_3(Length)
+    QUICK_OUT_3(MaxExclusive)
+    QUICK_OUT_3(MaxInclusive)
+    QUICK_OUT_3(MinExclusive)
+    QUICK_OUT_3(MinInclusive)
+    QUICK_OUT_3(MaxLength)
+    QUICK_OUT_3(MinLength)
+    QUICK_OUT_3(Pattern)
+    QUICK_OUT_3(TotalDigits)
+    QUICK_OUT_3(WhiteSpace)
+    QuickOutFooter(cout, XSD_RESTRICTION_STR, offset);
+}
+
+void CRestriction::getDocumentation(StringBuffer &strDoc) const
+{
+    if (m_pEnumerationArray != NULL)
+    {
+        strDoc.appendf("<%s>",DM_PARA);
+        DEBUG_MARK_STRDOC
+        m_pEnumerationArray->getDocumentation(strDoc);
+        strDoc.appendf("</%s>",DM_PARA);
+        DEBUG_MARK_STRDOC
+    }
+}
+
+void CRestriction::getQML(StringBuffer &strQML, int idx) const
+{
+    if (m_pEnumerationArray != NULL)
+    {
+        assert(this->getConstAncestorNode(3) != NULL && this->getConstAncestorNode(3)->getNodeType() == XSD_ATTRIBUTE);
+
+        const CAttribute *pAttrib = dynamic_cast<const CAttribute*>(this->getConstAncestorNode(3));
+        assert(pAttrib != NULL);
+
+        strQML.append(QML_ROW_BEGIN);
+        strQML.append(QML_RECTANGLE_DEFAULT_COLOR_SCHEME_1_BEGIN);
+        DEBUG_MARK_QML;
+
+        strQML.append(QML_TEXT_BEGIN_2).append("\"  ").append(pAttrib->getName()).append("\"").append(QML_TEXT_END_2);
+        strQML.append(QML_RECTANGLE_LIGHT_STEEEL_BLUE_END);
+
+        StringBuffer strComboBoxID("combobox");
+        CQMLMarkupHelper::getRandomID(&strComboBoxID);
+
+        strQML.append(QML_COMBO_BOX_BEGIN);
+        strQML.append(strComboBoxID);
+        DEBUG_MARK_QML;
+        strQML.append(QML_LIST_MODEL_BEGIN);
+        DEBUG_MARK_QML;
+        m_pEnumerationArray->getQML(strQML);
+        DEBUG_MARK_QML;
+        strQML.append(QML_LIST_MODEL_END);
+        strQML.append(QML_COMBO_BOX_CURRENT_INDEX).append(QML_APP_DATA_GET_INDEX_BEGIN).append(this->getEnvXPath()).append(QML_APP_DATA_GET_INDEX_END);
+        DEBUG_MARK_QML;
+        strQML.append(QML_ON_CURRENT_INDEX_CHANGED).append(QML_APP_DATA_SET_INDEX_BEGIN).append(this->getEnvXPath()).append("\", ").append(strComboBoxID).append(QML_APP_DATA_SET_INDEX_END);
+        DEBUG_MARK_QML;
+        strQML.append(QML_COMBO_BOX_END);
+        strQML.append(QML_ROW_END);
+        DEBUG_MARK_QML;
+    }
+}
+
+void CRestriction::populateEnvXPath(StringBuffer strXPath, unsigned int index)
+{
+    this->setEnvXPath(strXPath);
+    CConfigSchemaHelper::getInstance()->getSchemaMapManager()->addMapOfXPathToRestriction(this->getEnvXPath(), this);
+
+    if (this->m_pEnumerationArray != NULL)
+        this->m_pEnumerationArray->populateEnvXPath(strXPath);
+}
+
+void CRestriction::loadXMLFromEnvXml(const IPropertyTree *pEnvTree)
+{
+    if (m_pEnumerationArray != NULL)
+        m_pEnumerationArray->loadXMLFromEnvXml(pEnvTree);
+}
+
+CRestriction* CRestriction::load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath)
+{
+    if (pParentNode == NULL || pSchemaRoot == NULL)
+        return NULL;
+
+    IPropertyTree *pTree = pSchemaRoot->queryPropTree(xpath);
+    const char* pID =  NULL;
+    const char* pBase =  NULL;
+
+    pID = pTree->queryProp(XML_ATTR_ID);
+    pBase = pTree->queryProp(XML_ATTR_BASE);
+
+    CRestriction* pRestriction = new CRestriction(pParentNode, pID, pBase);
+    pRestriction->setXSDXPath(xpath);
+
+    StringBuffer strXPathExt;
+    QUICK_LOAD_XSD_RESTRICTIONS(EnumerationArray, XSD_TAG_ENUMERATION)
+    QUICK_LOAD_XSD_RESTRICTIONS(FractionDigits, XSD_TAG_FRACTION_DIGITS)
+    QUICK_LOAD_XSD_RESTRICTIONS(Length, XSD_TAG_LENGTH)
+    QUICK_LOAD_XSD_RESTRICTIONS(MaxExclusive, XSD_TAG_MAX_EXCLUSIVE)
+    QUICK_LOAD_XSD_RESTRICTIONS(MaxInclusive, XSD_TAG_MAX_INCLUSIVE)
+    QUICK_LOAD_XSD_RESTRICTIONS(MinExclusive, XSD_TAG_MIN_EXCLUSIVE)
+    QUICK_LOAD_XSD_RESTRICTIONS(MinInclusive, XSD_TAG_MIN_INCLUSIVE)
+    QUICK_LOAD_XSD_RESTRICTIONS(MaxLength, XSD_TAG_MAX_LENGTH)
+    QUICK_LOAD_XSD_RESTRICTIONS(MinLength, XSD_TAG_MIN_LENGTH)
+    QUICK_LOAD_XSD_RESTRICTIONS(Pattern, XSD_TAG_PATTERN)
+    QUICK_LOAD_XSD_RESTRICTIONS(TotalDigits, XSD_TAG_TOTAL_DIGITS)
+    QUICK_LOAD_XSD_RESTRICTIONS(WhiteSpace, XSD_TAG_WHITE_SPACE)
+
+    if (pBase != NULL && *pBase != 0 && pRestriction != NULL)
+        CConfigSchemaHelper::getInstance()->addNodeForBaseProcessing(pRestriction);
+
+    return pRestriction;
+}
+
+const char* CRestriction::getXML(const char* /*pComponent*/)
+{
+    if (m_strXML.length () == 0)
+    {
+        m_strXML.append("<").append(getBase()).append("\n");
+        m_strXML.append("<").append(getID()).append("\n");
+        m_strXML.append("/>\n");
+    }
+    return m_strXML.str();
+}
+
+bool CRestriction::checkConstraint(const char *pValue) const
+{
+    const CXSDNodeBase *pNodeBase = this->getBaseNode();
+    assert(pNodeBase != NULL);
+
+    if (pNodeBase != NULL)
+    {
+        const CXSDBuiltInDataType *pNodeBuiltInType = dynamic_cast<const CXSDBuiltInDataType*>(pNodeBase);
+
+        if (pNodeBuiltInType != NULL && pNodeBuiltInType->checkConstraint(pValue) == false)
+            return false;
+
+        if (pNodeBase->getNodeType() == XSD_SIMPLE_TYPE)
+        {
+            const CSimpleType *pNodeSimpleType = dynamic_cast<const CSimpleType*>(pNodeBase);
+
+            if (pNodeSimpleType != NULL && pNodeSimpleType->checkConstraint(pValue) == false)
+               return false;
+        }
+        else if (pNodeBase->getNodeType() == XSD_SIMPLE_CONTENT)
+        {
+            const CSimpleContent *pNodeSimpleContent = dynamic_cast<const CSimpleContent*>(pNodeBase);
+
+            if (pNodeSimpleContent != NULL && pNodeSimpleContent->checkConstraint(pValue) == false)
+                return false;
+        }
+         assert(!"Unknown base node in restriction");
+         return false;
+    }
+    return true;
+}

--- a/configuration/configurator/SchemaRestriction.hpp
+++ b/configuration/configurator/SchemaRestriction.hpp
@@ -1,0 +1,85 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef _SCHEMA_RESTRICTION_HPP_
+#define _SCHEMA_RESTRICTION_HPP_
+
+#include "SchemaCommon.hpp"
+
+class CEnumerationArray;
+class CFractionDigits;
+class CLength;
+class CMaxExclusive;
+class CMaxInclusive;
+class CMinExclusive;
+class CMinInclusive;
+class CMaxLength;
+class CMinLength;
+class CPattern;
+class CTotalDigits;
+class CWhiteSpace;
+
+class CRestriction : public CXSDNodeWithBase
+{
+public:
+
+    virtual ~CRestriction();
+
+    GETTERSETTER(ID)
+
+    virtual void dump(std::ostream& cout, unsigned int offset = 0) const;
+    virtual void getDocumentation(StringBuffer &strDoc) const;
+    virtual void getQML(StringBuffer &strQML, int idx = -1) const;
+    virtual const char* getXML(const char* /*pComponent*/);
+    virtual void populateEnvXPath(StringBuffer strXPath, unsigned int index = 1);
+    virtual void loadXMLFromEnvXml(const IPropertyTree *pEnvTree);
+    bool checkConstraint(const char *pValue) const;
+
+    static CRestriction* load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath);
+
+protected:
+
+    CRestriction(CXSDNodeBase* pParentNode = NULL, const char* pID = NULL, const char* pBase = NULL) : CXSDNodeWithBase::CXSDNodeWithBase(pParentNode, XSD_RESTRICTION), m_strID(pID), m_pEnumerationArray(NULL)
+    {
+    }
+    GETTERSETTERTYPE(EnumerationArray)
+    GETTERSETTERTYPE(FractionDigits)
+    GETTERSETTERTYPE(Length)
+    GETTERSETTERTYPE(MaxExclusive)
+    GETTERSETTERTYPE(MaxInclusive)
+    GETTERSETTERTYPE(MinExclusive)
+    GETTERSETTERTYPE(MinInclusive)
+    GETTERSETTERTYPE(MaxLength)
+    GETTERSETTERTYPE(MinLength)
+    GETTERSETTERTYPE(Pattern)
+    GETTERSETTERTYPE(TotalDigits)
+    GETTERSETTERTYPE(WhiteSpace)
+
+protected:
+
+    CXSDNodeBase *m_pXSDNode;
+
+private:
+
+    CRestriction(CXSDNodeBase* pParentNode = NULL) : CXSDNodeWithBase::CXSDNodeWithBase(pParentNode, XSD_RESTRICTION), m_pEnumerationArray(NULL), m_pFractionDigits(NULL), m_pLength(NULL),
+        m_pMaxExclusive(NULL), m_pMaxInclusive(NULL), m_pMinExclusive(NULL), m_pMinInclusive(NULL), m_pMaxLength(NULL), m_pMinLength(NULL),
+        m_pPattern(NULL), m_pTotalDigits(NULL), m_pWhiteSpace(NULL), m_pXSDNode(NULL)
+    {
+    }
+};
+
+#endif // _SCHEMA_RESTRICTION_HPP_

--- a/configuration/configurator/SchemaSchema.cpp
+++ b/configuration/configurator/SchemaSchema.cpp
@@ -1,0 +1,415 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include "jptree.hpp"
+#include "XMLTags.h"
+#include "SchemaSchema.hpp"
+#include "ConfigSchemaHelper.hpp"
+#include "DocumentationMarkup.hpp"
+#include "SchemaMapManager.hpp"
+#include "QMLMarkup.hpp"
+
+CSchema::~CSchema()
+{
+    assert(this->getLinkCount() == 1);
+}
+
+CSchema* CSchema::load(const char* pSchemaLocation, const IPropertyTree *pSchemaRoot, const char* xpath)
+{
+    assert(pSchemaRoot != NULL);
+    if (pSchemaRoot == NULL)
+        return NULL;
+
+    CConfigSchemaHelper *pSchemaHelper = (CConfigSchemaHelper::getInstance());
+    if (pSchemaHelper->getSchemaMapManager()->getSchemaForXSD(pSchemaLocation) != NULL)  // check to see if the this schema has already been processed
+        return pSchemaHelper->getSchemaMapManager()->getSchemaForXSD(pSchemaLocation);
+
+
+    CSchema* pSchema = new CSchema(pSchemaLocation);
+    pSchema->setXSDXPath(xpath);
+
+    IPropertyTree *pTree = pSchemaRoot->queryPropTree(xpath);
+    if (pTree == NULL)
+        return NULL;
+
+    pSchema->setXMLNS_XS(pTree->queryProp(XML_ATTR_XMLNS_XS));
+    pSchema->setElementFormDefault(pTree->queryProp(XML_ATTR_ELEMENTFORMDEFAULT));
+    pSchema->setAttributeFormDefault(pTree->queryProp(XML_ATTR_ATTRIBUTEFORMDEFAULT));
+
+    StringBuffer strXPathExt(xpath);
+    strXPathExt.clear().append(xpath).append(XSD_TAG_INCLUDE);
+
+    CIncludeArray* pIncludeArray = CIncludeArray::load(pSchema, pSchemaRoot, strXPathExt);
+
+    strXPathExt.clear().append(xpath).append(XSD_TAG_SIMPLE_TYPE);
+
+    CSimpleTypeArray* pSimpleTypeArray = CSimpleTypeArray::load(pSchema, pSchemaRoot, strXPathExt);
+
+    strXPathExt.clear().append(xpath).append(XSD_TAG_COMPLEX_TYPE);
+    CComplexTypeArray* pComplexTypeArray = CComplexTypeArray::load(pSchema, pSchemaRoot, strXPathExt);
+
+    strXPathExt.clear().append(xpath).append(XSD_TAG_ELEMENT);
+    CElementArray* pElemArray = CElementArray::load(pSchema, pSchemaRoot, strXPathExt.str());
+
+    strXPathExt.clear().append(xpath).append(XSD_TAG_ATTRIBUTE_GROUP);
+    CAttributeGroupArray* pAttributeGroupArray = CAttributeGroupArray::load(pSchema, pSchemaRoot, strXPathExt);
+
+    strXPathExt.clear().append(xpath).append(XSD_TAG_ANNOTATION);
+    CAnnotation* pAnnotation = CAnnotation::load(pSchema, pSchemaRoot, strXPathExt);
+    pSchema->m_pAnnotation = pAnnotation;
+
+    pSchema->m_pElementArray = pElemArray;
+    pSchema->m_pComplexTypeArray = pComplexTypeArray;
+
+    if (pSchema->m_pAttributeGroupArray == NULL)
+        pSchema->m_pAttributeGroupArray = pAttributeGroupArray;
+    else
+        // copy contents from from pAttributeGroupArray to pSchema->m_pAttributeGroupArray
+
+    pSchema->m_pSimpleTypeArray = pSimpleTypeArray;
+    pSchema->m_pIncludeArray = pIncludeArray;
+
+    pSchemaHelper->getSchemaMapManager()->setSchemaForXSD(pSchemaLocation, pSchema);
+
+    CConfigSchemaHelper::getInstance()->processAttributeGroupArr();
+    CConfigSchemaHelper::getInstance()->processExtensionArr();
+    CConfigSchemaHelper::getInstance()->processNodeWithTypeArr(pSchema);
+
+    return pSchema;
+}
+
+CSchema* CSchema::load(const char* pSchemaLocation, CXSDNodeBase* pParentNode)
+{
+    if (pSchemaLocation == NULL)
+        return NULL;
+
+    Linked<IPropertyTree> pSchemaRoot;
+    StringBuffer schemaPath;
+
+    if (CConfigSchemaHelper::getInstance()->getBasePath() == NULL)
+        schemaPath.appendf("%s%s", DEFAULT_SCHEMA_DIRECTORY, pSchemaLocation);
+    else
+        schemaPath.appendf("%s/%s", CConfigSchemaHelper::getInstance()->getBasePath(), pSchemaLocation);
+
+    try
+    {
+       pSchemaRoot.setown(createPTreeFromXMLFile(schemaPath.str()));
+    }
+    catch (...)
+    {
+        // TODO: Hanlde exceptions
+        std::cout << "Can't open " << schemaPath.str() << std::endl;
+        exit(-1);
+    }
+
+    CSchema *pSchema = CSchema::load(pSchemaLocation, pSchemaRoot, XSD_TAG_SCHEMA);
+    SETPARENTNODE(pSchema, pParentNode)
+
+    return pSchema;
+}
+
+void CSchema::dump(std::ostream& cout, unsigned int offset) const
+{
+    offset+= STANDARD_OFFSET_1;
+
+    QuickOutHeader(cout, XSD_SCHEMA_STR, offset);
+    QUICK_OUT_2(XMLNS_XS);
+    QUICK_OUT_2(ElementFormDefault);
+    QUICK_OUT_2(AttributeFormDefault);
+    QUICK_OUT(cout, XSDXPath,  offset);
+    QUICK_OUT(cout, EnvXPath,  offset);
+
+    if (m_pElementArray != NULL)
+        m_pElementArray->dump(cout, offset);
+    if (m_pComplexTypeArray != NULL)
+        m_pComplexTypeArray->dump(cout, offset);
+    if (m_pSimpleTypeArray != NULL)
+        m_pSimpleTypeArray->dump(cout, offset);
+    if (m_pIncludeArray != NULL)
+        m_pIncludeArray->dump(cout, offset);
+    if (m_pAnnotation != NULL)
+        m_pAnnotation->dump(cout, offset);
+    if (m_pAttributeGroupArray != NULL)
+        m_pAttributeGroupArray->dump(cout, offset);
+
+    QuickOutFooter(cout, XSD_SCHEMA_STR, offset);
+}
+
+void CSchema::getDocumentation(StringBuffer &strDoc) const
+{
+    if (m_pElementArray != NULL)
+        m_pElementArray->getDocumentation(strDoc);
+    if (m_pComplexTypeArray != NULL)
+        m_pComplexTypeArray->getDocumentation(strDoc);
+    if (m_pAttributeGroupArray != NULL)
+        m_pAttributeGroupArray->getDocumentation(strDoc);
+    if (m_pSimpleTypeArray != NULL)
+        m_pSimpleTypeArray->getDocumentation(strDoc);
+    if (m_pIncludeArray != NULL)
+        m_pIncludeArray->getDocumentation(strDoc);
+
+    strDoc.append(DM_SECT2_END);
+}
+
+void CSchema::getQML(StringBuffer &strQML, int idx) const
+{
+    strQML.append(QML_START);
+    DEBUG_MARK_QML;
+    strQML.append(QML_VERTICAL_SCROLL_BAR);
+    DEBUG_MARK_QML;
+    strQML.append(QML_HORIZONTAL_SCROLL_BAR);
+    DEBUG_MARK_QML;
+    strQML.append(QML_SCROLL_BAR_TRANSITIONS);
+    DEBUG_MARK_QML;
+
+    if (m_pElementArray != NULL)
+        m_pElementArray->getQML(strQML, idx);
+    if (m_pComplexTypeArray != NULL)
+        m_pComplexTypeArray->getQML(strQML);
+    if (m_pAttributeGroupArray != NULL)
+        m_pAttributeGroupArray->getQML(strQML);
+    if (m_pSimpleTypeArray != NULL)
+        m_pSimpleTypeArray->getQML(strQML);
+    if (m_pIncludeArray != NULL)
+        m_pIncludeArray->getQML(strQML);
+
+    strQML.append(QML_END);
+    DEBUG_MARK_QML;
+}
+
+void CSchema::getQML2(StringBuffer &strQML, int idx) const
+{
+    DEBUG_MARK_QML;
+    strQML.append(QML_START);
+    DEBUG_MARK_QML;
+    strQML.append(QML_TAB_VIEW_BEGIN);
+    DEBUG_MARK_QML;
+
+    if (m_pElementArray != NULL)
+    {
+        DEBUG_MARK_QML;
+        m_pElementArray->setUIType(QML_UI_EMPTY);
+        m_pElementArray->getQML2(strQML, idx);
+        DEBUG_MARK_QML;
+    }
+    if (m_pComplexTypeArray != NULL)
+    {
+        DEBUG_MARK_QML;
+        assert(!"Is this valid?");
+        m_pComplexTypeArray->getQML2(strQML);
+        DEBUG_MARK_QML;
+    }
+    if (m_pAttributeGroupArray != NULL)
+    {
+        DEBUG_MARK_QML;
+        m_pAttributeGroupArray->getQML2(strQML);
+        DEBUG_MARK_QML;
+    }
+    if (m_pSimpleTypeArray != NULL)
+    {
+        DEBUG_MARK_QML;
+        m_pSimpleTypeArray->getQML2(strQML);
+        DEBUG_MARK_QML;
+    }
+    if (m_pIncludeArray != NULL)
+    {
+        DEBUG_MARK_QML;
+        m_pIncludeArray->getQML2(strQML);
+        DEBUG_MARK_QML;
+    }
+    strQML.append(QML_TAB_VIEW_STYLE);
+    DEBUG_MARK_QML;
+    strQML.append(QML_TAB_VIEW_END);
+    DEBUG_MARK_QML;
+    strQML.append(QML_TAB_TEXT_STYLE);
+    DEBUG_MARK_QML;
+    DEBUG_MARK_QML;
+    strQML.append(QML_END);
+    DEBUG_MARK_QML;
+}
+
+void CSchema::getQML3(StringBuffer &strQML, int idx) const
+{
+    // Generates QML ListModel
+    DEBUG_MARK_QML;
+    strQML.append(QML_FILE_START);
+
+    if (m_pElementArray != NULL)
+    {
+        DEBUG_MARK_QML;
+        m_pElementArray->getQML3(strQML, idx);
+        DEBUG_MARK_QML;
+    }
+    strQML.append(QML_DOUBLE_END_BRACKET);
+}
+
+void  CSchema::populateEnvXPath(StringBuffer strXPath, unsigned int index)
+{
+    strXPath.append("./").append(XML_TAG_SOFTWARE);
+
+    if (m_pElementArray != NULL)
+    {
+        m_pElementArray->populateEnvXPath(strXPath);
+        CConfigSchemaHelper::getInstance()->getSchemaMapManager()->addMapOfXSDXPathToElementArray(m_pElementArray->getXSDXPath(), m_pElementArray);
+    }
+    if (m_pAttributeGroupArray != NULL)
+        m_pAttributeGroupArray->populateEnvXPath(strXPath);
+    if (m_pSimpleTypeArray != NULL)
+        m_pSimpleTypeArray->populateEnvXPath(strXPath);
+    if (m_pIncludeArray != NULL)
+        m_pIncludeArray->populateEnvXPath(strXPath);
+    if (m_pComplexTypeArray != NULL)
+    {
+        assert(m_pComplexTypeArray != 0);
+        m_pComplexTypeArray->populateEnvXPath(strXPath);
+    }
+    this->setEnvXPath(strXPath);
+}
+
+void CSchema::loadXMLFromEnvXml(const IPropertyTree *pEnvTree)
+{
+    assert(pEnvTree != NULL);
+
+    if (m_pElementArray != NULL)
+        m_pElementArray->loadXMLFromEnvXml(pEnvTree);
+    if (m_pComplexTypeArray != NULL)
+        m_pComplexTypeArray->loadXMLFromEnvXml(pEnvTree);
+    if (m_pAttributeGroupArray != NULL)
+        m_pAttributeGroupArray->loadXMLFromEnvXml(pEnvTree);
+    if (m_pSimpleTypeArray != NULL)
+        m_pSimpleTypeArray->loadXMLFromEnvXml(pEnvTree);
+    if (m_pIncludeArray != NULL)
+        m_pIncludeArray->loadXMLFromEnvXml(pEnvTree);
+    if (m_pAttributeGroupArray != NULL)
+        m_pAttributeGroupArray->loadXMLFromEnvXml(pEnvTree);
+}
+const char* CSchema::getXML(const char* /*pComponent*/)
+{
+    if (m_strXML.length() == 0)
+    {
+        int length =  m_pElementArray->length();
+
+        if (m_pElementArray != NULL)
+        {
+            for (int idx = 0; idx < length; idx++)
+            {
+                CElement &Element = m_pElementArray->item(idx);
+                m_strXML.append(Element.getXML(NULL));
+
+                if (idx+1 < length)
+                    m_strXML.append("\n");
+            }
+        }
+        if (m_pAttributeGroupArray != NULL)
+        {
+            length = m_pAttributeGroupArray->length();
+            for (int idx = 0; idx < length; idx++)
+            {
+                CAttributeGroup &AttributeGroup  = m_pAttributeGroupArray->item(idx);
+                m_strXML.append(AttributeGroup.getXML(NULL));
+
+                if (idx+1 < length)
+                    m_strXML.append("\n");
+            }
+        }
+
+        m_strXML.append("/>\n");
+
+        if (m_pComplexTypeArray != NULL)
+        {
+            length = m_pComplexTypeArray->length();
+            for (int idx = 0; idx < length; idx++)
+            {
+                CComplexType &ComplexType = m_pComplexTypeArray->item(idx);
+                m_strXML.append(ComplexType.getXML(NULL));
+
+                if (idx+1 < length)
+                     m_strXML.append("\n");
+            }
+        }
+        if (m_pSimpleTypeArray != NULL)
+        {
+            length = m_pSimpleTypeArray->length();
+            for (int idx = 0; idx < length; idx++)
+            {
+                CSimpleType &SimpleType = m_pSimpleTypeArray->item(idx);
+
+                m_strXML.append(SimpleType.getXML(NULL));
+
+                if (idx+1 < length)
+                    m_strXML.append("\n");
+            }
+        }
+        if (m_pIncludeArray != NULL)
+        {
+            length = m_pIncludeArray->length();
+            for (int idx = 0; idx < length; idx++)
+            {
+                CInclude &Include = m_pIncludeArray->item(idx);
+                m_strXML.append(Include.getXML(NULL));
+
+                if (idx+1 < length)
+                    m_strXML.append("\n");
+            }
+        }
+    }
+    return m_strXML.str();
+}
+
+CXSDNode* CSchema::getExtensionType(const char* pExtensionTypeName) const
+{
+    if (pExtensionTypeName == NULL)
+        return NULL;
+
+    if (m_pSimpleTypeArray != NULL)
+    {
+        int length = m_pSimpleTypeArray->length();
+
+        for (int idx = 0; idx < length; idx++)
+        {
+            CSimpleType &SimpleType = m_pSimpleTypeArray->item(idx);
+
+            if (strcmp(SimpleType.getName(), pExtensionTypeName) == 0)
+                return &SimpleType;
+        }
+    }
+    if (m_pComplexTypeArray != NULL)
+    {
+        int length = m_pComplexTypeArray->length();
+
+        for (int idx = 0; idx < length; idx++)
+        {
+            CComplexType &ComplexType = m_pComplexTypeArray->item(idx);
+
+            if (strcmp(ComplexType.getName(), pExtensionTypeName) == 0)
+                return &ComplexType;
+        }
+    }
+    return NULL;
+}
+
+const char* CSchema::getSchemaFileName() const
+{
+    String tempString(m_strSchemaLocation.str());
+
+    int idx = tempString.lastIndexOf('\\');
+
+    if (idx == -1)
+        return m_strSchemaLocation.str();
+    else
+        return &((m_strSchemaLocation.str())[idx]);
+}

--- a/configuration/configurator/SchemaSchema.hpp
+++ b/configuration/configurator/SchemaSchema.hpp
@@ -1,0 +1,91 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef _SCHEMA_SCHEMA_HPP_
+#define _SCHEMA_SCHEMA_HPP_
+
+#include "jarray.hpp"
+#include "jstring.hpp"
+#include "SchemaAll.hpp"
+#include "SchemaCommon.hpp"
+
+class CSchema : public InterfaceImpl, public CXSDNodeBase
+{
+public:
+
+    virtual ~CSchema();
+
+    GETTERSETTER(XMLNS_XS)
+    GETTERSETTER(ElementFormDefault)
+    GETTERSETTER(AttributeFormDefault)
+
+    virtual void dump(std::ostream& cout, unsigned int offset = 0) const;
+    virtual void getDocumentation(StringBuffer &strDoc) const;
+    virtual void getQML(StringBuffer &strQML, int idx = -1) const;
+    virtual void getQML2(StringBuffer &strQML, int idx = -1) const;
+    virtual void getQML3(StringBuffer &strQML, int idx = -1) const;
+    virtual void populateEnvXPath(StringBuffer strXPath, unsigned int index = 1);
+    virtual const char* getXML(const char* /*pComponent*/);
+    virtual void loadXMLFromEnvXml(const IPropertyTree *pEnvTree);
+
+    CXSDNode* getExtensionType(const char* pExtensionTypeName) const;
+
+    const char* getSchemaLocation() const
+    {
+        return m_strSchemaLocation.str();
+    }
+
+    const char* getSchemaFileName() const;
+
+    CComplexTypeArray* getComplexTypeArray() const
+    {
+        return m_pComplexTypeArray;
+    }
+
+    virtual CAnnotation* getAnnotation() const
+    {
+        return m_pAnnotation;
+    }
+
+    static CSchema* load(const char* pSchemaLocation, const IPropertyTree *pSchemaRoot, const char* xpath);
+    static CSchema* load(const char* pSchemaLocation, CXSDNodeBase* pParentNode);
+
+protected:
+
+    CSchema(const char * pSchemaLocation, const char* pXMLNS_XS = NULL, const char* pElementFormDefault = NULL, const char* pAttributeFormDefault = NULL,
+            CElementArray* pElementArray = NULL, CComplexTypeArray* pComplexTypeArray = NULL, CAttributeGroupArray* pAttributeGroupArray = NULL,
+            CSimpleTypeArray* pSimpleTypeArray = NULL, CIncludeArray* pIncludeArray = NULL, CAnnotation *pAnnotation = NULL) : CXSDNodeBase::CXSDNodeBase(NULL, XSD_SCHEMA), m_strSchemaLocation(pSchemaLocation),
+                m_strXMLNS_XS(pXMLNS_XS), m_strElementFormDefault(pElementFormDefault), m_strAttributeFormDefault(pAttributeFormDefault),
+                m_pElementArray(pElementArray), m_pComplexTypeArray(pComplexTypeArray), m_pAttributeGroupArray(pAttributeGroupArray),
+                m_pSimpleTypeArray(pSimpleTypeArray), m_pIncludeArray(pIncludeArray), m_pAnnotation(pAnnotation)
+    {
+    }
+
+    StringBuffer            m_strSchemaLocation;
+    CElementArray*          m_pElementArray;
+    CComplexTypeArray*      m_pComplexTypeArray;
+    CAttributeGroupArray*   m_pAttributeGroupArray;
+    CSimpleTypeArray*       m_pSimpleTypeArray;
+    CIncludeArray*          m_pIncludeArray;
+    CAnnotation*            m_pAnnotation;
+
+private:
+};
+
+
+
+#endif // _SCHEMA_SCHEMA_HPP_

--- a/configuration/configurator/SchemaSelector.cpp
+++ b/configuration/configurator/SchemaSelector.cpp
@@ -1,0 +1,89 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include "SchemaSelector.hpp"
+#include "SchemaCommon.hpp"
+
+CSelector* CSelector::load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath)
+{
+    assert(pSchemaRoot != NULL);
+    assert(pParentNode != NULL);
+    assert(pParentNode->getNodeType() == XSD_KEY || pParentNode->getNodeType() == XSD_KEYREF || pParentNode->getNodeType() == XSD_UNIQUE);
+
+    if (pSchemaRoot == NULL || pParentNode == NULL)
+    {
+        // TODO: Throw Exception
+        assert(false);
+        return NULL;
+    }
+
+    CSelector *pSelector = NULL;
+
+    if (xpath != NULL && *xpath != 0)
+    {
+        IPropertyTree* pTree = pSchemaRoot->queryPropTree(xpath);
+
+        if (pTree == NULL)
+        {
+            assert(!"Selector reuqired");
+            // TODO: throw MakeExceptionFromMap("EX_STR_MISSING_SELECTOR_MISSING");
+        }
+        const char* pXPath = pSchemaRoot->getPropTree(xpath)->queryProp(XML_ATTR_XPATH);
+        assert(pXPath != NULL && *pXPath != 0);
+
+        if (pXPath == NULL || *pXPath == 0)
+        {
+            assert(!"Throw Exception");
+            return NULL;
+             // TODO: throw exception
+        }
+        if (pXPath != NULL)
+        {
+            pSelector = new CSelector(pParentNode);
+            pSelector->setXSDXPath(xpath);
+            pSelector->setXPath(pXPath);
+        }
+        else
+        {
+            assert(!"selector can not be be empty!");
+            // TODO: throw MakeExceptionFromMap(EX_STR_MISSING_VALUE_ATTRIBUTE_IN_LENGTH);
+        }
+
+        const char *pID = pSchemaRoot->getPropTree(xpath)->queryProp(XML_ATTR_ID);
+        if (pID != NULL)
+         pSelector->setID(pID);
+    }
+    return pSelector;
+}
+
+void CSelector::dump(std::ostream& cout, unsigned int offset) const
+{
+    offset += STANDARD_OFFSET_1;
+
+    QuickOutHeader(cout, XSD_SELECTOR_STR, offset);
+    QUICK_OUT(cout, XPath, offset);
+    QUICK_OUT(cout, ID, offset);
+    QUICK_OUT(cout, XSDXPath,  offset);
+    QuickOutFooter(cout, XSD_SELECTOR_STR, offset);
+}
+
+void CSelector::populateEnvXPath(StringBuffer strXPath, unsigned int index)
+{
+    this->setEnvXPath(&(strXPath.str()[1]));  // strip out .
+    PROGLOG("Function: %s() at %s:%d", __func__, __FILE__, __LINE__);
+    PROGLOG("Setting selector %s to EnvXPath = %s", this->getXSDXPath(), this->getEnvXPath());
+}

--- a/configuration/configurator/SchemaSelector.hpp
+++ b/configuration/configurator/SchemaSelector.hpp
@@ -1,0 +1,56 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef _SCHEMA_SELECTOR_HPP_
+#define _SCHEMA_SELECTOR_HPP_
+
+#include "SchemaCommon.hpp"
+#include "jstring.hpp"
+
+class CSelector : public CXSDNode
+{
+public:
+
+    virtual ~CSelector()
+    {
+    }
+
+    virtual void dump(std::ostream &cout, unsigned int offset = 0) const;
+    virtual void populateEnvXPath(StringBuffer strXPath, unsigned int index = 1);
+
+    virtual void getDocumentation(StringBuffer &strDoc) const
+    {
+        UNIMPLEMENTED;
+    }
+    virtual void getQML(StringBuffer &strQML, int idx = -1) const
+    {
+        UNIMPLEMENTED;
+    }
+
+    static CSelector* load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath);
+
+    GETTERSETTER(ID)
+    GETTERSETTER(XPath)
+
+protected:
+
+    CSelector(CXSDNodeBase* pParentNode) : CXSDNode::CXSDNode(pParentNode, XSD_SELECTOR)
+    {
+    }
+};
+
+#endif // _SCHEMA_SELECTOR_HPP_

--- a/configuration/configurator/SchemaSequence.cpp
+++ b/configuration/configurator/SchemaSequence.cpp
@@ -1,0 +1,122 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include <cassert>
+#include "jptree.hpp"
+#include "XMLTags.h"
+#include "SchemaSequence.hpp"
+#include "SchemaElement.hpp"
+#include "QMLMarkup.hpp"
+
+const CXSDNodeBase* CSequence::getNodeByTypeAndNameDescending(NODE_TYPES eNodeType, const char *pName) const
+{
+    const CXSDNodeBase* pMatchingNode = NULL;
+
+    if (eNodeType == this->getNodeType() && (pName != NULL ? !strcmp(pName, this->getNodeTypeStr()) : true))
+        return this;
+    if (m_pElementArray != NULL)
+        pMatchingNode = m_pElementArray->getNodeByTypeAndNameDescending(eNodeType, pName);
+
+    return pMatchingNode;
+}
+
+CSequence* CSequence::load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath)
+{
+    assert(pSchemaRoot != NULL);
+    CSequence *pSequence = NULL;
+
+    if (pSchemaRoot == NULL)
+        return NULL;
+    if (pSchemaRoot->queryPropTree(xpath) == NULL)
+        return NULL;  // no sequence node
+
+    StringBuffer strXPath(xpath);
+    strXPath.append("/").append(XSD_TAG_ELEMENT);
+
+    CElementArray *pElemArray = CElementArray::load(NULL, pSchemaRoot, strXPath.str());
+
+    if (pElemArray != NULL)
+    {
+        pSequence = new CSequence(pParentNode, pElemArray);
+        pSequence->setXSDXPath(xpath);
+    }
+    SETPARENTNODE(pElemArray, pSequence)
+
+    return pSequence;
+}
+
+void CSequence::dump(std::ostream& cout, unsigned int offset) const
+{
+    offset+= STANDARD_OFFSET_1;
+
+    QuickOutHeader(cout, XSD_SEQUENCE_STR, offset);
+    QUICK_OUT(cout, XSDXPath,  offset);
+
+    if (m_pElementArray != NULL)
+        m_pElementArray->dump(cout, offset);
+
+    QuickOutFooter(cout, XSD_SEQUENCE_STR, offset);
+}
+
+void CSequence::getDocumentation(StringBuffer &strDoc) const
+{
+    if (m_pElementArray != NULL)
+        m_pElementArray->getDocumentation(strDoc);
+}
+
+void CSequence::getQML(StringBuffer &strQML, int idx) const
+{
+    if (m_pElementArray != NULL)
+        m_pElementArray->getQML(strQML);
+}
+
+void CSequence::getQML2(StringBuffer &strQML, int idx) const
+{
+    if (m_pElementArray != NULL)
+    {
+        this->setUIType(this->getParentNode()->getUIType());
+        m_pElementArray->getQML2(strQML);
+    }
+}
+
+void CSequence::getQML3(StringBuffer &strQML, int idx) const
+{   
+    if (m_pElementArray != NULL)
+        m_pElementArray->getQML3(strQML);
+}
+
+void CSequence::populateEnvXPath(StringBuffer strXPath, unsigned int index)
+{
+    if (m_pElementArray != NULL)
+        m_pElementArray->populateEnvXPath(strXPath);
+
+    this->setEnvXPath(strXPath);
+}
+
+void CSequence::loadXMLFromEnvXml(const IPropertyTree *pEnvTree)
+{
+    if (m_pElementArray != NULL)
+        m_pElementArray->loadXMLFromEnvXml(pEnvTree);
+}
+
+bool CSequence::hasChildElements() const
+{
+    if (this->m_pElementArray->length() > 0)
+        return true;
+    else
+        return false;
+}

--- a/configuration/configurator/SchemaSequence.hpp
+++ b/configuration/configurator/SchemaSequence.hpp
@@ -1,0 +1,55 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef _SCHEMA_SEQUENCE_HPP_
+#define _SCHEMA_SEQUENCE_HPP_
+
+#include "SchemaCommon.hpp"
+
+class CElementArray;
+class IPropertyTree;
+
+class CSequence : public CXSDNode
+{
+public:
+
+    CSequence(CXSDNodeBase* pParentNode = NULL, CElementArray* pElemArray = NULL) : CXSDNode::CXSDNode(pParentNode, XSD_SEQUENCE), m_pElementArray(pElemArray)
+    {
+    }
+    virtual ~CSequence()
+    {
+    }
+    virtual const CXSDNodeBase* getNodeByTypeAndNameDescending(NODE_TYPES eNodeType, const char *pName) const;
+    virtual void dump(std::ostream& cout, unsigned int offset  = 0) const;
+    virtual void getDocumentation(StringBuffer &strDoc) const;
+    virtual void getQML(StringBuffer &strQML, int idx = -1) const;
+    virtual void getQML2(StringBuffer &strQML, int idx = -1) const;
+    virtual void getQML3(StringBuffer &strQML, int idx = -1) const;
+    virtual void populateEnvXPath(StringBuffer strXPath, unsigned int index = 1);
+    virtual void loadXMLFromEnvXml(const IPropertyTree *pEnvTree);
+    bool hasChildElements() const;
+
+    static CSequence* load(CXSDNodeBase* pRootNode, const IPropertyTree *pSchemaRoot, const char* xpath = NULL);
+
+protected:
+
+    CElementArray *m_pElementArray;
+
+private:
+};
+
+#endif // _SCHEMA_SEQUENCE_HPP_

--- a/configuration/configurator/SchemaSimpleContent.cpp
+++ b/configuration/configurator/SchemaSimpleContent.cpp
@@ -1,0 +1,77 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include "SchemaSimpleContent.hpp"
+#include "SchemaAnnotation.hpp"
+#include "SchemaExtension.hpp"
+#include "SchemaRestriction.hpp"
+
+CSimpleContent* CSimpleContent::load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath)
+{
+    if (pParentNode == NULL || pSchemaRoot == NULL)
+        return NULL;
+
+    CExtension *pExtension = NULL;
+    CAnnotation *pAnnotation = NULL;
+    CRestriction *pRestriction = NULL;
+    IPropertyTree *pTree = pSchemaRoot->queryPropTree(xpath);
+    StringBuffer strXPathExt(xpath);
+    strXPathExt.append("/").append(XSD_TAG_EXTENSION);
+
+    if (pSchemaRoot->queryPropTree(strXPathExt.str()) != NULL)
+    {
+        pExtension = CExtension::load(NULL, pSchemaRoot, strXPathExt.str());
+
+        if (pExtension != NULL)
+            pExtension->initExtension();
+    }
+
+    strXPathExt.set(xpath);
+    strXPathExt.append("/").append(XSD_TAG_ANNOTATION);
+
+    if (pSchemaRoot->queryPropTree(strXPathExt.str()) != NULL)
+        pAnnotation = CAnnotation::load(NULL, pSchemaRoot, strXPathExt.str());
+
+    strXPathExt.set(xpath);
+    strXPathExt.append("/").append(XSD_TAG_RESTRICTION);
+
+    if (pSchemaRoot->queryPropTree(strXPathExt.str()) != NULL)
+        pRestriction = CRestriction::load(NULL, pSchemaRoot, strXPathExt.str());
+
+    const char* pID =  NULL;
+    pID = pTree->queryProp(XML_ATTR_ID);
+
+    CSimpleContent *pSimpleContent = new CSimpleContent(pParentNode, pID);
+
+    SETPARENTNODE(pExtension, pSimpleContent);
+    SETPARENTNODE(pAnnotation, pSimpleContent);
+    SETPARENTNODE(pRestriction, pSimpleContent);
+
+    return pSimpleContent;
+}
+
+CSimpleContent::~CSimpleContent()
+{
+    delete m_pRestriction;
+    delete m_pAnnotation;
+    delete m_pExtension;
+}
+
+bool CSimpleContent::checkConstraint(const char *pValue) const
+{
+    return true;
+}

--- a/configuration/configurator/SchemaSimpleContent.hpp
+++ b/configuration/configurator/SchemaSimpleContent.hpp
@@ -1,0 +1,91 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef _SCHEMA_SIMPLECONTENT_HPP_
+#define _SCHEMA_SIMPLECONTENT_HPP_
+
+#include "SchemaCommon.hpp"
+
+class CRestriction;
+class CExtension;
+class CAnnotation;
+
+class CSimpleContent : public CXSDNode
+{
+    GETTERSETTER(ID)
+
+public:
+
+    virtual ~CSimpleContent();
+    bool checkConstraint(const char *pValue) const;
+
+    const CRestriction* getRestriction() const
+    {
+        return m_pRestriction;
+    }
+    const CAnnotation* getAnnotation() const
+    {
+        return m_pAnnotation;
+    }
+    const CExtension* getExtension() const
+    {
+        return m_pExtension;
+    }
+    virtual void dump(std::ostream& cout, unsigned int offset = 0) const
+    {
+        UNIMPLEMENTED;
+    }
+    virtual void getDocumentation(StringBuffer &strDoc) const
+    {
+        UNIMPLEMENTED;
+    }
+    virtual void getQML(StringBuffer &strQML, int idx = -1) const
+    {
+        UNIMPLEMENTED;
+    }
+    virtual const char* getXML(const char* /*pComponent*/)
+    {
+        UNIMPLEMENTED;
+        return NULL;
+    }
+    virtual void populateEnvXPath(StringBuffer strXPath, unsigned int index = 1)
+    {
+        UNIMPLEMENTED;
+    }
+    virtual void loadXMLFromEnvXml(const IPropertyTree *pEnvTree)
+    {
+        UNIMPLEMENTED;
+    }
+    static CSimpleContent* load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath);
+
+protected:
+
+    CRestriction *m_pRestriction;
+    CAnnotation *m_pAnnotation;
+    CExtension *m_pExtension;
+
+private:
+
+    CSimpleContent(CXSDNodeBase* pParentNode = NULL, const char* pID = NULL) : CXSDNode::CXSDNode(pParentNode, XSD_SIMPLE_CONTENT), m_strID(pID), m_pRestriction(NULL),
+        m_pAnnotation(NULL), m_pExtension(NULL)
+    {
+    }
+};
+
+
+
+#endif // _SCHEMA_SIMPLECONTENT_HPP_

--- a/configuration/configurator/SchemaSimpleType.cpp
+++ b/configuration/configurator/SchemaSimpleType.cpp
@@ -1,0 +1,205 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include "jptree.hpp"
+#include "XMLTags.h"
+#include "SchemaSimpleType.hpp"
+#include "SchemaRestriction.hpp"
+#include "ConfigSchemaHelper.hpp"
+#include "SchemaMapManager.hpp"
+#include "jlib.hpp"
+
+
+CXSDNodeBase* CSimpleType::getNodeByTypeAndNameAscending(NODE_TYPES eNodeType, const char *pName)
+{
+    return (this->checkSelf(eNodeType, pName, this->getName()) ? this : NULL);
+}
+
+CXSDNodeBase* CSimpleType::getNodeByTypeAndNameDescending(NODE_TYPES eNodeType, const char *pName)
+{
+    return (this->checkSelf(eNodeType, pName, this->getName()) ? this : NULL);
+}
+
+void CSimpleType::dump(std::ostream& cout, unsigned int offset) const
+{
+    offset+= STANDARD_OFFSET_1;
+
+    QuickOutHeader(cout, XSD_SIMPLE_TYPE_STR, offset);
+    QUICK_OUT_2(Name);
+    QUICK_OUT_2(ID);
+    QUICK_OUT(cout, XSDXPath,   offset);
+    QUICK_OUT(cout, EnvXPath,  offset);
+    QUICK_OUT(cout, EnvValueFromXML,  offset);
+
+    if (m_pRestriction != NULL)
+        m_pRestriction->dump(cout, offset);
+
+    QuickOutFooter(cout, XSD_SIMPLE_TYPE_STR, offset);
+}
+
+void CSimpleType::getDocumentation(StringBuffer &strDoc) const
+{
+    if (m_pRestriction != NULL)
+        m_pRestriction->getDocumentation(strDoc);
+}
+
+void CSimpleType::getQML(StringBuffer &strQML, int idx) const
+{
+    if (m_pRestriction != NULL)
+        m_pRestriction->getQML(strQML);
+}
+
+void CSimpleType::populateEnvXPath(StringBuffer strXPath, unsigned int index)
+{
+    this->setEnvXPath(strXPath);
+
+    if (this->m_pRestriction != NULL)
+        this->m_pRestriction->populateEnvXPath(strXPath);
+}
+
+void CSimpleType::loadXMLFromEnvXml(const IPropertyTree *pEnvTree)
+{
+    assert(pEnvTree != NULL);
+
+    if (this->m_pRestriction != NULL)
+        this->m_pRestriction->loadXMLFromEnvXml(pEnvTree);
+}
+
+CSimpleType* CSimpleType::load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath)
+{
+    assert(pSchemaRoot != NULL);
+
+    if (pSchemaRoot == NULL || pParentNode == NULL)
+        return NULL;
+
+    IPropertyTree *pTree = pSchemaRoot->queryPropTree(xpath);
+
+    if (pTree == NULL)
+        return NULL;
+
+    const char* pName =  NULL;
+    const char* pID =  NULL;
+
+    pName = pTree->queryProp(XML_ATTR_NAME);
+    pID = pTree->queryProp(XML_ATTR_ID);
+
+    CSimpleType* pSimpleType = new CSimpleType(pParentNode, pName,pID);
+    pSimpleType->setXSDXPath(xpath);
+    assert(pSimpleType != NULL);
+
+    if (pSimpleType == NULL)
+        return NULL;
+
+    StringBuffer strXPathExt(xpath);
+    strXPathExt.append("/").append(XSD_TAG_RESTRICTION);
+
+    CRestriction *pRestriction = CRestriction::load(pSimpleType, pSchemaRoot, strXPathExt.str());
+
+    if (pRestriction != NULL)
+        pSimpleType->setRestriciton(pRestriction);
+    if (pName != NULL)
+        CConfigSchemaHelper::getInstance()->getSchemaMapManager()->setSimpleTypeWithName(pName, pSimpleType);
+
+    return pSimpleType;
+}
+
+const char* CSimpleType::getXML(const char* /*pComponent*/)
+{
+    if (m_strXML.length () == 0)
+    {
+        m_strXML.append("<").append(getName()).append("\n");
+        m_strXML.append("<").append(getID()).append("\n");
+
+        if (m_pRestriction != NULL)
+            m_strXML.append(m_pRestriction->getXML(NULL));
+
+        m_strXML.append("/>\n");
+    }
+    return m_strXML.str();
+}
+
+bool CSimpleType::checkConstraint(const char *pValue) const
+{
+    if (this->getRestriction() == NULL)
+        return true;
+    else
+        return this->getRestriction()->checkConstraint(pValue);
+}
+
+void CSimpleTypeArray::dump(std::ostream& cout, unsigned int offset) const
+{
+    offset+= STANDARD_OFFSET_1;
+
+    QuickOutHeader(cout, XSD_SIMPLE_TYPE_ARRAY_STR, offset);
+    QUICK_OUT(cout, XSDXPath, offset);
+    QUICK_OUT(cout, EnvXPath,  offset);
+    QUICK_OUT(cout, EnvValueFromXML,  offset);
+    QUICK_OUT_ARRAY(cout, offset);
+    QuickOutFooter(cout, XSD_SIMPLE_TYPE_ARRAY_STR, offset);
+}
+
+CSimpleTypeArray* CSimpleTypeArray::load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath)
+{
+    assert(pParentNode != NULL);
+    assert(pSchemaRoot != NULL);
+    if (pSchemaRoot == NULL)
+        return NULL;
+
+    CSimpleTypeArray *pSimpleTypeArray = new CSimpleTypeArray(pParentNode);
+    pSimpleTypeArray->setXSDXPath(xpath);
+
+    Owned<IPropertyTreeIterator> elemIter = pSchemaRoot->getElements(xpath);
+
+    int count = 1;
+    ForEach(*elemIter)
+    {
+        StringBuffer strXPathExt(xpath);
+        strXPathExt.appendf("[%d]", count);
+
+        CSimpleType *pSimpleType = CSimpleType::load(pSimpleTypeArray, pSchemaRoot, strXPathExt.str());
+
+        assert(pSimpleType != NULL);
+        pSimpleTypeArray->append(*pSimpleType);
+
+        count++;
+    }
+    return pSimpleTypeArray;
+}
+
+void CSimpleTypeArray::getDocumentation(StringBuffer &strDoc) const
+{
+    QUICK_DOC_ARRAY(strDoc);
+}
+
+void CSimpleTypeArray::getQML(StringBuffer &strQML, int idx) const
+{
+    QUICK_QML_ARRAY(strQML);
+}
+
+void CSimpleTypeArray::populateEnvXPath(StringBuffer strXPath, unsigned int index)
+{
+    assert(index == 1);  // Only 1 array of elements per node
+
+    this->setEnvXPath(strXPath);
+    QUICK_ENV_XPATH(strXPath)
+}
+
+void CSimpleTypeArray::loadXMLFromEnvXml(const IPropertyTree *pEnvTree)
+{
+    assert(pEnvTree != NULL);
+    QUICK_LOAD_ENV_XML(pEnvTree)
+}

--- a/configuration/configurator/SchemaSimpleType.hpp
+++ b/configuration/configurator/SchemaSimpleType.hpp
@@ -1,0 +1,111 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef _SCHEMA_SIMPLE_TYPE_HPP_
+#define _SCHEMA_SIMPLE_TYPE_HPP_
+
+#include "jstring.hpp"
+#include "jarray.hpp"
+#include "SchemaCommon.hpp"
+#include "SchemaRestriction.hpp"
+
+class CRestriction;
+
+class CSimpleType : public CXSDNode
+{
+public:
+
+    virtual ~CSimpleType()
+    {
+    }
+
+    virtual CXSDNodeBase* getNodeByTypeAndNameAscending(NODE_TYPES eNodeType, const char *pName);
+    virtual CXSDNodeBase* getNodeByTypeAndNameDescending(NODE_TYPES eNodeType, const char *pName);
+    virtual void dump(std::ostream& cout, unsigned int offset = 0) const;
+    virtual void getDocumentation(StringBuffer &strDoc) const;
+    virtual void getQML(StringBuffer &strQML, int idx = -1) const;
+    virtual void populateEnvXPath(StringBuffer strXPath, unsigned int index = 1);
+    virtual void loadXMLFromEnvXml(const IPropertyTree *pEnvTree);
+    virtual const char* getXML(const char* /*pComponent*/);
+
+    static CSimpleType* load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath);
+
+    GETTERSETTER(Name)
+    GETTERSETTER(ID)
+
+    const CRestriction* getRestriction() const
+    {
+        return m_pRestriction;
+    }
+
+    void setRestriciton(CRestriction *pRestriction)
+    {
+        if (m_pRestriction != NULL)
+        {
+            m_pRestriction->Release();
+            m_pRestriction = NULL;
+        }
+        m_pRestriction = pRestriction;
+    }
+
+    bool checkConstraint(const char *pValue) const;
+
+protected:
+
+    CSimpleType(CXSDNodeBase* pRootNode, const char* pName = NULL, const char* pID = NULL, CRestriction* pRestriction = NULL) : CXSDNode::CXSDNode(pRootNode, XSD_SIMPLE_TYPE),m_strName(pName), m_strID(pID), m_pRestriction(pRestriction)
+    {
+    }
+
+    CRestriction* m_pRestriction;
+
+private:
+
+    CSimpleType() : CXSDNode::CXSDNode(NULL)
+    {
+    }
+};
+
+class CSimpleTypeArray : public CIArrayOf<CSimpleType>, public InterfaceImpl, public CXSDNodeBase
+{
+public:
+
+    CSimpleTypeArray(CXSDNodeBase* pParentNode) : CXSDNodeBase::CXSDNodeBase(pParentNode, XSD_SIMPLE_TYPE_ARRAY)
+    {
+    }
+
+    virtual ~CSimpleTypeArray()
+    {
+    }
+
+    virtual void dump(std::ostream& cout, unsigned int offset = 0) const;
+    virtual void getDocumentation(StringBuffer &strDoc) const;
+    virtual void getQML(StringBuffer &strQML, int idx = -1) const;
+    virtual void populateEnvXPath(StringBuffer strXPath, unsigned int index = 1);
+    virtual void loadXMLFromEnvXml(const IPropertyTree *pEnvTree);
+
+    static CSimpleTypeArray* load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath);
+
+protected:
+
+private:
+
+    CSimpleTypeArray() : CXSDNodeBase::CXSDNodeBase(NULL)
+    {
+    }
+};
+
+#endif // _SCHEMA_SIMPLE_TYPE_HPP_

--- a/configuration/configurator/SchemaTotalDigits.cpp
+++ b/configuration/configurator/SchemaTotalDigits.cpp
@@ -1,0 +1,29 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include "SchemaTotalDigits.hpp"
+
+CTotalDigits* CTotalDigits::load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath)
+{
+    CTotalDigits *pTotalDigits = CXSDNodeWithRestrictions<CTotalDigits>::load(pParentNode, pSchemaRoot, xpath);
+
+    if (pTotalDigits == NULL)
+        return NULL;
+
+    pTotalDigits->setTotalDigits(pTotalDigits->getValue());
+    return pTotalDigits;
+}

--- a/configuration/configurator/SchemaTotalDigits.hpp
+++ b/configuration/configurator/SchemaTotalDigits.hpp
@@ -1,0 +1,42 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef _SCHEMA_TOTAL_DIGITS_HPP_
+#define _SCHEMA_TOTAL_DIGITS_HPP_
+
+#include "SchemaCommon.hpp"
+
+class CTotalDigits : public CXSDNodeWithRestrictions<CTotalDigits>
+{
+    friend class CXSDNodeWithRestrictions<CTotalDigits>;
+public:
+
+    virtual ~CTotalDigits()
+    {
+    }
+    static CTotalDigits* load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath);
+
+    GETTERSETTERINT(TotalDigits)
+
+protected:
+
+    CTotalDigits(CXSDNodeBase* pParentNode = NULL) : CXSDNodeWithRestrictions<CTotalDigits>::CXSDNodeWithRestrictions(pParentNode, XSD_TOTAL_DIGITS), m_nTotalDigits(-1)
+    {
+    }
+};
+
+#endif // _SCHEMA_TOTAL_DIGITS_HPP_

--- a/configuration/configurator/SchemaUnique.cpp
+++ b/configuration/configurator/SchemaUnique.cpp
@@ -1,0 +1,111 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include "SchemaUnique.hpp"
+
+CUnique* CUnique::load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath)
+{
+    assert(pSchemaRoot != NULL);
+    assert(pParentNode != NULL);
+    assert(pParentNode->getNodeType() == XSD_UNIQUE_ARRAY);
+
+    if (pSchemaRoot == NULL || pParentNode == NULL) 
+        return NULL;    // TODO: Throw Exception
+
+    CUnique *pUnique = NULL;
+
+    if (xpath != NULL && *xpath != 0)
+    {
+        IPropertyTree* pTree = pSchemaRoot->queryPropTree(xpath);
+
+        if (pTree == NULL)
+            return NULL;
+
+        const char* pName = pSchemaRoot->getPropTree(xpath)->queryProp(XML_ATTR_NAME);
+        assert(pName != NULL && *pName != 0);
+
+        if (pName == NULL || *pName == 0)
+            assert(!"Throw Exception name can not be empty");     // TODO: throw exception
+        else
+        {
+            pUnique = new CUnique(pParentNode);
+            pUnique->setXSDXPath(xpath);
+        }
+
+        const char *pID = pSchemaRoot->getPropTree(xpath)->queryProp(XML_ATTR_ID);
+        if (pID != NULL)
+            pUnique->setID(pID);
+    }
+    return pUnique;
+}
+
+void CUnique::dump(std::ostream& cout, unsigned int offset) const
+{
+    offset += STANDARD_OFFSET_1;
+
+    QuickOutHeader(cout, XSD_UNIQUE_STR, offset);
+    QUICK_OUT(cout, ID, offset);
+    QUICK_OUT(cout, Name, offset);
+    QUICK_OUT(cout, XSDXPath,  offset);
+    QuickOutFooter(cout, XSD_UNIQUE_STR, offset);
+}
+
+CUniqueArray* CUniqueArray::load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath)
+{
+    assert(pSchemaRoot != NULL);
+    if (pSchemaRoot == NULL || xpath == NULL)
+        return NULL;
+
+    Owned<IPropertyTreeIterator> attributeIter = pSchemaRoot->getElements(xpath, ipt_ordered);
+    StringBuffer strXPathExt(xpath);
+
+    CUniqueArray *pUniqueArray = new CUniqueArray(pParentNode);
+    pUniqueArray->setXSDXPath(xpath);
+
+    int count = 1;
+    ForEach(*attributeIter)
+    {
+        strXPathExt.clear().append(xpath).appendf("[%d]",count);
+
+        CUnique *pUnique = CUnique::load(pUniqueArray, pSchemaRoot, strXPathExt.str());
+
+        if (pUnique != NULL)
+            pUniqueArray->append(*pUnique);
+
+        count++;
+    }
+
+    if (pUniqueArray->length() == 0)
+    {
+        delete pUniqueArray;
+        pUniqueArray = NULL;
+    }
+    return pUniqueArray;
+}
+
+void CUniqueArray::dump(std::ostream &cout, unsigned int offset) const
+{
+    offset+= STANDARD_OFFSET_1;
+
+    QuickOutHeader(cout, XSD_UNIQUE_ARRAY_STR, offset);
+    QUICK_OUT(cout, XSDXPath,  offset);
+    QUICK_OUT(cout, EnvXPath,  offset);
+    QUICK_OUT_ARRAY(cout, offset);
+    QuickOutFooter(cout, XSD_UNIQUE_ARRAY_STR, offset);
+}
+
+

--- a/configuration/configurator/SchemaUnique.hpp
+++ b/configuration/configurator/SchemaUnique.hpp
@@ -1,0 +1,95 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef _SCHEMA_UNIQUE_HPP_
+#define _SCHEMA_UNIQUE_HPP_
+
+#include "SchemaCommon.hpp"
+#include "SchemaKey.hpp"
+#include "jstring.hpp"
+
+class CSchemaUnique;
+
+class CUnique : public CXSDNode
+{
+public:
+
+    virtual ~CUnique()
+    {
+    }
+
+    virtual void dump(std::ostream &cout, unsigned int offset = 0) const;
+    virtual void getDocumentation(StringBuffer &strDoc) const
+    {
+        UNIMPLEMENTED;
+    }
+    virtual void getQML(StringBuffer &strQML, int idx = -1) const
+    {
+        UNIMPLEMENTED;
+    }
+    virtual void populateEnvXPath(StringBuffer strXPath, unsigned int index = 1)
+    {
+        UNIMPLEMENTED;
+    }
+    static CUnique* load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath);
+
+    GETTERSETTER(ID)
+    GETTERSETTER(Name)
+
+protected:
+
+    CUnique(CXSDNodeBase *pParentNode) : CXSDNode::CXSDNode(pParentNode, XSD_UNIQUE)
+    {
+    }
+
+};
+
+class CUniqueArray : public CIArrayOf<CUnique>, public InterfaceImpl, public CXSDNodeBase
+{
+public:
+
+    virtual ~CUniqueArray()
+    {
+    }
+
+    virtual void dump(std::ostream& cout, unsigned int offset = 0) const;
+    virtual void getDocumentation(StringBuffer &strDoc) const
+    {
+        UNIMPLEMENTED;
+    }
+    virtual void getQML(StringBuffer &strQML, int idx = -1) const
+    {
+        UNIMPLEMENTED;
+    }
+    virtual void populateEnvXPath(StringBuffer strXPath, unsigned int index = 1)
+    {
+        UNIMPLEMENTED;
+    }
+    virtual void loadXMLFromEnvXml(const IPropertyTree *pEnvTree)
+    {
+        UNIMPLEMENTED;
+    }
+    static CUniqueArray* load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath);
+
+protected:
+
+    CUniqueArray(CXSDNodeBase* pParentNode = NULL) : CXSDNodeBase::CXSDNodeBase(pParentNode, XSD_UNIQUE_ARRAY)
+    {
+    }
+};
+
+#endif // _SCHEMA_UNIQUE_HPP_

--- a/configuration/configurator/SchemaWhiteSpace.cpp
+++ b/configuration/configurator/SchemaWhiteSpace.cpp
@@ -1,0 +1,27 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include "SchemaWhiteSpace.hpp"
+
+CWhiteSpace* CWhiteSpace::load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath)
+{
+    CWhiteSpace *pWhiteSpace = CXSDNodeWithRestrictions<CWhiteSpace>::load(pParentNode, pSchemaRoot, xpath);
+    if (pWhiteSpace == NULL)
+        return NULL;
+
+    return pWhiteSpace;
+}

--- a/configuration/configurator/SchemaWhiteSpace.hpp
+++ b/configuration/configurator/SchemaWhiteSpace.hpp
@@ -1,0 +1,44 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef _SCHEMA_WHITE_SPACE_HPP_
+#define _SCHEMA_WHITE_SPACE_HPP_
+
+#include "SchemaCommon.hpp"
+
+class CWhiteSpace : public CXSDNodeWithRestrictions<CWhiteSpace>
+{
+    friend class CXSDNodeWithRestrictions<CWhiteSpace>;
+public:
+
+    virtual ~CWhiteSpace()
+    {
+    }
+    static CWhiteSpace* load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchemaRoot, const char* xpath);
+
+    GETTERSETTER(Value)
+
+protected:
+
+    CWhiteSpace(CXSDNodeBase* pParentNode = NULL) : CXSDNodeWithRestrictions<CWhiteSpace>::CXSDNodeWithRestrictions(pParentNode, XSD_WHITE_SPACE)
+    {
+    }
+
+    int m_nWhiteSpace;
+};
+
+#endif // _SCHEMA_WHITE_SPACE_HPP_

--- a/configuration/configurator/WizardBase.cpp
+++ b/configuration/configurator/WizardBase.cpp
@@ -1,0 +1,38 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include "WizardBase.hpp"
+#include "XMLTags.h"
+#include "jstring.hpp"
+#include "jptree.hpp"
+
+CWizardBase::CWizardBase()
+{
+}
+
+CWizardBase::~CWizardBase()
+{
+}
+
+bool CWizardBase::generate(CEnvironmentConfiguration *pConfig)
+{
+    UNIMPLEMENTED;
+
+    StringBuffer xpath;
+    xpath.clear().appendf("<%s><%s></%s>", XML_HEADER, XML_TAG_ENVIRONMENT, XML_TAG_ENVIRONMENT);
+    return true;
+}

--- a/configuration/configurator/WizardBase.hpp
+++ b/configuration/configurator/WizardBase.hpp
@@ -1,0 +1,40 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef _WIZARD_BASE_HPP
+#define _WIZARD_BASE_HPP
+
+#include "WizardInterface.ipp"
+
+class CWizardBase : public IWizardInterface
+{
+public:
+
+    IMPLEMENT_IINTERFACE
+
+    CWizardBase();
+    virtual ~CWizardBase();
+
+    virtual bool generate(CEnvironmentConfiguration *pConfig);
+
+protected:
+
+private:
+
+};
+
+#endif // _WIZARD_BASE_HPP

--- a/configuration/configurator/WizardInterface.ipp
+++ b/configuration/configurator/WizardInterface.ipp
@@ -1,0 +1,16 @@
+#ifndef _WIZARD_INTERFACE_IPP_
+#define _WIZARD_INTERFACE_IPP_
+
+#include "jiface.hpp"
+
+class CEnvironmentConfiguration;
+
+interface IWizardInterface : public CInterface
+{
+public:
+
+    virtual bool generate(CEnvironmentConfiguration *pConfig) = 0;
+
+};
+
+#endif // _WIZARD_INTERFACE_IPP_

--- a/configuration/configurator_app/CMakeLists.txt
+++ b/configuration/configurator_app/CMakeLists.txt
@@ -1,0 +1,47 @@
+PROJECT ( configurator_app )
+
+CMAKE_MINIMUM_REQUIRED( VERSION 2.8.11)
+
+SET( CMAKE_INCLUDE_CURRENT_DIR ON )
+SET( CMAKE_AUTOMOC ON )
+
+FIND_PACKAGE( Qt5Core )
+FIND_PACKAGE( Qt5Widgets )
+FIND_PACKAGE( Qt5OpenGL )
+FIND_PACKAGE( Qt5Quick )
+FIND_PACKAGE( Qt5Qml )
+
+QT5_WRAP_UI( UI_HDRS MainWindow.ui )
+
+INCLUDE_DIRECTORIES(
+        ${Qt5_INCLUDE_DIRS}
+        ${Qt5_INCLUDE_DIRS}/QtGui
+        ${Qt5_INCLUDE_DIRS}/QtWidgets
+        ${Qt5_INCLUDE_DIRS}/QtCore
+        ${Qt5_INCLUDE_DIRS}/QtQml
+        ${HPCC_SOURCE_DIR}/configuration/configurator
+        ${HPCC_SOURCE_DIR}/configuration/configurator_ui/
+        ${HPCC_SOURCE_DIR}/system/jlib
+        ${HPCC_SOURCE_DIR}/system/include
+        ${HPCC_SOURCE_DIR}/deployment/deploy
+ )
+
+SET(    SRCS
+        Main.cpp
+        MainWindow.cpp
+        Worker.cpp
+        ComponentSelectorDialog.cpp
+        ${HPCC_SOURCE_DIR}/configuration/configurator_ui/AppData.cpp
+)
+
+HPCC_ADD_EXECUTABLE ( configurator_app ${SRCS} ${UI_HDRS} )
+
+TARGET_LINK_LIBRARIES( configurator_app
+    jlib
+    Qt5::Qml
+    Qt5::Widgets
+    Qt5::Quick
+    ${Qt5Core_LIBRARIES}
+    configurator
+    configurator_ui
+)

--- a/configuration/configurator_app/ComponentSelectorDialog.cpp
+++ b/configuration/configurator_app/ComponentSelectorDialog.cpp
@@ -1,0 +1,114 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include <QtWidgets>
+#include <QMessageBox>
+#include "ComponentSelectorDialog.h"
+#include "ConfiguratorAPI.hpp"
+
+CComponenetSelectorDialog::CComponenetSelectorDialog(QWidget *parent, enum OUTPUT_TYPE outputType)
+    : QDialog(parent), m_eOutputMode(outputType)
+{
+        label = new QLabel(tr("Component List:"));
+        saveButton = new QPushButton(tr("&Save"));
+        cancelButton = new QPushButton(tr("&Cancel"));
+        listWidget = new QListWidget();
+
+        int nCount = CONFIGURATOR_API::getNumberOfAvailableComponents();
+        for (int idx = 0; idx < nCount; idx++)
+        {
+            listWidget->addItem(const_cast<char*>(CONFIGURATOR_API::getComponentName(idx)));
+        }
+
+        QVBoxLayout *extensionLayout = new QVBoxLayout;
+        extensionLayout->setMargin(0);
+        QHBoxLayout *topLeftLayout = new QHBoxLayout;
+        topLeftLayout->addWidget(label);
+        QVBoxLayout *leftLayout = new QVBoxLayout;
+        leftLayout->addLayout(topLeftLayout);
+
+        QGridLayout *mainLayout = new QGridLayout;
+        mainLayout->addLayout(leftLayout, 0, 0);
+        mainLayout->addWidget(listWidget, 0, 0, 1, 2);
+        mainLayout->addWidget(saveButton, 1, 0);
+        mainLayout->addWidget(cancelButton, 1, 1);
+        extensionLayout->addWidget(listWidget);
+        setLayout(mainLayout);
+
+        if (m_eOutputMode == QML_OUTPUT)
+            setWindowTitle(tr("Select component for QML generation"));
+        else if (m_eOutputMode == DOCBOOK_OUTPUT)
+            setWindowTitle(tr("Select component for DocBook generation"));
+        connect(saveButton,     SIGNAL(pressed()),  this,   SLOT(saveOutput()));
+        connect(cancelButton,   SIGNAL(pressed()),  this,   SLOT(reject()));
+}
+
+void CComponenetSelectorDialog::writeOutput(int idx)
+{
+    QFileDialog dialog(this);
+    dialog.setFileMode(QFileDialog::AnyFile);
+
+    QString qstrFileName;
+
+    if (m_eOutputMode == QML_OUTPUT)
+        qstrFileName = dialog.getSaveFileName(this, tr("Save QML File"), "/tmp",tr("QML (*.qml)"));
+    else if (m_eOutputMode == DOCBOOK_OUTPUT)
+        qstrFileName = dialog.getSaveFileName(this, tr("Save DocBook File"), "/tmp",tr("XML (*.xml)"));
+
+    const char *pFileName = qstrFileName.toLocal8Bit().data();
+    qDebug() << pFileName;
+
+    QFile::remove(qstrFileName);
+    QFile qFile(qstrFileName.toLocal8Bit().data());
+
+    if (qFile.open(QIODevice::WriteOnly | QIODevice::Truncate) == 0)
+        return;
+
+    QTextStream out(&qFile);
+    char *pOutput = NULL;
+
+    try
+    {
+        if (m_eOutputMode == QML_OUTPUT)
+        {
+            pOutput = (char*)(malloc(sizeof(char)));
+            CONFIGURATOR_API::getQMLByIndex(idx, pOutput);
+            out << pOutput;
+        }
+        else if (m_eOutputMode == DOCBOOK_OUTPUT)
+        {
+            pOutput = const_cast<char*>(CONFIGURATOR_API::getDocBookByIndex(idx));
+            out << pOutput;
+        }
+        qFile.close();
+
+        if (pOutput != NULL && *pOutput != 0)
+            QMessageBox::information( this, tr("Success"), tr("Completed with no errors!") );
+        else
+            QMessageBox::warning( this, tr("Failure"), tr("Failed.  Nothing generated!") );
+    }
+    catch (...)
+    {
+        QMessageBox::warning( this, tr("Exception"), tr("Failed.  Exception thrown!") );
+    }
+    done(0);
+}
+
+void CComponenetSelectorDialog::saveOutput()
+{
+    writeOutput(listWidget->currentRow());
+}

--- a/configuration/configurator_app/ComponentSelectorDialog.h
+++ b/configuration/configurator_app/ComponentSelectorDialog.h
@@ -1,0 +1,58 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef _COMPONENT_SELECTOR_DIALOG_H_
+#define _COMPONENT_SELECTOR_DIALOG_H_
+
+#include <QDialog>
+
+QT_BEGIN_NAMESPACE
+class QDialogButtonBox;
+class QLabel;
+class QPushButton;
+class QWidget;
+class QListWidget;
+QT_END_NAMESPACE
+
+enum OUTPUT_TYPE
+{
+    QML_OUTPUT = 0,
+    DOCBOOK_OUTPUT,
+    DEBUG_OUTPUT
+};
+
+class CComponenetSelectorDialog : public QDialog
+{
+    Q_OBJECT
+public:
+    CComponenetSelectorDialog(QWidget *parent, enum OUTPUT_TYPE outputType);
+
+public Q_SLOTS:
+    virtual void saveOutput();
+
+private:
+
+    enum OUTPUT_TYPE m_eOutputMode;
+    void writeOutput(int idx);
+
+    QLabel *label;
+    QPushButton *saveButton;
+    QPushButton *cancelButton;
+    QListWidget *listWidget;
+};
+
+#endif // _COMPONENT_SELECTOR_DIALOG_H_

--- a/configuration/configurator_app/Main.cpp
+++ b/configuration/configurator_app/Main.cpp
@@ -1,0 +1,53 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#define CONFIGURATOR_LIB 1
+
+#include "MainWindow.hpp"
+#include <QApplication>
+#include <QThread>
+#include "MainWindowThread.hpp"
+#include <cstdlib>
+#include "ConfiguratorAPI.hpp"
+
+QApplication *pApp = NULL;
+MainWindow *pMW = NULL;
+
+int main(int argc, char *argv[])
+{
+    QApplication a(argc, argv);
+    MainWindow w;
+    w.show();
+
+    CONFIGURATOR_API::initialize();
+
+    int nCount = CONFIGURATOR_API::getNumberOfAvailableComponents();
+
+    for (int idx = 0; idx < nCount; idx++)
+    {
+        w.addComponentToList(const_cast<char*>(CONFIGURATOR_API::getComponentName(idx)));
+    }
+
+    nCount = CONFIGURATOR_API::getNumberOfAvailableServices();
+
+    for (int idx = 0; idx < nCount; idx++)
+    {
+        w.addServiceToList(const_cast<char*>(CONFIGURATOR_API::getServiceName(idx)));
+    }
+
+    return a.exec();
+}

--- a/configuration/configurator_app/MainWindow.cpp
+++ b/configuration/configurator_app/MainWindow.cpp
@@ -1,0 +1,188 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include "MainWindow.hpp"
+#include "Worker.hpp"
+#include "ui_MainWindow.h"
+#include "Worker.hpp"
+#include "AppData.hpp"
+#include <QThread>
+#include <QFileDialog>
+#include <QtQuick/QQuickView>
+#include <QQmlContext>
+#include <QFileSystemModel>
+#include <QUrl>
+#include <QFile>
+#include <QTextStream>
+#include <QDebug>
+#include <QQmlEngine>
+#include <QStringListModel>
+#include <QComboBox>
+#include <QListWidget>
+#include <QMessageBox>
+#include "ComponentSelectorDialog.h"
+#include "../configurator_ui/AppData.hpp"
+
+MainWindow::MainWindow(QWidget *parent) :
+    QMainWindow(parent),
+    ui(new Ui::MainWindow),
+    m_pView(NULL),
+    m_pAppData(NULL),
+    m_pTableDataModel(NULL),
+    m_pComponentDataModel(NULL),
+    m_bRegenerateQML(true)
+{
+    ui->setupUi(this);
+    m_pAppData = new ApplicationData();
+    m_pTableDataModel = new TableDataModel[MAX_ARRAY_X];
+
+    QTableWidgetItem *item = new QTableWidgetItem("item1");
+    QTableWidgetItem *item2 = new QTableWidgetItem("item2");
+    item->setText("Status");
+    this->ui->notificationTableWidget->setColumnCount(1);
+    this->ui->notificationTableWidget->setRowCount(1);
+
+    this->ui->notificationTableWidget->setItem(0,0,item);
+    this->ui->notificationTableWidget->setHorizontalHeaderItem(0,item2);
+    this->ui->notificationTableWidget->horizontalHeaderItem(0)->setText(CONFIGURATOR_API::getNotificationTypeName(0));
+}
+
+MainWindow::~MainWindow()
+{
+    delete m_pAppData;
+    //delete m_pTableDataModel;
+    delete m_pComponentDataModel;
+    delete ui;
+}
+
+void MainWindow::addComponentToList(char *pComponent)
+{
+    QString qstrComp(pComponent);
+    this->ui->menuAdd_Component->addAction(qstrComp);
+}
+
+void MainWindow::addServiceToList(char *pService)
+{
+    QString qstrComp(pService);
+    this->ui->menuAdd_Service->addAction(qstrComp);
+}
+
+void MainWindow::on_actionOpen_triggered()
+{
+    QString qstrFileName = QFileDialog::getOpenFileName(this, "Open Environment Configuration File", "/etc/HPCCSystems/source", ("*.xml"));
+
+    if (qstrFileName.length() == 0)
+        return;
+
+    m_pView = new QQuickView();
+
+    if (m_envFile != "")
+        CONFIGURATOR_API::reload(m_envFile.toLocal8Bit().data());
+    else
+        CONFIGURATOR_API::openConfigurationFile(qstrFileName.toLocal8Bit().data());
+
+    m_envFile = qstrFileName;
+    m_pView->rootContext()->setContextProperty("ApplicationData", m_pAppData);
+
+    for (int idx = 0; idx < MAX_ARRAY_X; idx++)
+    {
+        m_pView->rootContext()->setContextProperty(getTableDataModelName(idx), &(m_pTableDataModel[idx]));
+    }
+
+    QWidget *container = QWidget::createWindowContainer(m_pView);
+
+    m_pView->setResizeMode(QQuickView::SizeRootObjectToView);
+
+    this->ui->verticalLayout->addWidget(container);
+
+    delete m_pComponentDataModel;
+    m_pComponentDataModel = NULL;
+
+    m_pComponentDataModel = new ComponentDataModel(container);
+
+    this->ui->treeView->setModel(m_pComponentDataModel);
+    this->ui->labelConfigurationFile->setText(qstrFileName);
+
+    QPalette palette = this->ui->labelConfigurationFile->palette();
+    palette.setColor(this->ui->labelConfigurationFile->foregroundRole(), Qt::red);
+    this->ui->labelConfigurationFile->setPalette(palette);
+}
+
+void MainWindow::on_treeView_clicked(const QModelIndex &index)
+{
+    QString qstrFileName("/tmp/");
+    qstrFileName.append(CONFIGURATOR_API::getFileName(index.internalPointer()));
+    qstrFileName.append(".qml");
+
+    qDebug() << qstrFileName;
+
+    QFile qFile(qstrFileName.toLocal8Bit().data());
+    qDebug() << "this->getRegenerateQML() =" << this->getRegenerateQML() << " qFile.exists() = " << qFile.exists();
+    if (this->getRegenerateQML() == true || qFile.exists() == false)
+    {
+        QFile::remove(qstrFileName);
+        if (qFile.open(QIODevice::WriteOnly | QIODevice::Truncate) == 0)
+            return;
+
+        QTextStream out(&qFile);
+        char *pOutput = NULL;
+
+        CONFIGURATOR_API::getQML(index.internalPointer(), &pOutput, index.row());
+        out << pOutput;
+        free(pOutput);
+    }
+    qFile.close();
+
+    m_pView->engine()->clearComponentCache();
+    m_pView->setSource(QUrl::fromLocalFile(qstrFileName.toLocal8Bit().data()));
+}
+
+void MainWindow::on_actionReload_triggered()
+{
+    CONFIGURATOR_API::reload(m_envFile.toLocal8Bit().data());
+}
+
+void MainWindow::on_actionGenerate_QML_triggered()
+{
+    CComponenetSelectorDialog compSelDialog(this, QML_OUTPUT);
+    compSelDialog.setModal(true);
+    compSelDialog.exec();
+}
+
+void MainWindow::on_actionGenerate_DockBook_triggered()
+{
+    CComponenetSelectorDialog compSelDialog(this, DOCBOOK_OUTPUT);
+    compSelDialog.setModal(true);
+    compSelDialog.exec();
+}
+
+void MainWindow::on_actionGenerate_Internal_Data_Structure_Debug_triggered()
+{
+}
+
+void MainWindow::on_actionRegenerate_QML_toggled(bool arg1)
+{
+    m_bRegenerateQML = arg1;
+}
+
+void MainWindow::on_actionSave_triggered()
+{
+    if (CONFIGURATOR_API::saveConfigurationFile() == true)
+        QMessageBox::information( this, tr("File Save"), tr("Saved sucessfully") );
+    else
+        QMessageBox::warning( this, tr("File Save"), tr("Saved failed") );
+}

--- a/configuration/configurator_app/MainWindow.hpp
+++ b/configuration/configurator_app/MainWindow.hpp
@@ -1,0 +1,76 @@
+﻿/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef MAINWINDOW_HPP
+#define MAINWINDOW_HPP
+
+#include <QMainWindow>
+#include <QThread>
+#include <QString>
+#include "Worker.hpp"
+#include "AppData.hpp"
+
+class QQuickView;
+class ApplicationData;
+class TableDataModel;
+class ComponentDataModel;
+
+namespace Ui {
+class MainWindow;
+}
+
+class MainWindow : public QMainWindow
+{
+    Q_OBJECT
+
+public:
+    explicit MainWindow(QWidget *parent = 0);
+
+    ~MainWindow();
+
+    void addComponentToList(char *pComponent);
+    void addServiceToList(char *pService);
+
+private:
+
+    bool getRegenerateQML() const
+    {
+       return m_bRegenerateQML;
+    }
+
+private:
+    Ui::MainWindow *ui;
+    QQuickView *m_pView;
+    QString m_envFile;
+    ApplicationData *m_pAppData;
+    TableDataModel *m_pTableDataModel;
+    ComponentDataModel *m_pComponentDataModel;
+
+    bool m_bRegenerateQML;
+
+private slots:
+    void on_actionOpen_triggered();
+    void on_treeView_clicked(const QModelIndex &index);
+    void on_actionReload_triggered();
+    void on_actionGenerate_QML_triggered();
+    void on_actionGenerate_DockBook_triggered();
+    void on_actionGenerate_Internal_Data_Structure_Debug_triggered();
+    void on_actionRegenerate_QML_toggled(bool arg1);
+    void on_actionSave_triggered();
+};
+
+#endif // MAINWINDOW_HPP

--- a/configuration/configurator_app/MainWindow.ui
+++ b/configuration/configurator_app/MainWindow.ui
@@ -1,0 +1,338 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>MainWindow</class>
+ <widget class="QMainWindow" name="MainWindow">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>1020</width>
+    <height>663</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Configurator Central</string>
+  </property>
+  <widget class="QWidget" name="centralWidget">
+   <widget class="QScrollArea" name="scrollArea_2">
+    <property name="geometry">
+     <rect>
+      <x>300</x>
+      <y>20</y>
+      <width>981</width>
+      <height>931</height>
+     </rect>
+    </property>
+    <property name="widgetResizable">
+     <bool>true</bool>
+    </property>
+    <widget class="QWidget" name="scrollAreaWidgetContents_2">
+     <property name="geometry">
+      <rect>
+       <x>0</x>
+       <y>0</y>
+       <width>979</width>
+       <height>929</height>
+      </rect>
+     </property>
+     <widget class="QWidget" name="verticalLayoutWidget">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>981</width>
+        <height>941</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <property name="spacing">
+        <number>1</number>
+       </property>
+       <property name="sizeConstraint">
+        <enum>QLayout::SetDefaultConstraint</enum>
+       </property>
+      </layout>
+     </widget>
+    </widget>
+   </widget>
+   <widget class="QTreeView" name="treeView">
+    <property name="geometry">
+     <rect>
+      <x>0</x>
+      <y>20</y>
+      <width>291</width>
+      <height>301</height>
+     </rect>
+    </property>
+   </widget>
+   <widget class="QLabel" name="labelConfigurationFile">
+    <property name="geometry">
+     <rect>
+      <x>50</x>
+      <y>0</y>
+      <width>321</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>&lt;Open a file&gt;</string>
+    </property>
+   </widget>
+   <widget class="QLabel" name="label">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>0</y>
+      <width>41</width>
+      <height>21</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>File:</string>
+    </property>
+   </widget>
+   <widget class="QTableWidget" name="notificationTableWidget">
+    <property name="geometry">
+     <rect>
+      <x>0</x>
+      <y>330</y>
+      <width>291</width>
+      <height>261</height>
+     </rect>
+    </property>
+   </widget>
+  </widget>
+  <widget class="QMenuBar" name="menuBar">
+   <property name="geometry">
+    <rect>
+     <x>0</x>
+     <y>0</y>
+     <width>1020</width>
+     <height>22</height>
+    </rect>
+   </property>
+   <widget class="QMenu" name="menuFile">
+    <property name="title">
+     <string>File</string>
+    </property>
+    <addaction name="separator"/>
+    <addaction name="actionOpen"/>
+    <addaction name="actionReload"/>
+    <addaction name="actionRecent"/>
+    <addaction name="actionSave"/>
+    <addaction name="actionSave_As"/>
+    <addaction name="actionClose"/>
+   </widget>
+   <widget class="QMenu" name="menuAdd_Component">
+    <property name="title">
+     <string>Add Component</string>
+    </property>
+   </widget>
+   <widget class="QMenu" name="menuAdd_Service">
+    <property name="title">
+     <string>Add Service</string>
+    </property>
+   </widget>
+   <widget class="QMenu" name="menuHelp">
+    <property name="title">
+     <string>Help</string>
+    </property>
+    <addaction name="actionAbout"/>
+   </widget>
+   <widget class="QMenu" name="menuEdit">
+    <property name="title">
+     <string>Edit</string>
+    </property>
+    <addaction name="actionUndo"/>
+    <addaction name="actionRedo"/>
+   </widget>
+   <widget class="QMenu" name="menuWizards">
+    <property name="title">
+     <string>Wizards</string>
+    </property>
+    <widget class="QMenu" name="menuMacros">
+     <property name="title">
+      <string>Macros</string>
+     </property>
+     <addaction name="actionStart_Macro_Capture"/>
+     <addaction name="actionStop_Macro_Capture"/>
+     <addaction name="actionSave_Macro"/>
+    </widget>
+    <addaction name="separator"/>
+    <addaction name="actionAdd_Roxie"/>
+    <addaction name="actionAdd_Thor_s"/>
+    <addaction name="separator"/>
+    <addaction name="menuMacros"/>
+   </widget>
+   <widget class="QMenu" name="menuSettings">
+    <property name="title">
+     <string>Settings</string>
+    </property>
+    <addaction name="actionRegenerate_QML"/>
+   </widget>
+   <widget class="QMenu" name="menuValidation">
+    <property name="title">
+     <string>Validation</string>
+    </property>
+    <addaction name="actionCheck_For_Issues"/>
+   </widget>
+   <widget class="QMenu" name="menuTools">
+    <property name="title">
+     <string>Tools</string>
+    </property>
+    <addaction name="actionGenerate_QML"/>
+    <addaction name="actionGenerate_DockBook"/>
+    <addaction name="separator"/>
+    <addaction name="actionGenerate_Internal_Data_Structure_Debug"/>
+   </widget>
+   <widget class="QMenu" name="menuView">
+    <property name="title">
+     <string>View</string>
+    </property>
+    <addaction name="actionShow_Action_List"/>
+   </widget>
+   <addaction name="menuFile"/>
+   <addaction name="menuEdit"/>
+   <addaction name="menuView"/>
+   <addaction name="menuAdd_Component"/>
+   <addaction name="menuAdd_Service"/>
+   <addaction name="menuWizards"/>
+   <addaction name="menuSettings"/>
+   <addaction name="menuValidation"/>
+   <addaction name="menuTools"/>
+   <addaction name="menuHelp"/>
+  </widget>
+  <widget class="QStatusBar" name="statusBar"/>
+  <widget class="QToolBar" name="toolBar">
+   <property name="windowTitle">
+    <string>toolBar</string>
+   </property>
+   <attribute name="toolBarArea">
+    <enum>TopToolBarArea</enum>
+   </attribute>
+   <attribute name="toolBarBreak">
+    <bool>false</bool>
+   </attribute>
+  </widget>
+  <action name="actionOpen">
+   <property name="text">
+    <string>Open</string>
+   </property>
+  </action>
+  <action name="actionRecent">
+   <property name="text">
+    <string>Recent</string>
+   </property>
+  </action>
+  <action name="actionSave">
+   <property name="text">
+    <string>Save</string>
+   </property>
+  </action>
+  <action name="actionSave_As">
+   <property name="text">
+    <string>Save As</string>
+   </property>
+  </action>
+  <action name="actionClose">
+   <property name="text">
+    <string>Close</string>
+   </property>
+  </action>
+  <action name="actionAbout">
+   <property name="text">
+    <string>About</string>
+   </property>
+  </action>
+  <action name="actionUndo">
+   <property name="text">
+    <string>Undo</string>
+   </property>
+  </action>
+  <action name="actionRedo">
+   <property name="text">
+    <string>Redo</string>
+   </property>
+  </action>
+  <action name="actionStart_Macro_Capture">
+   <property name="text">
+    <string>Start Macro Capture</string>
+   </property>
+  </action>
+  <action name="actionStop_Macro_Capture">
+   <property name="text">
+    <string>Stop Macro Capture</string>
+   </property>
+  </action>
+  <action name="actionSave_Macro">
+   <property name="text">
+    <string>Save Macro</string>
+   </property>
+  </action>
+  <action name="actionAdd_Roxie">
+   <property name="text">
+    <string>Add New Hardware and Configure</string>
+   </property>
+  </action>
+  <action name="actionAdd_Thor_s">
+   <property name="text">
+    <string>Reconfigure Existing Hardware</string>
+   </property>
+  </action>
+  <action name="actionReload">
+   <property name="text">
+    <string>Reload</string>
+   </property>
+  </action>
+  <action name="actionGenerate_QML">
+   <property name="text">
+    <string>Generate QML</string>
+   </property>
+  </action>
+  <action name="actionGenerate_DockBook">
+   <property name="text">
+    <string>Generate DocBook</string>
+   </property>
+   <property name="toolTip">
+    <string>Generate DocBook formatted documentation for XSD component definitions.</string>
+   </property>
+  </action>
+  <action name="actionGenerate_Dojo">
+   <property name="text">
+    <string>Generate Dojo</string>
+   </property>
+  </action>
+  <action name="actionGenerate_Internal_Data_Structure_Debug">
+   <property name="text">
+    <string>Generate Internal Data Structure (Debug)</string>
+   </property>
+  </action>
+  <action name="actionShow_Action_List">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Show Action List</string>
+   </property>
+  </action>
+  <action name="actionCheck_For_Issues">
+   <property name="text">
+    <string>Check For Issues</string>
+   </property>
+  </action>
+  <action name="actionRegenerate_QML">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Regenerate QML</string>
+   </property>
+  </action>
+ </widget>
+ <layoutdefault spacing="6" margin="11"/>
+ <resources/>
+ <connections/>
+</ui>

--- a/configuration/configurator_app/MainWindowInterface.h
+++ b/configuration/configurator_app/MainWindowInterface.h
@@ -1,0 +1,27 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef _MAIN_WINDOW_INTERFACE_H_
+#define _MAIN_WINDOW_INTERFACE_H_
+
+extern "C" int StartMainWindowUI(int argc, char *argv[]);
+extern "C" void SetComponentList(int nCount, const char *pComponentList[]);
+extern "C" void AddComponentToList(const char *pComponent);
+extern "C" void SetServiceList(int argc, char *pServiceList[]);
+extern "C" int ShowMainWindowUI();
+
+#endif // _MAIN_WINDOW_INTERFACE_H_

--- a/configuration/configurator_app/MainWindowThread.cpp
+++ b/configuration/configurator_app/MainWindowThread.cpp
@@ -1,0 +1,36 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include "MainWindowThread.hpp"
+#include "MainWindow.hpp"
+#include <QThread>
+#include <QApplication>
+
+MainWindowThread::MainWindowThread( MainWindow* pMW )
+{
+    m_pMainWindow = pMW;
+}
+
+void MainWindowThread::SetApplication (QApplication *pApplication)
+{
+    this->m_pApplication = pApplication;
+}
+
+void MainWindowThread::run()
+{
+    this->m_pMainWindow->show();
+}

--- a/configuration/configurator_app/MainWindowThread.hpp
+++ b/configuration/configurator_app/MainWindowThread.hpp
@@ -1,0 +1,34 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include <QThread>
+class MainWindow;
+class QApplication;
+
+
+class MainWindowThread : public QThread
+{
+    public:
+        void run();
+        MainWindowThread( MainWindow* pMainWindow );
+        void SetApplication (QApplication *pApplication);
+
+     MainWindow * m_pMainWindow;
+     QApplication *m_pApplication;
+private:
+
+};

--- a/configuration/configurator_app/Worker.cpp
+++ b/configuration/configurator_app/Worker.cpp
@@ -1,0 +1,72 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include "Worker.hpp"
+#include <QEventLoop>
+#include <QTimer>
+
+CWorker::CWorker(QObject *parent) : m_bAbort(false), m_bWorking(false),
+    QObject(parent)
+{    
+}
+
+void CWorker::requestWork()
+{
+    m_mutex.lock();
+
+    m_bWorking = true;
+    m_bAbort = false;
+
+    m_mutex.unlock();
+
+    emit workRequested();
+}
+
+void CWorker::abort()
+{
+    m_mutex.lock();
+
+    if (m_bWorking == true)
+        m_bAbort = true;
+
+    m_mutex.unlock();
+}
+
+void CWorker::doWork()
+{
+    for (int i = 0; i < 2; i ++)
+    {
+        m_mutex.lock();
+
+        bool abort = m_bAbort;
+
+        m_mutex.unlock();
+
+        if (abort)
+            break;
+
+        QEventLoop loop;
+        QTimer::singleShot(1000, &loop, SLOT(quit()));
+        loop.exec();
+      }
+
+      m_mutex.lock();
+      m_bWorking = false;
+      m_mutex.unlock();
+
+      emit finished();
+}

--- a/configuration/configurator_app/Worker.hpp
+++ b/configuration/configurator_app/Worker.hpp
@@ -1,0 +1,51 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef _WORKER_HPP_
+#define _WORKER_HPP_
+
+#include <QObject>
+#include <QMutex>
+
+class CWorker : public QObject
+{
+    Q_OBJECT
+public:
+
+    explicit CWorker(QObject *parent = 0);
+    void requestWork();
+    void abort();
+
+private:
+
+    bool m_bAbort;
+    bool m_bWorking;
+
+    QMutex m_mutex;
+
+signals:
+
+    void workRequested();
+    void valueChanged();
+    void finished();
+
+public slots:
+
+    void doWork();
+};
+
+#endif // _WORKER_HPP_

--- a/configuration/configurator_ui/AppData.cpp
+++ b/configuration/configurator_ui/AppData.cpp
@@ -1,0 +1,259 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include "AppData.hpp"
+#include "jlog.hpp"
+#include <cassert>
+
+// TODO: REMOVE REFERENCES TO SCHEMA
+#include "SchemaCommon.hpp"
+//
+
+static const int TOP_LEVEL = 1;
+static void* P_TOP_LEVEL = (void*)(&TOP_LEVEL);
+
+//#define LOG_DATA_CALL
+//#define LOG_ROW_COUNT_CALL
+//#define LOG_PARENT_CALL
+//#define LOG_INDEX_CALL
+
+TableDataModel::TableDataModel()
+{
+}
+
+int TableDataModel::rowCount(const QModelIndex& /*parent*/) const
+{
+    int nCount = CONFIGURATOR_API::getNumberOfRows(this->m_pActiveTable);
+    return nCount;
+}
+
+int TableDataModel::columnCount(const QModelIndex & /*parent*/) const
+{
+    return 1;
+}
+
+QVariant TableDataModel::data(const QModelIndex & index, int role) const
+{
+    QHash<int, QByteArray> Roles = roleNames();
+
+    const char *pValue  = CONFIGURATOR_API::getTableValue(Roles.value(role), index.row()+1);
+
+    if (STRICTNESS_LEVEL >= DEFAULT_STRICTNESS)
+        assert(pValue != NULL);
+
+    return QString(pValue);
+}
+
+QHash<int, QByteArray> TableDataModel::roleNames() const
+{
+    static QHash<int, QByteArray> Roles;
+
+    int nColumns = CONFIGURATOR_API::getNumberOfUniqueColumns();
+
+    for (int idx = 0; idx < nColumns; idx++)
+    {
+        const char *pRole =  CONFIGURATOR_API::getColumnName(idx);
+        Roles[Qt::UserRole + idx+1] = pRole;
+    }
+    return Roles;
+}
+
+ComponentDataModel::ComponentDataModel( QObject *parent) : QAbstractItemModel(parent)
+{
+}
+
+ComponentDataModel::~ComponentDataModel()
+{
+}
+
+int ComponentDataModel::columnCount(const QModelIndex &/*parent*/) const
+{
+    return 1;
+}
+
+
+QVariant ComponentDataModel::data(const QModelIndex &index, int role) const
+{
+
+    if (index.isValid() == false)
+    {
+#ifdef LOG_DATA_CALL
+        PROGLOG("Function: %s() at %s:%d", __func__, __FILE__, __LINE__);
+        PROGLOG("\tindex.row() = %d index.column() = %d index.internalPointer() = %p", index.row(), index.column(), index.internalPointer());
+        PROGLOG("\tindex.isValid() == false");
+#endif // LOG_DATA_CALL
+        return QVariant();
+    }
+
+    if (Qt::DisplayRole != role)
+        return QVariant();
+
+    if (index.column() != 0)
+        assert(false);
+
+    const char *pName = CONFIGURATOR_API::getData(index.internalPointer());
+
+#ifdef LOG_DATA_CALL
+    PROGLOG("Function: %s() at %s:%d", __func__, __FILE__, __LINE__);
+    PROGLOG("\tindex.row() = %d index.column() = %d index.internalPointer() = %p", index.row(), index.column(), index.internalPointer());
+    PROGLOG("\tpName = %s", pName);
+#endif // LOG_DATA_CALL
+
+    if (pName == NULL)
+    {
+        assert(false);
+        return QVariant();
+    }
+    return QString(pName);
+}
+
+Qt::ItemFlags ComponentDataModel::flags(const QModelIndex &index) const
+{
+    if (index.isValid() == false)
+        return 0;
+    return Qt::ItemIsEnabled | Qt::ItemIsSelectable;
+}
+
+QVariant ComponentDataModel::headerData(int section, Qt::Orientation orientation, int role) const
+{
+    if (role == Qt::DisplayRole)
+        return QString("Components");
+    return QAbstractItemModel::headerData(section, orientation, role);
+}
+
+QModelIndex ComponentDataModel::index(int row, int column, const QModelIndex & parent) const
+{
+    assert(column == 0);
+    if (hasIndex(row, column, parent) == false)
+        return QModelIndex();
+
+#ifdef LOG_INDEX_CALL
+    PROGLOG("Function: %s() at %s:%d", __func__, __FILE__, __LINE__);
+    PROGLOG("\trow = %d parent.row() = %d parent.column() = %d parent.internalPointer() = %p (%s) number_of_children = %d", row, parent.row(), parent.column(), parent.internalPointer(),\
+                CONFIGURATOR_API::getData(parent.internalPointer()), parent.isValid() ? CONFIGURATOR_API::getNumberOfChildren(parent.internalPointer()) : 0);
+#endif // LOG_INDEX_CALL
+
+    void *pParentNode = NULL;
+
+    if (parent.isValid() == false)
+    {
+#ifdef LOG_INDEX_CALL
+          PROGLOG("\tparent.isValid = false");
+#endif // LOG_INDEX_CALL
+        //return createIndex(row, column, CONFIGURATOR_API::getChild(CONFIGURATOR_API::getRootNode(), row));
+        pParentNode = CONFIGURATOR_API::getModel();
+    }
+    else
+    {
+#ifdef LOG_INDEX_CALL
+          PROGLOG("\tparent.isValid = true");
+#endif // LOG_INDEX_CALL
+        pParentNode = parent.internalPointer();
+    }
+
+    assert(pParentNode != NULL);
+    void *pChildNode = CONFIGURATOR_API::getChild(pParentNode, row);
+
+    if (pChildNode != NULL)
+    {
+#ifdef LOG_INDEX_CALL
+        PROGLOG("\tcreating index for row=%d and pChildNode=%p for parent %s and child %s", row, pChildNode,\
+                CONFIGURATOR_API::getData(pParentNode), CONFIGURATOR_API::getData(pChildNode));
+#endif // LOG_INDEX_CALL
+        return createIndex(row, column, pChildNode);
+
+    }
+    else
+    {
+#ifdef LOG_INDEX_CALL
+        PROGLOG("\tcreating invalid index for row=%d for parent %s", row, CONFIGURATOR_API::getData(parent.internalPointer()));
+#endif // LOG_INDEX_CALL
+        return QModelIndex();
+    }
+}
+
+QModelIndex ComponentDataModel::parent(const QModelIndex & index) const
+{
+#ifdef LOG_PARENT_CALL
+    PROGLOG("Function: %s() at %s:%d", __func__, __FILE__, __LINE__);
+    PROGLOG("\tindex.row() = %d index.column() = %d index.internalPointer() = %p (%s) number_of_children = %d", index.row(), index.column(), index.internalPointer(),\
+                CONFIGURATOR_API::getData(index.internalPointer()), CONFIGURATOR_API::getNumberOfChildren(index.internalPointer()));
+#endif // LOG_PARENT_CALL
+
+    if (index.isValid() == false)
+        return QModelIndex();
+
+    void *pChildNode = index.internalPointer();
+#ifdef LOG_PARENT_CALL
+    if (pChildNode != CONFIGURATOR_API::getModel())
+    {
+        PROGLOG("\tpChildNode is %s", CONFIGURATOR_API::getData(pChildNode));
+    }
+    else
+    {
+        PROGLOG("\tpChildNode (%p) is model pointer", pChildNode);
+    }
+#endif
+    void *pParentNode = CONFIGURATOR_API::getParent(pChildNode);
+
+    if (pParentNode == CONFIGURATOR_API::getModel())
+        return QModelIndex();
+
+    if (pParentNode == NULL)
+    {
+        assert(false);
+        return QModelIndex();
+    }
+    int nParentRow = CONFIGURATOR_API::getIndexFromParent(pParentNode);
+#ifdef LOG_PARENT_CALL
+    PROGLOG("\tcalling createIndex(%d, 0, %p) for %s", nParentRow, pParentNode, CONFIGURATOR_API::getData(pParentNode));
+#endif // LOG_PARENT_CALL
+    return createIndex(nParentRow, 0, pParentNode);
+}
+
+int ComponentDataModel::rowCount(const QModelIndex &parent) const
+{
+#ifdef LOG_ROW_COUNT_CALL
+    PROGLOG("Function: %s() at %s:%d", __func__, __FILE__, __LINE__);
+#endif // LOG_ROW_COUNT_CALL
+
+    int nRetVal = 0;
+
+    if (parent.column() > 0)
+        return 0;
+
+    void *pParentNode = NULL;
+
+    if (parent.isValid() == false)
+    {
+#ifdef LOG_ROW_COUNT_CALL
+        PROGLOG("\tusing root node");
+#endif // LOG_ROW_COUNT_CALL
+        pParentNode = CONFIGURATOR_API::getModel();
+        //return 1;
+    }
+    else
+        pParentNode = parent.internalPointer();
+
+    nRetVal = CONFIGURATOR_API::getNumberOfChildren(pParentNode);
+
+#ifdef LOG_ROW_COUNT_CALL
+    PROGLOG("\tparent.row() = %d parent.column() = %d pParentNode = %p (%s) number_of_children = %d", parent.row(), parent.column(), pParentNode,\
+                CONFIGURATOR_API::getData(pParentNode), CONFIGURATOR_API::getNumberOfChildren(pParentNode));
+#endif
+    return nRetVal;
+}

--- a/configuration/configurator_ui/AppData.hpp
+++ b/configuration/configurator_ui/AppData.hpp
@@ -1,0 +1,109 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef _APP_DATA_HPP_
+#define _APP_DATA_HPP_
+
+#include <QObject>
+#include <QtQuick/QQuickView>
+#include <QGuiApplication>
+#include <QDateTime>
+#include <QString>
+#include <QAbstractListModel>
+#include "ConfiguratorAPI.hpp"
+
+#define BUFFER_SIZE 2048
+
+class TableDataModel : public QAbstractListModel
+{
+    Q_OBJECT
+
+public:
+
+    TableDataModel();
+
+    int rowCount(const QModelIndex & parent = QModelIndex()) const;
+    int columnCount(const QModelIndex & parent = QModelIndex()) const;
+    QVariant data(const QModelIndex & index, int role = Qt::DisplayRole) const;
+    QString getActiveTable()
+    {
+        return m_qstrActiveTable;
+    }
+    Q_INVOKABLE void setActiveTable(const QString &XPath)
+    {
+        m_qstrActiveTable = XPath;
+        strncpy(m_pActiveTable, XPath.toStdString().c_str(), XPath.length());
+        m_pActiveTable[XPath.length()] = 0;
+    }
+
+protected:
+    QHash<int, QByteArray> roleNames() const;
+
+private:
+    QString m_qstrActiveTable;
+    char m_pActiveTable[BUFFER_SIZE];
+};
+
+class ApplicationData : public QObject
+{
+    Q_OBJECT
+public:
+    Q_INVOKABLE QString getValue(QString XPath)
+    {
+        char pValue[BUFFER_SIZE];
+
+        if (CONFIGURATOR_API::getValue(XPath.toStdString().c_str(), pValue) )
+            return pValue;
+        else
+            return "";
+    }
+
+    Q_INVOKABLE void setValue(QString XPath, QString qstrNewValue)
+    {
+        CONFIGURATOR_API::setValue(XPath.toStdString().c_str(), qstrNewValue.toStdString().c_str());
+    }
+
+    Q_INVOKABLE int getIndex(QString XPath)
+    {
+        return CONFIGURATOR_API::getIndex(XPath.toStdString().c_str());
+    }
+
+    Q_INVOKABLE void setIndex(QString XPath, int index)
+    {
+        return CONFIGURATOR_API::setIndex(XPath.toStdString().c_str(), index);
+    }
+};
+
+class ComponentDataModel : public QAbstractItemModel
+{
+    Q_OBJECT
+
+public:
+
+    ComponentDataModel( QObject *parent = NULL);
+
+    virtual ~ComponentDataModel();
+    int rowCount(const QModelIndex & parent = QModelIndex()) const;
+    int columnCount(const QModelIndex & parent = QModelIndex()) const;
+    QModelIndex parent(const QModelIndex & index) const;
+    QModelIndex index(int row, int column, const QModelIndex & parent = QModelIndex()) const;
+    QVariant data(const QModelIndex & index, int role = Qt::DisplayRole) const;
+    Qt::ItemFlags flags(const QModelIndex &index) const;
+    QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const;
+};
+
+#endif // _APP_DATA_HPP_

--- a/configuration/configurator_ui/CMakeLists.txt
+++ b/configuration/configurator_ui/CMakeLists.txt
@@ -1,0 +1,27 @@
+CMAKE_MINIMUM_REQUIRED( VERSION 2.8.11 )
+
+PROJECT(configurator_ui)
+
+SET( SRCS AppData.cpp ConfiguratorUI.cpp )
+
+# Find includes in corresponding build directories
+SET(CMAKE_INCLUDE_CURRENT_DIR ON)
+# Instruct CMake to run moc automatically when needed.
+SET(CMAKE_AUTOMOC ON)
+
+INCLUDE_DIRECTORIES(
+        ${Qt5_INCLUDE_DIRS}
+        ${Qt5_INCLUDE_DIRS}/QtCore
+        ${Qt5_INCLUDE_DIRS}/QtGui
+        ${Qt5_INCLUDE_DIRS}/QtQml
+        ${HPCC_SOURCE_DIR}/configuration/configurator
+        ${HPCC_SOURCE_DIR}/configuration/configurator_app
+        ${HPCC_SOURCE_DIR}/system/jlib
+        ${HPCC_SOURCE_DIR}/system/include
+	${HPCC_SOURCE_DIR}/deployment/deploy
+
+)
+
+ADD_DEFINITIONS( -D_USRDLL )
+HPCC_ADD_LIBRARY ( configurator_ui  ${SRCS} )
+

--- a/configuration/configurator_ui/ConfiguratorUI.cpp
+++ b/configuration/configurator_ui/ConfiguratorUI.cpp
@@ -1,0 +1,60 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include <QtQuick/QQuickView>
+#include <QGuiApplication>
+#include <QQmlContext>
+#include <QObject>
+#include <QtQuick/QQuickView>
+#include <QGuiApplication>
+#include <QString>
+#include "ConfiguratorUI.hpp"
+#include "AppData.hpp"
+#include "../configurator/ConfiguratorMain.hpp"
+#include <cassert>
+
+int main2(int argc, char *argv[])
+{
+    QGuiApplication app(argc, argv);
+    QQuickView view;
+    ApplicationData data;
+    int nTables = CONFIGURATOR_API::getNumberOfTables();
+    TableDataModel tableDataModel[MAX_ARRAY_X];
+
+    assert(nTables <= MAX_ARRAY_X);
+
+    view.rootContext()->setContextProperty("ApplicationData", &data);
+
+    for (int idx = 0; idx < MAX_ARRAY_X; idx++)
+    {
+        view.rootContext()->setContextProperty(getTableDataModelName(idx), &(tableDataModel[idx]));
+    }
+
+    view.setResizeMode(QQuickView::SizeRootObjectToView);
+    view.setSource(QUrl::fromLocalFile(*argv));
+    view.show();
+
+    int retVal = app.exec();
+
+    deleteTableModels();
+    return retVal;
+}
+
+extern "C" void StartQMLUI(char* pQMLFile)
+{
+    main2(1,&pQMLFile);
+}

--- a/configuration/configurator_ui/ConfiguratorUI.hpp
+++ b/configuration/configurator_ui/ConfiguratorUI.hpp
@@ -1,0 +1,24 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef CONFIGURATORUI_HPP
+#define CONFIGURATORUI_HPP
+
+extern "C" void StartQMLUI(char* pQMLFile);
+extern "C" int main2(int argc, char *argv[]);
+
+#endif // CONFIGURATORUI_HPP

--- a/configuration/configurator_ui/ConfiguratorWidget.html
+++ b/configuration/configurator_ui/ConfiguratorWidget.html
@@ -1,0 +1,8 @@
+<div class="${baseClass}">
+    <div id="BorderContainer" class="${baseClass}BorderContainer" style="width: 100%; height: 100%" data-dojo-type="dijit.layout.BorderContainer">
+      <div id="${id}TabContainer" data-dojo-props="region: 'center', tabPosition: 'top'" style="width: 100%; height: 100%" data-dojo-type="dijit.layout.TabContainer">
+      </div> 
+        <div style="border:0px; padding: 0px; border-color:none" data-dojo-props="region: 'center'" data-dojo-type="dijit.layout.ContentPane">
+        </div>
+    </div>
+</div>

--- a/configuration/configurator_utils/makeDocs.sh
+++ b/configuration/configurator_utils/makeDocs.sh
@@ -1,0 +1,21 @@
+mkdir ./Docs
+
+./configurator -doc -use dafilesrv.xsd -b /opt/HPCCSystems/componentfiles/configxml/ -t ./Docs
+./configurator -doc -use dali.xsd -b /opt/HPCCSystems/componentfiles/configxml/ -t ./Docs
+
+./configurator -doc -use dfuplus.xsd -b /opt/HPCCSystems/componentfiles/configxml/ -t ./Docs
+./configurator -doc -use dfuserver.xsd -b /opt/HPCCSystems/componentfiles/configxml/ -t ./Docs
+
+./configurator -doc -use eclagent_config.xsd -b /opt/HPCCSystems/componentfiles/configxml/ -t ./Docs
+./configurator -doc -use eclccserver.xsd -b /opt/HPCCSystems/componentfiles/configxml/ -t ./Docs
+
+./configurator -doc -use eclscheduler.xsd -b /opt/HPCCSystems/componentfiles/configxml/ -t ./Docs
+./configurator -doc -use esp.xsd -b /opt/HPCCSystems/componentfiles/configxml/ -t ./Docs
+
+./configurator -doc -use ftslave_linux.xsd -b /opt/HPCCSystems/componentfiles/configxml/ -t ./Docs
+./configurator -doc -use ldapserver.xsd -b /opt/HPCCSystems/componentfiles/configxml/ -t ./Docs/
+
+./configurator -doc -use roxie.xsd -b /opt/HPCCSystems/componentfiles/configxml/ -t ./Docs
+./configurator -doc -use sasha.xsd -b /opt/HPCCSystems/componentfiles/configxml/ -t ./Docs
+
+./configurator -doc -use thor.xsd -b /opt/HPCCSystems/componentfiles/configxml/ -t ./Docs

--- a/configuration/lib_qml/AccordionItem.qml
+++ b/configuration/lib_qml/AccordionItem.qml
@@ -1,0 +1,149 @@
+import QtQuick 2.4
+
+Rectangle {
+    id: accordion
+    property string title
+    property string altTitle
+    property bool edited: false
+    property int index : -1
+    property var originalParent : parent
+    property var colorSchemePicker:[
+		["#1be7ff","#6eeb83","#e4ff1a","#e8aa14","#ff5714"],
+		["#ed6a5a","#f4f1bb","#9bc1bc","#5ca4a9","#e6ebe0"],
+		["#ff4e00","#8ea604","#f5bb00","#ec9f05","#bf3100"],
+		["#e3b505","#95190c","#610345","#107e7d","#044b7f"],
+		["#69995d","#cbac88","#edb6a3","#d2f1e4","#f8e9e9"],
+		["#69995d","#84dcc6","#cbac88","#f8e9e9","#D3BEFF"], // Runner up?
+		["#41771F","#F24141","#ffe066","#247ba0","#70c1b3"], // Me Gusta
+		["#41771F","#F24141","#ffe066","#247ba0","#4CB963"], // Similar to Above, imo better
+		["#247ba0","#70c1b3","#b2dbbf","#f3ffbd","#ff1654"],
+		["#05668d","#028090","#00a896","#02c39a","#f0f3bd"],
+    ]
+    property var colorScheme: colorSchemePicker[7]
+    property alias contentModel: theContentModel.sourceComponent
+	property int nest: parent ? parent.parent ? parent.parent.nest >= -1 ? parent.parent.nest + 1 : 1 : 1 : 1
+	property int originalNest: nest
+	property bool expanded: false
+	layer.enabled: true
+    color: {
+    	return colorScheme[nest%colorScheme.length]}
+	border.color: "black"
+	border.width: 2
+    anchors.left: parent ? parent.left : root.left
+    anchors.right: parent ? parent.right : root.right
+    implicitHeight: titleText.height + itemView.contentHeight + 12
+    height: titleText.height + 8
+
+    Binding on height{
+    	when: expanded
+    	value: titleText.height + itemView.contentHeight + 12
+    }
+
+    Behavior on height { 
+    	PropertyAnimation {
+	    	duration: 200
+	    	easing.type: Easing.OutQuad
+    	} 
+    }
+
+	state:""
+	states: [
+		State {
+			name: "EXPANDED"
+			StateChangeScript { script: {
+		    		
+			}}
+			ParentChange{
+				target: accordion
+				parent: scrollRoot
+			}
+			PropertyChanges{
+				target: accordion
+				nest: originalNest
+			}
+			AnchorChanges{
+				target: accordion
+				anchors.top: parent == null ? undefined : parent.top
+			}
+		}
+	]
+	transitions: Transition {
+        AnchorAnimation {
+            duration: 500
+            easing.type: Easing.OutQuad 
+        }
+        ParentAnimation {
+            NumberAnimation { 
+            	duration: 500
+            	easing.type: Easing.OutQuad 
+            }
+            ScriptAction { script:{
+            	if(state == "")
+            		listRoot.visibility = listRoot.visibility - 1
+            	else if(state == "EXPANDED")
+            		listRoot.visibility = listRoot.visibility + 1
+            	console.log(listRoot.visibility)
+            }}
+        }
+
+    }
+
+	Text {
+    	id: titleText
+    	text: (altTitle ? (typeof ApplicationData != 'undefined' ? ApplicationData.getValue(altTitle) : altTitle) + "|" : "") + title + (edited ? "*" :"")
+        font.bold: edited
+		anchors.horizontalCenter: parent.horizontalCenter
+		anchors.top: parent.top
+		anchors.topMargin: 4
+
+	    MouseArea {
+	    	width: accordion.width
+	    	height: parent.height
+	    	anchors.horizontalCenter: parent.horizontalCenter
+	    	onClicked: {
+	    		expanded = !expanded
+	    	}
+		}
+	}
+	Rectangle{
+		anchors.top: titleText.top
+		anchors.bottom: titleText.bottom
+		anchors.left: titleText.right
+		anchors.leftMargin: 100
+		width: 100
+		color: "blue"
+		visible: originalNest != 1
+		MouseArea {
+	        anchors.fill: parent
+	        onClicked: {
+	        	switch(accordion.state){
+	        		case "":
+	        			accordion.state = "EXPANDED"
+	        			break;
+	        		case "EXPANDED":
+	        			accordion.state = ""
+	        			break;
+	        	}
+	        }
+	    }
+	}
+
+	Loader {
+		id: theContentModel
+	}
+
+	ListView {
+		id: itemView
+		model: theContentModel.item
+		property int nest: accordion.nest
+		visible: expanded
+
+		spacing: 8
+		anchors.left: accordion.left
+		anchors.right: accordion.right
+		anchors.top: titleText.bottom
+		anchors.bottom: accordion.bottom
+		anchors.leftMargin: 8
+		anchors.rightMargin: 8
+	}
+}

--- a/configuration/lib_qml/Table.qml
+++ b/configuration/lib_qml/Table.qml
@@ -1,0 +1,138 @@
+import QtQuick 2.4
+import QtQuick.Controls 1.3
+import QtQml.Models 2.1
+
+Item{
+	id: tableRoot
+	property var columnNames
+	property alias tableContent: tableContent.sourceComponent
+	width: parent ? parent.width : 500
+	height: childrenRect.height
+	layer.enabled: true
+
+
+	Loader {
+		id: tableContent
+	}
+
+	Component
+	{
+	    id: columnComponent
+	    TableViewColumn{width: 100 }
+	}
+	Component {
+		id: fieldCol
+		TextField{
+            property string origText
+            text: {
+                var result = value;
+                if (typeof ApplicationData != 'undefined' && value){
+                    result = ApplicationData.getValue(value);
+                    console.log(value + "|" + result)
+                    if(!result){
+                        console.log("I didn't like the result: ", result)
+                        result = ""
+                    }
+                }
+                origText = result;
+                return result;
+            }
+			placeholderText: placeholder
+			onEditingFinished: {
+                if(origText != text){
+                        tableRoot.parent.parent.parent.edited = true;
+                    if(typeof ApplicationData != 'undefined')
+                    {
+    					console.log("Setting text \"" + text + "\" to xpath \"" + value + "\"")
+    					ApplicationData.setValue(value,text)
+    				}
+                }
+
+			}
+		}
+	}
+	Component{
+		id: textCol
+		Text{
+			text: {
+				var result = value;
+				if (typeof ApplicationData != 'undefined' && value){
+					result = ApplicationData.getValue(value);
+					if(!result){
+						console.log("I didn't like the result: ", result)
+						result = ""
+					}
+				}
+				return result;
+			}
+		}
+	}
+	Component{
+		id: comboCol
+		ComboBox{
+			model: value
+            property int origIndex: {origIndex = currentIndex}
+            onActivated:{
+                if(origIndex != currentIndex){
+                    tableRoot.parent.parent.parent.edited = true;
+                    if(typeof ApplicationData != 'undefined')
+                    {
+                        console.log("Setting text \"" + currentText + "\" to xpath \"" + value + "\"")
+                        ApplicationData.setValue(value,currentText)
+                    }
+                }
+            }
+		}
+	}
+	TableView {
+	    id: view
+	    width: parent.width
+	    model: tableContent.item
+	    resources:
+	    {
+	        var temp = []
+	        for(var i=0; i<columnNames.length; i++)
+	        {
+	            var column  = columnNames[i]
+	            temp.push(columnComponent.createObject(view, { "role": column.role, "title": column.title, "width": Qt.binding(function(){return (parent.width/columnNames.length)-16;})}))
+	        }
+	        return temp
+	    }
+	    itemDelegate: Component{
+	    	Loader {
+    			property var value: {
+    				var result = []
+    				if(styleData.value.get(0)['type'] != null && styleData.value.get(0)['type'] == "combo"){
+    					for(var i = 0; i < styleData.value.get(0)['value'].count; i++){
+    						result.push(styleData.value.get(0)['value'].get(i)['value'])
+    					}
+    				} else {
+    					result = styleData.value.get(0)['value'].get(0)['value']
+    				}
+    				return result
+    			}
+                property string placeholder: styleData.value.get(0)['placeholder'] ? styleData.value.get(0)['placeholder'] : ""
+                property string tooltip: styleData.value.get(0)['tooltip'] ? styleData.value.get(0)['tooltip'] : ""
+                property string viewType: styleData.value.get(0)['type'] ? styleData.value.get(0)['type'] : "text"
+                sourceComponent: {
+                    switch (viewType){
+                        case "text":
+                            return textCol
+                            break;
+                        case "field":
+                            return fieldCol
+                            break;
+                        case "combo":
+                        	return comboCol
+                        	break;
+                        default: return textCol;
+                    }
+                }
+	    	}
+	    }
+	    rowDelegate: Rectangle{
+	    	height: 20
+	    	color: styleData.alternate ? "lightgrey" : "white"
+	    }
+	}
+}

--- a/configuration/lib_qml/test.qml
+++ b/configuration/lib_qml/test.qml
@@ -1,0 +1,195 @@
+import QtQuick 2.4
+import QtQuick.Controls 1.3
+
+Item {
+    id: gRoot
+    width: 900
+    height: 700
+    property alias root: gRoot
+    ScrollView{
+        id: scrollRoot
+        anchors.fill: parent
+        ListView{
+            id: listRoot
+            property int nest: 0
+            property int visibility: 0
+            anchors.fill: parent
+            spacing: 4
+            model: accordionModel
+            opacity: !visibility
+            transitions: Transition {
+                NumberAnimation { properties: "opacity"; easing.type: Easing.InOutQuad; duration: 1000  }
+            }
+        }
+    }
+    VisualItemModel {
+        id: accordionModel
+        AccordionItem{
+            title: "1"
+            contentModel: VisualItemModel {
+                Table{
+                    tableContent: ListModel {
+                        ListElement {
+                            value: ListElement {value: [ListElement{value: "A Masterpiece"}] type: "field"; tooltip:"Hey" }
+                            key: ListElement {value: [ListElement{value: "Gabriel"}]}
+                            alphabet: ListElement { value: [ListElement{value: "soup"}] type: "field" }
+                        }
+                        ListElement {
+                            value: ListElement {value: [ListElement{value: "Brilliance"}] type: "field"; placeholder: "lel"}
+                            key: ListElement { value: [ListElement{value: "Jens"}] type: "field"}
+                            alphabet: ListElement { value: [ListElement{value: "order"}] }
+                        }
+                        ListElement {
+                            value: ListElement {value: [ListElement{value: "Outstanding"}] type: "field"}
+                            key: ListElement { value: [ListElement{value: "Frederik"},ListElement{value: "Jacob"},ListElement{value: "Markus"}] type: "combo" }
+                            alphabet: ListElement { value: [ListElement{value: "yodels"}] }
+                        }
+                    }
+                    columnNames: [{role:"key",title:"key"}, {role:"value",title:"value"},{role:"alphabet",title:"Alpha"}]
+                }
+                Table{
+                    tableContent: ListModel {
+                        ListElement {
+                            value: ListElement {value: [ListElement{value: "A Masterpiece"}] type: "field"; tooltip:"Hey" }
+                            key: ListElement {value: [ListElement{value: "Gabriel"}]}
+                        }
+                        ListElement {
+                            value: ListElement {value: [ListElement{value: "Brilliance"}] type: "field"; placeholder: "lel"}
+                            key: ListElement { value: [ListElement{value: "Jens"}] type: "field"}
+                        }
+                        ListElement {
+                            value: ListElement {value: [ListElement{value: "Outstanding"}] type: "field"}
+                            key: ListElement { value: [ListElement{value: "Frederik"},ListElement{value: "Jacob"},ListElement{value: "Markus"}] type: "combo" }
+                        }
+                    }
+                    columnNames: [{role:"key",title:"key"}, {role:"value",title:"value"}]
+                }
+                AccordionItem{
+                    title: "2"
+                    contentModel: VisualItemModel {
+                        Text {text: "Hello"}
+                        AccordionItem{
+                            title: "3"
+                            contentModel: VisualItemModel {
+                                AccordionItem{
+                                    title: "4"
+                                    contentModel: VisualItemModel {
+                                        Text {text: "Hello"}
+                                        AccordionItem{
+                                            title: "5"
+                                            contentModel: VisualItemModel {
+                                                Text {text: "Hello"}
+                                                AccordionItem{
+                                                    title: "6"
+                                                    contentModel: VisualItemModel {
+                                                        Table{
+                                                            tableContent: ListModel {
+                                                                ListElement {
+                                                                    value: ListElement {value: [ListElement{value: "A Masterpiece"}] type: "field"; tooltip:"Hey" }
+                                                                    key: ListElement {value: [ListElement{value: "Gabriel"}]}
+                                                                }
+                                                                ListElement {
+                                                                    value: ListElement {value: [ListElement{value: "Brilliance"}] type: "field"; placeholder: "lel"}
+                                                                    key: ListElement { value: [ListElement{value: "Jens"}] type: "field"}
+                                                                }
+                                                                ListElement {
+                                                                    value: ListElement {value: [ListElement{value: "Outstanding"}] type: "field"}
+                                                                    key: ListElement { value: [ListElement{value: "Frederik"},ListElement{value: "Jacob"},ListElement{value: "Markus"}] type: "combo" }
+                                                                }
+                                                            }
+                                                            columnNames: [{role:"key",title:"key"}, {role:"value",title:"value"}]
+                                                        }
+                                                        Text {text: "Hello"}
+                                                    }
+                                                }
+                                            }
+                                        }
+                                        Text {text: "World"}
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                Text {text: "World"}
+            }
+        }
+        AccordionItem{
+            title: "7"
+            contentModel: VisualItemModel {
+                Table{
+                    tableContent: ListModel {
+                        ListElement {
+                            value: ListElement {value: [ListElement{value: "A Masterpiece"}] type: "field"; tooltip:"Hey" }
+                            key: ListElement {value: [ListElement{value: "Gabriel"}]}
+                        }
+                        ListElement {
+                            value: ListElement {value: [ListElement{value: "Brilliance"}] type: "field"; placeholder: "lel"}
+                            key: ListElement { value: [ListElement{value: "Jens"}] type: "field"}
+                        }
+                        ListElement {
+                            value: ListElement {value: [ListElement{value: "Outstanding"}] type: "field"}
+                            key: ListElement { value: [ListElement{value: "Frederik"},ListElement{value: "Jacob"},ListElement{value: "Markus"}] type: "combo" }
+                        }
+                    }
+                    columnNames: [{role:"key",title:"key"}, {role:"value",title:"value"}]
+                }
+                Text {text: "Hello"}
+
+            }
+        }
+        AccordionItem{
+            title: "8"
+            contentModel: VisualItemModel {
+                Text {text: "Hello"}
+                AccordionItem{
+                    title: "9"
+                    contentModel: VisualItemModel {
+                        Text {text: "Hello"}
+                        Text {text: "World"}
+                    }
+                }
+                Text {text: "World"}
+            }
+        }
+        AccordionItem{
+            title: "10"
+            contentModel: VisualItemModel {
+                Text {text: "Hello"}
+                AccordionItem{
+                    title: "11"
+                    contentModel: VisualItemModel {
+                        Text {text: "Hello"}
+                        AccordionItem{
+                            title: "12"
+                            contentModel: VisualItemModel {
+                                /*Table{
+                                    tableContent: ListModel {
+                                        ListElement {
+                                            value: ListElement {value: "A Masterpiece"; type: "field"; tooltip:"Hey" }
+                                            key: ListElement {value: "Gabriel"}
+                                            alphabet: ListElement { value: "soup" }
+                                        }
+                                        ListElement {
+                                            value: ListElement {value: "Brilliance"; type: "field"; placeholder: "lel"}
+                                            key: ListElement { value: "Jens" }
+                                            alphabet: ListElement { value: "order" }
+                                        }
+                                        ListElement {
+                                            value: ListElement {value: "Outstanding"; type: "field"}
+                                            key: ListElement { value: "Frederik" }
+                                            alphabet: ListElement { value: "yodels" }
+                                        }
+                                    }
+                                    columnNames: [{role:"key",title:"key"}, {role:"value",title:"value"},{role:"alphabet",title:"Alpha"}]
+                                }*/
+                                Text {text: "Hello"}
+                            }
+                        }
+                    }
+                }
+                Text {text: "World"}
+            }
+        }
+    }
+}		

--- a/configuration/xsds_xmls/environment.xsd
+++ b/configuration/xsds_xmls/environment.xsd
@@ -1,0 +1,1365 @@
+<!--
+################################################################################
+#    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems®.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+################################################################################
+-->
+
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSPY v5 rel. 2 U (http://www.xmlspy.com) by Richard (Seisint, Inc.) -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
+    <xs:element name="Environment">
+        <xs:annotation>
+            <xs:documentation>Defines a Seisint Environment</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:choice maxOccurs="unbounded">
+                <xs:element name="Programs">
+                    <xs:annotation>
+                        <xs:documentation>Section to describe the programs that are executed in the environment.</xs:documentation>
+                    </xs:annotation>
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="Build" maxOccurs="unbounded">
+                                <xs:annotation>
+                                    <xs:documentation>Describes a build containing instances of various programs.</xs:documentation>
+                                </xs:annotation>
+                                <xs:complexType>
+                                    <xs:sequence>
+                                        <xs:element name="BuildSet" maxOccurs="unbounded">
+                                            <xs:annotation>
+                                                <xs:documentation>Describes an instance of a specific version of an InstallSet.</xs:documentation>
+                                            </xs:annotation>
+                                            <xs:complexType>
+                                                <xs:attribute name="name" type="xs:string"/>
+                                                <xs:attribute name="path" type="xs:string" use="required"/>
+                                                <xs:attribute name="installSet" type="xs:string" use="required"/>
+                                                <xs:attribute name="processName" type="xs:string"/>
+                                                <xs:attribute name="schema" type="xs:string"/>
+                                            </xs:complexType>
+                                        </xs:element>
+                                    </xs:sequence>
+                                    <xs:attribute name="include" type="xs:string"/>
+                                    <xs:attribute name="url" type="xs:string"/>
+                                    <xs:attribute name="name" type="xs:string"/>
+                                </xs:complexType>
+                                <xs:unique name="buildSetUnique">
+                                    <xs:selector xpath="BuildSet"/>
+                                    <xs:field xpath="@name"/>
+                                </xs:unique>
+                            </xs:element>
+                        </xs:sequence>
+                        <xs:attribute name="include" type="xs:string"/>
+                    </xs:complexType>
+                    <xs:key name="buildKey">
+                        <xs:selector xpath="./Build"/>
+                        <xs:field xpath="@name"/>
+                    </xs:key>
+                </xs:element>
+                <xs:element name="Hardware">
+                    <xs:annotation>
+                        <xs:documentation>Section to describe the hardware that composes the environment.</xs:documentation>
+                    </xs:annotation>
+                    <xs:complexType>
+                        <xs:choice maxOccurs="unbounded">
+                            <xs:element name="ComputerType" type="ComputerTypeType">
+                                <xs:annotation>
+                                    <xs:documentation>Defines a generalized type of computer that is used in the environment.</xs:documentation>
+                                </xs:annotation>
+                            </xs:element>
+                            <xs:element name="Domain" type="DomainType">
+                                <xs:annotation>
+                                    <xs:documentation>Describes a domain that is contained in the environment.</xs:documentation>
+                                </xs:annotation>
+                            </xs:element>
+                            <xs:element name="Switch">
+                                <xs:annotation>
+                                    <xs:documentation>Describes a switch that is contained in the environment.</xs:documentation>
+                                </xs:annotation>
+                                <xs:complexType>
+                                    <xs:attribute name="name" type="xs:string"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="Computer">
+                                <xs:annotation>
+                                    <xs:documentation>Describes a computer that is contained in the environment.</xs:documentation>
+                                </xs:annotation>
+                                <xs:complexType>
+                                    <xs:sequence>
+                                        <xs:element name="AltAddress" minOccurs="0" maxOccurs="unbounded">
+                                            <xs:annotation>
+                                                <xs:documentation>List of addition network addresses assigned to this computer.</xs:documentation>
+                                            </xs:annotation>
+                                            <xs:complexType>
+                                                <xs:attribute name="netAddress" type="ipAddress"/>
+                                            </xs:complexType>
+                                        </xs:element>
+                                    </xs:sequence>
+                                    <xs:attribute name="name" type="xs:string" use="required"/>
+                                    <xs:attribute name="netAddress" type="ipAddress"/>
+                                    <xs:attribute name="state" use="required">
+                                        <xs:simpleType>
+                                            <xs:restriction base="xs:string">
+                                                <xs:enumeration value="Available"/>
+                                                <xs:enumeration value="Unavailable"/>
+                                                <xs:enumeration value=""/>
+                                            </xs:restriction>
+                                        </xs:simpleType>
+                                    </xs:attribute>
+                                    <xs:attribute name="switch" type="xs:string"/>
+                                    <xs:attribute name="domain" type="xs:string"/>
+                                    <xs:attribute name="computerType" type="xs:string"/>
+                                </xs:complexType>
+                            </xs:element>
+                        </xs:choice>
+                        <xs:attribute name="include" type="xs:string"/>
+                    </xs:complexType>
+                    <xs:key name="switchKey">
+                        <xs:selector xpath="./Switch"/>
+                        <xs:field xpath="@name"/>
+                    </xs:key>
+                    <xs:keyref name="switchKeyRef" refer="switchKey">
+                        <xs:selector xpath="./*"/>
+                        <xs:field xpath="@switch"/>
+                    </xs:keyref>
+                    <xs:key name="domainKey">
+                        <xs:selector xpath="./Domain"/>
+                        <xs:field xpath="@name"/>
+                    </xs:key>
+                    <xs:keyref name="domainKeyRef" refer="domainKey">
+                        <xs:selector xpath="./*"/>
+                        <xs:field xpath="@domain"/>
+                    </xs:keyref>
+                </xs:element>
+                <xs:element name="Software">
+                    <xs:annotation>
+                        <xs:documentation>Section to describe the processes that run in the environment.</xs:documentation>
+                    </xs:annotation>
+                    <xs:complexType>
+                        <xs:choice minOccurs="0" maxOccurs="unbounded">
+                            <xs:element name="EspProcess">
+                                <xs:complexType>
+                                    <xs:complexContent>
+                                        <xs:extension base="ProcessBase">
+                                            <xs:choice maxOccurs="unbounded">
+                                                <xs:element name="EspProtocol" type="EspProtocolType" maxOccurs="unbounded"/>
+                                                <xs:element name="EspBinding" type="EspBindingType" maxOccurs="unbounded"/>
+                                                <xs:element name="EspTopology" type="EspTopologyType" minOccurs="0"/>
+                                                <xs:element name="EspBindingMap" type="EspBindingMapType" minOccurs="0"/>
+                                                <xs:element name="EspUriMap" type="EspUriMapType" minOccurs="0"/>
+                                            </xs:choice>
+                                        </xs:extension>
+                                    </xs:complexContent>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="EspService" type="EspServiceType">
+                                <xs:annotation>
+                                    <xs:documentation>Describes an ESP service.</xs:documentation>
+                                </xs:annotation>
+                            </xs:element>
+                            <xs:element name="WebServerProcess">
+                                <xs:annotation>
+                                    <xs:documentation>Describes a Web Server.</xs:documentation>
+                                </xs:annotation>
+                                <xs:complexType>
+                                    <xs:complexContent>
+                                        <xs:extension base="ProcessBase"/>
+                                    </xs:complexContent>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="DFSProcess" type="ProcessBase">
+                                <xs:annotation>
+                                    <xs:documentation>Describes a DFS instance.</xs:documentation>
+                                </xs:annotation>
+                            </xs:element>
+                            <xs:element name="SybaseProcess">
+                                <xs:annotation>
+                                    <xs:documentation>Describes a sybase database server.</xs:documentation>
+                                </xs:annotation>
+                                <xs:complexType>
+                                    <xs:complexContent>
+                                        <xs:extension base="SimpleProcessBase">
+                                            <xs:attribute name="port" type="xs:nonNegativeInteger" use="optional" default="7560"/>
+                                        </xs:extension>
+                                    </xs:complexContent>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="MySQLProcess">
+                                <xs:annotation>
+                                    <xs:documentation>Describes a MySQL database server.</xs:documentation>
+                                </xs:annotation>
+                                <xs:complexType>
+                                    <xs:complexContent>
+                                        <xs:extension base="SimpleProcessBase">
+                                            <xs:attribute name="dbUser" type="xs:string" use="optional"/>
+                                            <xs:attribute name="dbPassword" type="xs:string" use="optional"/>
+                                        </xs:extension>
+                                    </xs:complexContent>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="EclServerProcess">
+                                <xs:annotation>
+                                    <xs:documentation>Describes an ecl repository server</xs:documentation>
+                                </xs:annotation>
+                                <xs:complexType>
+                                    <xs:complexContent>
+                                        <xs:extension base="ProcessServerBase">
+                                            <xs:choice maxOccurs="unbounded">
+                                                <xs:element name="EclJackProcess" minOccurs="0">
+                                                    <xs:annotation>
+                                                        <xs:documentation>Describes an eclrunagent</xs:documentation>
+                                                    </xs:annotation>
+                                                    <xs:complexType>
+                                                        <xs:attribute name="fullXmlLogging" type="xs:boolean" use="optional" default="false"/>
+                                                        <xs:attribute name="traceLevel" type="xs:nonNegativeInteger" use="optional" default="1"/>
+                                                        <xs:attribute name="runAgentName" type="xs:string" use="optional"/>
+                                                        <xs:attribute name="jackIP" type="xs:string" use="required"/>
+                                                        <xs:attribute name="defaultHole" type="xs:string" use="optional"/>
+                                                    </xs:complexType>
+                                                </xs:element>
+                                                <xs:element name="Model" minOccurs="0" maxOccurs="unbounded">
+                                                    <xs:complexType>
+                                                        <xs:attribute name="dataVersion" type="xs:string" use="required"/>
+                                                    </xs:complexType>
+                                                </xs:element>
+                                                <xs:element name="Instance" maxOccurs="unbounded">
+                                                    <xs:complexType>
+                                                        <xs:complexContent>
+                                                            <xs:extension base="ProcessInstanceBase">
+                                                                <xs:attribute name="port" type="xs:nonNegativeInteger" use="optional" default="7000"/>
+                                                                <xs:attribute name="jackAgentIP" type="xs:string" use="optional"/>
+                                                            </xs:extension>
+                                                        </xs:complexContent>
+                                                    </xs:complexType>
+                                                </xs:element>
+                                                <xs:element name="PluginRef" minOccurs="0" maxOccurs="unbounded">
+                                                    <xs:complexType>
+                                                        <xs:attribute name="process" type="xs:string" use="required"/>
+                                                    </xs:complexType>
+                                                </xs:element>
+                                            </xs:choice>
+                                            <xs:attribute name="daliServer" type="xs:string" use="optional"/>
+                                            <xs:attribute name="pluginsPath" type="xs:string" use="optional" default="./plugins"/>
+                                            <xs:attribute name="traceLevel" type="xs:nonNegativeInteger" use="optional" default="1"/>
+                                            <xs:attribute name="sybase" type="xs:string" use="required"/>
+                                            <xs:attribute name="compilerPath" type="xs:string" use="optional" default="./cl"/>
+                                            <xs:attribute name="compileOptions" type="xs:string" use="optional"/>
+                                            <xs:attribute name="queue" type="xs:string" use="optional"/>
+                                            <xs:attribute name="monitorEnabled" type="xs:boolean" use="optional"/>
+                                            <xs:attribute name="monitorDiskThreshold" type="xs:nonNegativeInteger" use="optional"/>
+                                            <xs:attribute name="monitorEmail" type="xs:string" use="optional"/>
+                                            <xs:attribute name="monitorTimeout" type="xs:nonNegativeInteger" use="optional"/>
+                                            <xs:attribute name="thorConnectTimeoutSeconds" type="xs:nonNegativeInteger" use="optional"/>
+                                            <xs:attribute name="generatedEclToWorkUnit" type="xs:boolean" use="optional" default="false"/>
+                                        </xs:extension>
+                                    </xs:complexContent>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="EclAgentProcess">
+                                <xs:annotation>
+                                    <xs:documentation>Describes an ecl agent.</xs:documentation>
+                                </xs:annotation>
+                                <xs:complexType>
+                                    <xs:complexContent>
+                                        <xs:extension base="ProcessServerBase">
+                                            <xs:sequence>
+                                                <xs:element name="Instance" type="ProcessInstanceBase" maxOccurs="unbounded"/>
+                                            </xs:sequence>
+                                        </xs:extension>
+                                    </xs:complexContent>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="EclBatchProcess">
+                                <xs:annotation>
+                                    <xs:documentation>Describes an eclbatch process</xs:documentation>
+                                </xs:annotation>
+                                <xs:complexType>
+                                    <xs:complexContent>
+                                        <xs:extension base="ProcessServerBase">
+                                            <xs:sequence>
+                                                <xs:element name="ThorRef" maxOccurs="unbounded">
+                                                    <xs:complexType>
+                                                        <xs:attribute name="process" type="xs:string" use="required"/>
+                                                    </xs:complexType>
+                                                </xs:element>
+                                            </xs:sequence>
+                                            <xs:attribute name="directory" type="absolutePath" use="required"/>
+                                        </xs:extension>
+                                    </xs:complexContent>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="OldThorCluster">
+                                <xs:annotation>
+                                    <xs:documentation>Describes a thor cluster</xs:documentation>
+                                </xs:annotation>
+                                <xs:complexType>
+                                    <xs:complexContent>
+                                        <xs:extension base="ProcessBase">
+                                            <xs:choice maxOccurs="unbounded">
+                                                <xs:element name="ThorSpareProcess" minOccurs="0" maxOccurs="unbounded">
+                                                    <xs:annotation>
+                                                        <xs:documentation>Describes a thor spare</xs:documentation>
+                                                    </xs:annotation>
+                                                    <xs:complexType>
+                                                        <xs:complexContent>
+                                                            <xs:extension base="SimpleProcessBase"/>
+                                                        </xs:complexContent>
+                                                    </xs:complexType>
+                                                </xs:element>
+                                                <xs:element name="ThorSlaveProcess" maxOccurs="unbounded">
+                                                    <xs:annotation>
+                                                        <xs:documentation>Describes a thor slave</xs:documentation>
+                                                    </xs:annotation>
+                                                    <xs:complexType>
+                                                        <xs:complexContent>
+                                                            <xs:extension base="SimpleProcessBase"/>
+                                                        </xs:complexContent>
+                                                    </xs:complexType>
+                                                </xs:element>
+                                                <xs:element name="ThorMasterProcess">
+                                                    <xs:annotation>
+                                                        <xs:documentation>Describes a thormaster</xs:documentation>
+                                                    </xs:annotation>
+                                                    <xs:complexType>
+                                                        <xs:complexContent>
+                                                            <xs:extension base="SimpleProcessBase"/>
+                                                        </xs:complexContent>
+                                                    </xs:complexType>
+                                                </xs:element>
+                                                <xs:element name="HMonRef" minOccurs="0" maxOccurs="unbounded">
+                                                    <xs:annotation>
+                                                        <xs:documentation>Refers to an HMonProcess instance.</xs:documentation>
+                                                    </xs:annotation>
+                                                    <xs:complexType>
+                                                        <xs:attribute name="hmon" type="xs:string" use="required"/>
+                                                    </xs:complexType>
+                                                </xs:element>
+                                                <xs:element name="Topology">
+                                                    <xs:annotation>
+                                                        <xs:documentation>Describes the Topology of the given thor cluster</xs:documentation>
+                                                    </xs:annotation>
+                                                    <xs:complexType>
+                                                        <xs:sequence maxOccurs="unbounded">
+                                                            <xs:element name="Node" type="NodeType" minOccurs="0"/>
+                                                        </xs:sequence>
+                                                    </xs:complexType>
+                                                    <xs:keyref name="thorProcessKeyRef" refer="thorProcessKey">
+                                                        <xs:selector xpath=".//*"/>
+                                                        <xs:field xpath="@process"/>
+                                                    </xs:keyref>
+                                                </xs:element>
+                                            </xs:choice>
+                                            <xs:attribute name="port" type="xs:nonNegativeInteger" use="optional"/>
+                                            <xs:attribute name="slaves" type="xs:nonNegativeInteger" use="required"/>
+                                            <xs:attribute name="slavesName" type="xs:string" use="optional"/>
+                                            <xs:attribute name="sparesName" type="xs:string" use="optional"/>
+                                            <xs:attribute name="holeTimeout" type="xs:nonNegativeInteger" use="optional" default="30000"/>
+                                            <xs:attribute name="holeDirectPrefix" type="xs:string" use="optional"/>
+                                            <xs:attribute name="holePrefix" type="xs:string" use="optional"/>
+                                            <xs:attribute name="watchdogEnabled" type="xs:boolean" use="optional" default="true"/>
+                                            <xs:attribute name="watchdogProgressEnabled" type="xs:boolean" use="optional" default="true"/>
+                                            <xs:attribute name="watchdogProgressInterval" type="xs:nonNegativeInteger" use="optional"/>
+                                            <xs:attribute name="monitorEnabled" type="xs:boolean" use="optional" default="true"/>
+                                            <xs:attribute name="monitorDiskThreshold" type="xs:nonNegativeInteger" use="optional" default="10"/>
+                                            <xs:attribute name="monitorEmail" type="xs:string" use="optional"/>
+                                            <xs:attribute name="monitorTimeout" type="xs:nonNegativeInteger" use="optional" default="120"/>
+                                            <xs:attribute name="perfDataLevel" type="xs:nonNegativeInteger" use="optional" default="1"/>
+                                            <xs:attribute name="jackEnabled" type="xs:boolean" use="optional" default="true"/>
+                                            <xs:attribute name="jackMonitorOutput" type="xs:boolean" use="optional" default="true"/>
+                                            <xs:attribute name="jackTraceLevel" type="xs:nonNegativeInteger" use="optional"/>
+                                            <xs:attribute name="statusMsgsEnabled" type="xs:boolean" use="optional" default="true"/>
+                                            <xs:attribute name="logDir" type="xs:string" use="optional"/>
+                                            <xs:attribute name="createSubDirectories" type="xs:string" use="optional" default="true"/>
+                                            <xs:attribute name="nameServices" type="xs:string" use="optional"/>
+                                            <xs:attribute name="socacheDir" type="xs:string" use="optional"/>
+                                            <xs:attribute name="external_prog_dir" type="xs:string" use="optional"/>
+                                            <xs:attribute name="minimalLogging" type="xs:boolean" use="optional" default="false"/>
+                                            <xs:attribute name="syncSendDlls" type="xs:boolean" use="optional" default="false"/>
+                                            <xs:attribute name="dllToSlaves" type="xs:boolean" use="optional" default="true"/>
+                                            <xs:attribute name="breakoutLimit" type="xs:nonNegativeInteger" use="optional"/>
+                                            <xs:attribute name="refreshRate" type="xs:nonNegativeInteger" use="optional"/>
+                                        </xs:extension>
+                                    </xs:complexContent>
+                                </xs:complexType>
+                                <xs:key name="thorProcessKey">
+                                    <xs:selector xpath="./ThorMasterProcess|./ThorSlaveProcess"/>
+                                    <xs:field xpath="@name"/>
+                                </xs:key>
+                            </xs:element>
+                            <xs:element name="HoleCluster">
+                                <xs:annotation>
+                                    <xs:documentation>Describes a hole cluster</xs:documentation>
+                                </xs:annotation>
+                                <xs:complexType>
+                                    <xs:complexContent>
+                                        <xs:extension base="ProcessBase">
+                                            <xs:choice maxOccurs="unbounded">
+                                                <xs:element name="HoleControlProcess">
+                                                    <xs:annotation>
+                                                        <xs:documentation>Describes a hole control node</xs:documentation>
+                                                    </xs:annotation>
+                                                    <xs:complexType>
+                                                        <xs:complexContent>
+                                                            <xs:extension base="SimpleProcessBase"/>
+                                                        </xs:complexContent>
+                                                    </xs:complexType>
+                                                </xs:element>
+                                                <xs:element name="HoleSocketProcess">
+                                                    <xs:annotation>
+                                                        <xs:documentation>Describes a hole socket node</xs:documentation>
+                                                    </xs:annotation>
+                                                    <xs:complexType>
+                                                        <xs:complexContent>
+                                                            <xs:extension base="SimpleProcessBase">
+                                                                <xs:attribute name="port" type="xs:nonNegativeInteger" use="optional" default="5050"/>
+                                                            </xs:extension>
+                                                        </xs:complexContent>
+                                                    </xs:complexType>
+                                                </xs:element>
+                                                <xs:element name="HoleCollatorProcess">
+                                                    <xs:annotation>
+                                                        <xs:documentation>Describes a hole socket node</xs:documentation>
+                                                    </xs:annotation>
+                                                    <xs:complexType>
+                                                        <xs:complexContent>
+                                                            <xs:extension base="SimpleProcessBase">
+                                                                <xs:attribute name="port" type="xs:nonNegativeInteger" use="optional" default="5050"/>
+                                                            </xs:extension>
+                                                        </xs:complexContent>
+                                                    </xs:complexType>
+                                                </xs:element>
+                                                <xs:element name="HoleProcessorProcess">
+                                                    <xs:annotation>
+                                                        <xs:documentation>Describes a hole socket node</xs:documentation>
+                                                    </xs:annotation>
+                                                    <xs:complexType>
+                                                        <xs:complexContent>
+                                                            <xs:extension base="SimpleProcessBase">
+                                                                <xs:attribute name="dataSegment" type="xs:nonNegativeInteger" use="required"/>
+                                                                <xs:attribute name="port" type="xs:nonNegativeInteger" use="optional" default="5050"/>
+                                                            </xs:extension>
+                                                        </xs:complexContent>
+                                                    </xs:complexType>
+                                                </xs:element>
+                                                <xs:element name="HoleStandbyProcess" maxOccurs="unbounded">
+                                                    <xs:annotation>
+                                                        <xs:documentation>Describes a hole standby node</xs:documentation>
+                                                    </xs:annotation>
+                                                    <xs:complexType>
+                                                        <xs:complexContent>
+                                                            <xs:extension base="SimpleProcessBase">
+                                                                <xs:attribute name="port" type="xs:nonNegativeInteger" use="optional" default="5050"/>
+                                                            </xs:extension>
+                                                        </xs:complexContent>
+                                                    </xs:complexType>
+                                                </xs:element>
+                                                <xs:element name="HMonRef" minOccurs="0" maxOccurs="unbounded">
+                                                    <xs:annotation>
+                                                        <xs:documentation>Refers to an HMonProcess instance.</xs:documentation>
+                                                    </xs:annotation>
+                                                    <xs:complexType>
+                                                        <xs:attribute name="hmon" type="xs:string" use="required"/>
+                                                    </xs:complexType>
+                                                </xs:element>
+                                                <xs:element name="Topology">
+                                                    <xs:annotation>
+                                                        <xs:documentation>Describes the topology of the given hole cluster.</xs:documentation>
+                                                    </xs:annotation>
+                                                    <xs:complexType>
+                                                        <xs:sequence maxOccurs="unbounded">
+                                                            <xs:element name="Node" type="NodeType" minOccurs="0"/>
+                                                        </xs:sequence>
+                                                    </xs:complexType>
+                                                    <xs:keyref name="holeProcessKeyRef" refer="holeProcessKey">
+                                                        <xs:selector xpath=".//*"/>
+                                                        <xs:field xpath="@process"/>
+                                                    </xs:keyref>
+                                                </xs:element>
+                                                <xs:element name="Module" minOccurs="0" maxOccurs="unbounded">
+                                                    <xs:annotation>
+                                                        <xs:documentation>Describes a 'module' section for a .scr file</xs:documentation>
+                                                    </xs:annotation>
+                                                    <xs:complexType>
+                                                        <xs:sequence>
+                                                            <xs:element name="Function" maxOccurs="unbounded">
+                                                                <xs:complexType>
+                                                                    <xs:attribute name="name" type="xs:string" use="required"/>
+                                                                    <xs:attribute name="prototype" type="xs:string" use="required"/>
+                                                                    <xs:attribute name="returnType" type="xs:string" use="required"/>
+                                                                </xs:complexType>
+                                                            </xs:element>
+                                                        </xs:sequence>
+                                                        <xs:attribute name="name" type="xs:string" use="required"/>
+                                                    </xs:complexType>
+                                                </xs:element>
+                                            </xs:choice>
+                                            <xs:attribute name="dataBuild" type="xs:string" use="required"/>
+                                            <xs:attribute name="keepCPP" type="xs:boolean" use="optional" default="false">
+                                                <xs:annotation>
+                                                    <xs:documentation>Keep CPP files around (for debuggingpurposes)</xs:documentation>
+                                                </xs:annotation>
+                                            </xs:attribute>
+                                            <xs:attribute name="remoteFormat" type="xs:boolean" use="optional" default="true"/>
+                                            <xs:attribute name="compilerPath" type="xs:string" use="optional" default="c:\cl"/>
+                                            <xs:attribute name="copyDLL" type="xs:boolean" use="optional" default="true"/>
+                                            <xs:attribute name="copyDir" type="xs:string" default="c:\winnt\temp"/>
+                                            <xs:attribute name="tempDir" type="xs:string" default="c:\winnt\temp"/>
+                                            <xs:attribute name="serverCurDir" type="xs:string" default="c:\cl"/>
+                                            <xs:attribute name="processCount" type="xs:nonNegativeInteger" use="required"/>
+                                            <xs:attribute name="localCache" type="xs:string" use="optional" default="c:\cache"/>
+                                            <xs:attribute name="loaderName" type="xs:string" use="required"/>
+                                            <xs:attribute name="customerName" type="xs:string" use="optional"/>
+                                            <xs:attribute name="oprhansAsErrors" type="xs:boolean" use="optional" default="true"/>
+                                        </xs:extension>
+                                    </xs:complexContent>
+                                </xs:complexType>
+                                <xs:key name="holeProcessKey">
+                                    <xs:selector xpath="./HoleControlProcess|./HoleSocketProcess|./HoleCollatorProcess|./HoleProcessorProcess|./HoleStandbyProcess"/>
+                                    <xs:field xpath="@name"/>
+                                </xs:key>
+                            </xs:element>
+                            <xs:element name="CCdCluster">
+                                <xs:annotation>
+                                    <xs:documentation>Describes a ccd cluster</xs:documentation>
+                                </xs:annotation>
+                                <xs:complexType>
+                                    <xs:complexContent>
+                                        <xs:extension base="ProcessBase">
+                                            <xs:choice minOccurs="0" maxOccurs="unbounded">
+                                                <xs:element name="CCdProcess">
+                                                    <xs:annotation>
+                                                        <xs:documentation>Describes a CCD</xs:documentation>
+                                                    </xs:annotation>
+                                                    <xs:complexType>
+                                                        <xs:complexContent>
+                                                            <xs:extension base="SimpleProcessBase">
+                                                                <xs:sequence>
+                                                                    <xs:element name="Channel" minOccurs="0" maxOccurs="unbounded"/>
+                                                                </xs:sequence>
+                                                                <xs:attribute name="channels" type="xs:string"/>
+                                                            </xs:extension>
+                                                        </xs:complexContent>
+                                                    </xs:complexType>
+                                                </xs:element>
+                                                <xs:element name="CCdAgentProcess">
+                                                    <xs:annotation>
+                                                        <xs:documentation>Describes a CCD</xs:documentation>
+                                                    </xs:annotation>
+                                                    <xs:complexType>
+                                                        <xs:complexContent>
+                                                            <xs:extension base="SimpleProcessBase">
+                                                                <xs:sequence>
+                                                                    <xs:element name="Channel" minOccurs="0" maxOccurs="unbounded"/>
+                                                                </xs:sequence>
+                                                                <xs:attribute name="channels" type="xs:string"/>
+                                                            </xs:extension>
+                                                        </xs:complexContent>
+                                                    </xs:complexType>
+                                                </xs:element>
+                                                <xs:element name="CCdPlugin" type="PluginsBase"/>
+                                                <xs:element name="Topology">
+                                                    <xs:annotation>
+                                                        <xs:documentation>Describes the Topology of the given thor cluster</xs:documentation>
+                                                    </xs:annotation>
+                                                    <xs:complexType>
+                                                        <xs:sequence maxOccurs="unbounded">
+                                                            <xs:element name="Node" type="NodeType" minOccurs="0"/>
+                                                        </xs:sequence>
+                                                    </xs:complexType>
+                                                </xs:element>
+                                            </xs:choice>
+                                            <xs:attribute name="multicastBase" type="xs:string" use="required"/>
+                                            <xs:attribute name="logDir" type="xs:string" use="optional"/>
+                                            <xs:attribute name="clusterSize" type="xs:nonNegativeInteger"/>
+                                        </xs:extension>
+                                    </xs:complexContent>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="SpareProcess">
+                                <xs:annotation>
+                                    <xs:documentation>Describes an unallocated node</xs:documentation>
+                                </xs:annotation>
+                                <xs:complexType>
+                                    <xs:complexContent>
+                                        <xs:extension base="SimpleProcessBase"/>
+                                    </xs:complexContent>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="Topology">
+                                <xs:annotation>
+                                    <xs:documentation>Describes the Topology of the environment.</xs:documentation>
+                                </xs:annotation>
+                                <xs:complexType>
+                                    <xs:sequence maxOccurs="unbounded">
+                                        <xs:element name="Node" type="NodeType" minOccurs="0"/>
+                                    </xs:sequence>
+                                </xs:complexType>
+                                <xs:keyref name="processKeyRef" refer="processKey">
+                                    <xs:selector xpath=".//*"/>
+                                    <xs:field xpath="@process"/>
+                                </xs:keyref>
+                            </xs:element>
+                            <xs:element name="DaliServerProcess">
+                                <xs:annotation>
+                                    <xs:documentation>Describes a dali cluster</xs:documentation>
+                                </xs:annotation>
+                                <xs:complexType>
+                                    <xs:complexContent>
+                                        <xs:extension base="ProcessServerBase">
+                                            <xs:sequence>
+                                                <xs:element name="Instance" maxOccurs="unbounded">
+                                                    <xs:complexType>
+                                                        <xs:complexContent>
+                                                            <xs:extension base="ProcessInstanceBase">
+                                                                <xs:attribute name="port" type="xs:nonNegativeInteger" use="optional" default="7070"/>
+                                                            </xs:extension>
+                                                        </xs:complexContent>
+                                                    </xs:complexType>
+                                                </xs:element>
+                                            </xs:sequence>
+                                        </xs:extension>
+                                    </xs:complexContent>
+                                </xs:complexType>
+                                <xs:key name="daliProcessKey">
+                                    <xs:selector xpath="./DaliServerProcess"/>
+                                    <xs:field xpath="@name"/>
+                                </xs:key>
+                            </xs:element>
+                            <xs:element name="OldFTSlaveProcess">
+                                <xs:annotation>
+                                    <xs:documentation>Describes an ftslave installation</xs:documentation>
+                                </xs:annotation>
+                                <xs:complexType>
+                                    <xs:complexContent>
+                                        <xs:extension base="ProcessServerBase">
+                                            <xs:sequence>
+                                                <xs:element name="Instance" type="ProcessInstanceBase" maxOccurs="unbounded"/>
+                                            </xs:sequence>
+                                            <xs:attribute name="version" type="xs:string" use="required"/>
+                                        </xs:extension>
+                                    </xs:complexContent>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="AttrServerProcess">
+                                <xs:annotation>
+                                    <xs:documentation>Describes an atribute server</xs:documentation>
+                                </xs:annotation>
+                                <xs:complexType>
+                                    <xs:complexContent>
+                                        <xs:extension base="ProcessServerBase">
+                                            <xs:sequence>
+                                                <xs:element name="AttrServerInstance" maxOccurs="unbounded">
+                                                    <xs:complexType>
+                                                        <xs:complexContent>
+                                                            <xs:extension base="ProcessInstanceBase">
+                                                                <xs:attribute name="port" type="xs:nonNegativeInteger" use="optional"/>
+                                                            </xs:extension>
+                                                        </xs:complexContent>
+                                                    </xs:complexType>
+                                                </xs:element>
+                                            </xs:sequence>
+                                            <xs:attribute name="sybase" type="xs:string" use="optional"/>
+                                            <xs:attribute name="mysql" type="xs:string" use="optional"/>
+                                            <xs:attribute name="traceLevel" type="xs:nonNegativeInteger" use="optional" default="1"/>
+                                            <xs:attribute name="logDir" type="xs:string" use="optional"/>
+                                        </xs:extension>
+                                    </xs:complexContent>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="PluginProcess" type="PluginsBase"/>
+                        </xs:choice>
+                        <xs:attribute name="include" type="xs:string"/>
+                        <xs:attribute name="name" type="xs:string"/>
+                    </xs:complexType>
+                    <xs:keyref name="buildKeyRef" refer="buildKey">
+                        <xs:selector xpath="./NameServicesProcess|./WebServerProcess|./JackProcess|./DFSProcess|./EclServerProcess|./EclAgentProcess|./ThorCluster|./HoleCluster|./DaliServer"/>
+                        <xs:field xpath="@build"/>
+                    </xs:keyref>
+                </xs:element>
+                <xs:element name="Data">
+                    <xs:annotation>
+                        <xs:documentation>Section containing definitions of the data that is leveraged in the environment.</xs:documentation>
+                    </xs:annotation>
+                    <xs:complexType>
+                        <xs:choice maxOccurs="unbounded">
+                            <xs:element name="Build">
+                                <xs:complexType>
+                                    <xs:complexContent>
+                                        <xs:extension base="SettingsBase">
+                                            <xs:sequence>
+                                                <xs:element name="Location" maxOccurs="unbounded">
+                                                    <xs:complexType>
+                                                        <xs:attribute name="logicalName" type="xs:string" use="required"/>
+                                                        <xs:attribute name="table" type="xs:string" use="required"/>
+                                                    </xs:complexType>
+                                                </xs:element>
+                                            </xs:sequence>
+                                            <xs:attribute name="description" type="xs:string" use="optional"/>
+                                            <xs:attribute name="dataModel" type="xs:string" use="required"/>
+                                            <xs:attribute name="nameservices" type="xs:string" use="optional"/>
+                                            <xs:attribute name="baseLoadName" type="xs:string" use="optional"/>
+                                            <xs:attribute name="prefix" type="xs:string" use="optional"/>
+                                            <xs:attribute name="suffix" type="xs:string" use="optional"/>
+                                            <xs:attribute name="blobDirectory" type="absolutePath" use="optional"/>
+                                            <xs:attribute name="blobName" type="xs:string" use="optional"/>
+                                            <xs:attribute name="useBlobs" type="xs:boolean" use="optional" default="false"/>
+                                        </xs:extension>
+                                    </xs:complexContent>
+                                </xs:complexType>
+                                <xs:keyref name="buildTableKeyRef" refer="dataTableKey">
+                                    <xs:selector xpath="Location"/>
+                                    <xs:field xpath="@table"/>
+                                </xs:keyref>
+                            </xs:element>
+                            <xs:element name="Model" type="ModelType">
+                                <xs:keyref name="dataMapKeyRef" refer="dataMapKey">
+                                    <xs:selector xpath="Map"/>
+                                    <xs:field xpath="@name"/>
+                                </xs:keyref>
+                                <xs:keyref name="dataTableKeyRef" refer="dataTableKey">
+                                    <xs:selector xpath="Table"/>
+                                    <xs:field xpath="@name"/>
+                                </xs:keyref>
+                                <xs:keyref name="dataViewKeyRef" refer="dataViewKey">
+                                    <xs:selector xpath="View"/>
+                                    <xs:field xpath="@name"/>
+                                </xs:keyref>
+                            </xs:element>
+                        </xs:choice>
+                        <xs:attribute name="include" type="xs:string"/>
+                    </xs:complexType>
+                    <xs:key name="dataModelKey">
+                        <xs:selector xpath="Model"/>
+                        <xs:field xpath="@name"/>
+                    </xs:key>
+                    <xs:keyref name="dataModelKeyRef" refer="dataModelKey">
+                        <xs:selector xpath="Build"/>
+                        <xs:field xpath="@model"/>
+                    </xs:keyref>
+                    <xs:key name="dataMapKey">
+                        <xs:selector xpath="Map"/>
+                        <xs:field xpath="@name"/>
+                    </xs:key>
+                    <xs:key name="dataTableKey">
+                        <xs:selector xpath="ThorTable|HoleTable|LogicalTable|SqlTable|FlatTable"/>
+                        <xs:field xpath="@name"/>
+                    </xs:key>
+                    <xs:key name="dataViewKey">
+                        <xs:selector xpath="View"/>
+                        <xs:field xpath="@name"/>
+                    </xs:key>
+                </xs:element>
+            </xs:choice>
+        </xs:complexType>
+        <xs:key name="sybaseProcessKey">
+            <xs:selector xpath=".//SybaseProcess"/>
+            <xs:field xpath="@name"/>
+        </xs:key>
+        <xs:keyref name="sybaseProcessKeyRef" refer="sybaseProcessKey">
+            <xs:selector xpath=".//*"/>
+            <xs:field xpath="@sybase"/>
+        </xs:keyref>
+        <xs:key name="computerTypeKey">
+            <xs:selector xpath=".//ComputerType"/>
+            <xs:field xpath="@name"/>
+        </xs:key>
+        <xs:keyref name="computerTypeKeyRef" refer="computerTypeKey">
+            <xs:selector xpath=".//*"/>
+            <xs:field xpath="@computerType"/>
+        </xs:keyref>
+        <xs:key name="computerKey">
+            <xs:selector xpath=".//Computer"/>
+            <xs:field xpath="@name"/>
+        </xs:key>
+        <xs:keyref name="computerKeyRef" refer="computerKey">
+            <xs:selector xpath=".//*"/>
+            <xs:field xpath="@computer"/>
+        </xs:keyref>
+        <xs:key name="programKey">
+            <xs:selector xpath=".//Program"/>
+            <xs:field xpath="@name"/>
+        </xs:key>
+        <xs:keyref name="programKeyRef" refer="programKey">
+            <xs:selector xpath=".//Program"/>
+            <xs:field xpath="@program"/>
+        </xs:keyref>
+        <xs:key name="processKey">
+            <xs:selector xpath=".//EclServerProcess|.//EclAgentProcess|.//SybaseProcess|.//SpareProcess|.//HoleCluster|.//ThorCluster|.//DaliServer"/>
+            <xs:field xpath="@name"/>
+        </xs:key>
+        <xs:key name="hmonKey">
+            <xs:selector xpath=".//HMonProcess"/>
+            <xs:field xpath="@name"/>
+        </xs:key>
+        <xs:keyref name="hmonKeyRef" refer="hmonKey">
+            <xs:selector xpath=".//*"/>
+            <xs:field xpath="@hmon"/>
+        </xs:keyref>
+    </xs:element>
+    <xs:complexType name="FieldType">
+        <xs:complexContent>
+            <xs:extension base="SettingsBase">
+                <xs:sequence minOccurs="0">
+                    <xs:element name="Expression"/>
+                </xs:sequence>
+                <xs:attribute name="label" type="xs:string" use="required"/>
+                <xs:attribute name="description" type="xs:string" use="optional"/>
+                <xs:attribute name="type" type="xs:string" use="optional"/>
+                <xs:attribute name="size" type="xs:nonNegativeInteger" use="optional"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="HoleFieldType">
+        <xs:complexContent>
+            <xs:extension base="SettingsBase">
+                <xs:sequence minOccurs="0">
+                    <xs:element name="Expression"/>
+                </xs:sequence>
+                <xs:attribute name="label" type="xs:string" use="required"/>
+                <xs:attribute name="description" type="xs:string" use="optional"/>
+                <xs:attribute name="type" type="xs:string" use="required"/>
+                <xs:attribute name="physicalSize" type="xs:nonNegativeInteger" use="optional"/>
+                <xs:attribute name="physicalType" type="xs:string" use="optional"/>
+                <xs:attribute name="size" type="xs:nonNegativeInteger" use="required"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="ParentTableType">
+        <xs:complexContent>
+            <xs:extension base="SettingsBase">
+                <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                    <xs:element name="Table" type="ChildTableType"/>
+                </xs:sequence>
+                <xs:attribute name="version" type="xs:string" use="required"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="ChildTableType">
+        <xs:complexContent>
+            <xs:extension base="SettingsBase">
+                <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                    <xs:element name="Table" type="ChildTableType"/>
+                </xs:sequence>
+                <xs:attribute name="version" type="xs:string" use="required"/>
+                <xs:attribute name="childField" type="xs:string" use="required"/>
+                <xs:attribute name="parentField" type="xs:string" use="required"/>
+                <xs:attribute name="cardinality" type="xs:nonNegativeInteger" use="required"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="NodeType">
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="Node" type="NodeType"/>
+            <xs:element name="NodeRef">
+                <xs:complexType>
+                    <xs:attribute name="name" type="xs:string" use="optional"/>
+                    <xs:attribute name="node" type="xs:string" use="required"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="Cluster">
+                <xs:complexType>
+                    <xs:sequence maxOccurs="unbounded">
+                        <xs:element name="Node" type="NodeType"/>
+                    </xs:sequence>
+                    <xs:attribute name="name" type="xs:string" use="required"/>
+                    <xs:attribute name="prefix" type="xs:string" use="required"/>
+                </xs:complexType>
+            </xs:element>
+        </xs:choice>
+        <xs:attribute name="name" type="xs:string"/>
+        <xs:attribute name="process" type="xs:string" use="required"/>
+    </xs:complexType>
+    <xs:complexType name="EspNodeType">
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:choice>
+                <xs:element name="Node" type="EspNodeType"/>
+                <xs:element name="NodeRef">
+                    <xs:complexType>
+                        <xs:attribute name="name" type="xs:string" use="optional"/>
+                        <xs:attribute name="node" type="xs:string" use="required"/>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="Cluster">
+                    <xs:complexType>
+                        <xs:sequence maxOccurs="unbounded">
+                            <xs:element name="Node" type="EspNodeType"/>
+                        </xs:sequence>
+                        <xs:attribute name="name" type="xs:string" use="required"/>
+                        <xs:attribute name="prefix" type="xs:string" use="required"/>
+                    </xs:complexType>
+                </xs:element>
+            </xs:choice>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string"/>
+        <xs:attribute name="process" type="xs:string" use="required"/>
+        <xs:attribute name="binding" type="xs:string" use="required"/>
+    </xs:complexType>
+    <xs:complexType name="ComputerTypeType">
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="nicSpeed" type="xs:nonNegativeInteger"/>
+        <xs:attribute name="manufacturer" type="xs:string"/>
+        <xs:attribute name="memory" type="xs:nonNegativeInteger"/>
+        <xs:attribute name="computerType" type="xs:string"/>
+        <xs:attribute name="opSys" type="xs:string"/>
+    </xs:complexType>
+    <xs:complexType name="DomainType">
+        <xs:complexContent>
+            <xs:extension base="SettingsBase"/>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="SettingsBase">
+        <xs:attributeGroup ref="BaseAttributes"/>
+    </xs:complexType>
+    <xs:complexType name="SimpleProcessBase">
+        <xs:complexContent>
+            <xs:extension base="SettingsBase">
+                <xs:attribute name="computer" type="xs:string" use="required"/>
+                <xs:attribute name="netAddress" type="ipAddress" use="optional"/>
+                <xs:attribute name="description" type="xs:string" use="optional"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="ProcessBase">
+        <xs:complexContent>
+            <xs:extension base="SimpleProcessBase">
+                <xs:attributeGroup ref="ProcessFileAttributes"/>
+                <xs:attribute name="daliServer" type="xs:string" use="optional"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="ProcessServerBase">
+        <xs:complexContent>
+            <xs:extension base="SettingsBase">
+                <xs:attribute name="description" type="xs:string" use="optional"/>
+                <xs:attribute name="build" type="xs:string" use="required"/>
+                <xs:attribute name="buildSet" type="xs:string" use="required"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="ProcessInstanceBase">
+        <xs:complexContent>
+            <xs:extension base="SettingsBase">
+                <xs:attribute name="description" type="xs:string" use="optional"/>
+                <xs:attribute name="computer" type="xs:string" use="required"/>
+                <xs:attribute name="netAddress" type="ipAddress" use="optional"/>
+                <xs:attribute name="directory" type="absolutePath" use="required"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="PluginsBase">
+        <xs:complexContent>
+            <xs:extension base="SettingsBase">
+                <xs:attribute name="description" type="xs:string" use="optional"/>
+                <xs:attribute name="build" type="xs:string" use="required"/>
+                <xs:attribute name="buildSet" type="xs:string" use="required"/>
+                <xs:attribute name="loadOrder" type="xs:string" use="optional"/>
+                <xs:attribute name="directory" type="absolutePath" use="required"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="JackServiceBase">
+        <xs:complexContent>
+            <xs:extension base="SettingsBase">
+                <xs:attributeGroup ref="JackServiceAttributes"/>
+                <xs:attribute name="jackAgentName" type="xs:string" use="required"/>
+                <xs:attribute name="path" type="xs:string"/>
+                <xs:attribute name="build" type="xs:string"/>
+                <xs:attribute name="buildSet" type="xs:string"/>
+                <xs:attribute name="exe" type="xs:string"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="MapTablesType">
+        <xs:complexContent>
+            <xs:extension base="SettingsBase">
+                <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                    <xs:element name="MapFields">
+                        <xs:complexType>
+                            <xs:complexContent>
+                                <xs:extension base="SettingsBase">
+                                    <xs:attribute name="destField" type="xs:string" use="required"/>
+                                    <xs:attribute name="sourceField" type="xs:string" use="required"/>
+                                </xs:extension>
+                            </xs:complexContent>
+                        </xs:complexType>
+                    </xs:element>
+                </xs:sequence>
+                <xs:attribute name="sourceTable" type="xs:string" use="required"/>
+                <xs:attribute name="sourceVersion" type="xs:string" use="required"/>
+                <xs:attribute name="destTable" type="xs:string" use="required"/>
+                <xs:attribute name="destVersion" type="xs:string" use="required"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="NotifyType">
+        <xs:attributeGroup ref="NotificationAttributes"/>
+    </xs:complexType>
+    <xs:complexType name="HmonTaskType">
+        <xs:attributeGroup ref="BaseAttributes"/>
+        <xs:attributeGroup ref="NotificationAttributes"/>
+        <xs:attribute name="description" type="xs:string"/>
+        <xs:attribute name="process" type="xs:string"/>
+        <xs:attribute name="logFile" type="xs:string"/>
+        <xs:attribute name="maxLogFileSize" type="xs:nonNegativeInteger"/>
+        <xs:attribute name="deadbeatTimer" type="xs:nonNegativeInteger"/>
+    </xs:complexType>
+    <xs:attributeGroup name="NotificationAttributes">
+        <xs:attribute name="nfyEvent" default="Any">
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="Any"/>
+                    <xs:enumeration value="Success"/>
+                    <xs:enumeration value="Failure"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="nfyMethod" default="Email">
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="Email"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="nfyAddress" type="xs:string"/>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="BaseAttributes">
+        <xs:attribute name="include" type="xs:string"/>
+        <xs:attribute name="name" type="xs:string"/>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="ProcessFileAttributes">
+        <xs:attribute name="directory" type="absolutePath" use="required"/>
+        <xs:attribute name="build" type="xs:string" use="required"/>
+        <xs:attribute name="buildSet" type="xs:string" use="required"/>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="DatabaseAttributes">
+        <xs:attribute name="dbProcess" type="xs:string"/>
+        <xs:attribute name="dbName" type="xs:string"/>
+        <xs:attribute name="dbUser" type="xs:string"/>
+        <xs:attribute name="dbPassword" type="xs:string"/>
+        <xs:attribute name="dbConnections" type="xs:string"/>
+        <xs:attribute name="dbTimeout" type="xs:nonNegativeInteger"/>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="JackServiceAttributes">
+        <xs:attribute name="traceLevel" type="xs:nonNegativeInteger"/>
+        <xs:attribute name="logfile" type="xs:string"/>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="PoolingAttributes">
+        <xs:attribute name="poolIdleCount" type="xs:nonNegativeInteger"/>
+        <xs:attribute name="poolIdleTimer" type="xs:nonNegativeInteger"/>
+        <xs:attribute name="poolMinCount" type="xs:nonNegativeInteger"/>
+        <xs:attribute name="poolMaxCount" type="xs:nonNegativeInteger"/>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="LogFileAttributes"/>
+    <xs:complexType name="EspProtocolType">
+        <xs:attribute name="include" type="xs:string"/>
+        <xs:attribute name="name" type="xs:string"/>
+        <xs:attribute name="type" type="xs:string"/>
+        <xs:attribute name="plugin" type="xs:string"/>
+        <xs:attribute name="computer" type="xs:string"/>
+    </xs:complexType>
+    <xs:complexType name="EspBindingType">
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="Scripts"/>
+            <xs:element name="Daliservers"/>
+            <xs:element name="LayoutProgram"/>
+            <xs:element name="Authenticate">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="Location">
+                            <xs:complexType>
+                                <xs:attribute name="path" type="xs:string"/>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                    <xs:attribute name="type" type="xs:string"/>
+                    <xs:attribute name="method" type="xs:string"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:any namespace="##any">
+                <xs:annotation>
+                    <xs:documentation>Allow additional nodes as needed</xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:choice>
+        <xs:attribute name="include" type="xs:string"/>
+        <xs:attribute name="name" type="xs:string"/>
+        <xs:attribute name="type" type="xs:string"/>
+        <xs:attribute name="protocol" type="xs:string"/>
+        <xs:attribute name="service" type="xs:string"/>
+        <xs:attribute name="port" type="xs:nonNegativeInteger"/>
+        <xs:attribute name="plugin" type="xs:string"/>
+        <xs:attribute name="netAddress" type="ipAddress"/>
+        <xs:anyAttribute namespace="##any"/>
+    </xs:complexType>
+    <xs:complexType name="EspServiceType">
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="Daliservers"/>
+            <xs:element name="ClusterName"/>
+            <xs:element name="UserName"/>
+            <xs:element name="EclServer"/>
+            <xs:element name="AttributeServer"/>
+            <xs:element name="DefaultStyle"/>
+            <xs:element name="WuTimeout"/>
+            <xs:element name="FilesPath"/>
+            <xs:element name="StyleSheets">
+                <xs:complexType>
+                    <xs:sequence maxOccurs="unbounded">
+                        <xs:element name="xslt">
+                            <xs:complexType>
+                                <xs:attribute name="name" type="xs:string" use="required"/>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:any namespace="##any">
+                <xs:annotation>
+                    <xs:documentation>Allow additional nodes as needed</xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:choice>
+        <xs:attribute name="name" type="xs:string"/>
+        <xs:attribute name="type" type="xs:string"/>
+        <xs:attribute name="plugin" type="xs:string"/>
+        <xs:anyAttribute namespace="##any"/>
+    </xs:complexType>
+    <xs:complexType name="EspBindingMapType">
+        <xs:sequence>
+            <xs:element name="EspBindingEntry" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:attribute name="name" type="xs:string"/>
+                    <xs:attribute name="service" type="xs:string"/>
+                    <xs:attribute name="type" type="xs:string"/>
+                    <xs:attribute name="plugin" type="xs:string"/>
+                    <xs:attribute name="expr" type="xs:string"/>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string"/>
+        <xs:attribute name="type" type="xs:string"/>
+        <xs:attribute name="protocol" type="xs:string"/>
+        <xs:attribute name="plugin" type="xs:string"/>
+        <xs:attribute name="netAddress" type="ipAddress"/>
+        <xs:attribute name="port" type="xs:nonNegativeInteger"/>
+    </xs:complexType>
+    <xs:complexType name="EspUriMapType">
+        <xs:choice maxOccurs="unbounded">
+            <xs:element name="UriLocalFile">
+                <xs:complexType>
+                    <xs:attribute name="regExpr" type="xs:string"/>
+                    <xs:attribute name="fileRoot" type="xs:string"/>
+                    <xs:attribute name="filePath" type="xs:string"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="UriSoap">
+                <xs:complexType>
+                    <xs:attribute name="regExpr" type="xs:string"/>
+                    <xs:attribute name="binding" type="xs:string"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="UriMethod">
+                <xs:complexType>
+                    <xs:attribute name="regExpr" type="xs:string"/>
+                    <xs:attribute name="binding" type="xs:string"/>
+                    <xs:attribute name="method" type="xs:string"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="UriForm">
+                <xs:complexType>
+                    <xs:attribute name="regExpr" type="xs:string"/>
+                    <xs:attribute name="binding" type="xs:string"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="UriWSDL">
+                <xs:complexType>
+                    <xs:attribute name="regExpr" type="xs:string"/>
+                    <xs:attribute name="binding" type="xs:string"/>
+                </xs:complexType>
+            </xs:element>
+        </xs:choice>
+        <xs:attribute name="protocol" type="xs:string"/>
+        <xs:attribute name="port" type="xs:nonNegativeInteger"/>
+    </xs:complexType>
+    <xs:complexType name="EspTopologyType">
+        <xs:sequence>
+            <xs:element name="Node" type="EspNodeType" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="ModelType">
+        <xs:complexContent>
+            <xs:extension base="SettingsBase">
+                <xs:choice minOccurs="0" maxOccurs="unbounded">
+                    <xs:element name="View" minOccurs="0">
+                        <xs:complexType>
+                            <xs:sequence>
+                                <xs:element name="Table" type="TableType"/>
+                            </xs:sequence>
+                        </xs:complexType>
+                    </xs:element>
+                    <xs:element name="Map" minOccurs="0">
+                        <xs:complexType>
+                            <xs:sequence>
+                                <xs:element name="MapTables" maxOccurs="unbounded">
+                                    <xs:complexType>
+                                        <xs:attribute name="destTable" type="xs:string" use="required"/>
+                                        <xs:attribute name="sourceTable" type="xs:string" use="required"/>
+                                    </xs:complexType>
+                                </xs:element>
+                            </xs:sequence>
+                        </xs:complexType>
+                    </xs:element>
+                    <xs:element name="ThorTable" minOccurs="0" maxOccurs="unbounded">
+                        <xs:complexType>
+                            <xs:sequence>
+                                <xs:element name="Field" maxOccurs="unbounded">
+                                    <xs:complexType>
+                                        <xs:attribute name="label" type="xs:string" use="required"/>
+                                        <xs:attribute name="name" type="xs:string" use="required"/>
+                                        <xs:attribute name="size" type="xs:byte" use="required"/>
+                                        <xs:attribute name="type" type="xs:string" use="required"/>
+                                        <xs:attribute name="physicalSize" type="xs:byte"/>
+                                        <xs:attribute name="physicalType" type="xs:string"/>
+                                    </xs:complexType>
+                                </xs:element>
+                            </xs:sequence>
+                            <xs:attribute name="name" type="xs:string" use="required"/>
+                            <xs:attribute name="label" type="xs:string"/>
+                        </xs:complexType>
+                    </xs:element>
+                    <xs:element name="HoleTable" minOccurs="0" maxOccurs="unbounded">
+                        <xs:complexType>
+                            <xs:sequence>
+                                <xs:element name="Field" maxOccurs="unbounded">
+                                    <xs:complexType>
+                                        <xs:attribute name="label" type="xs:string" use="required"/>
+                                        <xs:attribute name="name" type="xs:string" use="required"/>
+                                        <xs:attribute name="size" type="xs:byte" use="required"/>
+                                        <xs:attribute name="type" type="xs:string" use="required"/>
+                                        <xs:attribute name="physicalSize" type="xs:byte"/>
+                                        <xs:attribute name="physicalType" type="xs:string"/>
+                                    </xs:complexType>
+                                </xs:element>
+                            </xs:sequence>
+                            <xs:attribute name="name" type="xs:string" use="required"/>
+                            <xs:attribute name="label" type="xs:string" use="required"/>
+                            <xs:attribute name="logicalName" type="xs:string" use="required"/>
+                        </xs:complexType>
+                    </xs:element>
+                    <xs:element name="LogicalTable" minOccurs="0" maxOccurs="unbounded">
+                        <xs:complexType>
+                            <xs:sequence>
+                                <xs:element name="Field" maxOccurs="unbounded">
+                                    <xs:complexType>
+                                        <xs:attribute name="label" type="xs:string" use="required"/>
+                                        <xs:attribute name="name" type="xs:string" use="required"/>
+                                        <xs:attribute name="size" type="xs:byte" use="required"/>
+                                        <xs:attribute name="type" type="xs:string" use="required"/>
+                                        <xs:attribute name="physicalSize" type="xs:byte"/>
+                                        <xs:attribute name="physicalType" type="xs:string"/>
+                                    </xs:complexType>
+                                </xs:element>
+                            </xs:sequence>
+                            <xs:attribute name="name" type="xs:string" use="required"/>
+                            <xs:attribute name="label" type="xs:string" use="optional"/>
+                        </xs:complexType>
+                    </xs:element>
+                </xs:choice>
+                <xs:attribute name="description" type="xs:string" use="optional"/>
+                <xs:attribute name="family" type="xs:string" use="required"/>
+                <xs:attribute name="version" type="xs:string" use="required"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="TableType">
+        <xs:sequence>
+            <xs:element name="Table" type="TableType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="childField" type="xs:string"/>
+        <xs:attribute name="parentField" type="xs:string"/>
+        <xs:attribute name="cardinality" type="xs:long"/>
+    </xs:complexType>
+    <xs:simpleType name="buildType">
+        <xs:restriction base="xs:string"/>
+    </xs:simpleType>
+    <xs:simpleType name="buildSetType">
+        <xs:restriction base="xs:string"/>
+    </xs:simpleType>
+    <xs:simpleType name="computerType">
+        <xs:restriction base="xs:string"/>
+    </xs:simpleType>
+    <xs:simpleType name="daliServersType">
+        <xs:restriction base="xs:string"/>
+    </xs:simpleType>
+    <xs:simpleType name="dataBuildType">
+        <xs:restriction base="xs:string"/>
+    </xs:simpleType>
+    <xs:simpleType name="sybaseType">
+        <xs:restriction base="xs:string"/>
+    </xs:simpleType>
+    <xs:simpleType name="ldapServerType">
+        <xs:restriction base="xs:string"/>
+    </xs:simpleType>
+    <xs:simpleType name="accurintServerType">
+        <xs:restriction base="xs:string"/>
+    </xs:simpleType>
+    <xs:simpleType name="espServiceType">
+        <xs:restriction base="xs:string"/>
+    </xs:simpleType>
+    <xs:simpleType name="eclServerType">
+        <xs:restriction base="xs:string"/>
+    </xs:simpleType>
+    <xs:simpleType name="espProcessType">
+        <xs:restriction base="xs:string"/>
+    </xs:simpleType>
+    <xs:simpleType name="espBindingType">
+        <xs:restriction base="xs:string"/>
+    </xs:simpleType>
+    <xs:simpleType name="processType">
+        <xs:restriction base="xs:string"/>
+    </xs:simpleType>
+    <xs:simpleType name="xpathType">
+        <xs:restriction base="xs:string"/>
+    </xs:simpleType>
+    <xs:simpleType name="roxieClusterType">
+        <xs:restriction base="xs:string"/>
+    </xs:simpleType>
+    <xs:simpleType name="mysqlType">
+        <xs:restriction base="xs:string"/>
+    </xs:simpleType>
+    <xs:simpleType name="absolutePath">
+        <xs:restriction base="xs:string"/>
+    </xs:simpleType>
+    <xs:simpleType name="relativePath">
+        <xs:restriction base="xs:string"/>
+    </xs:simpleType>
+    <xs:simpleType name="fileName">
+        <xs:restriction base="xs:string"/>
+    </xs:simpleType>
+    <xs:simpleType name="ipAddress">
+        <xs:restriction base="xs:string"/>
+    </xs:simpleType>
+    <xs:simpleType name="ipAddressAndPort">
+        <xs:restriction base="xs:string"/>
+    </xs:simpleType>
+    <xs:simpleType name="roxieAddress">
+        <xs:restriction base="xs:string"/>
+    </xs:simpleType>
+    <xs:simpleType name="sashaServerType">
+        <xs:restriction base="xs:string"/>
+    </xs:simpleType>
+    <xs:simpleType name="topologyClusterType">
+        <xs:restriction base="xs:string"/>
+    </xs:simpleType>
+</xs:schema>

--- a/configuration/xsds_xmls/environment2.xml
+++ b/configuration/xsds_xmls/environment2.xml
@@ -1,0 +1,1123 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Edited with THE CONFIGURATOR -->
+<Environment>
+ <EnvSettings>
+  <configs>/etc/HPCCSystems</configs>
+  <environment>environment.xml</environment>
+  <home>/home</home>
+  <lock>/var/lock/HPCCSystems</lock>
+  <log>/var/log/HPCCSystems</log>
+  <path>/opt/HPCCSystems</path>
+  <pid>/var/run/HPCCSystems</pid>
+  <ports>
+   <mpEnd>7500</mpEnd>
+   <mpStart>7101</mpStart>
+  </ports>
+  <runtime>/var/lib/HPCCSystems</runtime>
+  <sourcedir>/etc/HPCCSystems/source</sourcedir>
+  <user>hpcc</user>
+ </EnvSettings>
+ <Hardware>
+  <Computer computerType="linuxmachine"
+            domain="localdomain"
+            name="localhost"
+            netAddress="."/>
+  <ComputerType computerType="linuxmachine"
+                manufacturer="unknown"
+                name="linuxmachine"
+                opSys="linux"/>
+  <Domain name="localdomain" snmpSecurityString=""/>
+  <Switch name="Switch"/>
+ </Hardware>
+ <Programs>
+  <Build name="_" url="/opt/HPCCSystems">
+   <BuildSet installSet="deploy_map.xml"
+             name="dafilesrv"
+             path="componentfiles/dafilesrv"
+             processName="DafilesrvProcess"
+             schema="dafilesrv.xsd"/>
+   <BuildSet installSet="deploy_map.xml"
+             name="dali"
+             path="componentfiles/dali"
+             processName="DaliServerProcess"
+             schema="dali.xsd"/>
+   <BuildSet installSet="deploy_map.xml"
+             name="dfuplus"
+             overide="no"
+             path="componentfiles/dfuplus"
+             processName="DfuplusProcess"
+             schema="dfuplus.xsd"/>
+   <BuildSet installSet="deploy_map.xml"
+             name="dfuserver"
+             path="componentfiles/dfuserver"
+             processName="DfuServerProcess"
+             schema="dfuserver.xsd"/>
+   <BuildSet deployable="no"
+             installSet="deploy_map.xml"
+             name="DropZone"
+             path="componentfiles/DropZone"
+             processName="DropZone"
+             schema="dropzone.xsd"/>
+   <BuildSet installSet="deploy_map.xml"
+             name="eclagent"
+             path="componentfiles/eclagent"
+             processName="EclAgentProcess"
+             schema="eclagent_config.xsd"/>
+   <BuildSet installSet="deploy_map.xml"
+             name="eclminus"
+             overide="no"
+             path="componentfiles/eclminus"/>
+   <BuildSet installSet="deploy_map.xml"
+             name="eclplus"
+             overide="no"
+             path="componentfiles/eclplus"
+             processName="EclPlusProcess"
+             schema="eclplus.xsd"/>
+   <BuildSet installSet="eclccserver_deploy_map.xml"
+             name="eclccserver"
+             path="componentfiles/configxml"
+             processName="EclCCServerProcess"
+             schema="eclccserver.xsd"/>
+   <BuildSet installSet="eclscheduler_deploy_map.xml"
+             name="eclscheduler"
+             path="componentfiles/configxml"
+             processName="EclSchedulerProcess"
+             schema="eclscheduler.xsd"/>
+   <BuildSet installSet="deploy_map.xml"
+             name="esp"
+             path="componentfiles/esp"
+             processName="EspProcess"
+             schema="esp.xsd"/>
+   <BuildSet deployable="no"
+             installSet="deploy_map.xml"
+             name="espsmc"
+             path="componentfiles/espsmc"
+             processName="EspService"
+             schema="espsmcservice.xsd">
+    <Properties defaultPort="8010"
+                defaultResourcesBasedn="ou=SMC,ou=EspServices,ou=ecl"
+                defaultSecurePort="18010"
+                type="WsSMC">
+     <Authenticate access="Read"
+                   description="Root access to SMC service"
+                   path="/"
+                   required="Read"
+                   resource="SmcAccess"/>
+     <AuthenticateFeature description="Access to SMC service"
+                          path="SmcAccess"
+                          resource="SmcAccess"
+                          service="ws_smc"/>
+     <AuthenticateFeature description="Access to thor queues"
+                          path="ThorQueueAccess"
+                          resource="ThorQueueAccess"
+                          service="ws_smc"/>
+     <AuthenticateFeature description="Access to roxie control commands"
+                          path="RoxieControlAccess"
+                          resource="RoxieControlAccess"
+                          service="ws_smc"/>
+     <AuthenticateFeature description="Access to super computer environment"
+                          path="ConfigAccess"
+                          resource="ConfigAccess"
+                          service="ws_config"/>
+     <AuthenticateFeature description="Access to DFU"
+                          path="DfuAccess"
+                          resource="DfuAccess"
+                          service="ws_dfu"/>
+     <AuthenticateFeature description="Access to DFU XRef"
+                          path="DfuXrefAccess"
+                          resource="DfuXrefAccess"
+                          service="ws_dfuxref"/>
+     <AuthenticateFeature description="Access to machine information"
+                          path="MachineInfoAccess"
+                          resource="MachineInfoAccess"
+                          service="ws_machine"/>
+     <AuthenticateFeature description="Access to SNMP metrics information"
+                          path="MetricsAccess"
+                          resource="MetricsAccess"
+                          service="ws_machine"/>
+     <AuthenticateFeature description="Access to remote execution"
+                          path="ExecuteAccess"
+                          resource="ExecuteAccess"
+                          service="ws_machine"/>
+     <AuthenticateFeature description="Access to DFU workunits"
+                          path="DfuWorkunitsAccess"
+                          resource="DfuWorkunitsAccess"
+                          service="ws_fs"/>
+     <AuthenticateFeature description="Access to DFU exceptions"
+                          path="DfuExceptionsAccess"
+                          resource="DfuExceptions"
+                          service="ws_fs"/>
+     <AuthenticateFeature description="Access to spraying files"
+                          path="FileSprayAccess"
+                          resource="FileSprayAccess"
+                          service="ws_fs"/>
+     <AuthenticateFeature description="Access to despraying of files"
+                          path="FileDesprayAccess"
+                          resource="FileDesprayAccess"
+                          service="ws_fs"/>
+     <AuthenticateFeature description="Access to dkcing of key files"
+                          path="FileDkcAccess"
+                          resource="FileDkcAccess"
+                          service="ws_fs"/>
+     <AuthenticateFeature description="Access to file upload"
+                          path="FileUploadAccess"
+                          resource="FileUploadAccess"
+                          service="ws_fs"/>
+     <AuthenticateFeature description="Access to files in dropzone"
+                          path="FileIOAccess"
+                          resource="FileIOAccess"
+                          service="ws_fileio"/>
+     <AuthenticateFeature description="Access to permissions for file scopes"
+                          path="FileScopeAccess"
+                          resource="FileScopeAccess"
+                          service="ws_access"/>
+     <AuthenticateFeature description="Access to WS ECL service"
+                          path="WsEclAccess"
+                          resource="WsEclAccess"
+                          service="ws_ecl"/>
+     <AuthenticateFeature description="Access to Roxie queries and files"
+                          path="RoxieQueryAccess"
+                          resource="RoxieQueryAccess"
+                          service="ws_roxiequery"/>
+     <AuthenticateFeature description="Access to cluster topology"
+                          path="ClusterTopologyAccess"
+                          resource="ClusterTopologyAccess"
+                          service="ws_topology"/>
+     <AuthenticateFeature description="Access to own workunits"
+                          path="OwnWorkunitsAccess"
+                          resource="OwnWorkunitsAccess"
+                          service="ws_workunits"/>
+     <AuthenticateFeature description="Access to others&apos; workunits"
+                          path="OthersWorkunitsAccess"
+                          resource="OthersWorkunitsAccess"
+                          service="ws_workunits"/>
+     <AuthenticateFeature description="Access to ECL direct service"
+                          path="EclDirectAccess"
+                          resource="EclDirectAccess"
+                          service="ecldirect"/>
+     <ProcessFilters>
+      <Platform name="Windows">
+       <ProcessFilter name="any">
+        <Process name="dafilesrv"/>
+       </ProcessFilter>
+       <ProcessFilter multipleInstances="true" name="DfuServerProcess"/>
+       <ProcessFilter multipleInstances="true" name="EclCCServerProcess"/>
+       <ProcessFilter multipleInstances="true" name="EspProcess">
+        <Process name="dafilesrv" remove="true"/>
+       </ProcessFilter>
+      </Platform>
+      <Platform name="Linux">
+       <ProcessFilter name="any">
+        <Process name="dafilesrv"/>
+       </ProcessFilter>
+       <ProcessFilter multipleInstances="true" name="DfuServerProcess"/>
+       <ProcessFilter multipleInstances="true" name="EclCCServerProcess"/>
+       <ProcessFilter multipleInstances="true" name="EspProcess">
+        <Process name="dafilesrv" remove="true"/>
+       </ProcessFilter>
+       <ProcessFilter name="GenesisServerProcess">
+        <Process name="httpd"/>
+        <Process name="atftpd"/>
+        <Process name="dhcpd"/>
+       </ProcessFilter>
+      </Platform>
+     </ProcessFilters>
+    </Properties>
+   </BuildSet>
+   <BuildSet installSet="deploy_map.xml"
+             name="ftslave"
+             path="componentfiles/ftslave"
+             processName="FTSlaveProcess"
+             schema="ftslave_linux.xsd"/>
+   <BuildSet installSet="deploy_map.xml"
+             name="hqltest"
+             overide="no"
+             path="componentfiles/hqltest"
+             processName="HqlTestProcess"/>
+   <BuildSet deployable="no"
+             installSet="deploy_map.xml"
+             name="ldapServer"
+             path="componentfiles/ldapServer"
+             processName="LDAPServerProcess"
+             schema="ldapserver.xsd"/>
+   <BuildSet installSet="roxie_deploy_map.xml"
+             name="roxie"
+             path="componentfiles/configxml"
+             processName="RoxieCluster"
+             schema="roxie.xsd"/>
+   <BuildSet installSet="deploy_map.xml"
+             name="sasha"
+             path="componentfiles/sasha"
+             processName="SashaServerProcess"
+             schema="sasha.xsd"/>
+   <BuildSet deployable="no"
+             installSet="deploy_map.xml"
+             name="SiteCertificate"
+             overide="no"
+             path="componentfiles/SiteCertificate"
+             processName="SiteCertificate"
+             schema="SiteCertificate.xsd"/>
+   <BuildSet installSet="deploy_map.xml"
+             name="soapplus"
+             overide="no"
+             path="componentfiles/soapplus"
+             processName="SoapPlusProcess"
+             schema="soapplus.xsd"/>
+   <BuildSet installSet="deploy_map.xml"
+             name="thor"
+             path="componentfiles/thor"
+             processName="ThorCluster"
+             schema="thor.xsd"/>
+   <BuildSet deployable="no"
+             installSet="deploy_map.xml"
+             name="topology"
+             path="componentfiles/topology"
+             processName="Topology"
+             schema="topology.xsd"/>
+   <BuildSet deployable="no"
+             installSet="deploy_map.xml"
+             name="ws_ecl"
+             path="componentfiles/ws_ecl"
+             processName="EspService"
+             schema="esp_service_wsecl2.xsd">
+    <Properties bindingType="ws_eclSoapBinding"
+                defaultPort="8002"
+                defaultResourcesBasedn="ou=WsEcl,ou=EspServices,ou=ecl"
+                defaultSecurePort="18002"
+                plugin="ws_ecl"
+                type="ws_ecl">
+     <Authenticate access="Read"
+                   description="Root access to WS ECL service"
+                   path="/"
+                   required="Read"
+                   resource="WsEclAccess"/>
+     <AuthenticateFeature description="Access to WS ECL service"
+                          path="WsEclAccess"
+                          resource="WsEclAccess"
+                          service="ws_ecl"/>
+    </Properties>
+   </BuildSet>
+   <BuildSet deployable="no"
+             installSet="deploy_map.xml"
+             name="ecldirect"
+             path="componentfiles/ecldirect"
+             processName="EspService"
+             schema="esp_service_ecldirect.xsd">
+    <Properties bindingType="EclDirectSoapBinding"
+                defaultPort="8008"
+                defaultResourcesBasedn="ou=EclDirectAccess,ou=EspServices,ou=ecl"
+                defaultSecurePort="18008"
+                plugin="ecldirect"
+                type="ecldirect">
+     <Authenticate access="Read"
+                   description="Root access to ECL Direct service"
+                   path="/"
+                   required="Read"
+                   resource="EclDirectAccess"/>
+     <AuthenticateFeature description="Access to ECL Direct service"
+                          path="EclDirectAccess"
+                          resource="EclDirectAccess"
+                          service="ecldirect"/>
+    </Properties>
+   </BuildSet>
+  </Build>
+ </Programs>
+ <Software>
+  <DafilesrvProcess build="_"
+                    buildSet="dafilesrv"
+                    description="DaFileSrv process"
+                    name="mydafilesrv"
+                    version="1">
+   <Instance computer="localhost"
+             directory="/var/lib/HPCCSystems/mydafilesrv"
+             name="s1"
+             netAddress="."/>
+  </DafilesrvProcess>
+  <DaliServerProcess build="_"
+                     buildSet="dali"
+                     environment="/etc/HPCCSystems/environment.xml"
+                     name="mydali"
+                     recoverFromIncErrors="true">
+   <Instance computer="localhost"
+             directory="/var/lib/HPCCSystems/mydali"
+             name="s1"
+             netAddress="."
+             port="7070"/>
+  </DaliServerProcess>
+  <DfuServerProcess build="_"
+                    buildSet="dfuserver"
+                    daliServers="mydali"
+                    description="DFU Server"
+                    monitorinterval="900"
+                    monitorqueue="dfuserver_monitor_queue"
+                    name="mydfuserver"
+                    queue="dfuserver_queue"
+                    transferBufferSize="65536">
+   <Instance computer="localhost"
+             directory="/var/lib/HPCCSystems/mydfuserver"
+             name="s1"
+             netAddress="."/>
+   <SSH SSHidentityfile="$HOME/.ssh/id_rsa"
+        SSHpassword=""
+        SSHretries="3"
+        SSHtimeout="0"
+        SSHusername="hpcc"/>
+  </DfuServerProcess>
+  <Directories name="HPCCSystems">
+   <Category dir="/var/log/[NAME]/[INST]" name="log"/>
+   <Category dir="/var/lib/[NAME]/[INST]" name="run"/>
+   <Category dir="/etc/[NAME]/[INST]" name="conf"/>
+   <Category dir="/var/lib/[NAME]/[INST]/temp" name="temp"/>
+   <Category dir="/var/lib/[NAME]/hpcc-data/[COMPONENT]" name="data"/>
+   <Category dir="/var/lib/[NAME]/hpcc-data2/[COMPONENT]" name="data2"/>
+   <Category dir="/var/lib/[NAME]/hpcc-data3/[COMPONENT]" name="data3"/>
+   <Category dir="/var/lib/[NAME]/hpcc-data4/[COMPONENT]" name="data4"/>
+   <Category dir="/var/lib/[NAME]/hpcc-mirror/[COMPONENT]" name="mirror"/>
+   <Category dir="/var/lib/[NAME]/queries/[INST]" name="query"/>
+   <Category dir="/var/lock/[NAME]/[INST]" name="lock"/>
+  </Directories>
+  <DropZone build="_"
+            buildSet="DropZone"
+            computer="localhost"
+            description="DropZone process"
+            directory="/var/lib/HPCCSystems/mydropzone"
+            name="mydropzone"/>
+  <EclAgentProcess allowedPipePrograms="*"
+                   build="_"
+                   buildSet="eclagent"
+                   daliServers="mydali"
+                   defaultMemoryLimitMB="300"
+                   description="EclAgent process"
+                   name="myeclagent"
+                   pluginDirectory="/opt/HPCCSystems/plugins"
+                   thorConnectTimeout="600"
+                   traceLevel="0"
+                   wuQueueName="myeclagent_queue">
+   <Instance computer="localhost"
+             directory="/var/lib/HPCCSystems/myeclagent"
+             name="s1"
+             netAddress="."/>
+  </EclAgentProcess>
+  <EclCCServerProcess build="_"
+                      buildSet="eclccserver"
+                      daliServers="mydali"
+                      description="EclCCServer process"
+                      enableSysLog="true"
+                      maxEclccProcesses="4"
+                      name="myeclccserver"
+                      traceLevel="1">
+   <Instance computer="localhost"
+             directory="/var/lib/HPCCSystems/myeclccserver"
+             name="s1"
+             netAddress="."/>
+   <Option name="maxCompileThreads" value="2"/>
+  </EclCCServerProcess>
+  <EclSchedulerProcess build="_"
+                       buildSet="eclscheduler"
+                       daliServers="mydali"
+                       description="EclScheduler process"
+                       name="myeclscheduler">
+   <Instance computer="localhost"
+             directory="/var/lib/HPCCSystems/myeclscheduler"
+             name="s1"
+             netAddress="."/>
+  </EclSchedulerProcess>
+  <EspProcess build="_"
+              buildSet="esp"
+              componentfilesDir="/opt/HPCCSystems/componentfiles"
+              daliServers="mydali"
+              description="ESP server"
+              enableSEHMapping="true"
+              formOptionsAccess="false"
+              httpConfigAccess="true"
+              logLevel="1"
+              logRequests="false"
+              logResponses="false"
+              maxBacklogQueueSize="200"
+              maxConcurrentThreads="0"
+              maxRequestEntityLength="8000000"
+              name="myesp"
+              perfReportDelay="60"
+              portalurl="http://hpccsystems.com/download">
+   <Authentication htpasswdFile="/etc/HPCCSystems/.htpasswd"
+                   ldapAuthMethod="kerberos"
+                   ldapConnections="10"
+                   ldapServer=""
+                   method="none"/>
+   <EspBinding defaultForPort="true"
+               defaultServiceVersion=""
+               name="smc"
+               port="8010"
+               protocol="http"
+               resourcesBasedn="ou=SMC,ou=EspServices,ou=ecl"
+               service="EclWatch"
+               workunitsBasedn="ou=workunits,ou=ecl"
+               wsdlServiceAddress="">
+    <Authenticate access="Read"
+                  description="Root access to SMC service"
+                  path="/"
+                  required="Read"
+                  resource="SmcAccess"/>
+    <AuthenticateFeature authenticate="Yes"
+                         description="Access to SMC service"
+                         path="SmcAccess"
+                         resource="SmcAccess"
+                         service="ws_smc"/>
+    <AuthenticateFeature authenticate="Yes"
+                         description="Access to thor queues"
+                         path="ThorQueueAccess"
+                         resource="ThorQueueAccess"
+                         service="ws_smc"/>
+    <AuthenticateFeature authenticate="Yes"
+                         description="Access to roxie control commands"
+                         path="RoxieControlAccess"
+                         resource="RoxieControlAccess"
+                         service="ws_smc"/>
+    <AuthenticateFeature authenticate="Yes"
+                         description="Access to super computer environment"
+                         path="ConfigAccess"
+                         resource="ConfigAccess"
+                         service="ws_config"/>
+    <AuthenticateFeature authenticate="Yes"
+                         description="Access to DFU"
+                         path="DfuAccess"
+                         resource="DfuAccess"
+                         service="ws_dfu"/>
+    <AuthenticateFeature authenticate="Yes"
+                         description="Access to DFU XRef"
+                         path="DfuXrefAccess"
+                         resource="DfuXrefAccess"
+                         service="ws_dfuxref"/>
+    <AuthenticateFeature authenticate="Yes"
+                         description="Access to machine information"
+                         path="MachineInfoAccess"
+                         resource="MachineInfoAccess"
+                         service="ws_machine"/>
+    <AuthenticateFeature authenticate="Yes"
+                         description="Access to SNMP metrics information"
+                         path="MetricsAccess"
+                         resource="MetricsAccess"
+                         service="ws_machine"/>
+    <AuthenticateFeature authenticate="Yes"
+                         description="Access to remote execution"
+                         path="ExecuteAccess"
+                         resource="ExecuteAccess"
+                         service="ws_machine"/>
+    <AuthenticateFeature authenticate="Yes"
+                         description="Access to DFU workunits"
+                         path="DfuWorkunitsAccess"
+                         resource="DfuWorkunitsAccess"
+                         service="ws_fs"/>
+    <AuthenticateFeature authenticate="Yes"
+                         description="Access to DFU exceptions"
+                         path="DfuExceptionsAccess"
+                         resource="DfuExceptions"
+                         service="ws_fs"/>
+    <AuthenticateFeature authenticate="Yes"
+                         description="Access to spraying files"
+                         path="FileSprayAccess"
+                         resource="FileSprayAccess"
+                         service="ws_fs"/>
+    <AuthenticateFeature authenticate="Yes"
+                         description="Access to despraying of files"
+                         path="FileDesprayAccess"
+                         resource="FileDesprayAccess"
+                         service="ws_fs"/>
+    <AuthenticateFeature authenticate="Yes"
+                         description="Access to dkcing of key files"
+                         path="FileDkcAccess"
+                         resource="FileDkcAccess"
+                         service="ws_fs"/>
+    <AuthenticateFeature authenticate="Yes"
+                         description="Access to file upload"
+                         path="FileUploadAccess"
+                         resource="FileUploadAccess"
+                         service="ws_fs"/>
+    <AuthenticateFeature authenticate="Yes"
+                         description="Access to files in dropzone"
+                         path="FileIOAccess"
+                         resource="FileIOAccess"
+                         service="ws_fileio"/>
+    <AuthenticateFeature authenticate="Yes"
+                         description="Access to permissions for file scopes"
+                         path="FileScopeAccess"
+                         resource="FileScopeAccess"
+                         service="ws_access"/>
+    <AuthenticateFeature authenticate="Yes"
+                         description="Access to WS ECL service"
+                         path="WsEclAccess"
+                         resource="WsEclAccess"
+                         service="ws_ecl"/>
+    <AuthenticateFeature authenticate="Yes"
+                         description="Access to Roxie queries and files"
+                         path="RoxieQueryAccess"
+                         resource="RoxieQueryAccess"
+                         service="ws_roxiequery"/>
+    <AuthenticateFeature authenticate="Yes"
+                         description="Access to cluster topology"
+                         path="ClusterTopologyAccess"
+                         resource="ClusterTopologyAccess"
+                         service="ws_topology"/>
+    <AuthenticateFeature authenticate="Yes"
+                         description="Access to own workunits"
+                         path="OwnWorkunitsAccess"
+                         resource="OwnWorkunitsAccess"
+                         service="ws_workunits"/>
+    <AuthenticateFeature authenticate="Yes"
+                         description="Access to others&apos; workunits"
+                         path="OthersWorkunitsAccess"
+                         resource="OthersWorkunitsAccess"
+                         service="ws_workunits"/>
+    <AuthenticateFeature authenticate="Yes"
+                         description="Access to ECL direct service"
+                         path="EclDirectAccess"
+                         resource="EclDirectAccess"
+                         service="ecldirect"/>
+   </EspBinding>
+   <EspBinding defaultForPort="true"
+               defaultServiceVersion=""
+               name="ws_ecl"
+               port="8002"
+               protocol="http"
+               resourcesBasedn="ou=WsEcl,ou=EspServices,ou=ecl"
+               service="ws_ecl"
+               workunitsBasedn="ou=workunits,ou=ecl"
+               wsdlServiceAddress="">
+    <Authenticate access="Read"
+                  description="Root access to WS ECL service"
+                  path="/"
+                  required="Read"
+                  resource="WsEclAccess"/>
+    <AuthenticateFeature authenticate="Yes"
+                         description="Access to WS ECL service"
+                         path="WsEclAccess"
+                         resource="WsEclAccess"
+                         service="ws_ecl"/>
+   </EspBinding>
+   <HTTPS acceptSelfSigned="true"
+          CA_Certificates_Path="ca.pem"
+          certificateFileName="certificate.cer"
+          city=""
+          country="US"
+          daysValid="365"
+          enableVerification="false"
+          organization="Customer of HPCCSystems"
+          organizationalUnit=""
+          passphrase=""
+          privateKeyFileName="privatekey.cer"
+          regenerateCredentials="false"
+          requireAddressMatch="false"
+          state=""
+          trustedPeers="anyone"/>
+   <Instance computer="localhost"
+             directory="/var/lib/HPCCSystems/myesp"
+             FQDN=""
+             name="s1"
+             netAddress="."/>
+  </EspProcess>
+  <EspService ActivityInfoCacheSeconds="10"
+              allowNewRoxieOnDemandQuery="false"
+              AWUsCacheTimeout="15"
+              build="_"
+              buildSet="espsmc"
+              description="ESP services for SMC"
+              disableUppercaseTranslation="false"
+              enableSystemUseRewrite="false"
+              excludePartitions="/,/dev*,/sys,/usr,/proc/*"
+              monitorDaliFileServer="false"
+              name="EclWatch"
+              pluginsPath="/opt/HPCCSystems/plugins"
+              syntaxCheckQueue=""
+              viewTimeout="1000"
+              warnIfCpuLoadOver="95"
+              warnIfFreeMemoryUnder="5"
+              warnIfFreeStorageUnder="5">
+   <Properties defaultPort="8010"
+               defaultResourcesBasedn="ou=SMC,ou=EspServices,ou=ecl"
+               defaultSecurePort="18010"
+               type="WsSMC">
+    <Authenticate access="Read"
+                  description="Root access to SMC service"
+                  path="/"
+                  required="Read"
+                  resource="SmcAccess"/>
+    <AuthenticateFeature description="Access to SMC service"
+                         path="SmcAccess"
+                         resource="SmcAccess"
+                         service="ws_smc"/>
+    <AuthenticateFeature description="Access to thor queues"
+                         path="ThorQueueAccess"
+                         resource="ThorQueueAccess"
+                         service="ws_smc"/>
+    <AuthenticateFeature description="Access to roxie control commands"
+                         path="RoxieControlAccess"
+                         resource="RoxieControlAccess"
+                         service="ws_smc"/>
+    <AuthenticateFeature description="Access to super computer environment"
+                         path="ConfigAccess"
+                         resource="ConfigAccess"
+                         service="ws_config"/>
+    <AuthenticateFeature description="Access to DFU"
+                         path="DfuAccess"
+                         resource="DfuAccess"
+                         service="ws_dfu"/>
+    <AuthenticateFeature description="Access to DFU XRef"
+                         path="DfuXrefAccess"
+                         resource="DfuXrefAccess"
+                         service="ws_dfuxref"/>
+    <AuthenticateFeature description="Access to machine information"
+                         path="MachineInfoAccess"
+                         resource="MachineInfoAccess"
+                         service="ws_machine"/>
+    <AuthenticateFeature description="Access to SNMP metrics information"
+                         path="MetricsAccess"
+                         resource="MetricsAccess"
+                         service="ws_machine"/>
+    <AuthenticateFeature description="Access to remote execution"
+                         path="ExecuteAccess"
+                         resource="ExecuteAccess"
+                         service="ws_machine"/>
+    <AuthenticateFeature description="Access to DFU workunits"
+                         path="DfuWorkunitsAccess"
+                         resource="DfuWorkunitsAccess"
+                         service="ws_fs"/>
+    <AuthenticateFeature description="Access to DFU exceptions"
+                         path="DfuExceptionsAccess"
+                         resource="DfuExceptions"
+                         service="ws_fs"/>
+    <AuthenticateFeature description="Access to spraying files"
+                         path="FileSprayAccess"
+                         resource="FileSprayAccess"
+                         service="ws_fs"/>
+    <AuthenticateFeature description="Access to despraying of files"
+                         path="FileDesprayAccess"
+                         resource="FileDesprayAccess"
+                         service="ws_fs"/>
+    <AuthenticateFeature description="Access to dkcing of key files"
+                         path="FileDkcAccess"
+                         resource="FileDkcAccess"
+                         service="ws_fs"/>
+    <AuthenticateFeature description="Access to file upload"
+                         path="FileUploadAccess"
+                         resource="FileUploadAccess"
+                         service="ws_fs"/>
+    <AuthenticateFeature description="Access to files in dropzone"
+                         path="FileIOAccess"
+                         resource="FileIOAccess"
+                         service="ws_fileio"/>
+    <AuthenticateFeature description="Access to permissions for file scopes"
+                         path="FileScopeAccess"
+                         resource="FileScopeAccess"
+                         service="ws_access"/>
+    <AuthenticateFeature description="Access to WS ECL service"
+                         path="WsEclAccess"
+                         resource="WsEclAccess"
+                         service="ws_ecl"/>
+    <AuthenticateFeature description="Access to Roxie queries and files"
+                         path="RoxieQueryAccess"
+                         resource="RoxieQueryAccess"
+                         service="ws_roxiequery"/>
+    <AuthenticateFeature description="Access to cluster topology"
+                         path="ClusterTopologyAccess"
+                         resource="ClusterTopologyAccess"
+                         service="ws_topology"/>
+    <AuthenticateFeature description="Access to own workunits"
+                         path="OwnWorkunitsAccess"
+                         resource="OwnWorkunitsAccess"
+                         service="ws_workunits"/>
+    <AuthenticateFeature description="Access to others&apos; workunits"
+                         path="OthersWorkunitsAccess"
+                         resource="OthersWorkunitsAccess"
+                         service="ws_workunits"/>
+    <AuthenticateFeature description="Access to ECL direct service"
+                         path="EclDirectAccess"
+                         resource="EclDirectAccess"
+                         service="ecldirect"/>
+    <ProcessFilters>
+     <Platform name="Windows">
+      <ProcessFilter name="any">
+       <Process name="dafilesrv"/>
+      </ProcessFilter>
+      <ProcessFilter multipleInstances="true" name="DfuServerProcess"/>
+      <ProcessFilter multipleInstances="true" name="EclCCServerProcess"/>
+      <ProcessFilter multipleInstances="true" name="EspProcess">
+       <Process name="dafilesrv" remove="true"/>
+      </ProcessFilter>
+     </Platform>
+     <Platform name="Linux">
+      <ProcessFilter name="any">
+       <Process name="dafilesrv"/>
+      </ProcessFilter>
+      <ProcessFilter multipleInstances="true" name="DfuServerProcess"/>
+      <ProcessFilter multipleInstances="true" name="EclCCServerProcess"/>
+      <ProcessFilter multipleInstances="true" name="EspProcess">
+       <Process name="dafilesrv" remove="true"/>
+      </ProcessFilter>
+      <ProcessFilter name="GenesisServerProcess">
+       <Process name="httpd"/>
+       <Process name="atftpd"/>
+       <Process name="dhcpd"/>
+      </ProcessFilter>
+     </Platform>
+    </ProcessFilters>
+   </Properties>
+  </EspService>
+  <EspService build="_"
+              buildSet="ws_ecl"
+              description="WS ECL Service"
+              name="ws_ecl">
+   <Properties bindingType="ws_eclSoapBinding"
+               defaultPort="8002"
+               defaultResourcesBasedn="ou=WsEcl,ou=EspServices,ou=ecl"
+               defaultSecurePort="18002"
+               plugin="ws_ecl"
+               type="ws_ecl">
+    <Authenticate access="Read"
+                  description="Root access to WS ECL service"
+                  path="/"
+                  required="Read"
+                  resource="WsEclAccess"/>
+    <AuthenticateFeature description="Access to WS ECL service"
+                         path="WsEclAccess"
+                         resource="WsEclAccess"
+                         service="ws_ecl"/>
+   </Properties>
+  </EspService>
+  <FTSlaveProcess build="_"
+                  buildSet="ftslave"
+                  description="FTSlave process"
+                  name="myftslave"
+                  version="1">
+   <Instance computer="localhost"
+             directory="/var/lib/HPCCSystems/myftslave"
+             name="s1"
+             netAddress="."
+             program="/opt/HPCCSystems/bin/ftslave"/>
+  </FTSlaveProcess>
+  <Hardware_NEW attrib1name="gleb1">
+     <Computer computerType="linuxmachine"
+             domain="localdomain"
+             name="localhost"
+             netAddress="."/>
+   <ComputerType computerType="linuxmachine"
+                 manufacturer="unknown"
+                 name="linuxmachine"
+                 opSys="linux"/>
+   <Domain name="localdomain" snmpSecurityString=""/>
+   <Switches name="Switch">
+        <Deep2>
+            <Switch5>
+                <deep6>
+                    <table1 name7="hi1"/>
+                </deep6>
+            </Switch5>
+        </Deep2>
+   </Switches>
+  </Hardware_NEW>
+  <Hardware_NEW2>
+   <Computer computerType="linuxmachine"
+             domain="localdomain"
+             name="localhost"
+             netAddress="."/>
+   <ComputerType computerType="typ1"
+                 manufacturer="manu1"
+                 name="name1"
+                 opSys="user1"/>
+   <ComputerType computerType="typ1"
+                 manufacturer="manu1"
+                 name="name2"
+                 opSys="user1"/>
+   <ComputerType computerType="typ1"
+                 manufacturer="manu1"
+                 name="name3"
+                 opSys="user1"/>
+   <ComputerType computerType="typ1"
+                 manufacturer="manu1"
+                 name="name4"
+                 opSys="user1"/>
+   <ComputerType computerType="linuxmachine"
+                 manufacturer="unknown"
+                 name="linuxmachine"
+                 opSys="linux"/>
+   <Domain name="localdomain" snmpSecurityString="123"/>
+   <Domains name="domain1" snmpSecurityString="setting1"/>
+   <Level1-Item1 name="req1" name2="reg1">
+    <Level2-Item1 nameA1="reqA1" nameA2="regA1"/>
+   </Level1-Item1>
+   <NAS trace="trace1"/>
+   <NAS subnet="192.168.0.255" trace="trace2"/>
+   <Switch name="Switc1h"/>
+   <Switch name="Switc2h"/>
+   <Switches name="switch1"/>
+  </Hardware_NEW2>
+  <RoxieCluster allFilesDynamic="true"
+                blindLogging="false"
+                blobCacheMem="0"
+                build="_"
+                buildSet="roxie"
+                callbackRetries="3"
+                callbackTimeout="500"
+                channelsPerNode="1"
+                checkCompleted="true"
+                checkFileDate="true"
+                clusterWidth="1"
+                copyResources="false"
+                crcResources="false"
+                dafilesrvLookupTimeout="10000"
+                daliServers="mydali"
+                debugPermitted="true"
+                defaultConcatPreload="0"
+                defaultFetchPreload="0"
+                defaultFullKeyedJoinPreload="0"
+                defaultHighPriorityTimeLimit="0"
+                defaultHighPriorityTimeWarning="5000"
+                defaultKeyedJoinPreload="0"
+                defaultLowPriorityTimeLimit="0"
+                defaultLowPriorityTimeWarning="0"
+                defaultMemoryLimit="0"
+                defaultParallelJoinPreload="0"
+                defaultPrefetchProjectPreload="10"
+                defaultSLAPriorityTimeLimit="0"
+                defaultSLAPriorityTimeWarning="5000"
+                defaultStripLeadingWhitespace="true"
+                description="Roxie cluster"
+                directory="/var/lib/HPCCSystems/myroxie"
+                diskReadBufferSize="65536"
+                doIbytiDelay="true"
+                enableHeartBeat="true"
+                enableKeyDiff="true"
+                enableSysLog="true"
+                fastLaneQueue="true"
+                fieldTranslationEnabled="false"
+                flushJHtreeCacheOnOOM="true"
+                forceStdLog="false"
+                highTimeout="2000"
+                ignoreMissingFiles="false"
+                ignoreOrphans="true"
+                indexReadChunkSize="60000"
+                initIbytiDelay="100"
+                jumboFrames="false"
+                lazyOpen="smart"
+                leafCacheMem="50"
+                linuxYield="false"
+                localFilesExpire="-1"
+                localSlave="true"
+                lockSuperFiles="false"
+                logFullQueries="false"
+                logQueueDrop="32"
+                logQueueLen="512"
+                lowTimeout="10000"
+                maxBlockSize="10000000"
+                maxLocalFilesOpen="4000"
+                maxLockAttempts="5"
+                maxRemoteFilesOpen="1000"
+                memoryStatsInterval="60"
+                memTraceLevel="1"
+                memTraceSizeLimit="0"
+                minFreeDiskSpace="1073741824"
+                minIbytiDelay="0"
+                minLocalFilesOpen="2000"
+                minRemoteFilesOpen="500"
+                miscDebugTraceLevel="0"
+                monitorDaliFileServer="false"
+                multicastBase="239.1.1.1"
+                multicastLast="239.1.254.254"
+                name="myroxie"
+                nodeCacheMem="100"
+                nodeCachePreload="false"
+                numDataCopies="1"
+                parallelAggregate="0"
+                perChannelFlowLimit="10"
+                pingInterval="60"
+                pluginsPath="/opt/HPCCSystems/plugins"
+                preabortIndexReadsThreshold="100"
+                preabortKeyedJoinsThreshold="100"
+                preferredSubnet=""
+                preferredSubnetMask=""
+                preloadOnceData="true"
+                remoteFilesExpire="3600000"
+                roxieMulticastEnabled="true"
+                serverSideCacheSize="0"
+                serverThreads="30"
+                simpleLocalKeyedJoins="true"
+                siteCertificate=""
+                slaTimeout="2000"
+                slaveConfig="simple"
+                slaveQueryReleaseDelaySeconds="60"
+                slaveThreads="30"
+                soapTraceLevel="1"
+                socketCheckInterval="5000"
+                SSHidentityfile="$HOME/.ssh/id_rsa"
+                SSHpassword=""
+                SSHretries="3"
+                SSHtimeout="0"
+                SSHusername="hpcc"
+                statsExpiryTime="3600"
+                systemMonitorInterval="60000"
+                totalMemoryLimit="1073741824"
+                traceLevel="1"
+                trapTooManyActiveQueries="true"
+                udpFlowSocketsSize="131071"
+                udpInlineCollation="false"
+                udpInlineCollationPacketLimit="50"
+                udpLocalWriteSocketSize="131071"
+                udpMaxRetryTimedoutReqs="0"
+                udpMaxSlotsPerClient="2147483647"
+                udpMulticastBufferSize="131071"
+                udpOutQsPriority="0"
+                udpQueueSize="100"
+                udpRequestToSendTimeout="5"
+                udpResendEnabled="false"
+                udpRetryBusySenders="0"
+                udpSendCompletedInData="false"
+                udpSendQueueSize="50"
+                udpSnifferEnabled="true"
+                udpTraceLevel="1"
+                useHardLink="false"
+                useLogQueue="true"
+                useMemoryMappedIndexes="false"
+                useRemoteResources="true"
+                useTreeCopy="false">
+   <RoxieFarmProcess aclName=""
+                     listenQueue="200"
+                     name="farm1"
+                     numThreads="30"
+                     port="9876"
+                     requestArrayThreads="5"/>
+   <RoxieFarmProcess aclName=""
+                     listenQueue="200"
+                     name="farm2"
+                     numThreads="30"
+                     port="0"
+                     requestArrayThreads="5"/>
+   <RoxieServerProcess computer="localhost" name="s1" netAddress="."/>
+  </RoxieCluster>
+  <Sample_Attributes1 attribute1="attribute1"
+                      attribute2="attribute2"
+                      attribute3="attribute3"
+                      attribute4="attribute4">
+   <Attributes a11="a1"/>
+   <Attributes a11="a2"/>
+   <Attributes a11="a3"/>
+   <Attributes a11="a4"/>
+   <Attributes a11="new"/>
+   <Level1-Item1 aa1name2="5" ab2name2="3" ac3name2="2"/>
+   <tab3 tab3-1="val1" tab3-2="val2"/>
+   <tab4>
+    <tab4>
+       <tab6c>
+        <tab7 tab6c-1="hello1"/>
+       </tab6c>
+        </tab4>
+    <tab5 tab5-1="deep1"/>
+    <tab6>
+     <tab6-sub tab6-2="deep2"/>
+    </tab6>
+   </tab4>
+  </Sample_Attributes1>
+  <SashaServerProcess autoRestartInterval="0"
+                      build="_"
+                      buildSet="sasha"
+                      cachedWUat="* * * * *"
+                      cachedWUinterval="24"
+                      cachedWUlimit="100"
+                      coalesceAt="* * * * *"
+                      coalesceInterval="1"
+                      dafsmonAt="* * * * *"
+                      dafsmonInterval="0"
+                      dafsmonList="*"
+                      daliServers="mydali"
+                      description="Sasha Server process"
+                      DFUrecoveryAt="* * * * *"
+                      DFUrecoveryCutoff="4"
+                      DFUrecoveryInterval="12"
+                      DFUrecoveryLimit="20"
+                      DFUWUat="* * * * *"
+                      DFUWUcutoff="14"
+                      DFUWUduration="0"
+                      DFUWUinterval="24"
+                      DFUWUlimit="1000"
+                      DFUWUthrottle="0"
+                      ExpiryAt="* 3 * * *"
+                      ExpiryInterval="24"
+                      keepResultFiles="false"
+                      LDSroot="LDS"
+                      logDir="."
+                      minDeltaSize="50000"
+                      name="mysasha"
+                      recoverDeltaErrors="false"
+                      thorQMonInterval="1"
+                      thorQMonQueues="*"
+                      thorQMonSwitchMinTime="0"
+                      WUat="* * * * *"
+                      WUbackup="0"
+                      WUcutoff="8"
+                      WUduration="0"
+                      WUinterval="6"
+                      WUlimit="1000"
+                      WUretryinterval="7"
+                      WUthrottle="0"
+                      xrefAt="* 2 * * *"
+                      xrefCutoff="1"
+                      xrefEclWatchProvider="true"
+                      xrefInterval="672"
+                      xrefList="*"
+                      xrefMaxMemory="4096">
+   <Instance computer="localhost"
+             directory="/var/lib/HPCCSystems/mysasha"
+             name="s1"
+             netAddress="."
+             port="8877"/>
+  </SashaServerProcess>
+  <ThorCluster autoCopyBackup="false"
+               build="_"
+               buildSet="thor"
+               computer="localhost"
+               daliServers="mydali"
+               description="Thor process"
+               localThor="true"
+               monitorDaliFileServer="true"
+               name="mythor"
+               pluginsPath="/opt/HPCCSystems/plugins"
+               replicateAsync="false"
+               replicateOutputs="false"
+               slavesPerNode="1"
+               watchdogEnabled="true"
+               watchdogProgressEnabled="true">
+   <Debug/>
+   <SSH SSHidentityfile="$HOME/.ssh/id_rsa"
+        SSHpassword=""
+        SSHretries="3"
+        SSHtimeout="0"
+        SSHusername="hpcc"/>
+   <Storage/>
+   <SwapNode/>
+   <ThorMasterProcess computer="localhost" name="m1"/>
+   <ThorSlaveProcess computer="localhost" name="s1"/>
+  </ThorCluster>
+  <Topology build="_" buildSet="topology" name="topology">
+   <Cluster name="hthor" prefix="hthor">
+    <EclAgentProcess process="myeclagent"/>
+    <EclCCServerProcess process="myeclccserver"/>
+    <EclSchedulerProcess process="myeclscheduler"/>
+   </Cluster>
+   <Cluster name="thor" prefix="thor">
+    <EclAgentProcess process="myeclagent"/>
+    <EclCCServerProcess process="myeclccserver"/>
+    <EclSchedulerProcess process="myeclscheduler"/>
+    <ThorCluster process="mythor"/>
+   </Cluster>
+   <Cluster name="roxie" prefix="roxie">
+    <EclCCServerProcess process="myeclccserver"/>
+    <EclSchedulerProcess process="myeclscheduler"/>
+    <RoxieCluster process="myroxie"/>
+   </Cluster>
+   <Cluster name="thor_roxie" prefix="thor">
+    <EclCCServerProcess process="myeclccserver"/>
+    <EclSchedulerProcess process="myeclscheduler"/>
+    <RoxieCluster process="myroxie"/>
+    <ThorCluster process="mythor"/>
+   </Cluster>
+  </Topology>
+ </Software>
+</Environment>


### PR DESCRIPTION
```
- ConfigMgr 2.0 Initial baseline
```

Refer to: https://github.com/hpcc-systems/HPCC-Platform/pull/7531

```
    - Changes include
    - Code refactoring to remove Dojo UI prototype code, removal of unneeded files, and compaction of code.
    - Comments in previous commit incorporated
    - Specifically:  
        - tighter more compact code
        - most comments removed
        - prototyped code removed
        - standard use of UNIMPLEMENTED macro
        - confirmed standard use of QT environment variable for builds
        - removed static variable for string arrays
    - Added copyright
```

Signed-off-by: Gleb Aronsky gleb.aronsky@lexisnexis.com
