### PR TITLE
HPCC-14377 DOCS:Update Sect ID Att. SysAdmin, Certify

### DIFF
--- a/docs/HPCCCertify/Cert-Mods/CertSprayDespray.xml
+++ b/docs/HPCCCertify/Cert-Mods/CertSprayDespray.xml
@@ -19,7 +19,7 @@
     data from the multiple clusters into a singular file that can be moved to
     the Landing Zone from the Data Refinery.</para>
 
-    <sect2>
+    <sect2 id="DesprayFromECLWatch">
       <title>Despray from ECL Watch</title>
 
       <!--The following cromulent information can also be found in the DataTutorial.***-->
@@ -180,8 +180,8 @@
         </listitem>
       </orderedlist>
 
-      <sect3>
-        <title id="LandingZone_Expected_Results">EXPECTED RESULTS:</title>
+      <sect3 id="LandingZone_Expected_Results">
+        <title>EXPECTED RESULTS:</title>
 
         <para>Upon completion of the despray operation you will have a single
         file. You can then retrieve the file from the landing zone. This will
@@ -190,7 +190,7 @@
     </sect2>
   </sect1>
 
-  <sect1>
+  <sect1 id="CertifySpray">
     <title>Certify Spray</title>
 
     <para>The file will be sprayed from the Landing Zone to the Data Refinery,

--- a/docs/HPCCCertify/Cert-Mods/CertThorRox.xml
+++ b/docs/HPCCCertify/Cert-Mods/CertThorRox.xml
@@ -7,7 +7,7 @@
   <para>The following sections will help you to Certify that the Thor, hThor,
   and Roxie components of your system are all working correctly.</para>
 
-  <sect1 role="nobrk">
+  <sect1 id="Cert_BuildDataOnThor" role="nobrk">
     <title>Build Data on Thor</title>
 
     <para><orderedlist>
@@ -231,7 +231,7 @@
 
     <para></para>
 
-    <sect2>
+    <sect2 id="Cert_Thor">
       <title id="Certify_DR">Certify Thor</title>
 
       <orderedlist>
@@ -523,7 +523,7 @@
     </sect2>
   </sect1>
 
-  <sect1>
+  <sect1 id="Cert_VerifyIndexBuild">
     <title>Verify the Index Build</title>
 
     <orderedlist>
@@ -556,12 +556,12 @@
       <listitem>
         <para>Check the box next to <emphasis
         role="bold">certification::full_test_distributed_index</emphasis> ,
-        then press the <emphasis role="bold">Open</emphasis> action button.
-        </para>
+        then press the <emphasis role="bold">Open</emphasis> action
+        button.</para>
       </listitem>
 
       <listitem>
-        <para>Select the Contents tab. </para>
+        <para>Select the Contents tab.</para>
 
         <para><emphasis role="bold"></emphasis></para>
       </listitem>
@@ -583,7 +583,7 @@
 
     <para>This section certifies Thor access to indexed data.</para>
 
-    <sect2>
+    <sect2 id="CertifyThorAccess">
       <title>Certify Thor Access</title>
 
       <orderedlist>
@@ -658,7 +658,7 @@
       </orderedlist>
     </sect2>
 
-    <sect2>
+    <sect2 id="CertifyThor_ExpectedResult">
       <title>EXPECTED RESULT:</title>
 
       <para>The first 100 records from the query display, looking similar to
@@ -678,7 +678,7 @@
     </sect2>
   </sect1>
 
-  <sect1>
+  <sect1 id="Cert_CompilePublishRoxieQuery">
     <title>Compile and Publish a Roxie Query</title>
 
     <orderedlist>

--- a/docs/HPCCSystemAdmin/HPCCSystemAdministratorsGuide.xml
+++ b/docs/HPCCSystemAdmin/HPCCSystemAdministratorsGuide.xml
@@ -1415,7 +1415,7 @@ lock=/var/lock/HPCCSystems</programlisting>
         in a traditional shared storage high availability fail over
         model.</para>
 
-        <sect3>
+        <sect3 id="Thor_HA_Downside">
           <title>The Downside</title>
 
           <para>Costs twice as much initially because you essentially have to
@@ -1556,7 +1556,7 @@ lock=/var/lock/HPCCSystems</programlisting>
         run faster and benefit from huge page support. Huge pages of the
         appropriate type and size need to be allocated from the operating
         system. Almost all current Linux systems are set up with Transparent
-        Huge Pages (THP) available by default. </para>
+        Huge Pages (THP) available by default.</para>
 
         <para>Thor, Roxie, and ECL Agent clusters all have options in the
         configuration to enable huge page support. The Transparent Huge Pages
@@ -1568,7 +1568,7 @@ lock=/var/lock/HPCCSystems</programlisting>
         /sys/kernel/mm/transparent_hugepage/enabled to see what your OS
         setting is. With THP you do not have to explicitly set a size. If your
         system is not configured to use THP, then you may want to implement
-        Huge Pages. </para>
+        Huge Pages.</para>
 
         <sect3 id="SysAdm_BestPrac_SetUpHuge_Pgs">
           <title>Setting up Huge Pages</title>
@@ -1578,10 +1578,10 @@ lock=/var/lock/HPCCSystems</programlisting>
           administrator can allocate persistent huge pages (for the
           appropriate OS) on the kernel boot command line by specifying the
           "hugepages=N" parameter at boot. With huge pages you also need to
-          explicitly allocate the size. </para>
+          explicitly allocate the size.</para>
 
           <para>In HPCC, there are three places in the configuration manager
-          to set the attributes to use Huge Pages. </para>
+          to set the attributes to use Huge Pages.</para>
 
           <para>There are attributes in each component, in the ECL Agent
           attributes, in Roxie attributes, and in Thor attributes. In each

--- a/docs/HPCCSystemAdmin/SA-Mods/SysAdminConfigMod.xml
+++ b/docs/HPCCSystemAdmin/SA-Mods/SysAdminConfigMod.xml
@@ -392,7 +392,7 @@ sudo -u hpcc cp /etc/HPCCSystems/source/NewEnvironment.xml /etc/HPCCSystems/envi
       suggested configuration guides that can be helpful when planning your
       system.</para>
 
-      <sect2 role="nobrk">
+      <sect2 id="SysAdmin_MinSuggestedHW" role="nobrk">
         <title>Minimum Suggested Hardware</title>
 
         <para>HPCC was designed to run on common commodity hardware, and could
@@ -592,7 +592,7 @@ sudo -u hpcc cp /etc/HPCCSystems/source/NewEnvironment.xml /etc/HPCCSystems/envi
         <para>The following section provides some sample sizing for heavy
         processing with approximately the amount of data indicated.</para>
 
-        <sect3>
+        <sect3 id="SysAdm_BestPrac_750GB">
           <title>750 GB of Raw Data</title>
 
           <para>Thor = 3 (slaves) + 2 (management) = 5 Nodes</para>


### PR DESCRIPTION
FIX HPCC-14377 DOCS:Update Sect ID Attr. SysAdmin, Certify
Update Sect ID=Attributes as needed to harmonize with current docs.
Style Including Updates to Sect ID= Attributes: SysAdmin, Certify.

Signed-off-by: G Panagiotatos greg.panagiotatos@lexisnexis.com

@JamesDeFabia please review
