### PR TITLE
HPCC-14108 Libraries filter needs a clear label

### DIFF
--- a/esp/src/eclwatch/templates/QuerySetQueryWidget.html
+++ b/esp/src/eclwatch/templates/QuerySetQueryWidget.html
@@ -21,7 +21,7 @@
                         <input id="${id}Wuid" title="${i18n.WUID}:" name="WUID" colspan="2" data-dojo-props="trim: true, placeHolder:'W20130222-171723'" data-dojo-type="dijit.form.TextBox" />
                         <input id="${id}ClusterTargetSelect" title="${i18n.Cluster}:" name="QuerySetName" colspan="2" data-dojo-type="TargetSelectWidget" />
                         <input id="${id}FileName" title="${i18n.LogicalFile}:" name="FileName" colspan="2" data-dojo-props="trim: true, placeHolder: '${i18n.TargetNamePlaceholder}'" data-dojo-type="dijit.form.TextBox" />
-                        <input id="${id}LibraryName" title="${i18n.LibraryName}:" name="LibraryName" colspan="2" data-dojo-props="trim: true" data-dojo-type="dijit.form.TextBox" />
+                        <input id="${id}LibraryName" title="${i18n.LibrariesUsed}:" name="LibraryName" colspan="2" data-dojo-props="trim: true" data-dojo-type="dijit.form.TextBox" />
                         <select id="${id}SuspendedStates" title="${i18n.Suspended}:" name="SuspendedByUser" colspan="2" data-dojo-type="dijit.form.Select">
                             <option value="" selected="selected">${i18n.All}</option>
                             <option value="1">${i18n.SuspendedByUser}</option>


### PR DESCRIPTION
Whenever a user was filtering with the libraries option it was confusing as to what they were expecting. The filter returns libraries with that name that matches. So we are changing the label to "Libraries Used:"

Signed-off by: Miguel Vazquez miguel.vazquez@lexisnexis.com
