### PR TITLE
HPCC-13030 Add row tracing support to engines

### DIFF
--- a/system/include/portlist.h
+++ b/system/include/portlist.h
@@ -96,6 +96,7 @@
 
 #define ROXIE_SERVER_PORT               9876
 
+#define THOR_DEBUG_PORT                 16000
 #define HTHOR_DEBUG_BASE_PORT           17000
 #define HTHOR_DEBUG_PORT_RANGE          10
 

--- a/thorlcr/activities/choosesets/thchoosesetsslave.cpp
+++ b/thorlcr/activities/choosesets/thchoosesetsslave.cpp
@@ -250,7 +250,8 @@ public:
     virtual CActivityBase *queryFromActivity();
     virtual void dataLinkSerialize(MemoryBuffer &mb);
     unsigned __int64 queryTotalCycles() const;
-
+    unsigned __int64 queryEndCycles() const;
+    virtual void debugRequest(MemoryBuffer &msg);
     ChooseSetsPlusActivity & activity;
     IEngineRowAllocator *queryRowAllocator();
 };
@@ -559,6 +560,8 @@ void InputCounter::getMetaInfo(ThorDataLinkMetaInfo &info)  { activity.inputs.it
 CActivityBase *InputCounter::queryFromActivity()            { return activity.inputs.item(0)->queryFromActivity(); }
 void InputCounter::dataLinkSerialize(MemoryBuffer &mb)      { activity.inputs.item(0)->dataLinkSerialize(mb); }
 unsigned __int64 InputCounter::queryTotalCycles() const     { return activity.inputs.item(0)->queryTotalCycles(); }
+unsigned __int64 InputCounter::queryEndCycles() const       { return activity.inputs.item(0)->queryEndCycles(); }
+void InputCounter::debugRequest(MemoryBuffer &msg)          { return activity.inputs.item(0)->debugRequest(msg); }
 
 
 //---------------------------------------------------------------------------

--- a/thorlcr/activities/funnel/thfunnelslave.cpp
+++ b/thorlcr/activities/funnel/thfunnelslave.cpp
@@ -829,7 +829,7 @@ public:
             {
                 IThorDataLink *cur = inputs.item(i);
                 CActivityBase *activity = cur->queryFromActivity();
-                IThorNWayInput *nWayInput = dynamic_cast<IThorNWayInput *>(cur);
+                IThorNWayInput *nWayInput = dynamic_cast<IThorNWayInput *>(activity);
                 if (nWayInput)
                 {
                     unsigned numRealInputs = nWayInput->numConcreteOutputs();

--- a/thorlcr/activities/nsplitter/thnsplitterslave.cpp
+++ b/thorlcr/activities/nsplitter/thnsplitterslave.cpp
@@ -206,6 +206,9 @@ class NSplitterSlaveActivity : public CSlaveActivity, implements ISharedSmartBuf
             return input->queryTotalCycles();
         }
     };
+
+    IPointerArrayOf<CDelayedInput> delayInputsList;
+
 public:
     IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
 
@@ -235,9 +238,9 @@ public:
                     break;
             }
             assertex(io);
