### PR TITLE
HPCC-14333 Modified CFRunSSH code in ws_machineService.cpp

### DIFF
--- a/esp/services/ws_machine/ws_machineService.cpp
+++ b/esp/services/ws_machine/ws_machineService.cpp
@@ -1185,7 +1185,7 @@ int Cws_machineEx::runCommand(IEspContext& context, const char* sAddress, const 
             return exitCode;
 
         IFRunSSH * connection = createFRunSSH();
-        connection->init(command.str(),NULL,userId.str(),password.str(),m_SSHConnectTimeoutSeconds,0);
+        connection->init(command.str(),NULL,NULL,NULL,m_SSHConnectTimeoutSeconds,0);
         connection->exec(sAddress,NULL,true);
     }
     // CFRunSSH uses a MakeStringExceptionDirect throw to pass code and result string

--- a/esp/services/ws_machine/ws_machineServiceRexec.cpp
+++ b/esp/services/ws_machine/ws_machineServiceRexec.cpp
@@ -124,7 +124,7 @@ public:
             else
             {
                 IFRunSSH * connection = createFRunSSH();
-                connection->init(m_sCommand.str(),NULL,userId.str(),password.str(),5,0);
+                connection->init(m_sCommand.str(),NULL,NULL,NULL,5,0);
                 connection->exec(m_sAddress.str(),NULL,true);
             }
         }


### PR DESCRIPTION
I was erroneously passing userId.str() and password.str() to the CFRunSSH init code.  Which would cause us to suffer from an AES error (AES Decryption error: -7, Corrupted Data) because we tried to decrypt a string that wasn't encrypted.  I have changed both values to NULL, and tested on the 190 cluster.  @kunalaswani @cloLN Please review when you have time.
