### PR TITLE
HPCC-13833 Add description and owner to groups

### DIFF
--- a/esp/src/eclwatch/UserQueryWidget.js
+++ b/esp/src/eclwatch/UserQueryWidget.js
@@ -389,6 +389,12 @@ define([
                     }, "checkbox"),
                     name: {
                         label: this.i18n.GroupName
+                    },
+                    groupOwner: {
+                        label: this.i18n.ManagedBy
+                    },
+                    groupDesc: {
+                        label: this.i18n.Description
                     }
                 }
             }, this.id + "GroupsGrid");

--- a/esp/src/eclwatch/nls/hpcc.js
+++ b/esp/src/eclwatch/nls/hpcc.js
@@ -253,6 +253,8 @@ define({root:
     Logs: "Logs",
     log_analysis_1: "log_analysis_1*",
     Low: "Low",
+    ManagedBy: "Managed By",
+    ManagedByPlaceholder: "CN=HPCCAdmin,OU=users,OU=hpcc,DC=MyCo,DC=local",
     ManualCopy: "Press Ctrl+C",
     ManualOverviewSelection: "(Manual overview selection will be required)",
     ManualTreeSelection: "(Manual tree selection will be required)",

--- a/esp/src/eclwatch/templates/UserQueryWidget.html
+++ b/esp/src/eclwatch/templates/UserQueryWidget.html
@@ -68,6 +68,8 @@
                             <div id="${id}AddGroupForm" onsubmit="return false;" style="width:400px" data-dojo-type="dijit.form.Form">
                                 <div data-dojo-type="hpcc.TableContainer">
                                     <input id="${id}AddGroupName" title="${i18n.GroupName}:" name="groupname" data-dojo-props="trim: true, required: true" data-dojo-type="dijit.form.ValidationTextBox" />
+                                    <input id="${id}AddGroupOwner" placeholder="${i18n.ManagedByPlaceholder}:" title="${i18n.ManagedBy}:" name="groupOwner" data-dojo-props="trim: true, required: true" data-dojo-type="dijit.form.ValidationTextBox" />
+                                    <input id="${id}AddGroupDescription" title="${i18n.Description}:" name="groupDesc" data-dojo-props="trim: true, required: true" data-dojo-type="dijit.form.ValidationTextBox" />
                                 </div>
                                 <div class="dijitDialogPaneActionBar">
                                     <button type="submit" data-dojo-attach-event="onClick:_onAddGroupSubmit" data-dojo-type="dijit.form.Button">${i18n.Add}</button>


### PR DESCRIPTION
Add ability to add description and owner/managed by required fields to creation of groups in LDAP. Also, display them in the grid for users to see this information.

Signed-off by: Miguel Vazquez miguel.vazquez@lexisnexis.com
