### PR TITLE
HPCC-14287 Fix jptree attrvalue allocator to use memsize_t

### DIFF
--- a/system/jlib/jptree.cpp
+++ b/system/jlib/jptree.cpp
@@ -189,7 +189,7 @@ static AtomRefTable *keyTable, *keyTableNC;
 static CAttrValHashTable *attrHT=NULL;
 AttrValue **AttrMap::freelist=NULL; 
 unsigned AttrMap::freelistmax=0; 
-CLargeMemoryAllocator AttrMap::freeallocator((size32_t)-1,0x1000*sizeof(AttrValue),true);
+CLargeMemoryAllocator AttrMap::freeallocator((memsize_t)-1,0x1000*sizeof(AttrValue),true);
 
 
 MODULE_INIT(INIT_PRIORITY_JPTREE)


### PR DESCRIPTION
Previously based on size32_t limit, when underlying allocator
is based on memsize_t.
It meant that after 4GB of AttrValue's it would hit a jbuf error
'Out of memory'

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
