### PR TITLE
HPCC-14397 Prevent invalid filename from stopping XREF

### DIFF
--- a/dali/sasha/saxref.cpp
+++ b/dali/sasha/saxref.cpp
@@ -1492,13 +1492,17 @@ public:
             if (abort)
                 return;
             CDfsLogicalFileName lfn;
-            lfn.set(lostfiles.item(i0));
+            if (!lfn.setValidate(lostfiles.item(i0))) {
+                error(lostfiles.item(i0), "Invalid filename detected");
+                continue;
+            }
             Owned<IDistributedFile> file;
             try {
                 file.setown(queryDistributedFileDirectory().lookup(lfn,UNKNOWN_USER));
             }
             catch (IException *e) {
                 EXCLOG(e,"CNewXRefManager::listLost");
+                e->Release();
             }
             if (!file) {
                 error(lfn.get(),"could not lookup possible lost file");


### PR DESCRIPTION
Whilst processing a list of candidate orphan files, XREF could
hit an exception handling an invalid logical file name.
It should have used CDfsLogicalFileName::setValide in common with
other place, to validate, warn and skip.
Changed to do so.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