-            ForEachItemIn(o2, outputs)
+            ForEachItemIn(o2, delayInputsList)
             {
-                CDelayedInput *delayedInput = (CDelayedInput *)outputs.item(o2);
+                CDelayedInput *delayedInput = delayInputsList.item(o2);
                 if (o2 == o)
                     delayedInput->setInput(new CInputWrapper(*this, inputs.item(0)));
                 else
@@ -246,9 +249,9 @@ public:
         }
         else
         {
-            ForEachItemIn(o, outputs)
+            ForEachItemIn(o, delayInputsList)
             {
-                CDelayedInput *delayedInput = (CDelayedInput *)outputs.item(o);
+                CDelayedInput *delayedInput = delayInputsList.item(o);
                 if (NULL != container.connectedOutputs.queryItem(o))
                     delayedInput->setInput(new CSplitterOutput(*this, o), o);
                 else
@@ -268,9 +271,9 @@ public:
         if (inputsConfigured)
         {
             // ensure old inputs cleared, to avoid being reused before re-setup on subsequent executions
-            ForEachItemIn(o, outputs)
+            ForEachItemIn(o, delayInputsList)
             {
-                CDelayedInput *delayedInput = (CDelayedInput *)outputs.item(o);
+                CDelayedInput *delayedInput = delayInputsList.item(o);
                 delayedInput->setInput(NULL);
             }
             inputsConfigured = false;
@@ -279,7 +282,11 @@ public:
     void init(MemoryBuffer &data, MemoryBuffer &slaveData)
     {
         ForEachItemIn(o, container.outputs)
-            appendOutput(new CDelayedInput(*this));
+        {
+            CDelayedInput *delayedInput = new CDelayedInput(*this);
+            delayInputsList.append(delayedInput);
+            appendOutput(delayedInput);
+        }
         IHThorSplitArg *helper = (IHThorSplitArg *)queryHelper();
         int dV = getOptInt(THOROPT_SPLITTER_SPILL, -1);
         if (-1 == dV)
@@ -317,7 +324,7 @@ public:
                     // mark any unconnected outputs of smartBuf as already stopped.
                     ForEachItemIn(o, outputs)
                     {
-                        CDelayedInput *delayedInput = (CDelayedInput *)outputs.item(o);
+                        IThorDataLink *delayedInput = outputs.item(o);
                         if (NULL == container.connectedOutputs.queryItem(o))
                             smartBuf->queryOutput(o)->stop();
                     }
@@ -411,7 +418,7 @@ public:
         unsigned __int64 _totalCycles = totalCycles.totalCycles; // more() time
         ForEachItemIn(o, outputs)
         {
-            CDelayedInput *delayedInput = (CDelayedInput *)outputs.item(o);
+            IThorDataLink *delayedInput = outputs.item(o);
             _totalCycles += delayedInput->queryTotalCycles();
         }
         return _totalCycles;

--- a/thorlcr/activities/nsplitter/thnsplitterslave.cpp
+++ b/thorlcr/activities/nsplitter/thnsplitterslave.cpp
@@ -220,6 +220,10 @@ public:
         eofHit = inputsConfigured = writeBlocked = pagedOut = false;
         recsReady = 0;
     }
+    virtual ~NSplitterSlaveActivity()
+    {
+        delayInputsList.kill();
+    }
     void ensureInputsConfigured()
     {
         CriticalBlock block(startLock);
@@ -283,9 +287,9 @@ public:
     {
         ForEachItemIn(o, container.outputs)
         {
-            CDelayedInput *delayedInput = new CDelayedInput(*this);
-            delayInputsList.append(delayedInput);
-            appendOutput(delayedInput);
+            Owned<CDelayedInput> delayedInput = new CDelayedInput(*this);
+            delayInputsList.append(delayedInput.getLink());
+            appendOutput(delayedInput.getClear());
         }
         IHThorSplitArg *helper = (IHThorSplitArg *)queryHelper();
         int dV = getOptInt(THOROPT_SPLITTER_SPILL, -1);

--- a/thorlcr/activities/thactivityutil.cpp
+++ b/thorlcr/activities/thactivityutil.cpp
@@ -303,6 +303,8 @@ public:
         // no serialization information (yet)
     }
     unsigned __int64 queryTotalCycles() const { return in->queryTotalCycles(); }
+    unsigned __int64 queryEndCycles() const { return in->queryEndCycles(); }
+    virtual void debugRequest(MemoryBuffer &msg) { return in->debugRequest(msg); }
 };
 #ifdef _MSC_VER
 #pragma warning(pop)

--- a/thorlcr/activities/thactivityutil.ipp
+++ b/thorlcr/activities/thactivityutil.ipp
@@ -156,6 +156,7 @@ public:
     }
 
     unsigned __int64 queryTotalCycles() const { return ((CSlaveActivity *)owner)->queryTotalCycles(); }
+    unsigned __int64 queryEndCycles() const  { return ((CSlaveActivity *)owner)->queryEndCycles(); }
 
     inline rowcount_t getDataLinkGlobalCount()
     {
@@ -165,7 +166,7 @@ public:
     {
         return icount; 
     } 
-
+    virtual void debugRequest(MemoryBuffer &msg) { }
     CActivityBase *queryFromActivity() { return owner; }
 
     void initMetaInfo(ThorDataLinkMetaInfo &info); // for derived children to call from getMetaInfo

--- a/thorlcr/graph/thgraph.hpp
+++ b/thorlcr/graph/thgraph.hpp
@@ -74,7 +74,8 @@ enum msgids
     GraphInit,
     GraphEnd,
     GraphAbort,
-    GraphGetResult
+    GraphGetResult,
+    DebugRequest
 };
 
 interface ICodeContextExt : extends ICodeContext
@@ -709,6 +710,7 @@ public:
 //  virtual void getResult(size32_t & retSize, void * & ret, unsigned id);
 //  virtual void getLinkedResult(unsigned & count, byte * * & ret, unsigned id);
     virtual IEclGraphResults *evaluate(unsigned parentExtractSz, const byte * parentExtract);
+
 friend class CGraphElementBase;
 };
 
@@ -847,6 +849,7 @@ public:
     virtual IThorAllocator *createThorAllocator();
 
     virtual void abort(IException *e);
+    virtual void debugRequest(CMessageBuffer &msg, const char *request) const { }
 
 //
     virtual void addCreatedFile(const char *file) { assertex(false); }

--- a/thorlcr/graph/thgraphslave.hpp
+++ b/thorlcr/graph/thgraphslave.hpp
@@ -34,6 +34,7 @@
 #include "thorcommon.hpp"
 #include "thgraph.hpp"
 #include "jdebug.hpp"
+#include "traceslave.hpp"
 
 class CSlaveActivity;
 
@@ -64,15 +65,17 @@ public:
     IThorDataLink *queryOutput(unsigned index);
     IThorDataLink *queryInput(unsigned index);
     virtual void setInput(unsigned index, CActivityBase *inputActivity, unsigned inputOutIdx);
-    void appendOutput(IThorDataLink *itdl) { outputs.append(itdl); };
-    void appendOutputLinked(IThorDataLink *itdl) { itdl->Link(); appendOutput(itdl); };
+    void appendOutput(IThorDataLink *itdl);
+    void appendOutputLinked(IThorDataLink *itdl);
     void startInput(IThorDataLink *itdl, const char *extra=NULL);
     void stopInput(IRowStream *itdl, const char *extra=NULL);
 
     ActivityTimeAccumulator &getTotalCyclesRef() { return totalCycles; }
     unsigned __int64 queryLocalCycles() const;
     virtual unsigned __int64 queryTotalCycles() const; // some acts. may calculate accumulated total from inputs (e.g. splitter)
+    virtual unsigned __int64 queryEndCycles() const;
     virtual void serializeStats(MemoryBuffer &mb);
+    void debugRequest(unsigned edgeIdx, CMessageBuffer &msg);
 };
 
 class graphslave_decl CSlaveGraphElement : public CGraphElementBase
