### PR TITLE
HPCC-14465 Fix __linux__ typo preventing memory mapped files working

### DIFF
--- a/system/jlib/jfile.cpp
+++ b/system/jlib/jfile.cpp
@@ -6239,7 +6239,7 @@ public:
             DWORD err = GetLastError();
             throw makeOsException(err,"CMemoryMappedFile::reinit");
         }
-#elif defined (_linux__)
+#elif defined (__linux__)
         ptr = (byte *) mmap(NULL, mapsz, writeaccess?(PROT_READ|PROT_WRITE):PROT_READ, MAP_SHARED|MAP_NORESERVE, hfile, realofs);
             // error checking TBD
 #else


### PR DESCRIPTION
Signed-off-by: Jake Smith jake.smith@lexisnexis.com
