### PR TITLE
HPCC-13547 Add WsSMC.LockQuery to report locks

### DIFF
--- a/esp/scm/ws_smc.ecm
+++ b/esp/scm/ws_smc.ecm
@@ -369,6 +369,7 @@ ESPStruct [nil_remove] Lock
 {
     string EPIP;
     string XPath;
+    string LogicalFile;
     int64 SessionID;
     unsigned DurationMS;
     string TimeLocked;

--- a/esp/scm/ws_smc.ecm
+++ b/esp/scm/ws_smc.ecm
@@ -357,6 +357,43 @@ GetStatusServerInfoResponse
     ESPstruct StatusServerInfo StatusServerInfo;
 };
 
+ESPenum LockModes : string
+{
+    READ("READ"),
+    WRITE("WRITE"),
+    HOLD("HOLD"),
+    SUB("SUB")
+};
+
+ESPStruct [nil_remove] Lock
+{
+    string EPIP;
+    string XPath;
+    int64 SessionID;
+    unsigned DurationMS;
+    string TimeLocked;
+    string Modes;
+    ESParray<string> ModeNames;
+};
+
+ESPrequest [nil_remove] LockQueryRequest
+{
+    string EPIP;
+    string XPath;
+    unsigned DurationMSLow;
+    unsigned DurationMSHigh;
+    string TimeLockedLow;
+    string TimeLockedHigh;
+    ESPenum LockModes Mode;
+    bool AllFileLocks(false);
+};
+
+ESPresponse [exceptions_inline] LockQueryResponse
+{
+    ESParray<ESPstruct Lock> Locks;
+    int NumLocks;
+};
+
 ESPservice [noforms, version("1.19"), exceptions_inline("./smc_xslt/exceptions.xslt"), use_method_name] WsSMC
 {
     ESPmethod Index(SMCIndexRequest, SMCIndexResponse);
@@ -383,6 +420,7 @@ ESPservice [noforms, version("1.19"), exceptions_inline("./smc_xslt/exceptions.x
 
     ESPmethod RoxieControlCmd(RoxieControlCmdRequest, RoxieControlCmdResponse);
     ESPmethod GetStatusServerInfo(GetStatusServerInfoRequest, GetStatusServerInfoResponse);
+    ESPmethod LockQuery(LockQueryRequest, LockQueryResponse);
 };
 
 SCMexportdef(WSSMC);

--- a/esp/scm/ws_smc.ecm
+++ b/esp/scm/ws_smc.ecm
@@ -359,6 +359,7 @@ GetStatusServerInfoResponse
 
 ESPenum LockModes : string
 {
+    ALL("ALL"),
     READ("READ"),
     WRITE("WRITE"),
     HOLD("HOLD"),

--- a/esp/services/ws_smc/ws_smcService.hpp
+++ b/esp/services/ws_smc/ws_smcService.hpp
@@ -19,6 +19,7 @@
 #define _ESPWIZ_WsSMC_HPP__
 
 #include "ws_smc_esp.ipp"
+#include "dautils.hpp"
 #include "wujobq.hpp"
 #include "TpWrapper.hpp"
 #include "WUXMLInfo.hpp"
@@ -194,6 +195,7 @@ public:
     virtual bool onBrowseResources(IEspContext &context, IEspBrowseResourcesRequest & req, IEspBrowseResourcesResponse & resp);
     virtual bool onRoxieControlCmd(IEspContext &context, IEspRoxieControlCmdRequest &req, IEspRoxieControlCmdResponse &resp);
     virtual bool onGetStatusServerInfo(IEspContext &context, IEspGetStatusServerInfoRequest &req, IEspGetStatusServerInfoResponse &resp);
+    virtual bool onLockQuery(IEspContext &context, IEspLockQueryRequest &req, IEspLockQueryResponse &resp);
 private:
     void addCapabilities( IPropertyTree* pFeatureNode, const char* access, IArrayOf<IEspCapability>& capabilities);
     void addServerJobQueue(IArrayOf<IEspServerJobQueue>& jobQueues, const char* queueName, const char* serverName,
@@ -231,6 +233,7 @@ private:
     void setActiveWUs(IEspContext &context, const char *serverType, const char *clusterName, const char *queueName, const IArrayOf<IEspActiveWorkunit>& aws, IEspStatusServerInfo& statusServerInfo);
     void setActiveWUs(IEspContext &context, const char *serverType, const char *instance, const IArrayOf<IEspActiveWorkunit>& aws, IEspStatusServerInfo& statusServerInfo);
     void setActiveWUs(IEspContext &context, IEspActiveWorkunit& wu, IEspActiveWorkunit* wuToSet);
+    void addLockInfo(CLockMetaData& lD, const char* xPath, unsigned msNow, time_t ttNow, IArrayOf<IEspLock>& locks);
 };
 
 

--- a/esp/services/ws_smc/ws_smcService.hpp
+++ b/esp/services/ws_smc/ws_smcService.hpp
@@ -233,7 +233,7 @@ private:
     void setActiveWUs(IEspContext &context, const char *serverType, const char *clusterName, const char *queueName, const IArrayOf<IEspActiveWorkunit>& aws, IEspStatusServerInfo& statusServerInfo);
     void setActiveWUs(IEspContext &context, const char *serverType, const char *instance, const IArrayOf<IEspActiveWorkunit>& aws, IEspStatusServerInfo& statusServerInfo);
     void setActiveWUs(IEspContext &context, IEspActiveWorkunit& wu, IEspActiveWorkunit* wuToSet);
-    void addLockInfo(CLockMetaData& lD, const char* xPath, unsigned msNow, time_t ttNow, IArrayOf<IEspLock>& locks);
+    void addLockInfo(CLockMetaData& lD, const char* xPath, const char* lfn, unsigned msNow, time_t ttNow, IArrayOf<IEspLock>& locks);
 };
 
 


### PR DESCRIPTION
This new method is used to retrieve locks with optional
filters: endpoint IP, duration, locked time, mode (READ,
WRITE, etc), and xpath.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
