### PR TITLE
HPCC-14195 LZ directories should default to closed

### DIFF
--- a/esp/src/eclwatch/LZBrowseWidget.js
+++ b/esp/src/eclwatch/LZBrowseWidget.js
@@ -78,7 +78,6 @@ define([
         templateString: template,
         baseClass: "LZBrowseWidget",
         i18n: nlsHPCC,
-        firstLoad: true,
 
         postCreate: function (args) {
             this.inherited(arguments);
@@ -557,12 +556,6 @@ define([
                     displayName: tree({
                         label: this.i18n.Name,
                         sortable: false,
-                        shouldExpand: function (row, level, previouslyExpanded) {
-                            if (context.firstLoad === true) {
-                                return true;
-                            }
-                            return previouslyExpanded;
-                        },
                         formatter: function (_name, row) {
                             var img = "";
                             var name = _name;
@@ -694,7 +687,6 @@ define([
         },
 
         refreshGrid: function (clearSelection) {
-            this.firstLoad = false;
             this.landingZonesGrid.set("query", {
                 id: "*"
             });


### PR DESCRIPTION
We should initially collapse all Landing Zone directories to closed to eliminateunnecessary calls.

Signed-off by: Miguel Vazquez miguel.vazquez@lexisnexis.com
