### PR TITLE
HPCC-14273 Fix externals files not being listed in hthor workunits

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -998,6 +998,7 @@ public:
      * The caller must associated it with a name and credentials when it is attached (attach())
      */
     IDistributedFile *createNew(IFileDescriptor * fdesc, bool includeports=false);
+    IDistributedFile *createExternal(IFileDescriptor *desc, const char *name, bool includeports=false);
     IDistributedSuperFile *createSuperFile(const char *logicalname,IUserDescriptor *user,bool interleaved,bool ifdoesnotexist,IDistributedFileTransaction *transaction=NULL);
     void removeSuperFile(const char *_logicalname, bool delSubs, IUserDescriptor *user, IDistributedFileTransaction *transaction);
 
@@ -7280,14 +7281,10 @@ IDistributedFile *CDistributedFileDirectory::dolookup(CDfsLogicalFileName &_logi
     {
         checkLogicalName(*logicalname,user,true,writeattr,true,NULL);
         if (logicalname->isExternal()) {
-            CDateTime modTime;
-            Owned<IFileDescriptor> fDesc = getExternalFileDescriptor(logicalname->get(), &modTime);
+            Owned<IFileDescriptor> fDesc = getExternalFileDescriptor(logicalname->get());
             if (!fDesc)
                 return NULL;
-            CDistributedFile *ret = new CDistributedFile(this, fDesc, NULL, true);
-            ret->setLogicalName(logicalname->get());
-            ret->setModificationTime(modTime);
-            return ret;
+            return queryDistributedFileDirectory().createExternal(fDesc, logicalname->get(), true);
         }
         if (logicalname->isForeign()) {
             IDistributedFile * ret = getFile(logicalname->get(),user,NULL);
@@ -7449,6 +7446,13 @@ bool CDistributedFileDirectory::existsPhysical(const char *_logicalname, IUserDe
 IDistributedFile *CDistributedFileDirectory::createNew(IFileDescriptor *fdesc, bool includeports)
 {
     return new CDistributedFile(this, fdesc, NULL, includeports);
+}
+
+IDistributedFile *CDistributedFileDirectory::createExternal(IFileDescriptor *fdesc, const char *name, bool includeports)
+{
+    CDistributedFile *dFile = new CDistributedFile(this, fdesc, NULL, includeports);
+    dFile->setLogicalName(name);
+    return dFile;
 }
 
 ////////////////////////////////////

--- a/dali/base/dadfs.hpp
+++ b/dali/base/dadfs.hpp
@@ -555,7 +555,8 @@ interface IDistributedFileDirectory: extends IInterface
                                         unsigned timeout=INFINITE
                                     ) = 0;  // links, returns NULL if not found
 
-    virtual IDistributedFile *createNew(IFileDescriptor *desc,bool includeports=false) = 0;
+    virtual IDistributedFile *createNew(IFileDescriptor *desc, bool includeports=false) = 0;
+    virtual IDistributedFile *createExternal(IFileDescriptor *desc, const char *name, bool includeports=false) = 0;
 
     virtual IDistributedFileIterator *getIterator(const char *wildname, bool includesuper, IUserDescriptor *user) = 0;
             // wildname is in form scope/name and may contain wild components for either

--- a/dali/base/dafdesc.hpp
+++ b/dali/base/dafdesc.hpp
@@ -323,7 +323,7 @@ extern da_decl bool setReplicateDir(const char *name,StringBuffer &out, bool isr
 extern da_decl IFileDescriptor *createFileDescriptor();
 extern da_decl IFileDescriptor *createFileDescriptor(IPropertyTree *attr);      // ownership of attr tree is taken
 extern da_decl IFileDescriptor *createExternalFileDescriptor(const char *logicalname);
-extern da_decl IFileDescriptor *getExternalFileDescriptor(const char *logicalname, CDateTime *modTime=NULL);
+extern da_decl IFileDescriptor *getExternalFileDescriptor(const char *logicalname);
 extern da_decl ISuperFileDescriptor *createSuperFileDescriptor(IPropertyTree *attr);        // ownership of attr tree is taken
 extern da_decl IFileDescriptor *deserializeFileDescriptor(MemoryBuffer &mb);
 extern da_decl IFileDescriptor *deserializeFileDescriptorTree(IPropertyTree *tree, INamedGroupStore *resolver=NULL, unsigned flags=0);  // flags IFDSF_*

--- a/dali/base/dautils.cpp
+++ b/dali/base/dautils.cpp
@@ -2935,7 +2935,7 @@ public:
             if (lfn.isExternal())
             {
                 Owned<IFileDescriptor> fDesc = createExternalFileDescriptor(lfn.get());
-                dfile.setown(queryDistributedFileDirectory().createNew(fDesc, true));
+                dfile.setown(queryDistributedFileDirectory().createExternal(fDesc, lfn.get(), true));
                 Owned<IFile> file = getPartFile(0,0);
                 if (file.get())
                     fileExists = file->exists();


### PR DESCRIPTION
A regression introduced by HPCC-11136, meant that hthor workunits
were not publishing a name for external files in the workunits
FilesRead section.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
