### PR TITLE
HPCC-14530 Exclude TBB related sort versions from hthor.

### DIFF
--- a/testing/regress/ecl/sortfwd.ecl
+++ b/testing/regress/ecl/sortfwd.ecl
@@ -4,7 +4,7 @@
 //version algo='mergesort'
 //version algo='parmergesort'
 //version algo='heapsort'
-//version algo='tbbstableqsort'
+//version algo='tbbstableqsort',nohthor
 
 import ^ as root;
 algo := #IFDEFINED(root.algo, 'quicksort');

--- a/testing/regress/ecl/sortnorm.ecl
+++ b/testing/regress/ecl/sortnorm.ecl
@@ -4,7 +4,7 @@
 //version algo='mergesort'
 //version algo='parmergesort'
 //version algo='heapsort'
-//version algo='tbbstableqsort'
+//version algo='tbbstableqsort',nohthor
 
 import ^ as root;
 algo := #IFDEFINED(root.algo, 'quicksort');

--- a/testing/regress/ecl/sortrev.ecl
+++ b/testing/regress/ecl/sortrev.ecl
@@ -4,7 +4,7 @@
 //version algo='mergesort'
 //version algo='parmergesort'
 //version algo='heapsort'
-//version algo='tbbstableqsort'
+//version algo='tbbstableqsort',nohthor
 
 import ^ as root;
 algo := #IFDEFINED(root.algo, 'quicksort');

--- a/testing/regress/ecl/sortstable.ecl
+++ b/testing/regress/ecl/sortstable.ecl
@@ -4,7 +4,7 @@
 //version algo='mergesort'
 //version algo='parmergesort'
 //version algo='heapsort'
-//version algo='tbbstableqsort'
+//version algo='tbbstableqsort',nohthor
 
 import ^ as root;
 algo := #IFDEFINED(root.algo, 'quicksort');


### PR DESCRIPTION
Add exclusion for
- sortfwd.ecl ( version: algo='tbbstableqsort' )
- sortnorm.ecl ( version: algo='tbbstableqsort' )
- sortrev.ecl ( version: algo='tbbstableqsort' )
- sortstable.ecl ( version: algo='tbbstableqsort' )
  test cases

Signed-off-by: Attila Vamos attila.vamos@gmail.com
