### PR TITLE
HPCC-14725 Improve code to ensure fields are on separate cache lines

### DIFF
--- a/roxie/roxiemem/roxiemem.cpp
+++ b/roxie/roxiemem/roxiemem.cpp
@@ -1276,7 +1276,6 @@ public:
 #define ROWCOUNT_DESTRUCTOR_FLAG 0x80000000
 #define ROWCOUNT(x)              ((x) & ROWCOUNT_MASK)
 
-#define CACHE_LINE_SIZE 64
 #define HEAPLET_DATA_AREA_OFFSET(heapletType) ((size32_t) ((sizeof(heapletType) + CACHE_LINE_SIZE - 1) / CACHE_LINE_SIZE) * CACHE_LINE_SIZE)
 
 class CChunkedHeap;

--- a/system/include/platform.h
+++ b/system/include/platform.h
@@ -54,6 +54,8 @@
  #endif
 #endif
 
+#define CACHE_LINE_SIZE 64
+
 // **** START OF X-PLATFORM SECTION ****
 
 #if defined(_ARCH_X86_64_) || defined(_ARCH_ARM64_) || defined(_ARCH_PPC64EL_) || __WORDSIZE==64

--- a/system/jlib/jqueue.hpp
+++ b/system/jlib/jqueue.hpp
@@ -375,13 +375,10 @@ protected:
     unsigned maxWriters;
     std::atomic<int> activeWriters;
     std::atomic<bool> aborted;
-    char pad1[64];
-    Semaphore readers;
-    char pad2[64-sizeof(Semaphore)];
-    Semaphore writers;
-    char pad3[64-sizeof(Semaphore)];
+    Semaphore readers __attribute__((aligned(CACHE_LINE_SIZE)));
+    Semaphore writers __attribute__((aligned(CACHE_LINE_SIZE)));
     //Ensure the state is not on the same cache line as anything else, especially anything that is modified.
-    std::atomic<state_t> state;
+    std::atomic<state_t> state __attribute__((aligned(CACHE_LINE_SIZE)));
 };
 
 #endif


### PR DESCRIPTION
Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
