### PR TITLE
HPCC-14528 Refactor DFS update during publish/add-pkgmap/copy-query

### DIFF
--- a/common/workunit/referencedfilelist.hpp
+++ b/common/workunit/referencedfilelist.hpp
@@ -61,8 +61,8 @@ interface IReferencedFileList : extends IInterface
 
     virtual IReferencedFileIterator *getFiles()=0;
     virtual void resolveFiles(const char *process, const char *remoteIP, const char * remotePrefix, const char *srcCluster, bool checkLocalFirst, bool addSubFiles, bool trackSubFiles, bool resolveForeign=false)=0;
-    virtual void cloneAllInfo(IDFUhelper *helper, bool overwrite, bool cloneSuperInfo, bool cloneForeign, unsigned redundancy, unsigned channelsPerNode, int replicateOffset, const char *defRepFolder)=0;
-    virtual void cloneFileInfo(IDFUhelper *helper, bool overwrite, bool cloneSuperInfo, bool cloneForeign, unsigned redundancy, unsigned channelsPerNode, int replicateOffset, const char *defRepFolder)=0;
+    virtual void cloneAllInfo(unsigned updateFlags, IDFUhelper *helper, bool cloneSuperInfo, bool cloneForeign, unsigned redundancy, unsigned channelsPerNode, int replicateOffset, const char *defRepFolder)=0;
+    virtual void cloneFileInfo(unsigned updateFlags, IDFUhelper *helper, bool cloneSuperInfo, bool cloneForeign, unsigned redundancy, unsigned channelsPerNode, int replicateOffset, const char *defRepFolder)=0;
     virtual void cloneRelationships()=0;
 };
 

--- a/dali/dfu/dfuutil.cpp
+++ b/dali/dfu/dfuutil.cpp
@@ -778,7 +778,7 @@ public:
         dfile->getClusterNames(clusterNames);
         return clusterNames.find(cluster1)!=NotFound;
     }
-    bool checkIsKey(IPropertyTree *ftree)
+    inline bool checkIsKey(IPropertyTree *ftree)
     {
         const char * kind = ftree->queryProp("Attr/@kind");
         return kind && streq(kind, "key");

--- a/dali/dfu/dfuutil.hpp
+++ b/dali/dfu/dfuutil.hpp
@@ -29,6 +29,14 @@ interface IDfuFileCopier: extends IInterface
     virtual bool wait()=0; // waits for all outstanding copies to complete
 };
 
