### PR TITLE
HPCC-14428 Replace popen/pclose with _popen/_pclose on Windows

### DIFF
--- a/esp/services/ws_machine/componentstatus.cpp
+++ b/esp/services/ws_machine/componentstatus.cpp
@@ -331,7 +331,7 @@ static CComponentStatusFactory *csFactory = NULL;
 
 static CriticalSection getComponentStatusSect;
 
-extern COMPONENTSTATUS_API IComponentStatusFactory* getComponentStatusFactory()
+IComponentStatusFactory* getComponentStatusFactory()
 {
     CriticalBlock block(getComponentStatusSect);
 

--- a/esp/services/ws_machine/componentstatus.hpp
+++ b/esp/services/ws_machine/componentstatus.hpp
@@ -104,4 +104,4 @@ public:
     virtual void updateComponentStatus(const char* reporter, IArrayOf<IConstComponentStatus>& statusList);
 };
 
-extern "C" COMPONENTSTATUS_API IComponentStatusFactory* getComponentStatusFactory();
+COMPONENTSTATUS_API IComponentStatusFactory* getComponentStatusFactory();

--- a/esp/services/ws_machine/ws_machineService.cpp
+++ b/esp/services/ws_machine/ws_machineService.cpp
@@ -1232,8 +1232,13 @@ int Cws_machineEx::invokeProgram(const char *command_line, StringBuffer& respons
         DBGLOG("command_line=<%s>", command_line);
     }
 #ifndef NO_CONNECTION_DEBUG
+#ifdef _WINDOWS
+    if( (fp = _popen( command_line, "r" )) == NULL )
+        return -1;
+#else
     if( (fp = popen( command_line, "r" )) == NULL )
         return -1;
+#endif
 #else
     if( (fp = fopen( "c:\\temp\\preflight_result.txt", "r" )) == NULL )
         return -1;
@@ -1252,7 +1257,11 @@ int Cws_machineEx::invokeProgram(const char *command_line, StringBuffer& respons
     }
     // Close pipe and print return value of CHKDSK.
 #ifndef NO_CONNECTION_DEBUG
+#ifdef _WINDOWS
+    return _pclose( fp );
+#else
     return pclose( fp );
+#endif
 #else
     return fclose( fp );
 #endif

--- a/esp/services/ws_machine/ws_machineService.cpp
+++ b/esp/services/ws_machine/ws_machineService.cpp
@@ -23,6 +23,7 @@
 #include "roxiecommlibscm.hpp"
 #include "componentstatus.hpp"
 #include "rmtssh.hpp"
+#include "platform.h"
 
 #ifndef eqHoleCluster
 #define eqHoleCluster  "HoleCluster"
@@ -1232,13 +1233,8 @@ int Cws_machineEx::invokeProgram(const char *command_line, StringBuffer& respons
         DBGLOG("command_line=<%s>", command_line);
     }
 #ifndef NO_CONNECTION_DEBUG
-#ifdef _WINDOWS
-    if( (fp = _popen( command_line, "r" )) == NULL )
-        return -1;
-#else
     if( (fp = popen( command_line, "r" )) == NULL )
         return -1;
-#endif
 #else
     if( (fp = fopen( "c:\\temp\\preflight_result.txt", "r" )) == NULL )
         return -1;
@@ -1257,11 +1253,7 @@ int Cws_machineEx::invokeProgram(const char *command_line, StringBuffer& respons
     }
     // Close pipe and print return value of CHKDSK.
 #ifndef NO_CONNECTION_DEBUG
-#ifdef _WINDOWS
-    return _pclose( fp );
-#else
     return pclose( fp );
-#endif
 #else
     return fclose( fp );
 #endif

--- a/system/include/platform.h
+++ b/system/include/platform.h
@@ -495,4 +495,13 @@ typedef __int64 cycle_t;
 // BUILD_TAG not needed here anymore - defined in build_tag.h
 //#define BUILD_TAG "build_0000" // Will get substituted during pre-build
 
+#ifdef _WINDOWS
+#ifndef popen
+#define popen   _popen
+#endif
+#ifndef pclose
+#define pclose  _pclose
+#endif
+#endif
+
 #endif


### PR DESCRIPTION
HPCC 6.0.0 Platform builds failed on Windows due to popen/pclose not defined and dllimport is not allowed in *.cpp file

Provided fixes resolve these issues by replacing popen/pclose with _poen/_pclose on Windows and 
removing "extern COMPONENTSTATUS_API" in componentstatus.cpp

Signed-off-by: Xiaoming Wang xiaoming.wang@lexisnexi.com 

@wangkx please reivew
