### PR TITLE
HPCC-14045 Sorting via size column not sorting

### DIFF
--- a/esp/src/eclwatch/DFUQueryWidget.js
+++ b/esp/src/eclwatch/DFUQueryWidget.js
@@ -502,7 +502,7 @@ define([
                     Description: { label: this.i18n.Description, width: 153 },
                     NodeGroup: { label: this.i18n.Cluster, width: 108 },
                     RecordCount: { label: this.i18n.Records, width: 72},
-                    Totalsize: { label: this.i18n.Size, width: 72},
+                    IntSize: { label: this.i18n.Size, width: 72},
                     Parts: { label: this.i18n.Parts, width: 45},
                     Modified: { label: this.i18n.ModifiedUTCGMT, width: 155}
                 }


### PR DESCRIPTION
Whenever using the column sort heading in the logical files widget it sorts via a string in the response and not by integer. Modifying the column to accept the appropriate part of the response.

Signed-off by: Miguel Vazquez miguel.vazquez@lexisnexis.com
