### PR TITLE
HPCC-14523 ESP incorrectly parses user,pwd

### DIFF
--- a/esp/bindings/http/platform/httptransport.cpp
+++ b/esp/bindings/http/platform/httptransport.cpp
@@ -1564,8 +1564,19 @@ void CHttpRequest::getBasicAuthorization(StringBuffer& userid, StringBuffer& pas
 
     StringBuffer uidpair;
     Utils::base64decode(authheader.length() - strlen("Basic "), authheader.str() + strlen("Basic "), uidpair);
+
+    //uidpair formatted as   [domain\]username:password    (domain optional)
     
+    //Look for optional domain name separator. Assumes username cannot contain '\'
     const char* pairstr = strchr(uidpair.str(), '\\');
+
+    if (pairstr)
+    {
+        const char * pwdSep = strchr(uidpair, ':');//look for user:pwd separator
+        if (pwdSep && pwdSep < pairstr)//if : is before \, then \ is part of password and not domain separator
+            pairstr = NULL;
+    }
+
     if(pairstr!=NULL)
     {
         realm.append(pairstr - uidpair.str(),uidpair.str());


### PR DESCRIPTION
When parsing a [domain]username:password string, ESP incorrectly assumes the
presence of a backslash must be a domain name separator. This PR makes sure
it is only treated as a domain separator if it occurs before the : separator

Signed-off-by: Russ Whitehead william.whitehead@lexisnexis.com