@@ -159,6 +162,8 @@ public:
     virtual StringBuffer &getWorkUnitValue(const char *prop, StringBuffer &str) const;
     virtual bool getWorkUnitValueBool(const char *prop, bool defVal) const;
     virtual IThorAllocator *createThorAllocator();
+    virtual void debugRequest(CMessageBuffer &msg, const char *request) const;
+
 // IExceptionHandler
     virtual bool fireException(IException *e)
     {

--- a/thorlcr/master/thgraphmanager.cpp
+++ b/thorlcr/master/thgraphmanager.cpp
@@ -44,6 +44,7 @@
 #include "thactivitymaster.ipp"
 #include "thdemonserver.hpp"
 #include "thgraphmanager.hpp"
+#include "roxiehelper.hpp"
 
 class CJobManager : public CSimpleInterface, implements IJobManager, implements IExceptionHandler
 {
@@ -60,9 +61,162 @@ class CJobManager : public CSimpleInterface, implements IJobManager, implements 
     StringAttr          currentWuid;
     ILogMsgHandler *logHandler;
 
+    CJobMaster *getCurrentJob() { CriticalBlock b(jobCrit); return jobs.ordinality() ? &OLINK(jobs.item(0)) : NULL; }
     bool executeGraph(IConstWorkUnit &workunit, const char *graphName, const SocketEndpoint &agentEp);
     void addJob(CJobMaster &job) { CriticalBlock b(jobCrit); jobs.append(job); }
     void removeJob(CJobMaster &job) { CriticalBlock b(jobCrit); jobs.zap(job); }
+
+    class CThorDebugListener : public CSimpleInterfaceOf<IInterface>, implements IThreaded
+    {
+    protected:
+        CThreaded threaded;
+        unsigned port;
+        Owned<ISocket> sock;
+        CJobManager &mgr;
+    private:
+        volatile bool running;
+    public:
+        CThorDebugListener(CJobManager &_mgr) : threaded("CThorDebugListener", this), mgr(_mgr)
+        {
+            port = globals->getPropInt("DebugPort", THOR_DEBUG_PORT);
+            running = true;
+            threaded.start();
+        }
+        ~CThorDebugListener()
+        {
+            running = false;
+            if (sock)
+                sock->cancel_accept();
+            threaded.join();
+        }
+        virtual unsigned getPort() { return port; }
+
+        virtual void processDebugCommand(CSafeSocket &ssock, StringBuffer &rawText)
+        {
+            Owned<IPropertyTree> queryXml;
+            try
+            {
+                queryXml.setown(createPTreeFromXMLString(rawText.str(), ipt_caseInsensitive, (PTreeReaderOptions)(ptr_ignoreWhiteSpace|ptr_ignoreNameSpaces)));
+            }
+            catch (IException *E)
+            {
+                StringBuffer s;
+                DBGLOG("ERROR: Invalid XML received from %s:%s", E->errorMessage(s).str(), rawText.str());
+                throw;
+            }
+
+            Linked<CJobMaster> job = mgr.getCurrentJob();
+            const char *graphId = job->queryGraphName();
+            if (!job || !graphId)
+                throw MakeStringException(5300, "Command not available when no graph active");
+
+            const char *command = queryXml->queryName();
+            if (!command) throw MakeStringException(5300, "Invalid debug command");
+
+            FlushingStringBuffer response(&ssock, false, MarkupFmt_XML, false, false, queryDummyContextLogger());
+            response.startDataset("Debug", NULL, (unsigned) -1);
+
+            if (strncmp(command,"print", 5) == 0)
+            {
+                const char *edgeId = queryXml->queryProp("@edgeId");
+                if (!edgeId) throw MakeStringException(5300, "Debug command requires edgeId");
+
+                ICommunicator &comm = job->queryNodeComm();
+                CMessageBuffer mbuf;
+                mbuf.append(DebugRequest);
+                mbuf.append(job->queryKey());
+                mptag_t replyTag = createReplyTag();
+                serializeMPtag(mbuf, replyTag);
+                mbuf.append(rawText);
+                if (!comm.send(mbuf, RANK_ALL_OTHER, masterSlaveMpTag, MP_ASYNC_SEND))
+                {
+                    DBGLOG("Failed to send debug info to slave");
+                    throwUnexpected();
+                }
+                unsigned nodes = job->queryNodes();
+                response.appendf("<print graphId='%s' edgeId='%s'>", graphId, edgeId);
+                while (nodes)
+                {
+                    rank_t sender;
+                    mbuf.clear();
+                    comm.recv(mbuf, RANK_ALL, replyTag, &sender, 10000);
+                    while (mbuf.remaining())
+                    {
+                        StringAttr row;
+                        mbuf.read(row);
+                        response.append(row);
+                    }
+                    nodes--;
+                }
+                response.append("</print>");
+            }
+            else if (strncmp(command,"quit", 4) == 0)
+            {
+                LOG(MCwarning, thorJob, "ABORT detected from user during debug session");
+                Owned<IException> e = MakeThorException(TE_WorkUnitAborting, "User signalled abort during debug session");
+                job->fireException(e);
+                response.appendf("<quit state='quit'/>");
+            }
+            else
+                throw MakeStringException(5300, "Command not supported by Thor");
+
+            response.flush(true);
+        }
+        virtual void main()
+        {
+            sock.setown(ISocket::create(port));
+            while (running)
+            {
+                try
+                {
+                    Owned<ISocket> client = sock->accept(true);
+                    if (client)
+                    {
+                        client->set_linger(-1);
+                        CSafeSocket ssock(client.getClear());
+                        StringBuffer rawText;
+                        IpAddress peer;
+                        bool continuationNeeded;
+                        bool isStatus;
+
+                        ssock.querySocket()->getPeerAddress(peer);
+                        DBGLOG("Reading debug command from socket...");
+                        if (!ssock.readBlock(rawText, WAIT_FOREVER, NULL, continuationNeeded, isStatus, 1024*1024))
+                        {
+                            WARNLOG("No data reading query from socket");
+                            continue;
+                        }
+                        assertex(!continuationNeeded);
+                        assertex(!isStatus);
+
+                        try
+                        {
+                            processDebugCommand(ssock,rawText);
+                        }
+                        catch (IException *E)
+                        {
+                            StringBuffer s;
+                            ssock.sendException("Thor", E->errorCode(), E->errorMessage(s), false, queryDummyContextLogger());
+                            E->Release();
+                        }
+                        // Write terminator
+                        unsigned replyLen = 0;
+                        ssock.write(&replyLen, sizeof(replyLen));
+                    }
+                }
+                catch (IException *E)
+                {
+                    EXCLOG(E);
+                    E->Release();
+                }
+                catch (...)
+                {
+                    DBGLOG("Unexpected exception in CThorDebugListener");
+                }
+            }
+        }
+    };
+    Owned<CThorDebugListener> debugListener;
 
 public:
     IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
@@ -100,6 +254,7 @@ CJobManager::CJobManager(ILogMsgHandler *_logHandler) : logHandler(_logHandler)
         globals->setPropBool("@watchdogProgressEnabled", false);
     atomic_set(&activeTasks, 0);
     setJobManager(this);
+    debugListener.setown(new CThorDebugListener(*this));
 }
 
 CJobManager::~CJobManager()
@@ -511,6 +666,16 @@ void CJobManager::run()
                 throw makeStringException(0, "Attempting to execute a workunit that hasn't been compiled");
             if ((workunit->getCodeVersion() > ACTIVITY_INTERFACE_VERSION) || (workunit->getCodeVersion() < MIN_ACTIVITY_INTERFACE_VERSION))
                 throw MakeStringException(0, "Workunit was compiled for eclagent interface version %d, this thor requires version %d..%d", workunit->getCodeVersion(), MIN_ACTIVITY_INTERFACE_VERSION, ACTIVITY_INTERFACE_VERSION);
+
+            if (debugListener)
+            {
+                WorkunitUpdate wu(&workunit->lock());
+                StringBuffer sb;
+                queryHostIP().getIpText(sb);
+                wu->setDebugAgentListenerIP(sb); //tells debugger what IP to write commands to
+                wu->setDebugAgentListenerPort(debugListener->getPort());
+            }
+
             allDone = doit(workunit, graphName, agentep);
             daliLock.clear();
             reply(workunit, wuid, NULL, agentep, allDone);

--- a/thorlcr/master/thgraphmanager.cpp
+++ b/thorlcr/master/thgraphmanager.cpp
@@ -89,7 +89,7 @@ class CJobManager : public CSimpleInterface, implements IJobManager, implements 
                 sock->cancel_accept();
             threaded.join();
         }
