### PR TITLE
HPCC-14353 Unicode collator lookup should be case-sensitive

### DIFF
--- a/rtl/eclrtl/eclrtl.cpp
+++ b/rtl/eclrtl/eclrtl.cpp
@@ -326,7 +326,7 @@ RTLUnicodeConverter * queryRTLUnicodeConverter(char const * codepage)
 {
     if (!unicodeConverterMap) // NB: one per thread, so no contention
     {
-        unicodeConverterMap = new MapStrToUnicodeConverter(GetCurrentThreadId());
+        unicodeConverterMap = new MapStrToUnicodeConverter;
         // Use thread terminator hook to clear them up on thread exit.
         // NB: May need to revisit if not on a jlib Thread.
         prevThreadTerminator = addThreadTermFunc(clearUnicodeConverterMap);


### PR DESCRIPTION
An inadvertant typo when fixing HPCC-13941 would have made collator lookups
case-insensitive.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
