### PR TITLE
HPCC-14474 Improve testing of sorts

### DIFF
--- a/testing/regress/ecl/key/sortfwd.xml
+++ b/testing/regress/ecl/key/sortfwd.xml
@@ -1,0 +1,3 @@
+<Dataset name='Result 1'>
+ <Row><Result_1>true</Result_1></Row>
+</Dataset>

--- a/testing/regress/ecl/key/sortnorm.xml
+++ b/testing/regress/ecl/key/sortnorm.xml
@@ -1,0 +1,3 @@
+<Dataset name='Result 1'>
+ <Row><Result_1>true</Result_1></Row>
+</Dataset>

--- a/testing/regress/ecl/key/sortrev.xml
+++ b/testing/regress/ecl/key/sortrev.xml
@@ -1,0 +1,3 @@
+<Dataset name='Result 1'>
+ <Row><Result_1>true</Result_1></Row>
+</Dataset>

--- a/testing/regress/ecl/key/sortstable.xml
+++ b/testing/regress/ecl/key/sortstable.xml
@@ -1,0 +1,3 @@
+<Dataset name='Result 1'>
+ <Row><Result_1>true</Result_1></Row>
+</Dataset>

--- a/testing/regress/ecl/sortfwd.ecl
+++ b/testing/regress/ecl/sortfwd.ecl
@@ -1,0 +1,17 @@
+//class=sort
+//version algo='quicksort'
+//version algo='parquicksort'
+//version algo='mergesort'
+//version algo='parmergesort'
+//version algo='heapsort'
+//version algo='tbbstableqsort'
+
+import ^ as root;
+algo := #IFDEFINED(root.algo, 'quicksort');
+
+numRows := 100000;
+
+ds := DATASET(numRows, TRANSFORM({unsigned id}, SELF.id := COUNTER));
+s1 := sort(ds, id, local, stable(algo));
+s2 := SORTED(NOFOLD(s1), id, local, assert);
+output(COUNT(NOFOLD(s2)) = numRows);

--- a/testing/regress/ecl/sortnorm.ecl
+++ b/testing/regress/ecl/sortnorm.ecl
@@ -1,0 +1,17 @@
+//class=sort
+//version algo='quicksort'
+//version algo='parquicksort'
+//version algo='mergesort'
+//version algo='parmergesort'
+//version algo='heapsort'
+//version algo='tbbstableqsort'
+
+import ^ as root;
+algo := #IFDEFINED(root.algo, 'quicksort');
+
+numRows := 100000;
+
+ds := DATASET(numRows, TRANSFORM({unsigned id}, SELF.id := HASH32(COUNTER)));
+s1 := sort(ds, id, local, stable(algo));
+s2 := SORTED(NOFOLD(s1), id, local, assert);
+output(COUNT(NOFOLD(s2)) = numRows);

--- a/testing/regress/ecl/sortrev.ecl
+++ b/testing/regress/ecl/sortrev.ecl
@@ -1,0 +1,17 @@
+//class=sort
+//version algo='quicksort'
+//version algo='parquicksort'
+//version algo='mergesort'
+//version algo='parmergesort'
+//version algo='heapsort'
+//version algo='tbbstableqsort'
+
+import ^ as root;
+algo := #IFDEFINED(root.algo, 'quicksort');
+
+numRows := 100000;
+
+ds := DATASET(numRows, TRANSFORM({unsigned id}, SELF.id := numRows - COUNTER));
+s1 := sort(ds, id, local, stable(algo));
+s2 := SORTED(NOFOLD(s1), id, local, assert);
+output(COUNT(NOFOLD(s2)) = numRows);

--- a/testing/regress/ecl/sortstable.ecl
+++ b/testing/regress/ecl/sortstable.ecl
@@ -1,0 +1,17 @@
+//class=sort
+//version algo='quicksort'
+//version algo='parquicksort'
+//version algo='mergesort'
+//version algo='parmergesort'
+//version algo='heapsort'
+//version algo='tbbstableqsort'
+
+import ^ as root;
+algo := #IFDEFINED(root.algo, 'quicksort');
+
+numRows := 100000;
+
+ds := DATASET(numRows, TRANSFORM({unsigned id}, SELF.id := COUNTER));
+s1 := sort(ds, HASH32(id % 256), local, stable(algo));
+s2 := SORTED(NOFOLD(s1), HASH32(id % 256), id, local, assert);
+output(COUNT(NOFOLD(s2)) = numRows);


### PR DESCRIPTION
Add random, sorted, reverse sorted tests, and check results
are sorted, and sorting is stable.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
