### PR TITLE
HPCC-14448 LDAP Creation of parent OU should be more lenient

### DIFF
--- a/system/security/LdapSecurity/ldapconnection.cpp
+++ b/system/security/LdapSecurity/ldapconnection.cpp
@@ -4481,6 +4481,17 @@ private:
         }
     }
 
+    virtual bool organizationalUnitExists(const char * ou)
+    {
+        Owned<ILdapConnection> lconn = m_connections->getConnection();
+        LDAP* sys_ld = ((CLdapConnection*)lconn.get())->getLd();
+        char* attrs[] = {"ou", NULL};
+        CLDAPMessage searchResult;
+        TIMEVAL timeOut = {LDAPTIMEOUT,0};
+        int rc = ldap_search_ext_s(sys_ld, (char*)ou, LDAP_SCOPE_ONELEVEL, NULL, attrs, 0, NULL, NULL, &timeOut, LDAP_NO_LIMIT, &searchResult.msg);
+        return rc == LDAP_SUCCESS;
+    }
+
     virtual void createLdapBasedn(ISecUser* user, const char* basedn, SecPermissionType ptype)
     {
         if(basedn == NULL || basedn[0] == '\0')
@@ -4504,7 +4515,7 @@ private:
             ptr = comma + 1;
         }
 
-        if(ptr != NULL)
+        if (ptr && !organizationalUnitExists(ptr))
             createLdapBasedn(user, ptr, ptype);
 
         addOrganizationalUnit(user, oubuf.str(), ptr, ptype);
@@ -4521,6 +4532,8 @@ private:
 
         StringBuffer dn;
         dn.append("ou=").append(name).append(",").append(basedn);
+        if (organizationalUnitExists(dn.str()))
+            return true;
 
         char *ou_values[] = {(char*)name, NULL };
         LDAPMod ou_attr = 


### PR DESCRIPTION
If the LDAP Admin account does not have create access to any node in a given
OU path, then it throws and terminates. Typically, these admin accounts will
be created to only have create access to a subbranch of the OU tree, and the
parent branches are created via iSIT tickets. This PR checks for the existence
of a given OU before trying to create it, eliminating the exception.

Signed-off-by: Russ Whitehead william.whitehead@lexisnexis.com
