### PR TITLE
HPCC-14246 Allow DynamicESDL service methods to be written in JAVA

### DIFF
--- a/esp/services/esdl_svc_engine/CMakeLists.txt
+++ b/esp/services/esdl_svc_engine/CMakeLists.txt
@@ -48,6 +48,7 @@ include_directories (
          ${HPCC_SOURCE_DIR}/system/mp
          ${HPCC_SOURCE_DIR}/common/deftype
          ${HPCC_SOURCE_DIR}/common/environment
+         ${HPCC_SOURCE_DIR}/common/dllserver 
          ${HPCC_SOURCE_DIR}/common/thorhelper
          ${HPCC_SOURCE_DIR}/common/workunit
          ${HPCC_SOURCE_DIR}/common/wuwebview
@@ -57,6 +58,7 @@ include_directories (
          ${HPCC_SOURCE_DIR}/esp/esdllib
          ${HPCC_SOURCE_DIR}/esp/logging
          ${CMAKE_BINARY_DIR}
+         ${CMAKE_BINARY_DIR}/oss
     )
 
 ADD_DEFINITIONS( -D_USRDLL )
@@ -77,6 +79,7 @@ target_link_libraries ( esdl_svc_engine
          remote
          dalibase
          esdllib
+         dllserver
     )
 
 IF (USE_OPENSSL)

--- a/esp/services/ws_esdlconfig/CMakeLists.txt
+++ b/esp/services/ws_esdlconfig/CMakeLists.txt
@@ -35,6 +35,7 @@ set (    SRCS
 include_directories (
          ${HPCC_SOURCE_DIR}/dali/base
          ${HPCC_SOURCE_DIR}/common/environment
+         ${HPCC_SOURCE_DIR}/common/dllserver
          ${HPCC_SOURCE_DIR}/system/include
          ${HPCC_SOURCE_DIR}/system/jlib
          ${HPCC_SOURCE_DIR}/system/security/shared
@@ -62,4 +63,5 @@ target_link_libraries ( ws_esdlconfig
          jlib
          esphttp
          environment
+         dllserver
     )

--- a/plugins/javaembed/javaembed.cpp
+++ b/plugins/javaembed/javaembed.cpp
@@ -3173,3 +3173,10 @@ JNIEXPORT jobject JNICALL Java_com_HPCCSystems_HpccUtils__1next (JNIEnv *JNIenv,
         return NULL;
     }
 }
+
+// Used for dynamically loading in ESDL
+
+extern "C" EXPORT IEmbedContext *getEmbedContextDynamic()
+{
+    return javaembed::getEmbedContext();
+}

--- a/rtl/eclrtl/eclrtl.hpp
+++ b/rtl/eclrtl/eclrtl.hpp
@@ -836,4 +836,6 @@ interface IEmbedContext : extends IInterface
     // MORE - add syntax checked here!
 };
 
+typedef IEmbedContext * (* GetEmbedContextFunction)();
+
 #endif


### PR DESCRIPTION
Fix some build issues.

Load java plugin dynamically so that jvm is only loaded when the feature is
used.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
