### PR TITLE
HPCC-14388 Force full warnings as errors for embedded C++

### DIFF
--- a/ecl/hqlcpp/hqlcpp.cpp
+++ b/ecl/hqlcpp/hqlcpp.cpp
@@ -11677,11 +11677,19 @@ void HqlCppTranslator::buildCppFunctionDefinition(BuildCtx &funcctx, IHqlExpress
     }
 
     funcctx.addQuotedCompound(proto);
+    funcctx.addQuoted("#if defined(__clang__) || (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 2))\n"
+                      "#pragma GCC diagnostic error \"-Wall\"\n"
+                      "#pragma GCC diagnostic error \"-Wextra\"\n"
+                      "#endif\n");
     if (location)
         funcctx.addLine(locationFilename, startLine);
     funcctx.addQuoted(body);
     if (location)
         funcctx.addLine();
+    funcctx.addQuoted("#if defined(__clang__) || (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 2))\n"
+                      "#pragma GCC diagnostic ignored \"-Wall\"\n
+                      "#pragma GCC diagnostic ignored \"-Wextra\"\n"
+                      "#endif\n");
 }
 
 void HqlCppTranslator::buildScriptFunctionDefinition(BuildCtx &funcctx, IHqlExpression * funcdef, const char *proto)

--- a/rtl/ecltpl/childtpl.cpp
+++ b/rtl/ecltpl/childtpl.cpp
@@ -16,6 +16,10 @@ $?doNotIncludeInGeneratedCode$
 ##############################################################################*/
 
 $?$/* Template for generating a child module for query */
+#if defined(__clang__) || (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 2))
+#pragma GCC diagnostic ignored "-Wall"
+#pragma GCC diagnostic ignored "-Wextra"
+#endif
 #include "eclinclude4.hpp"
 @include@
 @prototype@

--- a/rtl/ecltpl/thortpl.cpp
+++ b/rtl/ecltpl/thortpl.cpp
@@ -16,6 +16,10 @@ $?doNotIncludeInGeneratedCode$
 ############################################################################## */
 
 $?$/* Template for generating thor/hthor/roxie output */
+#if defined(__clang__) || (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 2))
+#pragma GCC diagnostic ignored "-Wall"
+#pragma GCC diagnostic ignored "-Wextra"
+#endif
 #include "eclinclude4.hpp"
 @include@
 @prototype@


### PR DESCRIPTION
Note that as well as enabling all warnings as errors for user code, this also
disables all warnings for generated code - otherwise as soon as there is an
error (from the user code) they get swampled with all the warnings from the
generated code.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
