### PR TITLE
HPCC-14649 Fix html/xml display in legacy ECLWatch WUDetails

### DIFF
--- a/esp/eclwatch/ws_XSLT/wuidcommon.xslt
+++ b/esp/eclwatch/ws_XSLT/wuidcommon.xslt
@@ -1092,7 +1092,7 @@
         </xsl:if>
 
         <xsl:value-of select="Code"/>:
-        <xsl:value-of select="Message"/>
+        <xsl:value-of select="Message" disable-output-escaping="yes"/>
       </td>
     </tr>
   </xsl:template>


### PR DESCRIPTION
In the WUDetails page, the existing errors session displays error
messages in escaped HTML/XML format, which is difficult to read.
This fix uses the disable-output-escaping attribute to convert
the error messages to non-escaped HTML/XML format.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
