### PR TITLE
HPCC-14260 Fix duplicate statistic for non root subgraph in child query

### DIFF
--- a/ecl/eclagent/eclgraph.cpp
+++ b/ecl/eclagent/eclgraph.cpp
@@ -929,6 +929,8 @@ void EclSubGraph::doExecute(const byte * parentExtract, bool checkDependencies)
         return;
     }
 
+    if (startGraphTime == 0)
+        startGraphTime = getTimeStampNowValue();
     cycle_t startGraphCycles = get_cycles_now();
     ForEachItemIn(idx, elements)
     {
@@ -974,8 +976,6 @@ void EclSubGraph::execute(const byte * parentExtract)
         return;
     }
 
-    startGraphTime = getTimeStampNowValue();
-    cycle_t startGraphCycles = get_cycles_now();
     createActivities();
     if (debugContext)
         debugContext->checkBreakpoint(DebugStateGraphStart, NULL, parent.queryGraphName() );    //debug probes exist so we can now check breakpoints
@@ -985,7 +985,7 @@ void EclSubGraph::execute(const byte * parentExtract)
 
     if(!owner)
         PROGLOG("Completed subgraph %u", id);
-    if (!parent.queryLibrary())
+    if (!owner && !parent.queryLibrary())
     {
         updateProgress();
         cleanupActivities();


### PR DESCRIPTION
Also add start time to root subgraph for child query

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
