### PR TITLE
HPCC-14483 A hash aggregate no longer treated as a trivial operation

### DIFF
--- a/ecl/hqlcpp/hqlhtcpp.cpp
+++ b/ecl/hqlcpp/hqlhtcpp.cpp
@@ -452,8 +452,12 @@ public:
                 return true;
             switch (search->getOperator())
             {
-            case no_selectnth:
             case no_newaggregate:
+                //Hash aggregate is NOT a trivial operation.
+                if (queryRealChild(search, 3))
+                    return false;
+                break;
+            case no_selectnth:
             case no_filter:
                 break;
             case no_select:


### PR DESCRIPTION
This was only significant when determining whether a conditional hash
aggregate should be evalauted as if it was unconditional.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
