### PR TITLE
HPCC-14555 SoapCall retries(0) still does one retry

### DIFF
--- a/common/thorhelper/thorsoapcall.cpp
+++ b/common/thorhelper/thorsoapcall.cpp
@@ -1908,7 +1908,7 @@ public:
                 // other IException ... retry up to maxRetries
                 StringBuffer s;
                 master->logctx.CTXLOG("Exception %s - retrying? (%d<%d)", e->errorMessage(s).str(), attempts, master->maxRetries);
-
+                attempts++;
                 if (attempts > master->maxRetries)
                 {
                     // error affects all inputRows
@@ -1917,7 +1917,6 @@ public:
                     break;
                 }
                 master->logctx.CTXLOG("Retrying: maxRetries not exceeded");
-                attempts++;
                 e->Release();
             }
             catch (std::exception & es)


### PR DESCRIPTION
Soapcall increments the "attempts" count after checking for maxRetries,
resulting in one more retry than was specified. This PR moves the counter
update to just before the test.

Signed-off-by: Russ Whitehead william.whitehead@lexisnexis.com
