### PR TITLE
HPCC-14439 Build errors in Rembed with RInside 0.2.13

### DIFF
--- a/plugins/Rembed/Rembed.cpp
+++ b/plugins/Rembed/Rembed.cpp
@@ -55,6 +55,7 @@
 #endif
 
 #include "RInside.h"
+#include "Rinterface.h"
 
 #include "jexcept.hpp"
 #include "jthread.hpp"


### PR DESCRIPTION
We were relying on RInside.h to include one of the the R headers for us... and
in 0.2.13 it stopped doing so...

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
