### PR TITLE
HPCC-13630 Configmgr's regex.awk script substitutes wrong file

### DIFF
--- a/initfiles/sbin/configmgr.in
+++ b/initfiles/sbin/configmgr.in
@@ -93,7 +93,7 @@ if [ $# -eq 3 ]; then
     conffile=$3
     echo "<filename> = ${filename}"
     echo "<portnumber> = ${portnum}"
-    echo "<LocalConfFile> = ${conffile}"
+    echo "<LocalEnvConfFile> = ${conffile}"
     #checking where files exists or not
     if [ ! -e ${filename} ] || [ ! -e ${conffile} ]
     then

--- a/initfiles/sbin/regex.awk.in.cmake
+++ b/initfiles/sbin/regex.awk.in.cmake
@@ -14,7 +14,7 @@
 #    limitations under the License.
 ################################################################################
 /LocalEnvFile/ && ( NEW_ENVFILE != "" ) { gsub("${CONFIG_DIR}/${ENV_XML_FILE}", NEW_ENVFILE )}
-/LocalConfFile/ && ( NEW_CONFFILE != "" ) { gsub("${CONFIG_DIR}/${ENV_CONF_FILE}", NEW_CONFFILE )  }
+/LocalEnvConfFile/ && ( NEW_CONFFILE != "" ) { gsub("${CONFIG_DIR}/${ENV_CONF_FILE}", NEW_CONFFILE )  }
 /EspBinding/ && ( NEW_PORT != "" )  { gsub(/port=\"[0-9]*\"/, "port=\""NEW_PORT  "\"" )  }
 
 { print $0 }


### PR DESCRIPTION
The LocalConfFile field which gets built in the esp.xml for configmgr should be pointing to /opt/HPCCSystems/etc/HPCCSystems/configmgr/configmgr.conf and LocalEnvConfFile should be pointing to /etc/HPCCSystems/environment.conf by default.
Signed-off-by: Michael Gardner michael.gardner@lexisnexis.com
