### PR TITLE
HPCC-14515 Issues sorting logical files

### DIFF
--- a/esp/src/eclwatch/ESPLogicalFile.js
+++ b/esp/src/eclwatch/ESPLogicalFile.js
@@ -66,7 +66,7 @@ define([
                 case "RecordCount":
                     request.Sortby = "Records";
                     break;
-                case "Totalsize":
+                case "IntSize":
                     request.Sortby = "FileSize";
                     break;
             }
@@ -84,10 +84,15 @@ define([
             }
         },
         preProcessRow: function (item, request, query, options) {
+            var convertNull;
+            if (item.IntSize === null) {
+                convertNull = 0;
+            }
             lang.mixin(item, {
                 __hpcc_id: createID(item.NodeGroup, item.Name),
                 __hpcc_isDir: false,
-                __hpcc_displayName: item.Name
+                __hpcc_displayName: item.Name,
+                Size: convertNull //superfiles causing issues sorting by returning null
             });
         },
         mayHaveChildren: function (object) {


### PR DESCRIPTION
There was previous issues sorting within the SearchResultsWidget we issues a fix for that which in turn caused issues in our DFUQueryWidget. Modified the service call to accomodate both areas. Also, "null" is returned at times for certain files which causes sorting issues. Will assign to 0 on a per row basis but not display 0.

Signed-off by: Miguel Vazquez miguel.vazquez@lexisnexis.com
