### PR TITLE
HPCC-14592 OBT should save any core files created during regression testing

### DIFF
--- a/ecl/eclagent/eclagent.cpp
+++ b/ecl/eclagent/eclagent.cpp
@@ -3113,7 +3113,10 @@ void EclAgent::fatalAbort(bool userabort,const char *excepttext)
 #ifdef _WIN32
     TerminateProcess(GetCurrentProcess(), 1);
 #else
-    kill(getpid(), SIGKILL);
+    if (userabort)
+        kill(getpid(), SIGKILL);
+    else
+        kill(getpid(), SIGABRT);
 #endif
 }
 

--- a/roxie/ccd/ccdmain.cpp
+++ b/roxie/ccd/ccdmain.cpp
@@ -374,6 +374,7 @@ public:
         {
             socketListeners.item(idx).stopListening();
         }
+        kill(getpid(), SIGABRT);
         return false;
     }
 } abortHandler;
@@ -1004,6 +1005,7 @@ int STARTQUERY_API start_query(int argc, const char *argv[])
         tmpFlag |= _CRTDBG_CHECK_ALWAYS_DF;
         _CrtSetDbgFlag( tmpFlag );
 #endif
+        EnableSEHtoExceptionMapping();
         setSEHtoExceptionHandler(&abortHandler);
         if (runOnce)
         {

--- a/system/jlib/jexcept.cpp
+++ b/system/jlib/jexcept.cpp
@@ -991,6 +991,7 @@ void excsighandler(int signum, siginfo_t *info, void *extra)
     signal(SIGBUS, SIG_DFL);
     signal(SIGILL, SIG_DFL);
     signal(SIGFPE, SIG_DFL);
+    signal(SIGABRT, SIG_DFL);
 #endif
     StringBuffer s;
 
@@ -1262,6 +1263,7 @@ void jlib_decl enableSEHtoExceptionMapping()
     sigaction(SIGILL, &act, NULL);
     sigaction(SIGBUS, &act, NULL);
     sigaction(SIGFPE, &act, NULL);
+    sigaction(SIGABRT, &act, NULL);
 #endif
 }
 
@@ -1284,6 +1286,7 @@ void  jlib_decl disableSEHtoExceptionMapping()
     signal(SIGBUS, SIG_DFL);
     signal(SIGILL, SIG_DFL);
     signal(SIGFPE, SIG_DFL);
+    signal(SIGABRT, SIG_DFL);
 #endif
 }
 


### PR DESCRIPTION
Add SIGABRT to handled signals set.

Ensure to create core dump after we caught an abort like signal.

Signed-off-by: Attila Vamos attila.vamos@gmail.com
