### PR TITLE
HPCC-14555 SoapCall retries(0) still does one retry

### DIFF
--- a/common/thorhelper/thorsoapcall.cpp
+++ b/common/thorhelper/thorsoapcall.cpp
@@ -1754,7 +1754,7 @@ public:
     {
         StringBuffer request;
         StringBuffer response;
-        unsigned attempts = 0;
+        unsigned numRetries = 0;
         unsigned retryInterval = 0;
 
         Url &url = master->urlArray.item(idx);
@@ -1917,17 +1917,17 @@ public:
 
                 // other IException ... retry up to maxRetries
                 StringBuffer s;
-                master->logctx.CTXLOG("Exception %s - retrying? (%d<%d)", e->errorMessage(s).str(), attempts, master->maxRetries);
+                master->logctx.CTXLOG("Exception %s", e->errorMessage(s).str());
 
-                attempts++;
-                if (attempts > master->maxRetries)
+                if (numRetries >= master->maxRetries)
                 {
                     // error affects all inputRows
-                    master->logctx.CTXLOG("Exiting: maxRetries exceeded");
+                    master->logctx.CTXLOG("Exiting: maxRetries %d exceeded", master->maxRetries);
                     processException(url, inputRows, e);
                     break;
                 }
-                master->logctx.CTXLOG("Retrying: maxRetries not exceeded");
+                numRetries++;
+                master->logctx.CTXLOG("Retrying: attempt %d of %d", numRetries, master->maxRetries);
                 e->Release();
             }
             catch (std::exception & es)

--- a/common/thorhelper/thorsoapcall.cpp
+++ b/common/thorhelper/thorsoapcall.cpp
@@ -1919,6 +1919,7 @@ public:
                 StringBuffer s;
                 master->logctx.CTXLOG("Exception %s - retrying? (%d<%d)", e->errorMessage(s).str(), attempts, master->maxRetries);
 
+                attempts++;
                 if (attempts > master->maxRetries)
                 {
                     // error affects all inputRows
@@ -1927,7 +1928,6 @@ public:
                     break;
                 }
                 master->logctx.CTXLOG("Retrying: maxRetries not exceeded");
-                attempts++;
                 e->Release();
             }
             catch (std::exception & es)


### PR DESCRIPTION
Soapcall "attempts" counter is being tested before being incremented,
resulting in always 1 more attempt than was requested. This PR updates the
count before the test.

Signed-off-by: Russ Whitehead william.whitehead@lexisnexis.com