-        virtual unsigned getPort() { return port; }
+        virtual unsigned getPort() const { return port; }
 
         virtual void processDebugCommand(CSafeSocket &ssock, StringBuffer &rawText)
         {

--- a/thorlcr/slave/slave.hpp
+++ b/thorlcr/slave/slave.hpp
@@ -87,6 +87,8 @@ interface IThorDataLink : extends IRowStream
     virtual CActivityBase *queryFromActivity() = 0; // activity that has this as an output
     virtual void dataLinkSerialize(MemoryBuffer &mb)=0;
     virtual unsigned __int64 queryTotalCycles() const=0;
+    virtual unsigned __int64 queryEndCycles() const=0;
+    virtual void debugRequest(MemoryBuffer &mb) = 0;
 };
 #ifdef _MSC_VER
 #pragma warning (pop)

--- a/thorlcr/slave/slavmain.cpp
+++ b/thorlcr/slave/slavmain.cpp
@@ -505,6 +505,26 @@ public:
                         }
                         break;
                     }
+                    case DebugRequest:
+                    {
+                        StringAttr jobKey;
+                        msg.read(jobKey);
+                        CJobSlave *job = jobs.find(jobKey.get());
+                        if (job)
+                        {
+                            mptag_t replyTag = job->deserializeMPTag(msg);
+                            msg.setReplyTag(replyTag);
+                            StringAttr rawText;
+                            msg.read(rawText);
+                            PROGLOG("DebugRequest: %s %s", jobKey.get(), rawText.get());
+                            msg.clear();
+                            job->debugRequest(msg, rawText);
+                        }
+                        else
+                            PROGLOG("DebugRequest: %s - Job not found", jobKey.get());
+
+                        break;
+                    }
                     default:
                         throwUnexpected();
                 }

