### PR TITLE
HPCC-14527 UDP sniffer still sends multicast when roxieMulticastEnabled=false

### DIFF
--- a/roxie/ccd/ccdmain.cpp
+++ b/roxie/ccd/ccdmain.cpp
@@ -716,7 +716,10 @@ int STARTQUERY_API start_query(int argc, const char *argv[])
         
         roxieMulticastEnabled = topology->getPropBool("@roxieMulticastEnabled", true);   // enable use of multicast for sending requests to slaves
         if (udpSnifferEnabled && !roxieMulticastEnabled)
+        {
             DBGLOG("WARNING: ignoring udpSnifferEnabled setting as multicast not enabled");
+            udpSnifferEnabled = false;
+        }
 
         indexReadChunkSize = topology->getPropInt("@indexReadChunkSize", 60000);
         numSlaveThreads = topology->getPropInt("@slaveThreads", 30);


### PR DESCRIPTION
Signed-off-by: Richard Chapman rchapman@hpccsystems.com
