### PR TITLE
HPCC-14270 Enth could deadlock if numerator = 0

### DIFF
--- a/thorlcr/activities/enth/thenthslave.cpp
+++ b/thorlcr/activities/enth/thenthslave.cpp
@@ -97,7 +97,9 @@ public:
             ThorDataLinkMetaInfo info;
             input->getMetaInfo(info);
             // Need lookahead _unless_ row count pre-known.
-            if (info.totalRowsMin == info.totalRowsMax)
+            if (0 == numerator)
+                localRecCount = 0;
+            else if (info.totalRowsMin == info.totalRowsMax)
             {
                 localRecCount = (rowcount_t)info.totalRowsMax;
                 ActPrintLog("%s: row count pre-known to be %" RCPF "d", actStr.str(), localRecCount);


### PR DESCRIPTION
With a numerator of 0, the count is known, but a lookahead was
started and waited for a signal that never came.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
