### PR TITLE
HPCC-14577 OSX builds warn about missing CLOCK_MONOTONIC

### DIFF
--- a/system/jlib/jdebug.cpp
+++ b/system/jlib/jdebug.cpp
@@ -364,7 +364,9 @@ cycle_t jlib_decl get_cycles_now()
     if (useRDTSC)
         return getTSC();
 #endif
-#ifndef __APPLE__
+#ifdef __APPLE__
+    return mach_absolute_time();
+#elif defined(CLOCK_MONOTONIC)
     if (!use_gettimeofday) {
         timespec tm;
         if (clock_gettime(CLOCK_MONOTONIC, &tm)>=0)
@@ -383,6 +385,9 @@ __int64 jlib_decl cycle_to_nanosec(cycle_t cycles)
 #if defined(_ARCH_X86_) || defined(_ARCH_X86_64_)
     if (useRDTSC)
         return (__int64)((double)cycles * cycleToNanoScale);
+#ifdef __APPLE__
+    return cycles * (uint64_t) timebase_info.numer / (uint64_t)timebase_info.denom;
+#endif
 #endif
     return cycles;
 }

--- a/system/jlib/jutil.hpp
+++ b/system/jlib/jutil.hpp
@@ -24,6 +24,12 @@
 #include "jarray.hpp"
 #include "jbuff.hpp"
 
+#if defined (__APPLE__)
+#include <mach-o/dyld.h>
+#include <mach/mach_time.h>
+extern mach_timebase_info_data_t timebase_info;   // Calibration for nanosecond timer
+#endif
+
 //#define NAMEDCOUNTS
 
 interface IPropertyTree;


### PR DESCRIPTION
Also improve accuracy of timers on OSX.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
