### PR TITLE
HPCC-14209 Add missing member function rtlRowAttr::set()

### DIFF
--- a/rtl/eclrtl/rtlds_imp.hpp
+++ b/rtl/eclrtl/rtlds_imp.hpp
@@ -154,6 +154,7 @@ public:
     inline void setown(byte * _row)     { dispose(); row = _row; }
     inline void set(const void * _row)  { rtlLinkRow(_row); setown(_row); }
     inline void setown(const void * _row)   { dispose(); row = static_cast<byte *>(const_cast<void *>(_row)); } // ugly - need to clean up const tracking in code generator
+    inline void set(const rtlRowAttr & other) { set(other.getbytes()); }
 
 protected:
     inline void dispose()               { rtlReleaseRow(row); }


### PR DESCRIPTION
Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
