### PR TITLE
HPCC-14111 To dfuplus, add capability to export and restore super files.

### DIFF
--- a/dali/base/dadfs.hpp
+++ b/dali/base/dadfs.hpp
@@ -395,6 +395,8 @@ interface IDistributedFile: extends IInterface
     
     virtual unsigned setDefaultTimeout(unsigned timems) = 0;                                // sets default timeout for SDS connections and locking
                                                                                             // returns previous value
+
+    virtual void validate() = 0;
 };
 
 
@@ -409,6 +411,7 @@ interface IDistributedFile: extends IInterface
  */
 interface IDistributedSuperFile: extends IDistributedFile
 {
+
     virtual IDistributedFileIterator *getSubFileIterator(bool supersub=false)=0;    // if supersub true recurse through sub-superfiles and only return normal files
     virtual void addSubFile(const char *subfile,
                             bool before=false,              // if true before other
@@ -432,7 +435,7 @@ interface IDistributedSuperFile: extends IDistributedFile
     virtual IDistributedFile *querySubFileNamed(const char *name,bool sub=true)=0;
     virtual unsigned numSubFiles(bool sub=false)=0;
 
-    // useful part funtions
+    // useful part functions
     virtual bool isInterleaved()=0;
     virtual IDistributedFile *querySubPart(unsigned partidx,                // superfile part index
                                            unsigned &subfilepartidx)=0;     // part index in subfile
@@ -580,6 +583,7 @@ interface IDistributedFileDirectory: extends IInterface
     virtual IFileDescriptor *getFileDescriptor(const char *lname,IUserDescriptor *user,const INode *foreigndali=NULL, unsigned foreigndalitimeout=FOREIGN_DALI_TIMEOUT) =0;
 
     virtual IDistributedSuperFile *createSuperFile(const char *logicalname,IUserDescriptor *user,bool interleaved,bool ifdoesnotexist=false,IDistributedFileTransaction *transaction=NULL) = 0;
+    virtual IDistributedSuperFile *createNewSuperFile(IPropertyTree *tree) = 0;
     virtual IDistributedSuperFile *lookupSuperFile(const char *logicalname,IUserDescriptor *user,
                                                     IDistributedFileTransaction *transaction=NULL, // transaction only used for looking up sub files
                                                     unsigned timeout=INFINITE) = 0;  // NB lookup will also return superfiles

--- a/dali/base/dafdesc.cpp
+++ b/dali/base/dafdesc.cpp
@@ -1975,7 +1975,6 @@ public:
         subfilecounts = NULL;
     }
 
-
     virtual ~CSuperFileDescriptor()
     {
         delete subfilecounts;
@@ -2330,7 +2329,6 @@ IFileDescriptor *deserializeFileDescriptorTree(IPropertyTree *tree, INamedGroupS
 {
     return new CFileDescriptor(tree, resolver, flags);
 }
-
 
 inline bool validFNameChar(char c)
 {

--- a/dali/dfuplus/dfuplus.cpp
+++ b/dali/dfuplus/dfuplus.cpp
@@ -1212,11 +1212,11 @@ int CDfuPlusHelper::superfile(const char* action)
 
         if(stricmp(action, "add") == 0)
         {
-            info("Addsuper successfully finished");
+            info("Addsuper successfully finished\n");
         }
         else if(stricmp(action, "remove") == 0)
         {
-            info("Removesuper successfully finished");
+            info("Removesuper successfully finished\n");
         }
     }
     else if(stricmp(action, "list") == 0)
@@ -1353,7 +1353,7 @@ int CDfuPlusHelper::add()
         }
     }
 
-    info("%s successfully added", lfn);
+    info("%s successfully added\n", lfn);
     return 0;
 }
 
@@ -1399,7 +1399,7 @@ int CDfuPlusHelper::status()
             return -1;
 
         case DFUstate_failed:
-            info("%s status: failed - %s", wuid, dfuwu.getSummaryMessage());
+            info("%s status: failed - %s\n", wuid, dfuwu.getSummaryMessage());
             return -1;
 
         case DFUstate_finished:

--- a/system/jlib/jsocket.cpp
+++ b/system/jlib/jsocket.cpp
@@ -5720,7 +5720,8 @@ void SocketEndpointArray::fromText(const char *text,unsigned defport)
     // this is quite complicated with (mixed) IPv4 and IPv6
     // only support 'full' IPv6 and no ranges
 
-
+    if (!text)
+        return;
     char *str = strdup(text);
     char *s = str;
     SocketEndpoint ep;


### PR DESCRIPTION
Improve savexml action to generate proper logical and super file xml blob.

Improve add action to load simple logical and superfile metainformation
from an XML file. If the restored metainformation belong to a superfile
then update all sub-files SuperOwner tag.

Fix missing '\n' at the end of some DFUPlus return messages.

Signed-off-by: Attila Vamos attila.vamos@gmail.com
