### PR TITLE
HPCC-14382 LDAP build break on Windows

### DIFF
--- a/system/security/LdapSecurity/ldapconnection.hpp
+++ b/system/security/LdapSecurity/ldapconnection.hpp
@@ -63,7 +63,7 @@ WINLDAPAPI ULONG LDAPAPI ldap_compare_ext_s(
 */
     #define LDAP_COMPARE_EXT_S(ld,dn,attr,bval,data,svrctrls,clientctrls) ldap_compare_ext_s(ld,(const PCHAR)dn,(const PCHAR)attr,(const PCHAR)bval,(struct berval *)data,svrctrls,clientctrls)
     #define LDAP_UNBIND(ld)     ldap_unbind(ld)
-    #define LDAP_INIT(ld,uri)   ldap_init(ld, uri);
+    #define LDAP_INIT(host,port) ldap_init((PCHAR)host, (ULONG)port);
 #else
 /* from openLDAP ldap.h
 ldap_compare_ext_s LDAP_P((
@@ -292,7 +292,7 @@ interface ILdapClient : extends IInterface
 ILdapClient* createLdapClient(IPropertyTree* cfg);
 
 #ifdef _WIN32
-bool verifyServerCert(LDAP* ld, PCCERT_CONTEXT pServerCert);
+extern LDAPSECURITY_API bool verifyServerCert(LDAP* ld, PCCERT_CONTEXT pServerCert);
 #endif
 
 

--- a/system/security/LdapSecurity/ldaputils.cpp
+++ b/system/security/LdapSecurity/ldaputils.cpp
@@ -81,13 +81,11 @@ LDAP* LdapUtils::LdapInit(const char* protocol, const char* host, int port, int 
     else
     {
         // Initialize an LDAP session
-        StringBuffer uri;
-        uri.appendf("ldap://%s:%d", host, port);
-        DBGLOG("connecting to %s", uri.str());
-        int rc = LDAP_INIT(&ld, uri.str());
-        if(rc != LDAP_SUCCESS)
+        DBGLOG("connecting to %s:%d", host, port);
+        ld = LDAP_INIT(host, port);
+        if(NULL == ld)
         {
-            throw MakeStringException(-1, "ldap_initialize(%s) error %s", uri.str(), ldap_err2string(rc));
+            throw MakeStringException(-1, "ldap_init(%s,%d) error %s", host, port, ldap_err2string(LdapGetLastError()));
         }
     }
     return ld;


### PR DESCRIPTION
WinLDAP defines ldap_init differently than the OpenLDAP call ldap_initialize,
which causes a platform build break in Windows. This PR corrects that problem,
and adds the export of the verifyServerCert method

Signed-off-by: Russ Whitehead william.whitehead@lexisnexis.com
