### PR TITLE
HPCC-14442 Fix regression setting memory limit to 0

### DIFF
--- a/roxie/roxiemem/roxiemem.cpp
+++ b/roxie/roxiemem/roxiemem.cpp
@@ -3800,6 +3800,8 @@ public:
         if (spillSize > systemMemoryLimit)
             spillSize = systemMemoryLimit;
         maxPageLimit = (unsigned) PAGES(bytes, HEAP_ALIGNMENT_SIZE);
+        if (maxPageLimit == 0)
+            maxPageLimit = UNLIMITED_PAGES;
         spillPageLimit = (unsigned) PAGES(spillSize, HEAP_ALIGNMENT_SIZE);
 
         if (memTraceLevel >= 2)


### PR DESCRIPTION
Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