+#define DALI_UPDATEF_REPLACE_FILE   0x0001
+#define DALI_UPDATEF_CLONE_FROM     0x0002
+#define DALI_UPDATEF_APPEND_CLUSTER 0x0004
+#define DALI_UPDATEF_SUPERFILES     0x0008
+#define DALI_UPDATEF_PACKAGEMAP     0x0100
+
+#define DALI_UPDATEF_SUBFILE_MASK (DALI_UPDATEF_REPLACE_FILE | DALI_UPDATEF_CLONE_FROM | DALI_UPDATEF_APPEND_CLUSTER)
+#define DALI_UPDATEF_MASK (DALI_UPDATEF_REPLACE_FILE | DALI_UPDATEF_CLONE_FROM | DALI_UPDATEF_APPEND_CLUSTER | DALI_UPDATEF_SUPERFILES | DALI_UPDATEF_PACKAGEMAP)
 
 interface IDFUhelper: extends IInterface
 {
@@ -82,7 +90,7 @@ interface IDFUhelper: extends IInterface
                          const char *defReplicateFolder,
                          IUserDescriptor *userdesc,                // user desc for local dali
                          const char *foreigndali,                  // can be omitted if srcname foreign or local
-                         bool overwrite                            // overwrite destination if exists
+                         unsigned overwriteFlags                   // overwrite destination options
                          ) = 0;
 
     virtual void cloneFileRelationships(

--- a/ecl/ecl-package/ecl-package.cpp
+++ b/ecl/ecl-package/ecl-package.cpp
@@ -481,7 +481,8 @@ private:
 class EclCmdPackageAdd : public EclCmdCommon
 {
 public:
-    EclCmdPackageAdd() : optActivate(false), optOverWrite(false), optGlobalScope(false), optAllowForeign(false), optPreloadAll(false)
+    EclCmdPackageAdd() : optActivate(false), optOverWrite(false), optGlobalScope(false), optAllowForeign(false), optPreloadAll(false),
+        optUpdateSuperfiles(false), optUpdateCloneFrom(false), optDontAppendCluster(false), optReplacePackagemap(false)
     {
     }
     virtual bool parseCommandLineOptions(ArgvIterator &iter)
@@ -514,6 +515,14 @@ public:
             if (iter.matchFlag(optActivate, ECLOPT_ACTIVATE)||iter.matchFlag(optActivate, ECLOPT_ACTIVATE_S))
                 continue;
             if (iter.matchFlag(optOverWrite, ECLOPT_OVERWRITE)||iter.matchFlag(optOverWrite, ECLOPT_OVERWRITE_S))
+                continue;
+            if (iter.matchFlag(optReplacePackagemap, ECLOPT_REPLACE))
+                continue;
+            if (iter.matchFlag(optUpdateSuperfiles, ECLOPT_UPDATE_SUPER_FILES))
+                continue;
+            if (iter.matchFlag(optUpdateCloneFrom, ECLOPT_UPDATE_CLONE_FROM))
+                continue;
+            if (iter.matchFlag(optDontAppendCluster, ECLOPT_DONT_APPEND_CLUSTER))
                 continue;
             if (iter.matchFlag(optGlobalScope, ECLOPT_GLOBAL_SCOPE))
                 continue;
@@ -577,6 +586,10 @@ public:
         request->setSourceProcess(optSourceProcess);
         request->setAllowForeignFiles(optAllowForeign);
         request->setPreloadAllPackages(optPreloadAll);
+        request->setReplacePackageMap(optReplacePackagemap);
+        request->setUpdateSuperFiles(optUpdateSuperfiles);
+        request->setUpdateCloneFrom(optUpdateCloneFrom);
+        request->setAppendCluster(!optDontAppendCluster);
 
         Owned<IClientAddPackageResponse> resp = packageProcessClient->AddPackage(request);
         if (resp->getExceptions().ordinality())
@@ -601,17 +614,21 @@ public:
                     "The 'add' command will add the package map information to dali \n"
                     "\n"
                     "ecl packagemap add [options] <target> <filename>\n"
+                    "   <target>                 Name of target to use when adding package map information\n"
+                    "   <filename>               Name of file containing package map information\n"
                     " Options:\n"
-                    "   -O, --overwrite             Overwrite existing information\n"
-                    "   -A, --activate              Activate the package information\n"
-                    "   --daliip=<ip>               IP of the remote dali to use for logical file lookups\n"
-                    "   --pmid                      Identifier of package map - defaults to filename if not specified\n"
-                    "   --global-scope              The specified packagemap can be shared across multiple targets\n"
-                    "   --source-process            Process cluster to copy files from\n"
-                    "   --allow-foreign             Do not fail if foreign files are used in packagemap\n"
-                    "   --preload-all               Set preload files option for all packages\n"
-                    "   <target>                    Name of target to use when adding package map information\n"
-                    "   <filename>                  Name of file containing package map information\n",
+                    "   -O, --overwrite          Replace existing packagemap and file information (dangerous)\n"
+                    "   -A, --activate           Activate the package information\n"
+                    "   --daliip=<ip>            IP of the remote dali to use for logical file lookups\n"
+                    "   --pmid                   Identifier of package map - defaults to filename if not specified\n"
+                    "   --global-scope           The specified packagemap can be shared across multiple targets\n"
+                    "   --source-process         Process cluster to copy files from\n"
+                    "   --allow-foreign          Do not fail if foreign files are used in packagemap\n"
+                    "   --preload-all            Set preload files option for all packages\n"
+                    "   --replace                Replace existing packagmap"
+                    "   --update-super-files     Update local DFS super-files if remote DALI has changed\n"
+                    "   --update-clone-from      Update local clone from location if remote DALI has changed\n"
+                    "   --dont-append-cluster    Only use to avoid locking issues due to adding cluster to file\n",
                     stdout);
 
         EclCmdCommon::usage();
@@ -626,6 +643,10 @@ private:
     StringAttr optSourceProcess;
     bool optActivate;
     bool optOverWrite;
+    bool optReplacePackagemap;
+    bool optUpdateSuperfiles;
+    bool optUpdateCloneFrom;
+    bool optDontAppendCluster; //Undesirable but here temporarily because DALI may have locking issues
     bool optGlobalScope;
     bool optAllowForeign;
     bool optPreloadAll;

--- a/ecl/eclcmd/eclcmd_common.hpp
+++ b/ecl/eclcmd/eclcmd_common.hpp
@@ -61,6 +61,7 @@ typedef IEclCommand *(*EclCommandFactory)(const char *cmdname);
 
 #define ECLOPT_NORELOAD "--no-reload"
 #define ECLOPT_OVERWRITE "--overwrite"
+#define ECLOPT_REPLACE "--replace"
 #define ECLOPT_OVERWRITE_S "-O"
 #define ECLOPT_OVERWRITE_INI "overwriteDefault"
 #define ECLOPT_OVERWRITE_ENV NULL
@@ -95,6 +96,9 @@ typedef IEclCommand *(*EclCommandFactory)(const char *cmdname);
 #define ECLOPT_CHECK_ALL_NODES "--check-all-nodes"
 #define ECLOPT_CHECK_ALL_NODES_INI "checkAllNodes"
 #define ECLOPT_CHECK_ALL_NODES_ENV "CHECK_ALL_NODES"
+#define ECLOPT_UPDATE_SUPER_FILES "--update-super-files"
+#define ECLOPT_UPDATE_CLONE_FROM "--update-clone-from"
+#define ECLOPT_DONT_APPEND_CLUSTER "--dont-append-cluster"
 
 #define ECLOPT_MAIN "--main"
 #define ECLOPT_MAIN_S "-main"  //eclcc compatible format

--- a/ecl/eclcmd/eclcmd_core.cpp
+++ b/ecl/eclcmd/eclcmd_core.cpp
@@ -280,7 +280,8 @@ class EclCmdPublish : public EclCmdWithEclTarget
 {
 public:
     EclCmdPublish() : optNoActivate(false), optSuspendPrevious(false), optDeletePrevious(false),
-        activateSet(false), optNoReload(false), optDontCopyFiles(false), optMsToWait(10000), optAllowForeign(false), optUpdateDfs(false)
+        activateSet(false), optNoReload(false), optDontCopyFiles(false), optMsToWait(10000), optAllowForeign(false), optUpdateDfs(false),
+        optUpdateSuperfiles(false), optUpdateCloneFrom(false), optDontAppendCluster(false)
     {
         optObj.accept = eclObjWuid | eclObjArchive | eclObjSharedObject;
         optTimeLimit = (unsigned) -1;
@@ -336,6 +337,12 @@ public:
             if (iter.matchFlag(optDeletePrevious, ECLOPT_DELETE_PREVIOUS)||iter.matchFlag(optDeletePrevious, ECLOPT_DELETE_PREVIOUS_S))
                 continue;
             if (iter.matchFlag(optUpdateDfs, ECLOPT_UPDATE_DFS))
+                continue;
+            if (iter.matchFlag(optUpdateSuperfiles, ECLOPT_UPDATE_SUPER_FILES))
+                continue;
+            if (iter.matchFlag(optUpdateCloneFrom, ECLOPT_UPDATE_CLONE_FROM))
+                continue;
+            if (iter.matchFlag(optDontAppendCluster, ECLOPT_DONT_APPEND_CLUSTER))
                 continue;
             if (EclCmdWithEclTarget::matchCommandLineOption(iter, true)!=EclCmdOptionMatch)
                 return false;
@@ -413,6 +420,9 @@ public:
         req->setDontCopyFiles(optDontCopyFiles);
         req->setAllowForeignFiles(optAllowForeign);
         req->setUpdateDfs(optUpdateDfs);
+        req->setUpdateSuperFiles(optUpdateSuperfiles);
+        req->setUpdateCloneFrom(optUpdateCloneFrom);
+        req->setAppendCluster(!optDontAppendCluster);
 
         if (optTimeLimit != (unsigned) -1)
             req->setTimeLimit(optTimeLimit);
@@ -470,7 +480,10 @@ public:
             "   --no-files             Do not copy DFS file information for referenced files\n"
             "   --allow-foreign        Do not fail if foreign files are used in query (roxie)\n"
             "   --daliip=<IP>          The IP of the DALI to be used to locate remote files\n"
-            "   --update-dfs           Update local DFS info if remote DALI has changed\n"
+            "   -O, --overwrite        Completely replace existing DFS file information (dangerous)\n"
+            "   --update-super-files   Update local DFS super-files if remote DALI has changed\n"
+            "   --update-clone-from    Update local clone from location if remote DALI has changed\n"
+            "   --dont-append-cluster  Only use to avoid locking issues due to adding cluster to file\n"
             "   --source-process       Process cluster to copy files from\n"
             "   --timeLimit=<ms>       Value to set for query timeLimit configuration\n"
             "   --warnTimeLimit=<ms>   Value to set for query warnTimeLimit configuration\n"
@@ -501,6 +514,9 @@ private:
     bool optDeletePrevious;
     bool optAllowForeign;
     bool optUpdateDfs;
+    bool optUpdateSuperfiles;
+    bool optUpdateCloneFrom;
+    bool optDontAppendCluster; //Undesirable but here temporarily because DALI may have locking issues
 };
 
 class EclCmdRun : public EclCmdWithEclTarget

--- a/ecl/eclcmd/queries/ecl-queries.cpp
+++ b/ecl/eclcmd/queries/ecl-queries.cpp
@@ -406,7 +406,8 @@ private:
 class EclCmdQueriesCopy : public EclCmdCommon
 {
 public:
-    EclCmdQueriesCopy() : optActivate(false), optNoReload(false), optMsToWait(10000), optDontCopyFiles(false), optOverwrite(false), optAllowForeign(false)
+    EclCmdQueriesCopy() : optActivate(false), optNoReload(false), optMsToWait(10000), optDontCopyFiles(false), optOverwrite(false), optAllowForeign(false),
+        optUpdateSuperfiles(false), optUpdateCloneFrom(false), optDontAppendCluster(false)
     {
         optTimeLimit = (unsigned) -1;
         optWarnTimeLimit = (unsigned) -1;
@@ -462,6 +463,18 @@ public:
                 continue;
             if (iter.matchFlag(optOverwrite, ECLOPT_OVERWRITE)||iter.matchFlag(optOverwrite, ECLOPT_OVERWRITE_S))
                 continue;
+            if (iter.matchFlag(optUpdateSuperfiles, ECLOPT_UPDATE_SUPER_FILES))
+                continue;
+            if (iter.matchFlag(optUpdateCloneFrom, ECLOPT_UPDATE_CLONE_FROM))
+                continue;
+            if (iter.matchFlag(optDontAppendCluster, ECLOPT_DONT_APPEND_CLUSTER))
+                continue;
+            if (iter.matchFlag(optUpdateSuperfiles, ECLOPT_UPDATE_SUPER_FILES))
+                continue;
+            if (iter.matchFlag(optUpdateCloneFrom, ECLOPT_UPDATE_CLONE_FROM))
+                continue;
+            if (iter.matchFlag(optDontAppendCluster, ECLOPT_DONT_APPEND_CLUSTER))
+                continue;
             if (iter.matchOption(optName, ECLOPT_NAME)||iter.matchOption(optName, ECLOPT_NAME_S))
                 continue;
             if (EclCmdCommon::matchCommandLineOption(iter, true)!=EclCmdOptionMatch)
@@ -503,6 +516,9 @@ public:
         req->setSourceProcess(optSourceProcess);
         req->setActivate(optActivate);
         req->setOverwrite(optOverwrite);
+        req->setUpdateSuperFiles(optUpdateSuperfiles);
+        req->setUpdateCloneFrom(optUpdateCloneFrom);
+        req->setAppendCluster(!optDontAppendCluster);
         req->setDontCopyFiles(optDontCopyFiles);
         req->setWait(optMsToWait);
         req->setNoReload(optNoReload);
@@ -554,7 +570,10 @@ public:
             "   --source-process       Process cluster to copy files from\n"
             "   -A, --activate         Activate the new query\n"
             "   --no-reload            Do not request a reload of the (roxie) cluster\n"
-            "   -O, --overwrite        Overwrite existing files\n"
+            "   -O, --overwrite        Completely replace existing DFS file information (dangerous)\n"
+            "   --update-super-files   Update local DFS super-files if remote DALI has changed\n"
+            "   --update-clone-from    Update local clone from location if remote DALI has changed\n"
+            "   --dont-append-cluster  Only use to avoid locking issues due to adding cluster to file\n"
             "   --allow-foreign        Do not fail if foreign files are used in query (roxie)\n"
             "   --wait=<ms>            Max time to wait in milliseconds\n"
             "   --timeLimit=<sec>      Value to set for query timeLimit configuration\n"
@@ -585,6 +604,9 @@ private:
     bool optActivate;
     bool optNoReload;
     bool optOverwrite;
+    bool optUpdateSuperfiles;
+    bool optUpdateCloneFrom;
+    bool optDontAppendCluster; //Undesirable but here temporarily because DALI may have locking issues
     bool optDontCopyFiles;
     bool optAllowForeign;
 };
@@ -592,7 +614,8 @@ private:
 class EclCmdQueriesCopyQueryset : public EclCmdCommon
 {
 public:
-    EclCmdQueriesCopyQueryset() : optCloneActiveState(false), optAllQueries(false), optDontCopyFiles(false), optOverwrite(false), optAllowForeign(false)
+    EclCmdQueriesCopyQueryset() : optCloneActiveState(false), optAllQueries(false), optDontCopyFiles(false), optOverwrite(false), optAllowForeign(false),
+        optUpdateSuperfiles(false), optUpdateCloneFrom(false), optDontAppendCluster(false)
     {
     }
     virtual bool parseCommandLineOptions(ArgvIterator &iter)
@@ -630,6 +653,12 @@ public:
                 continue;
             if (iter.matchFlag(optOverwrite, ECLOPT_OVERWRITE)||iter.matchFlag(optOverwrite, ECLOPT_OVERWRITE_S))
                 continue;
+            if (iter.matchFlag(optUpdateSuperfiles, ECLOPT_UPDATE_SUPER_FILES))
+                continue;
+            if (iter.matchFlag(optUpdateCloneFrom, ECLOPT_UPDATE_CLONE_FROM))
+                continue;
+            if (iter.matchFlag(optDontAppendCluster, ECLOPT_DONT_APPEND_CLUSTER))
+                continue;
             if (EclCmdCommon::matchCommandLineOption(iter, true)!=EclCmdOptionMatch)
                 return false;
         }
@@ -658,6 +687,9 @@ public:
         req->setSourceProcess(optSourceProcess);
         req->setCloneActiveState(optCloneActiveState);
         req->setOverwriteDfs(optOverwrite);
+        req->setUpdateSuperFiles(optUpdateSuperfiles);
+        req->setUpdateCloneFrom(optUpdateCloneFrom);
+        req->setAppendCluster(!optDontAppendCluster);
         req->setCopyFiles(!optDontCopyFiles);
         req->setAllowForeignFiles(optAllowForeign);
 
@@ -708,7 +740,10 @@ public:
             "   --daliip=<ip>          Remote Dali DFS to use for copying file information\n"
             "   --source-process       Process cluster to copy files from\n"
             "   --clone-active-state   Make copied queries active if active on source\n"
-            "   -O, --overwrite        Overwrite existing DFS file information\n"
+            "   -O, --overwrite        Completely replace existing DFS file information (dangerous)\n"
+            "   --update-super-files   Update local DFS super-files if remote DALI has changed\n"
+            "   --update-clone-from    Update local clone from location if remote DALI has changed\n"
+            "   --dont-append-cluster  Only use to avoid locking issues due to adding cluster to file\n"
             "   --allow-foreign        Do not fail if foreign files are used in query (roxie)\n"
             " Common Options:\n",
             stdout);
@@ -721,6 +756,9 @@ private:
     StringAttr optSourceProcess;
     bool optCloneActiveState;
     bool optOverwrite;
+    bool optUpdateSuperfiles;
+    bool optUpdateCloneFrom;
+    bool optDontAppendCluster; //Undesirable but here temporarily because DALI may have locking issues
     bool optDontCopyFiles;
     bool optAllowForeign;
     bool optAllQueries;

--- a/esp/scm/ws_packageprocess.ecm
+++ b/esp/scm/ws_packageprocess.ecm
@@ -29,7 +29,7 @@ ESPrequest AddPackageRequest
 {
     string Info;
     boolean Activate;
-    boolean OverWrite;
+    boolean OverWrite; //deprecated, use flags below
     string Target;
     string PackageMap;
     string Process;
@@ -38,6 +38,10 @@ ESPrequest AddPackageRequest
     string SourceProcess;
     bool AllowForeignFiles(true);
     [min_ver("1.02")] bool PreloadAllPackages(false);
+    bool ReplacePackageMap(false);
+    bool UpdateSuperFiles(false); //usually wouldn't be needed, packagemap referencing superfiles?
+    bool UpdateCloneFrom(false); //explicitly wan't to change where roxie will grab from
+    bool AppendCluster(true); //file exists on other local cluster, add new one, make optional in case of locking issues, but should be made to work
 };
 
 

--- a/esp/scm/ws_packageprocess.ecm
+++ b/esp/scm/ws_packageprocess.ecm
@@ -29,7 +29,7 @@ ESPrequest AddPackageRequest
 {
     string Info;
     boolean Activate;
-    boolean OverWrite; //deprecated, use flags below
+    boolean OverWrite; //use flags below unless you really want to overwrite the actual file metadata and packagemap
     string Target;
     string PackageMap;
     string Process;

--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -1213,6 +1213,9 @@ ESPrequest [nil_remove] WUPublishWorkunitRequest
     string SourceProcess;
     bool AllowForeignFiles(false);
     bool UpdateDfs(false);
+    bool UpdateSuperFiles(false); //update content of superfiles if changed
+    bool UpdateCloneFrom(false); //explicity wan't to change where roxie will grab from
+    bool AppendCluster(true); //file exists on other local cluster, add new one, make optional in case of locking issues, but should be made to work
 };
 
 ESPresponse [exceptions_inline] WUPublishWorkunitResponse
@@ -1577,6 +1580,9 @@ ESPrequest [nil_remove] WUQuerySetCopyQueryRequest
     string SourceProcess;
     string DestName;
     bool AllowForeignFiles(true);
+    bool UpdateSuperFiles(false); //usually wouldn't be needed, packagemap referencing superfiles?
+    bool UpdateCloneFrom(false); //explicity wan't to change where roxie will grab from
+    bool AppendCluster(true); //file exists on other local cluster, add new one, make optional in case of locking issues, but should be made to work
 };
 
 ESPresponse [exceptions_inline] WUQuerySetCopyQueryResponse
@@ -1596,6 +1602,9 @@ ESPrequest [nil_remove] WUCopyQuerySetRequest
     bool CopyFiles(true);
     bool OverwriteDfs(false);
     string SourceProcess;
+    bool UpdateSuperFiles(false); //usually wouldn't be needed, packagemap referencing superfiles?
+    bool UpdateCloneFrom(false); //explicity wan't to change where roxie will grab from
+    bool AppendCluster(true); //file exists on other local cluster, add new one, make optional in case of locking issues, but should be made to work
 };
 
 ESPresponse [exceptions_inline] WUCopyQuerySetResponse

