### PR TITLE
HPCC-14576 Fix incorrect code detected by compiler warning

### DIFF
--- a/system/jlib/jutil.cpp
+++ b/system/jlib/jutil.cpp
@@ -395,7 +395,7 @@ HINSTANCE LoadSharedObject(const char *name, bool isGlobal, bool raiseOnError)
         if (!streq(ext.str(), SharedObjectExtension))
         {
             // Assume if there's no .so, there may also be no lib at the beginning
-            if (strncmp(tail.str(), SharedObjectPrefix, strlen(SharedObjectPrefix) != 0))
+            if (strncmp(tail.str(), SharedObjectPrefix, strlen(SharedObjectPrefix)) != 0)
                 path.append(SharedObjectPrefix);
             path.append(tail).append(ext).append(SharedObjectExtension);
             name = path.str();


### PR DESCRIPTION
Code was incorrect, and would have resulted in libraries that started 'l' but
did not start 'lib' not having the 'lib' added when it should have. Unlikely
to have caused a problem in practice.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
