### PR TITLE
HPCC-14712 Build failure from array bounds jlib warning

### DIFF
--- a/system/jlib/CMakeLists.txt
+++ b/system/jlib/CMakeLists.txt
@@ -161,6 +161,7 @@ if (CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_CLANG)
 endif ()
 if (CMAKE_COMPILER_IS_GNUCC AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.0.0)
     set_property (SOURCE jencrypt.cpp APPEND_STRING PROPERTY COMPILE_FLAGS " -Wno-array-bounds")   # Compiler erroneously reports array bounds errors in some cases
+    set_property (SOURCE jlzw.cpp APPEND_STRING PROPERTY COMPILE_FLAGS " -Wno-array-bounds")   # Compiler erroneously reports array bounds errors in some cases
 endif ()
 
 include_directories ( 


### PR DESCRIPTION
Signed-off-by: Mark Kelly mark.kelly@lexisnexis.com
