### PR TITLE
HPCC-14434 Fix testsocket so it can run on windows

### DIFF
--- a/tools/backupnode/backupnode.cpp
+++ b/tools/backupnode/backupnode.cpp
@@ -517,9 +517,7 @@ static void waitSlaves(const char *dir,unsigned num,StringAttr *slaves)
 
 int main(int argc, const char *argv[])
 {
-#ifndef _WIN32
     InitModuleObjects();
-#endif
     int retValue = 0;
 
     bool compress = false;

--- a/tools/testsocket/testsocket.cpp
+++ b/tools/testsocket/testsocket.cpp
@@ -634,9 +634,7 @@ void usage(int exitCode)
 
 int main(int argc, char **argv) 
 {
-#ifndef _WIN32
     InitModuleObjects();
-#endif
     StringAttr outputName("result.txt");
 
     bool fromFile = false;


### PR DESCRIPTION
InitModuleObjects() needs to be called for all platforms.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
