### PR TITLE
HPCC-14266 TargetIP being ignored and assumed to be same as engine IP's.

### DIFF
--- a/testing/regress/README.rst
+++ b/testing/regress/README.rst
@@ -683,12 +683,8 @@ So if you have a new test case and it works well on all clusters (or some of the
 9. Configuration setting in ecl-test.json file:
 -------------------------------------------------------------
 
-        "IpAddress":{
-            "hthor":"127.0.0.1",
-            "thor":"127.0.0.1",
-            "roxie": "127.0.0.1"
-        },
         "roxieTestSocket": ":9876",                     - Roxie test socket address (not used)
+        "espIp": "127.0.0.1",                           - ESP server IP
         "espSocket": ":8010",                           - ESP service address
         "username": "regress",                          - Regression Suite dedicated username and pasword
         "password": "regress",

--- a/testing/regress/ecl-test
+++ b/testing/regress/ecl-test
@@ -77,7 +77,6 @@ class RegressMain:
         # Go through the cluster list
         for cluster in self.targetClusters:
             try:
-                self.regress.config.ip = self.regress.config.IpAddress[cluster]
                 if len(eclfiles) :
                     #Execute multiple ECL files like RUN to generates summary results and diff report.
                     self.regress.bootstrap(cluster, self.args,  eclfiles)
@@ -96,7 +95,6 @@ class RegressMain:
         # Go through the cluster list
         for cluster in self.targetClusters:
             self.args.target = cluster
-            self.regress.config.ip = self.regress.config.IpAddress[cluster]
             if  self.args.pq :
                 self.regress.runSuiteP(cluster, self.regress.Setup(self.args))
             else:
@@ -107,7 +105,6 @@ class RegressMain:
         for cluster in self.targetClusters:
             self.regress.bootstrap(cluster, self.args)
             self.args.target = cluster
-            self.regress.config.ip = self.regress.config.IpAddress[cluster]
             if  self.args.pq :
                 self.regress.runSuiteP(cluster, self.regress.suites[cluster])
             else:
@@ -234,7 +231,7 @@ class RegressMain:
                     raise Error("4000")
 
         try:
-            checkHpccStatus(self.targetClusters)
+            checkHpccStatus()
         except Error as e:
             exit(e.getErrorCode());
 

--- a/testing/regress/ecl-test.json
+++ b/testing/regress/ecl-test.json
@@ -1,11 +1,7 @@
 {
     "Regress":{
-        "IpAddress":{
-            "hthor": "127.0.0.1",
-            "thor" : "127.0.0.1",
-            "roxie": "127.0.0.1"
-        },
         "roxieTestSocket": ":9876",
+        "espIp" : "127.0.0.1",
         "espSocket": ":8010",
         "username": "regress",
         "password": "regress",
@@ -31,7 +27,9 @@
             "all"
         ],
         "Params":[
-            "PassTest.ecl:bla='A value'"
+            "PassTest.ecl:bla='A value'",
+            "httpcall_multiheader.ecl:TargetIP=.",
+            "soapcall_multihttpheader.ecl:TargetIP=."
         ]
     }
 }

--- a/testing/regress/hpcc/regression/regress.py
+++ b/testing/regress/hpcc/regression/regress.py
@@ -494,12 +494,12 @@ class Regression:
             try:
                 if publish:
                     res = eclCmd.runCmd("publish", cluster, query, report[0],
-                                      server=self.config.ip,
+                                      server=self.config.espIp,
                                       username=self.config.username,
                                       password=self.config.password)
                 else:
                     res = eclCmd.runCmd("run", cluster, query, report[0],
-                                      server=self.config.ip,
+                                      server=self.config.espIp,
                                       username=self.config.username,
                                       password=self.config.password)
             except Error as e:
@@ -523,7 +523,7 @@ class Regression:
             wuid="N/A"
 
         if wuid and wuid.startswith("W"):
-            url = "http://" + self.config.ip+self.config.espSocket
+            url = "http://" + self.config.espIp+self.config.espSocket
             url += "/?Widget=WUDetailsWidget&Wuid="
             url += wuid
         else:

--- a/testing/regress/hpcc/util/ecl/command.py
+++ b/testing/regress/hpcc/util/ecl/command.py
@@ -78,7 +78,6 @@ class ECLcmd(Shell):
 
             args = args + eclfile.getStoredInputParameters()
 
-            args.append('-XTargetIP=' + server)
 
             args.append(eclfile.getArchive())
 

--- a/testing/regress/hpcc/util/ecl/file.py
+++ b/testing/regress/hpcc/util/ecl/file.py
@@ -470,6 +470,7 @@ class ECLFile:
         return self.ignoreResult
 
     def getStoredInputParameters(self):
+        logging.debug("%3d. getStoredInputParameters (ecl:'%s', X parameters are:'%s')", self.taskId,  self.ecl, self.optX)
         return self.optX
 
     def getFParameters(self):


### PR DESCRIPTION
Fix "TargetIP" override by default value from ecl-test.json problem.

Remove "IpAddress" array from ecl-test.json configuration file.

Add "espIp" parameter to ecl-test.json file.

Modify Regression Test Engine to use espIp value istead of the target
engine related IP from "IpAddress" array.

Update README.rst

Signed-off-by: Attila Vamos attila.vamos@gmail.com
