### PR TITLE
HPCC-14252 Clear up a few minor MP leaks.

### DIFF
--- a/system/mp/mpcomm.cpp
+++ b/system/mp/mpcomm.cpp
@@ -2414,7 +2414,7 @@ public:
         }
 
         CTimeMon tm(timeout);
-        Linked<CMPChannel> channel = parent->lookup(dst->endpoint());
+        Owned<CMPChannel> channel = parent->lookup(dst->endpoint());
         unsigned remaining;
         if (tm.timedout(&remaining))
             return false;
@@ -2428,7 +2428,7 @@ public:
     {
         CriticalBlock block(verifysect);
         CTimeMon tm(timeout);
-        Linked<CMPChannel> channel = parent->lookup(node->endpoint());
+        Owned<CMPChannel> channel = parent->lookup(node->endpoint());
         unsigned remaining;
         if (tm.timedout(&remaining))
             return false;
@@ -2471,7 +2471,7 @@ public:
                 else
                     doverify = (myrank<rank);
                 if (doverify) {
-                    Linked<CMPChannel> channel = parent->lookup(group->queryNode(rank).endpoint());
+                    Owned<CMPChannel> channel = parent->lookup(group->queryNode(rank).endpoint());
                     unsigned remaining;
                     if (tm.timedout(&remaining)) {
                         return false;
@@ -2486,7 +2486,7 @@ public:
             ForEachNodeInGroup(rank,*group) {
                 bool doverify = ((rank&1)==(myrank&1))?(myrank<rank):(myrank>rank);
                 if (doverify) {
-                    Linked<CMPChannel> channel = parent->lookup(group->queryNode(rank).endpoint());
+                    Owned<CMPChannel> channel = parent->lookup(group->queryNode(rank).endpoint());
                     while (!channel->verifyConnection(tm,false)) {
                         unsigned remaining;
                         if (tm.timedout(&remaining))
@@ -2584,7 +2584,7 @@ public:
     void disconnect(INode *node)
     {
         CriticalBlock block(verifysect);
-        Linked<CMPChannel> channel = parent->lookup(node->endpoint());
+        Owned<CMPChannel> channel = parent->lookup(node->endpoint());
         channel->closeSocket();
         parent->removeChannel(channel);
     }
@@ -2661,7 +2661,7 @@ public:
                 endrank = dstrank;
             for (;dstrank<=endrank;dstrank++) {
                 if (dstrank!=myrank) {
-                    Linked<CMPChannel> channel = getChannel(dstrank);
+                    Owned<CMPChannel> channel = getChannel(dstrank);
                     unsigned remaining;
                     if (tm.timedout(&remaining))
                         return false;
@@ -2730,7 +2730,7 @@ public:
         assertex(rank!=RANK_RANDOM);
         assertex(rank!=RANK_ALL);
         CTimeMon tm(timeout);
-        Linked<CMPChannel> channel = getChannel(rank);
+        Owned<CMPChannel> channel = getChannel(rank);
         unsigned remaining;
         if (tm.timedout(&remaining))
             return false;
@@ -2752,7 +2752,7 @@ public:
                 else
                     doverify = (myrank<rank);
                 if (doverify) {
-                    Linked<CMPChannel> channel = getChannel(rank);
+                    Owned<CMPChannel> channel = getChannel(rank);
                     unsigned remaining;
                     if (tm.timedout(&remaining)) {
                         return false;
@@ -2766,7 +2766,7 @@ public:
             ForEachNodeInGroup(rank,*group) {
                 bool doverify = ((rank&1)==(myrank&1))?(myrank<rank):(myrank>rank);
                 if (doverify) {
-                    Linked<CMPChannel> channel = getChannel(rank);
+                    Owned<CMPChannel> channel = getChannel(rank);
                     while (!channel->verifyConnection(tm,false)) {
                         unsigned remaining;
                         if (tm.timedout(&remaining))
@@ -2882,7 +2882,7 @@ public:
         }
             
         CTimeMon tm(timeout);
-        Linked<CMPChannel> channel = parent->lookup(mbuf.getSender());
+        Owned<CMPChannel> channel = parent->lookup(mbuf.getSender());
         unsigned remaining;
         if (tm.timedout(&remaining)) {
             return false;
@@ -2929,6 +2929,14 @@ ICommunicator *createCommunicator(IGroup *group,bool outer)
 }
 
 static IInterCommunicator *worldcomm=NULL;
+MODULE_INIT(INIT_PRIORITY_STANDARD)
+{
+    return true;
+}
+MODULE_EXIT()
+{
+    ::Release(worldcomm);
+}
 
 IInterCommunicator &queryWorldCommunicator()
 {


### PR DESCRIPTION
Some spurious Linked vs Owned dealing with channels, meant they
were leaked and not cleared up on exit.
Has little impact since they are created once per destination,
and persist until end.

Also ensure worldComm is cleared up on module exit.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
