### PR TITLE
HPCC-14305 6.0.0-beta1 does not build on centos 5

### DIFF
--- a/roxie/ccd/ccdlistener.cpp
+++ b/roxie/ccd/ccdlistener.cpp
@@ -670,7 +670,17 @@ public:
         }
         else
         {
+#if __GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 6)
             cpuCores = CPU_COUNT(&cpuMask);
+#else
+            cpuCores = 0;
+            unsigned setSize = CPU_SETSIZE;
+            while (setSize--)
+            {
+                if (CPU_ISSET(setSize, &cpuMask))
+                    ++cpuCores;
+            }
+#endif /* GLIBC */
             if (traceLevel)
                 traceAffinity(&cpuMask);
         }


### PR DESCRIPTION
CPU_COUNT macro not available on earlier versions of glibc. Code stolen from
jlib.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