--- a/initfiles/etc/bash_completion/ecl
+++ b/initfiles/etc/bash_completion/ecl
@@ -89,7 +89,7 @@ _ecl_opts_queries()
             echo "--help list copy config"
             ;;
         copy)
-            echo -n "--no-reload --allow-foreign --wait= --timeLimit= --warnTimeLimit= --memoryLimit= --priority= --daliip= "
+            echo -n "--no-reload --allow-foreign --wait= --timeLimit= --warnTimeLimit= --memoryLimit= --priority= --daliip= --update-super-files --update-clone-from --dont-append-cluster "
             _ecl_opts_common
             ;;
         config)
@@ -140,7 +140,7 @@ _ecl_opts_packagemap()
             then
                 _ecl_opts_file
             else
-                echo -n "-O --overwrite --allow-foreign "
+                echo -n "-O --overwrite --allow-foreign --update-super-files --update-clone-from --dont-append-cluster --replace "
                 _ecl_opts_common
             fi
             ;;
@@ -170,7 +170,7 @@ _ecl_opts_core_file()
                 _ecl_opts_common
                 ;;
             publish)
-                echo -n "-A --activate --no-reload --allow-foreign --timeLimit= --warnTimeLimit= --memoryLimit= --priority= --daliip= "
+                echo -n "-A --activate --no-reload --allow-foreign --timeLimit= --warnTimeLimit= --memoryLimit= --priority= --daliip= --update-super-files --update-clone-from --dont-append-cluster "
                 _ecl_opts_deploy
                 _ecl_opts_common
                 ;;


### PR DESCRIPTION
Clean up DFS meta data update code used when publishing queries,
copying queries, and deploying packagemaps.

Make the options for what DFS information gets updated more flexible,
so that when locking issues are encountered it's not an all or nothing
update scenario.

Add more checking to only update when file information has really changed.

Add more logging so that when there are locking issues we can see
what types of updating was being done.

Signed-off-by: Anthony Fishbeck anthony.fishbeck@lexisnexis.com
