### PR TITLE
HPCC-14692 Fixed size keyed joins may allocate too much memory

### DIFF
--- a/common/thorhelper/thorcommon.ipp
+++ b/common/thorhelper/thorcommon.ipp
@@ -42,7 +42,7 @@
 class THORHELPER_API CachedOutputMetaData
 {
 public:
-    inline CachedOutputMetaData(IOutputMetaData * _rs = NULL) { set(_rs); }
+    explicit inline CachedOutputMetaData(IOutputMetaData * _rs = NULL) { set(_rs); }
 
     inline void set(IOutputMetaData * _meta)
     {

--- a/roxie/ccd/ccdactivities.cpp
+++ b/roxie/ccd/ccdactivities.cpp
@@ -4760,7 +4760,7 @@ IMessagePacker *CRoxieKeyedJoinIndexActivity::process()
 {
     MTIME_SECTION(queryActiveTimer(), "CRoxieKeyedJoinIndexActivity::process");
     Owned<IMessagePacker> output = ROQ->createOutputStream(packet->queryHeader(), false, logctx);
-    IOutputMetaData *joinFieldsMeta = helper->queryJoinFieldsRecordSize();
+    CachedOutputMetaData joinFieldsMeta(helper->queryJoinFieldsRecordSize());
     Owned<IEngineRowAllocator> joinFieldsAllocator = getRowAllocator(joinFieldsMeta, basefactory->queryId());
     OptimizedKJRowBuilder rowBuilder(joinFieldsAllocator, joinFieldsMeta, output);
 
@@ -5055,7 +5055,7 @@ IMessagePacker *CRoxieKeyedJoinFetchActivity::process()
     Owned<IEngineRowAllocator> diskAllocator = getRowAllocator(helper->queryDiskRecordSize(), basefactory->queryId());
     RtlDynamicRowBuilder diskRowBuilder(diskAllocator);
 
-    IOutputMetaData *joinFieldsMeta = helper->queryJoinFieldsRecordSize();
+    CachedOutputMetaData joinFieldsMeta(helper->queryJoinFieldsRecordSize());
     Owned<IEngineRowAllocator> joinFieldsAllocator = getRowAllocator(joinFieldsMeta, basefactory->queryId());
     OptimizedKJRowBuilder jfRowBuilder(joinFieldsAllocator, joinFieldsMeta, output);
     CachedOutputMetaData inputFields(helper->queryFetchInputRecordSize());


### PR DESCRIPTION
Fixed size keyed joins would use a reference to freed memory during the
calculation of the amount of memory to reserve for the return row. This could
result in memory allocation failures or possibly memory corruption, depending
on whether the memory was reused preior to being referenced.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
