### PR TITLE
HPCC-14395 Fixed regression with frunssh code in thor/slave

### DIFF
--- a/initfiles/bin/init_thorslave
+++ b/initfiles/bin/init_thorslave
@@ -85,8 +85,8 @@ start_slaves()
     ln -s -f $deploydir/thorslave_lcr ${slavename}
 
     # sync to current master thorgroup
-    log "rsync -e ssh -o StrictHostKeyChecking=no ${master}:${instancedir}/thorgroup ${instancedir}/thorgroup.slave"
-    rsync -e "ssh -o StrictHostKeyChecking=no" $master:$instancedir/thorgroup $instancedir/thorgroup.slave
+    log "rsync -e ssh -o LogLevel=QUIET -o StrictHostKeyChecking=no ${master}:${instancedir}/thorgroup ${instancedir}/thorgroup.slave"
+    rsync -e "ssh -o LogLevel=QUIET -o StrictHostKeyChecking=no" $master:$instancedir/thorgroup $instancedir/thorgroup.slave
 
     let "slavenum = 1";
     for slave in $(cat $instancedir/thorgroup.slave); do


### PR DESCRIPTION
Signed-off-by: Michael Gardner michael.gardner@lexisnexis.com

It is necessary to now squelch any banner or error message from rsync in order for the frunssh call within init_thor to process failures from init_thorslave correctly.  The output from rsync on any errors/warnings was filling up the stderr buffer and causing the frunssh call to throw an exception and exit with a non 0 return code.

@xwang2713 Please review
