### PR TITLE
HPCC-14106 Read query's xref info using IReferencedFile

### DIFF
--- a/common/workunit/referencedfilelist.hpp
+++ b/common/workunit/referencedfilelist.hpp
@@ -35,6 +35,7 @@
 #define RefFileCloned         0x100
 #define RefFileInPackage      0x200
 #define RefFileNotOnSource    0x400
+#define RefFileInGraph        0x800
 
 interface IReferencedFile : extends IInterface
 {
@@ -44,6 +45,7 @@ interface IReferencedFile : extends IInterface
     virtual const char *queryPackageId() const =0;
     virtual __int64 getFileSize()=0;
     virtual unsigned getNumParts()=0;
+    virtual const StringArray &getSubFileNames() const =0;
 };
 
 interface IReferencedFileIterator : extends IIteratorOf<IReferencedFile> { };

--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -1375,6 +1375,7 @@ ESPStruct QuerySuperFile
 {
     string Name;
     ESParray<string, File> SubFiles;
+    [min_ver("1.57")] ESParray<ESPstruct QuerySuperFile, SuperFile> SuperFiles;
 };
 
 ESPresponse [exceptions_inline] WUQueryDetailsResponse
@@ -1685,7 +1686,7 @@ ESPresponse [exceptions_inline, nil_remove] WUGetArchiveFileResponse
 };
 
 ESPservice [
-    version("1.56"), default_client_version("1.56"),
+    version("1.57"), default_client_version("1.57"),
     noforms,exceptions_inline("./smc_xslt/exceptions.xslt"),use_method_name] WsWorkunits
 {
     ESPmethod [resp_xsl_default("/esp/xslt/workunits.xslt")]     WUQuery(WUQueryRequest, WUQueryResponse);

--- a/esp/services/ws_workunits/ws_workunitsService.hpp
+++ b/esp/services/ws_workunits/ws_workunitsService.hpp
@@ -25,6 +25,7 @@
 #ifdef _USE_ZLIB
 #include "zcrypt.hpp"
 #endif
+#include "referencedfilelist.hpp"
 
 #define UFO_DIRTY                                0x01
 #define UFO_RELOAD_TARGETS_CHANGED_PMID          0x02
@@ -176,7 +177,7 @@ public:
     bool isValidCluster(const char *cluster);
     void deploySharedObjectReq(IEspContext &context, IEspWUDeployWorkunitRequest & req, IEspWUDeployWorkunitResponse & resp, const char *dir, const char *xml=NULL);
     unsigned getGraphIdsByQueryId(const char *target, const char *queryId, StringArray& graphIds);
-    bool getQueryFiles(const char* query, const char* target, StringArray& logicalFiles, IArrayOf<IEspQuerySuperFile> *superFiles);
+    bool getQueryFiles(IEspContext &context, const char* query, const char* target, const char* wuid, StringArray& logicalFiles, IArrayOf<IEspQuerySuperFile> *superFiles);
     void getGraphsByQueryId(const char *target, const char *queryId, const char *graphName, const char *subGraphId, IArrayOf<IEspECLGraphEx>& ECLGraphs);
     void checkAndSetClusterQueryState(IEspContext &context, const char* cluster, const char* querySetId, IArrayOf<IEspQuerySetQuery>& queries);
     void checkAndSetClusterQueryState(IEspContext &context, const char* cluster, StringArray& querySetIds, IArrayOf<IEspQuerySetQuery>& queries);
@@ -271,6 +272,8 @@ private:
     void readGraph(IEspContext& context, const char* subGraphId, WUGraphIDType& id, bool running,
         IConstWUGraph* graph, IArrayOf<IEspECLGraphEx>& graphs);
     IPropertyTree* getWorkunitArchive(IEspContext &context, WsWuInfo& winfo, const char* wuid, unsigned cacheMinutes);
+    void readSuperFiles(IEspContext &context, IReferencedFile* rf, const char* fileName, IReferencedFileList* wufiles, IArrayOf<IEspQuerySuperFile>* files);
+    IReferencedFile* getReferencedFileByName(const char* name, IReferencedFileList* wufiles);
 
     unsigned awusCacheMinutes;
     StringBuffer queryDirectory;


### PR DESCRIPTION
In the existing WsWorkunits.WUQueryDetails, query's dfu
info is read through control:getQueryXrefInfo. That does
not work for queries that failed to load. In this fix,
query's xref info is read through IReferencedFile.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
