### PR TITLE
HPCC-14634 Roxie publishes file info before file has finished writing

### DIFF
--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -10475,6 +10475,8 @@ public:
                 outSeq->flush(&crc);
             if (outSeq)
                 uncompressedBytesWritten = outSeq->getPosition();
+            outSeq.clear();
+            diskout.clear();  // Make sure file is properly closed or date may not match published info
             if (writer)
             {
                 updateWorkUnitResult(processed);


### PR DESCRIPTION
This can lead to the published file info failing to match the filesystem, for
compressed files.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
