### PR TITLE
HPCC-14388 Force full warnings as errors for embedded C++

### DIFF
--- a/ecl/hqlcpp/hqlcpp.cpp
+++ b/ecl/hqlcpp/hqlcpp.cpp
@@ -11676,20 +11676,20 @@ void HqlCppTranslator::buildCppFunctionDefinition(BuildCtx &funcctx, IHqlExpress
         startLine += memcount(body-start, start, '\n');
     }
 
-    funcctx.addQuotedCompound(proto);
     funcctx.addQuoted("#if defined(__clang__) || (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 2))\n"
-                      "#pragma GCC diagnostic error \"-Wall\"\n"
-                      "#pragma GCC diagnostic error \"-Wextra\"\n"
-                      "#endif\n");
+            "#pragma GCC diagnostic error \"-Wall\"\n"
+            "#pragma GCC diagnostic error \"-Wextra\"\n"
+            "#endif\n");
+
+    funcctx.addQuotedCompound(proto, "\n#if defined(__clang__) || (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 2))\n"
+            "#pragma GCC diagnostic ignored \"-Wall\"\n"
+            "#pragma GCC diagnostic ignored \"-Wextra\"\n"
+            "#endif\n");
     if (location)
         funcctx.addLine(locationFilename, startLine);
     funcctx.addQuoted(body);
     if (location)
         funcctx.addLine();
-    funcctx.addQuoted("#if defined(__clang__) || (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 2))\n"
-                      "#pragma GCC diagnostic ignored \"-Wall\"\n"
-                      "#pragma GCC diagnostic ignored \"-Wextra\"\n"
-                      "#endif\n");
 }
 
 void HqlCppTranslator::buildScriptFunctionDefinition(BuildCtx &funcctx, IHqlExpression * funcdef, const char *proto)

--- a/ecl/hqlcpp/hqlcpp.cpp
+++ b/ecl/hqlcpp/hqlcpp.cpp
@@ -11679,6 +11679,7 @@ void HqlCppTranslator::buildCppFunctionDefinition(BuildCtx &funcctx, IHqlExpress
     funcctx.addQuoted("#if defined(__clang__) || (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 2))\n"
             "#pragma GCC diagnostic error \"-Wall\"\n"
             "#pragma GCC diagnostic error \"-Wextra\"\n"
+            "#pragma GCC diagnostic ignored \"-Wunused-parameter\"\n"  // Generated prototype tends to include ctx that is often not used
             "#endif\n");
 
     funcctx.addQuotedCompound(proto, "\n#if defined(__clang__) || (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 2))\n"

--- a/testing/regress/ecl/bloom2.ecl
+++ b/testing/regress/ecl/bloom2.ecl
@@ -38,11 +38,10 @@ bloomFilter(UNSIGNED DECIMAL6_3 falsePositiveProbability,
         unsigned long long slot = 0;
         unsigned int shift      = 0;
         unsigned int mask       = 0;
-        unsigned int test       = 0;
         const int slotsize = 8;
         unsigned long long numbits = _tablesize * slotsize;
         byte * outbits = self + sizeof(unsigned);
-        for (int i=0; i< _numhashes; i++) {
+        for (unsigned i=0; i< _numhashes; i++) {
           // Kirsch and Mitzenmacher technique (Harvard U)
           bit   =  (hash1 + (i * hash2)) % numbits;
           slot  = bit / slotsize;
@@ -91,7 +90,7 @@ bloomFilter(UNSIGNED DECIMAL6_3 falsePositiveProbability,
         bool retval = true;
 
         // Test each bit in the char array
-        for (int i=0; i< _numhashes; i++) {
+        for (unsigned i=0; i< _numhashes; i++) {
             // Kirsch and Mitzenmacher technique (Harvard U)
             bit   =  (hash1 + (i * hash2)) % numbits;
             slot  = bit / 8;


### PR DESCRIPTION
Make sure the diagnostics are outside the function body, as required by some
vintages of gcc.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
