### PR TITLE
HPCC-14194 DFUServer asserted in wildcard fixed spray if there is no input file.

### DIFF
--- a/dali/dfuplus/dfuplus.cpp
+++ b/dali/dfuplus/dfuplus.cpp
@@ -343,6 +343,9 @@ bool CDfuPlusHelper::fixedSpray(const char* srcxml,const char* srcip,const char*
     if(globals->hasProp("transferbuffersize"))
         req->setTransferBufferSize(globals->getPropInt("transferbuffersize"));
 
+    if(globals->hasProp("failIfNoSourceFile"))
+        req->setFailIfNoSourceFile(globals->getPropBool("failIfNoSourceFile",false));
+
     if(srcxml == NULL)
         info("\nFixed spraying from %s on %s to %s\n", srcfile, srcip, dstname);
     else

--- a/dali/ft/filecopy.cpp
+++ b/dali/ft/filecopy.cpp
@@ -2902,6 +2902,9 @@ bool FileSprayer::isSameSizeHeaderFooter()
     headerSize = 0;
     footerSize = 0;
 
+    if (sources.ordinality() == 0)
+        return retVal;
+
     ForEachItemIn(idx, partition)
     {
         PartitionPoint & cur = partition.item(idx);


### PR DESCRIPTION
Pass 'failIfNoSourceFile' parameter from DFUPlus to DFUServer for
fixed spray.

Prevent source file header/footer length checking if there is no source.

Signed-off-by: Attila Vamos attila.vamos@gmail.com