--- a/thorlcr/slave/slwatchdog.cpp
+++ b/thorlcr/slave/slwatchdog.cpp
@@ -30,7 +30,7 @@
 
 class CGraphProgressHandlerBase : public CSimpleInterface, implements ISlaveWatchdog, implements IThreaded
 {
-    CriticalSection crit;
+    mutable CriticalSection crit;
     CGraphArray activeGraphs;
     bool stopped, progressEnabled;
     CThreaded threaded;
@@ -130,6 +130,34 @@ public:
                 sizeMark.write();
             }
             activeGraphs.zap(graph);
+        }
+    }
+    virtual void debugRequest(CMessageBuffer &msg, const char *request) const
+    {
+        Owned<IPTree> req = createPTreeFromXMLString(request);
+
+        StringBuffer edgeString;
+        req->getProp("@edgeId", edgeString);
+
+        // Split edge string in activityId and edgeIdx
+        const char *pEdge=edgeString.str();
+        const activity_id actId = _atoi64(pEdge);
+        if (!actId) return;
+
+        while (*pEdge && *pEdge!='_')  ++pEdge;
+        if (!*pEdge) return;
+        const unsigned edgeIdx = _atoi64(++pEdge);
+
+        CriticalBlock b(crit);
+        ForEachItemIn(g, activeGraphs) // NB: 1 for each slavesPerProcess
+        {
+            CGraphBase &graph = activeGraphs.item(g);
+            CGraphElementBase *element = graph.queryElement(actId);
+            if (element)
+            {
+                CSlaveActivity *activity = (CSlaveActivity*) element->queryActivity();
+                if (activity) activity->debugRequest(edgeIdx,msg);
+            }
         }
     }
 

