### PR TITLE
HPCC-12706 DOCS:Update Installing and Running doc Hardware section

### DIFF
--- a/docs/Installing_and_RunningTheHPCCPlatform/Installing_and_RunningTheHPCCPlatform.xml
+++ b/docs/Installing_and_RunningTheHPCCPlatform/Installing_and_RunningTheHPCCPlatform.xml
@@ -209,10 +209,6 @@
     </sect1>
   </chapter>
 
-  <xi:include href="Installing_and_RunningTheHPCCPlatform/Inst-Mods/Hardware.xml"
-              xpointer="Hardware-and-Software-Chapter"
-              xmlns:xi="http://www.w3.org/2001/XInclude" />
-
   <chapter id="HPCC-installation-and-startup">
     <title>HPCC Installation and Startup</title>
 


### PR DESCRIPTION
FIX HPCC-12706 DOCS:Update Installing and Running doc Hardware section
Removing this section (reference) from the Installing and Running book.
Section still exists, in the Systems Administrators guide,
will be revised/updated there under seperate cover.

Signed-off-by: G Panagiotatos greg.panagiotatos@lexisnexis.com

@JamesDeFabia please review
