### PR TITLE
HPCC-14468 LDAP SecMgr unable to search distinguishedName with backslash

### DIFF
--- a/system/security/LdapSecurity/ldapconnection.cpp
+++ b/system/security/LdapSecurity/ldapconnection.cpp
@@ -3908,6 +3908,11 @@ private:
         StringBuffer filter;
         filter.append("distinguishedName=").append(dn);
 
+        filter.replaceString("\\", "\\5c");//Replace special characters with valid UTF-8 string (see valueencoding rule in RFC 4515)
+        filter.replaceString("*", "\\2a");
+        filter.replaceString("(", "\\28");
+        filter.replaceString(")", "\\29");
+
         char        *attribute;
         LDAPMessage *message;
 


### PR DESCRIPTION
Using OpenLDAP, if a DistinguishedName has a backslash escape character in it such as
CN=Whitehead\, William,OU=BCT,OU=Users
then calls to ldap_search_ext_s fail with a "bad filter" return code. According
to LDAP RFC 4515, these characters should be encoded as \xx , where xx is the
hex ascii code for that character. These characters are \,(,),and *

Signed-off-by: Russ Whitehead william.whitehead@lexisnexis.com