--- a/thorlcr/slave/slwatchdog.hpp
+++ b/thorlcr/slave/slwatchdog.hpp
@@ -27,6 +27,7 @@ interface ISlaveWatchdog : extends IInterface
     virtual void startGraph(CGraphBase &graph) = 0;
     virtual void stopGraph(CGraphBase &graph, MemoryBuffer *mb=NULL) = 0;
     virtual void stop() = 0;
+    virtual void debugRequest(CMessageBuffer &msg, const char *request) const = 0;
 };
 
 ISlaveWatchdog *createProgressHandler(bool udp=false);

--- a/thorlcr/slave/traceslave.hpp
+++ b/thorlcr/slave/traceslave.hpp
@@ -1,0 +1,220 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef TRACESLAVE_HPP
+#define TRACESLAVE_HPP
+
+#include <sys/time.h>
+#include "thmem.hpp"
+
+class tm;
+class CTracingThorDataLink : implements CInterfaceOf<IThorDataLink>
+{
+private:
+    class CThorRowHistory
+    {
+        OwnedConstThorRow row;
+        __int64 cycleStamp;
+
+    public:
+        inline CThorRowHistory() : cycleStamp(0) { }
+
+        inline void set(const void * _row, __int64 _cycleStamp)
+        {
+            cycleStamp = _cycleStamp;
+            row.set(_row);
+        }
+        inline void getTimeStamp(StringBuffer &retTimeStamp) const
+        {
+            struct timeval tvNow, tvAdjust, tvResult;
+            struct tm tm;
+
+            gettimeofday(&tvNow, NULL);
+
+            const __int64 diffUSec = cycle_to_microsec(get_cycles_now() - cycleStamp);
+            tvAdjust.tv_sec = diffUSec / 1000000;
+            tvAdjust.tv_usec = diffUSec % 1000000;
+            timersub(&tvNow, &tvAdjust, &tvResult);
+
+            localtime_r(&tvResult.tv_sec, &tm);
+            retTimeStamp.setf("%d:%02d:%02d.%d", tm.tm_hour, tm.tm_min, tm.tm_sec, (int)(tvResult.tv_usec/1000));
+        }
+        inline const void * get() const      { return row.get(); }
+        inline void clear()                  { row.clear(); }
+        inline __int64 getCycleStamp() const { return cycleStamp; }
+    };
+    class CTraceQueue
+    {
+    public:
+        CThorRowHistory *rowBuffer;
+        unsigned rowBufferSize;
+        unsigned rowTailp;
+
+        CTraceQueue() : rowBuffer(NULL), rowBufferSize(0), rowTailp(0) { }
+
+        ~CTraceQueue()
+        {
+            delete [] rowBuffer;
+        }
+        void init(unsigned _bufsize)
+        {
+            if (!rowBuffer && _bufsize)
+            {
+                rowBufferSize = _bufsize;
+                rowBuffer = new CThorRowHistory[rowBufferSize];
+                rowTailp = 0;
+            }
+        }
+        inline void enqueue(const void *row, __int64 _cycleStamp)
+        {
+            // NOTE - updates then sets rowHeadp (atomically) so that the code
+            // below (ignoring oldest record) is safe
+            rowBuffer[rowTailp].set(row, _cycleStamp);
+            unsigned nextTailp = rowTailp + 1;
+            if (nextTailp==rowBufferSize)
+                nextTailp = 0;
+            rowTailp = nextTailp;
+        }
+        inline void enqueue(const CThorRowHistory &_rowBuffer)
+        {
+            enqueue(_rowBuffer.get(),_rowBuffer.getCycleStamp());
+        }
+        // Move items in current queue into a second queue (clear out 'this' queue)
+        // NOTE - set skipLast to true when the oldest item must be skipped.  This should
+        // be used where the queue COULD have been updated after the buffers are swapped and
+        // the enqueueRowForTrace overwriting the oldest entry.
+        void queueOut(CTraceQueue &traceOutQueue, bool skipOldestEntry)
+        {
+            const unsigned numberRowsToSkip = skipOldestEntry ? 1 : 0;
+            unsigned rowPos = rowTailp + numberRowsToSkip;
+            if (rowPos==rowBufferSize) rowPos = 0;
+            for (unsigned n=numberRowsToSkip; n<rowBufferSize;++n)
+            {
+                if (rowBuffer[rowPos].get())
+                {
+                    traceOutQueue.enqueue(rowBuffer[rowPos]);
+                    rowBuffer[rowPos].clear();
+                }
+                if (++rowPos==rowBufferSize) rowPos = 0;
+            }
+        }
+        // Dump items to MemoryBuffer (without clearing items from queue)
+        void dump(MemoryBuffer &mb, IHThorArg *helper) const
+        {
+            CommonXmlWriter xmlwrite(XWFnoindent|XWFtrim);
+            IOutputMetaData *meta = helper->queryOutputMeta();
+            unsigned rowPos = rowTailp;
+            for (unsigned n=0; n<rowBufferSize;++n)
+            {
+                const CThorRowHistory &rowCurrent = rowBuffer[rowPos];
+                if (rowCurrent.get())
+                {
+                    xmlwrite.outputBeginNested("Row", true);
+                    xmlwrite.outputInt(meta->getRecordSize(rowCurrent.get()), sizeof(size32_t), "@size");
+                    StringBuffer timeStamp;
+                    rowCurrent.getTimeStamp(timeStamp);
+                    xmlwrite.outputString(timeStamp.length(), timeStamp.str(), "@timestamp");
+                    try
+                    {
+                        meta->toXML((const byte*)(rowCurrent.get()), xmlwrite);
+                    }
+                    catch (IException *e)
+                    {
+                        EXCLOG(e, "CTracingThorDataLink::dump");
+                        e->Release();
+                    }
+                    xmlwrite.outputEndNested("Row", true);
+                    mb.append(xmlwrite.str());
+                    xmlwrite.clear();
+                }
+                if (++rowPos==rowBufferSize) rowPos = 0;
+            }
+        }
+    };
+    const unsigned traceQueueSize;
+    CTraceQueue buffers[2];
+    CTraceQueue rowBufferLogCache;
+    atomic_t rowBufInUse;
+    Owned<IThorDataLink> thorDataLink;
+    IHThorArg *helper;
+
+    inline void enqueueRowForTrace(const void *row)
+    {
+        buffers[atomic_read(&rowBufInUse)].enqueue(row,thorDataLink->queryEndCycles());
+    }
+public:
+    virtual void start()
+    {
+        thorDataLink->start();
+    }
+    virtual bool isGrouped() { return thorDataLink->isGrouped(); }
+    virtual const void *nextRowGE(const void * seek, unsigned numFields, bool &wasCompleteMatch, const SmartStepExtra &stepExtra)
+    {
+        const void *row = thorDataLink->nextRowGE(seek, numFields, wasCompleteMatch, stepExtra);
+        enqueueRowForTrace(row);
+        return row;
+    }    // can only be called on stepping fields.
+    virtual IInputSteppingMeta *querySteppingMeta() { return thorDataLink->querySteppingMeta(); }
+    virtual bool gatherConjunctions(ISteppedConjunctionCollector & collector) { return thorDataLink->gatherConjunctions(collector); }
+    virtual void resetEOF() { thorDataLink->resetEOF(); }
+
+    virtual void getMetaInfo(ThorDataLinkMetaInfo &info) { thorDataLink->getMetaInfo(info); }
+    virtual CActivityBase *queryFromActivity() {return thorDataLink->queryFromActivity(); } // activity that has this as an output
+    virtual void dataLinkSerialize(MemoryBuffer &mb) {thorDataLink->dataLinkSerialize(mb); }
+    virtual unsigned __int64 queryTotalCycles() const { return thorDataLink->queryTotalCycles(); }
+    virtual unsigned __int64 queryEndCycles() const { return thorDataLink->queryEndCycles(); }
+
+    virtual const void *nextRow()
+    {
+        const void *row = thorDataLink->nextRow();
+        enqueueRowForTrace(row);
+        return row;
+    }
+    virtual void stop()
+    {
+        thorDataLink->stop();
+    }
+
+    inline const void *ungroupedNextRow() { return thorDataLink->ungroupedNextRow(); }
+
+    virtual void debugRequest(MemoryBuffer &mb)
+    {
+        // NOTE - cannot be called by more than one thread
+        buffers[1].init(traceQueueSize+1);
+        rowBufferLogCache.init(traceQueueSize);
+        int bufToDump = atomic_read(&rowBufInUse);
+        int inactiveBuf = 1 - bufToDump;
+
+        // Queue any remaining rows from inactive buffer as the oldest row is skipped
+        // when queue out from active buffer to avoid race condition issues (this inactive buffer
+        // may have been formerly an active buffer)
+        buffers[inactiveBuf].queueOut(rowBufferLogCache, false);
+
+        atomic_set(&rowBufInUse, inactiveBuf);// Swap Active & inactiveBuf
+        buffers[bufToDump].queueOut(rowBufferLogCache, true);
+        rowBufferLogCache.dump(mb, helper);
+    }
+
+    CTracingThorDataLink(IThorDataLink *_input, IHThorArg *_helper, unsigned _traceQueueSize)
+        : thorDataLink(_input), helper(_helper), traceQueueSize(_traceQueueSize)
+    {
+        atomic_set(&rowBufInUse, 0);
+        buffers[0].init(traceQueueSize+1);
+    }
+};
+
+#endif


### PR DESCRIPTION
Return last 10 rows for a given activity & edge, when xml submitted to port 9877 (or as configured in global) in the form:

  <debug source="ACTIVITY_ID" edge="EDGE_ID"></debug>
