### PR TITLE
HPCC-14282 Spray of a zero byte file resulting in an exception

### DIFF
--- a/dali/ft/filecopy.cpp
+++ b/dali/ft/filecopy.cpp
@@ -1192,7 +1192,7 @@ void FileSprayer::calculateSprayPartition()
         // Store discovered CSV record structure into target logical file.
         StringBuffer recStru;
         partitioners.item(0).getRecordStructure(recStru);
-        if (recStru.length() > 0)
+        if ((recStru.length() > 0) && strstr(recStru.str(),"END;"))
         {
             if (distributedTarget)
                 distributedTarget->setECL(recStru.str());
@@ -2908,7 +2908,7 @@ bool FileSprayer::isSameSizeHeaderFooter()
     ForEachItemIn(idx, partition)
     {
         PartitionPoint & cur = partition.item(idx);
-        if (idx+1 == partition.ordinality() || partition.item(idx+1).whichOutput != cur.whichOutput)
+        if (cur.inputLength && (idx+1 == partition.ordinality() || partition.item(idx+1).whichOutput != cur.whichOutput))
         {
             if (isEmpty)
             {


### PR DESCRIPTION
Add input length check to avoid exception.

Add check to avoid incomplete record structure stored
into zero length file metadata.

Signed-off-by: Attila Vamos attila.vamos@gmail.com
