### PR TITLE
HPCC-14155 Skip slave unregister when asked to shutdown

### DIFF
--- a/thorlcr/slave/slavmain.hpp
+++ b/thorlcr/slave/slavmain.hpp
@@ -19,7 +19,7 @@
 #define SLAVMAIN_HPP
 
 void abortSlave();
-void slaveMain();
+void slaveMain(bool &jobListenerStopped);
 void enableThorSlaveAsDaliClient();
 void disableThorSlaveAsDaliClient();
 

--- a/thorlcr/slave/slwatchdog.cpp
+++ b/thorlcr/slave/slwatchdog.cpp
@@ -76,12 +76,15 @@ public:
     }
     virtual void stop()
     {
+        if (!stopped)
+        {
 #ifdef _WIN32
-        threaded.adjustPriority(0); // restore to normal before stopping
+            threaded.adjustPriority(0); // restore to normal before stopping
 #endif
-        stopped = true;
-        threaded.join();
-        LOG(MCdebugProgress, thorJob, "Stopped watchdog");
+            stopped = true;
+            threaded.join();
+            LOG(MCdebugProgress, thorJob, "Stopped watchdog");
+        }
     }
 
     size32_t gatherData(MemoryBuffer &mb)


### PR DESCRIPTION
Master waits for replies from all slaves before ending
so init script does not send kill signal to slaves which caused them
to unregister with a no longer running master.

@jakesmith please review

Signed-off-by: Mark Kelly mark.kelly@lexisnexis.com
