### PR TITLE
HPCC-14334 roxie resetStats should support specifying target querySet

### DIFF
--- a/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
+++ b/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
@@ -2509,9 +2509,15 @@ bool CWsWorkunitsEx::resetQueryStats(IEspContext& context, const char* target, I
         Owned<IPropertyIterator> it = queryIds->getIterator();
         ForEach(*it)
         {
-            const char *querySetId = it->getPropKey();
-            if (querySetId && *querySetId)
-                control.appendf("<Query id='%s'/>", querySetId);
+            const char *queryId = it->getPropKey();
+            if (queryId && *queryId)
+            {
+                appendXMLOpenTag(control, "Query", NULL, false);
+                appendXMLAttr(control, "id", queryId);
+                if (target && *target)
+                    appendXMLAttr(control, "target", target);
+                control.append("/>");
+            }
         }
         if (!control.length())
             throw MakeStringException(ECLWATCH_MISSING_PARAMS, "CWsWorkunitsEx::resetQueryStats: Query ID not specified");

--- a/roxie/ccd/ccdstate.cpp
+++ b/roxie/ccd/ccdstate.cpp
@@ -1326,24 +1326,21 @@ public:
         reply.appendf(" <PackageSet id=\"%s\" querySet=\"%s\"/>\n", queryPackageId(), querySet.get());
     }
 
-    void resetStats(const char *queryId, const IRoxieContextLogger &logctx)
+    bool resetStats(const char *queryId, const IRoxieContextLogger &logctx)
     {
         CriticalBlock b(updateCrit);
         if (queryId)
         {
             Owned<IQueryFactory> query = serverManager->getQuery(queryId, NULL, logctx);
-            if (query)
-            {
-                const char *id = query->queryQueryName();
-                serverManager->resetQueryTimings(id, logctx);
-                for (unsigned channel = 0; channel < numChannels; channel++)
-                    if (slaveManagers->item(channel))
-                    {
-                        slaveManagers->item(channel)->resetQueryTimings(id, logctx);
-                    }
-            }
-            else
-                throw MakeStringException(ROXIE_UNKNOWN_QUERY, "Unknown query %s", queryId);
+            if (!query)
+                return false;
+            const char *id = query->queryQueryName();
+            serverManager->resetQueryTimings(id, logctx);
+            for (unsigned channel = 0; channel < numChannels; channel++)
+                if (slaveManagers->item(channel))
+                {
+                    slaveManagers->item(channel)->resetQueryTimings(id, logctx);
+                }
         }
         else
         {
@@ -1352,6 +1349,7 @@ public:
                 if (slaveManagers->item(channel))
                     slaveManagers->item(channel)->resetAllQueryTimings();
         }
+        return true;
     }
 
     void getStats(const char *queryId, const char *action, const char *graphName, StringBuffer &reply, const IRoxieContextLogger &logctx) const
@@ -1390,6 +1388,10 @@ public:
     {
         CriticalBlock b2(updateCrit);
         serverManager->getAllQueryInfo(reply, full, slaveManagers, logctx);
+    }
+    const char *queryQuerySetName()
+    {
+        return querySet;
     }
 protected:
 
@@ -1660,12 +1662,23 @@ public:
         }
     }
 
-    void resetStats(const char *id, const IRoxieContextLogger &logctx) const
+    void resetStats(const char *target, const char *id, const IRoxieContextLogger &logctx) const
     {
+        bool matched = false;
         ForEachItemIn(idx, allQueryPackages)
         {
-            allQueryPackages.item(idx).resetStats(id, logctx);
+            CRoxieQueryPackageManager &queryPackage = allQueryPackages.item(idx);
+            if (target && *target && !strieq(queryPackage.queryQuerySetName(), target))
+                continue;
+            if (allQueryPackages.item(idx).resetStats(id, logctx))
+            {
+                if (target && *target)
+                    return;
+                matched = true;
+            }
         }
+        if (!matched && id && *id)
+            throw MakeStringException(ROXIE_UNKNOWN_QUERY, "Unknown query %s", id);
     }
 
 private:
@@ -2524,14 +2537,15 @@ private:
                     {
                         IPropertyTree &query = queries->query();
                         const char *id = query.queryProp("@id");
+                        const char *target = query.queryProp("@target");
                         if (!id)
                             badFormat();
-                        allQueryPackages->resetStats(id, logctx);
+                        allQueryPackages->resetStats(target, id, logctx);
                         queries->next();
                     }
                 }
                 else
-                    allQueryPackages->resetStats(NULL, logctx);
+                    allQueryPackages->resetStats(NULL, NULL, logctx);
             }
             else if (stricmp(queryName, "control:resetremotedalicache")==0)
             {


### PR DESCRIPTION
And if target is not specified roxie resetStats should look through all
targets before reporting query not found.

Signed-off-by: Anthony Fishbeck anthony.fishbeck@lexisnexis.com
