### PR TITLE
HPCC-14388 Force full warnings as errors for embedded C++

### DIFF
--- a/ecl/hqlcpp/hqlcpp.cpp
+++ b/ecl/hqlcpp/hqlcpp.cpp
@@ -11685,6 +11685,7 @@ void HqlCppTranslator::buildCppFunctionDefinition(BuildCtx &funcctx, IHqlExpress
     funcctx.addQuotedCompound(proto, "\n#if defined(__clang__) || (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 2))\n"
             "#pragma GCC diagnostic ignored \"-Wall\"\n"
             "#pragma GCC diagnostic ignored \"-Wextra\"\n"
+            "#pragma GCC diagnostic ignored \"-Wunused-variable\"\n"  // Some variants of gcc seemt to be buggy - this SHOULD be covered by -Wall above but gcc4.8.4 needs it explicit
             "#endif\n");
     if (location)
         funcctx.addLine(locationFilename, startLine);

--- a/testing/regress/ecl/normalize4.ecl
+++ b/testing/regress/ecl/normalize4.ecl
@@ -67,9 +67,9 @@ streamed dataset(out1Rec) extractResult3(doneRec done) := BEGINC++
         }
         virtual void stop() {}
     private:
+        Linked<IEngineRowAllocator> allocator;
         unsigned id;
         unsigned idx;
-        Linked<IEngineRowAllocator> allocator;
     };
     #body
     const unsigned id = *(unsigned *)done;


### PR DESCRIPTION
Work around an issue in some versions of gcc that do not disable the same
warnings as they enable when #pragma diagnostic -Wall is used.

Also update a test case that was triggering some compiler warnings in embedded
C++ on newer versions of gcc.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
