### PR TITLE
HPCC-14501 Remove annoying compile time warning

### DIFF
--- a/system/security/htpasswdSecurity/htpasswdSecurity.cpp
+++ b/system/security/htpasswdSecurity/htpasswdSecurity.cpp
@@ -179,7 +179,8 @@ private:
 						throw MakeStringException(-1, "htpasswd Password file appears malformed");
 					*colon = (char)NULL;
 					userMap.setValue(next, colon+1);//username, enctypted password
-				} while (next = strtok_r(NULL, seps, &saveptr));
+					next = strtok_r(NULL, seps, &saveptr);
+				} while (next);
 			}
 
 			io->close();


### PR DESCRIPTION
gcc compiler complains about assignments withing a test expression
do {} while (next = strtok_r(NULL, seps, &saveptr));

This PR separates them onto separate lines
do { next = strtok_r(NULL, seps, &saveptr)} while (next);

Signed-off-by: Russ Whitehead william.whitehead@lexisnexis.com
