### PR TITLE
HPCC-14653 STORED-FORMAT-SELECT to create drop down on generated form

### DIFF
--- a/esp/services/ws_ecl/ws_ecl_service.cpp
+++ b/esp/services/ws_ecl/ws_ecl_service.cpp
@@ -1176,7 +1176,7 @@ void CWsEclBinding::SOAPSectionToXsd(WsEclWuInfo &wuinfo, IPropertyTree *parmTre
             }
 
             schema.appendf("<xsd:element minOccurs=\"0\" maxOccurs=\"1\" name=\"%s\" type=\"%s\"", name, type.str());
-            if (part.hasProp("@width") || part.hasProp("@height") || part.hasProp("@password"))
+            if (part.hasProp("@width") || part.hasProp("@height") || part.hasProp("@password") || part.hasProp("select"))
             {
                 schema.append("><xsd:annotation><xsd:appinfo><form");
                 unsigned rows = part.getPropInt("@height");
@@ -1187,7 +1187,10 @@ void CWsEclBinding::SOAPSectionToXsd(WsEclWuInfo &wuinfo, IPropertyTree *parmTre
                     schema.appendf(" formCols='%u'", cols);
                 if (part.hasProp("@password"))
                     schema.appendf(" password='%s'", part.queryProp("@password"));
-                schema.appendf("/></xsd:appinfo></xsd:annotation></xsd:element>");
+                schema.appendf(">");
+                if (part.hasProp("select"))
+                    toXML(part.queryPropTree("select"), schema);
+                schema.appendf("</form></xsd:appinfo></xsd:annotation></xsd:element>");
             }
             else
                 schema.append("/>");

--- a/esp/xslt/wsecl3_form.xsl
+++ b/esp/xslt/wsecl3_form.xsl
@@ -1080,6 +1080,20 @@ function switchInputForm()
         <xsl:param name="field_len"/>
         <xsl:param name="maxoccurs"/>
         <xsl:choose>
+            <xsl:when test="$annot/select/option">
+                <xsl:text disable-output-escaping="yes"><![CDATA[<select ]]></xsl:text>
+                    <xsl:text disable-output-escaping="yes"><![CDATA[name=']]></xsl:text>
+                    <xsl:value-of select="$fieldId"/>
+                    <xsl:text disable-output-escaping="yes"><![CDATA[' id=']]></xsl:text>
+                    <xsl:value-of select="$fieldId"/>
+                    <xsl:text disable-output-escaping="yes"><![CDATA['>]]></xsl:text>
+                    <xsl:for-each select="$annot/select/option">
+                        <xsl:text disable-output-escaping="yes"><![CDATA[<option value=']]></xsl:text>
+                        <xsl:value-of select="@value"/><xsl:if test="@selected"><xsl:text disable-output-escaping="yes"><![CDATA[' selected='true]]></xsl:text></xsl:if>
+                        <xsl:text disable-output-escaping="yes"><![CDATA['>]]></xsl:text><xsl:value-of select="@name"/><xsl:text disable-output-escaping="yes"><![CDATA[</option>]]></xsl:text>
+                    </xsl:for-each>
+                <xsl:text disable-output-escaping="yes"><![CDATA[</select>]]></xsl:text>
+            </xsl:when>
             <!-- string -->
             <xsl:when test="$typeName='string'">
                 <xsl:variable name="inputRows">

--- a/testing/regress/ecl/formatstored.ecl
+++ b/testing/regress/ecl/formatstored.ecl
@@ -34,7 +34,11 @@ integer5 i5 := 0 : stored('i5', format(fieldwidth(5), sequence(5)));
 unsigned5 u5 := 0 : stored('u5', format(fieldwidth(5), sequence(15)));
 integer4 i4 := 0 : stored('i4', format(fieldwidth(4), sequence(4)));
 unsigned3 u3 := 0 : stored('u3', format(fieldwidth(3), sequence(13)));
-unsigned8 u8 := 0 : stored('u8', format(fieldwidth(8), sequence(18)));
+unsigned8 u8 := 0 : stored('u8', format(fieldwidth(8), sequence(18), select('one=1,two=2,three=3,*four=4')));
+
+string ch1 := 'ban' : stored('ch1', format(select('apple=app,pear,*banana=ban,orange')));
+string ch2 := '' : stored('ch2', format(select(',apple=app,pear,banana=ban,orange'))); //start with empty, no specified default
+string ch3 := '' : stored('ch3', format(select('apple=app,pear,*,banana=ban,orange'))); //empty in middle, is default
 
 string pw := 'powow' : stored('pw', format(password, fieldwidth(40)));
 
@@ -57,5 +61,8 @@ output (u7, named('u7'));
 output (u8, named('u8'));
 
 output (s1, named('s1'));
+output (ch1, named('choice1'));
+output (ch2, named('choice2'));
+output (ch3, named('choice3'));
 
 output (pw, named('showpw'));

--- a/testing/regress/ecl/key/formatstored.xml
+++ b/testing/regress/ecl/key/formatstored.xml
@@ -49,6 +49,15 @@
 <Dataset name='s1'>
  <Row><s1>how now brown cow</s1></Row>
 </Dataset>
+<Dataset name='choice1'>
+ <Row><choice1>ban</choice1></Row>
+</Dataset>
+<Dataset name='choice2'>
+ <Row><choice2></choice2></Row>
+</Dataset>
+<Dataset name='choice3'>
+ <Row><choice3></choice3></Row>
+</Dataset>
 <Dataset name='showpw'>
  <Row><showpw>powow</showpw></Row>
 </Dataset>


### PR DESCRIPTION
Support new select attribute to STORED(FORMAT(...)) to create a drop down selection input
on the generated WsECL form.

string ch1 := 'none' : stored('ch1', format(select('apple,banana,pear')));

Will create a drop down on the generated form with choices "apple",
"banana", and "pear".

Signed-off-by: Anthony Fishbeck anthony.fishbeck@lexisnexis.com
