### PR TITLE
HPCC-14185 Support the option to sign code

### DIFF
--- a/ecl/hql/hqlgram.y
+++ b/ecl/hql/hqlgram.y
@@ -8795,7 +8795,7 @@ simpleDataSet
                             if (!parser->checkAllowed($1, "pipe", "PIPE"))
                                 attrs.setown(createComma(attrs.getClear(), createAttribute(_disallowed_Atom)));
                             parser->normalizeExpression($3, type_string, false);
-                            parser->checkValidPipeRecord($5, $5.queryExpr(), $6.queryExpr(), NULL);
+                            parser->checkValidPipeRecord($5, $5.queryExpr(), attrs, NULL);
                             $$.setExpr(createNewDataset(createConstant(""), $5.getExpr(), createValue(no_pipe, makeNullType(), $3.getExpr()), NULL, NULL, LINK(attrs)));
                             $$.setPosition($1);
                         }


### PR DESCRIPTION
Missing edit in prior fix caused pipe8 regression test to fail.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
