### PR TITLE
HPCC-14454 Fix incorrect constant folding of CHOOSE(0,...)

### DIFF
--- a/ecl/hqlcpp/hqlttcpp.cpp
+++ b/ecl/hqlcpp/hqlttcpp.cpp
@@ -11764,9 +11764,12 @@ IHqlExpression * HqlTreeNormalizer::createTransformed(IHqlExpression * expr)
             if (condValue)
             {
                 unsigned idx = (unsigned)condValue->getIntValue();
-                IHqlExpression * branch = queryRealChild(expr, idx);
-                if (branch)
-                    return transform(branch);
+                if (idx != 0)
+                {
+                    IHqlExpression * branch = queryRealChild(expr, idx);
+                    if (branch)
+                        return transform(branch);
+                }
                 IHqlExpression * defaultExpr = queryLastNonAttribute(expr);
                 return transform(defaultExpr);
             }

--- a/ecl/regress/issue14454.ecl
+++ b/ecl/regress/issue14454.ecl
@@ -1,0 +1,6 @@
+toText(UNSIGNED1 i) := CHOOSE(i,'one','two','elsevalue');
+OUTPUT(toText(0));
+OUTPUT(toText(1));
+OUTPUT(toText(2));
+OUTPUT(toText(3));
+OUTPUT(toText(4));


### PR DESCRIPTION
It would evaluate to 0, instead of the default value

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
