### PR TITLE
HPCC-14433 Allow <hpcc> user to run hpcc-init and dafilesrv

### DIFF
--- a/initfiles/bash/etc/init.d/dafilesrv.in
+++ b/initfiles/bash/etc/init.d/dafilesrv.in
@@ -72,7 +72,6 @@ component=""
 runSetupOnly=0
 source ${configgen_path}/hpcc_setenv
 
-is_root
 which_service
 get_commondirs
 

--- a/initfiles/bash/etc/init.d/hpcc-init.in
+++ b/initfiles/bash/etc/init.d/hpcc-init.in
@@ -90,10 +90,6 @@ source  ${INSTALL_DIR}/etc/init.d/hpcc_common
 source  ${INSTALL_DIR}/etc/init.d/init-functions
 source  ${INSTALL_DIR}/etc/init.d/export-path
 
-# Only root user can write following logfile
-is_root
-
-[ ! -e ${LOG_DIR} ] && mkdir -p ${LOG_DIR}
 export logfile=${LOG_DIR}/hpcc-init.log
 
 [ ! -e ${logfile}  ] && touch $logfile
@@ -277,6 +273,9 @@ if [ -z $arg ] || [ $# -ne 1 ]; then
 fi
 
 log "Debug log written to $LOG_DIR/hpcc-init.debug"
+[ -e $LOG_DIR/hpcc-init.debug ] && rm -rf ${LOG_DIR}/hpcc-init.debug
+touch ${LOG_DIR}/hpcc-init.debug
+chown ${user}:${user} ${LOG_DIR}/hpcc-init.debug
 exec 2>$LOG_DIR/hpcc-init.debug
 set -x
 

--- a/initfiles/bash/etc/init.d/hpcc_common.in
+++ b/initfiles/bash/etc/init.d/hpcc_common.in
@@ -302,7 +302,11 @@ configGenCmd() {
     validate_configuration
     configcmd="${configgen_path}/configgen -env ${envfile} -od ${runtime} -id ${componentFile} -c ${compName}"
     log "$configcmd"
-    su ${user} -c "$configcmd" 2>/dev/null
+    if [ "${USER}" != "${user}" ]; then
+        su ${user} -c "$configcmd" 2>/dev/null
+    else
+        ${configcmd} 2>/dev/null
+    fi
     rc=$?
     if [[ $rc -ne 0 ]]; then
         log  "configGenCmd(): failure in configgen call"
@@ -335,6 +339,7 @@ createRuntime() {
     chown -c $user:$group ${lock} 1> /dev/null 2>/dev/null
     chown -c $user:$group ${log}  1> /dev/null 2>/dev/null
 
+    [ -z "$compName" ] && return
 
     # Creating Component Specific directories
     # Creating pidfile specific directory and changing its owner permissions
@@ -548,6 +553,8 @@ startCmd() {
 
 stop_component() {
     printf "Stopping %-21s" "${compName}... "
+
+    cd ${compPath}
 
     ####
     ## This is handling for when daemon is running as an orphan daemon. That is process is

--- a/initfiles/bash/etc/init.d/install-init.in
+++ b/initfiles/bash/etc/init.d/install-init.in
@@ -297,6 +297,7 @@ if [ "${DISTRIB_NAME}" = "ubuntu" ] &&
    fi
 fi
 
-if [ -d ${CONFIG_DIR} ]; then
-    date > ${CONFIG_DIR}/installed
-fi
+createRuntime
+[ -e  ${LOG_DIR}/hpcc-init.debug ] && chown ${user}:${user} ${LOG_DIR}/hpcc-init.debug
+
+exit 0


### PR DESCRIPTION
remove is_root in hpcc-init and dafilesrv
move creating /var/log/HPCCSystems to install-init script
remove "su <hpcc> -c " if current user is <hpcc> user
Make sure debug log file owned by <hpcc> user
Create runtime directories and chown to <hpcc> user
Add handle empty $compName in createRuntime and remove redundant code
for generating log directores

Signed-off-by: Xiaoming Wang xiaoming.wang@lexisnexi.com

@Michael-Gardner please review
