### PR TITLE
HPCC-14336 Epoll assert for event on already removed fd

### DIFF
--- a/system/jlib/jsocket.cpp
+++ b/system/jlib/jsocket.cpp
@@ -4646,7 +4646,12 @@ public:
                             }
 # endif
                             if (epevents[j].data.fd >= 0) {
-                                assertex(epfdtbl[epevents[j].data.fd] >= 0);
+                                // assertex(epfdtbl[epevents[j].data.fd] >= 0);
+                                if (epfdtbl[epevents[j].data.fd] < 0)
+                                {
+                                    WARNLOG("epoll event for invalid fd: index = %d, fd = %d, eventmask = %u", j, epevents[j].data.fd, epevents[j].events);
+                                    continue;
+                                }
                                 SelectItem *epsi = items.getArray(epfdtbl[epevents[j].data.fd]);
                                 if (!epsi->del) {
                                     unsigned int ep_mode = 0;


### PR DESCRIPTION
This assert occurred:
    assert(epfdtbl[epevents[j].data.fd] >= 0)
But after several msgs:
    "jsocket(9,2197) shutdown err = 107
Where errno 107 is ENOTCONN
It appears we could get fd events for an fd we are about to remove and then next loop around hit this code.
This PR removes the assert and skips over events for already removed fd's
Further exploration into upstream code paths might reveal the sequence of events that happened.

Signed-off-by: Mark Kelly mark.kelly@lexisnexis.com
