### PR TITLE
HPCC-14212 Add node subscription could cause deadlock

### DIFF
--- a/dali/base/dasds.cpp
+++ b/dali/base/dasds.cpp
@@ -2809,6 +2809,8 @@ public:
     // ISubscriptionManager impl.
     virtual void add(ISubscription *sub, SubscriptionId id)
     {
+        CHECKEDDALIREADLOCKBLOCK(owner.dataRWLock, readWriteTimeout);
+        CHECKEDCRITICALBLOCK(owner.treeRegCrit, fakeCritTimeout);
         CriticalBlock b(lock);
         /* calls back out to owner to scan for match, so that SDSManager can protect root/treereg.
          * It calls back (associateSubscriber) in this class to add subscribers based on matches.
@@ -8636,8 +8638,6 @@ void CCovenSDSManager::addNodeSubscriber(ISubscription *sub, SubscriptionId id)
     mb.read(xpath);
     mb.read(sendValue);
 
-    CHECKEDDALIREADLOCKBLOCK(dataRWLock, readWriteTimeout);
-    CHECKEDCRITICALBLOCK(treeRegCrit, fakeCritTimeout);
     Owned<IPropertyTreeIterator> iter = root->getElements(xpath+1);
     if (!iter->first())
         throw MakeSDSException(SDSExcpt_SubscriptionNoMatch, "Failed to match any nodes: %s", xpath.get());


### PR DESCRIPTION
Add node subscription grabbed the subscriber crit 1st, then
the SDS data lock, this could deadlock with others who already
have the SDS data lock, then interact with the subscriber
manager.

Fix by grabbing the SDS data lock 1st, similar to fix HPCC-14190

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
