### PR TITLE
HPCC-13758 Test Page page cannot be found message

### DIFF
--- a/esp/src/eclwatch/QueryTestWidget.js
+++ b/esp/src/eclwatch/QueryTestWidget.js
@@ -85,8 +85,9 @@ define([
             var context = this;
             WsTopology.GetWsEclIFrameURL(type).then(function (response) {
                 var src = response + encodeURIComponent(context.params.QuerySetId + "/" + context.params.Id + (postfix ? postfix : ""));
+                var completeSrc = "http://" + dojoConfig.urlInfo.wseclhostandport + src;
                 target.set("content", dojo.create("iframe", {
-                    src: src,
+                    src: completeSrc,
                     style: "border: 0; width: 100%; height: 100%"
                 }));
             });

--- a/esp/src/eclwatch/dojoConfig.js
+++ b/esp/src/eclwatch/dojoConfig.js
@@ -9,6 +9,7 @@ var dojoConfig = (function () {
         return {
             hostname: location.hostname,
             port: location.port,
+            wseclhostandport: location.hostname + ":8002",
             pathname: location.pathname,
             hash: hashNodes.length >= 2 ? hashNodes[1] : "",
             params: searchNodes.length >= 2 ? searchNodes[1] : "",


### PR DESCRIPTION
The wsecl pages within the test pages tabs were not displaying and were giving a "Page Cannot Be Found"
error due to the port number defaulting to 8010. Modified some configurations and added a 8002 port option.

Signed-off by: Miguel Vazquez miguel.vazquez@lexisnexis.com
