### PR TITLE
HPCC-14733 DOCS:Change copyright date to 2016 for all docs

### DIFF
--- a/docs/common/Version.xml
+++ b/docs/common/Version.xml
@@ -5,11 +5,11 @@
   <chapterinfo>
     <date id="DateVer">DEVELOPER NON-GENERATED VERSION</date>
 
-    <releaseinfo id="FooterInfo">© 2015 HPCC
+    <releaseinfo id="FooterInfo">© 2016 HPCC
     Systems<superscript>®</superscript>. All rights reserved</releaseinfo>
 
     <copyright id="Copyright">
-      <year>2015 HPCC Systems<superscript>®</superscript>. All rights
+      <year>2016 HPCC Systems<superscript>®</superscript>. All rights
       reserved</year>
     </copyright>
   </chapterinfo>
@@ -24,7 +24,7 @@
     and that is to store the chapterinfo the above sections that are being
     used by several other documents.</para>
 
-    <para id="CHMVer">2015 Version X.X</para>
+    <para id="CHMVer">2016 Version X.X</para>
 
     <para>The following line is the code to be put into the document you wish
     to include the above version info in:</para>

--- a/docs/common/Version.xml.in
+++ b/docs/common/Version.xml.in
@@ -3,13 +3,13 @@
 "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
 <chapter>
   <chapterinfo>
-    <date id="DateVer">2015 Version ${DOC_VERSION}</date>
+    <date id="DateVer">2016 Version ${DOC_VERSION}</date>
 
-    <releaseinfo id="FooterInfo">© 2015 HPCC
+    <releaseinfo id="FooterInfo">© 2016 HPCC
     Systems<superscript>®</superscript>. All rights reserved</releaseinfo>
 
     <copyright id="Copyright">
-      <year>2015 HPCC Systems<superscript>®</superscript>. All rights
+      <year>2016 HPCC Systems<superscript>®</superscript>. All rights
       reserved</year>
     </copyright>
   </chapterinfo>
@@ -24,7 +24,7 @@
     serve one purpose and that is to store the chapterinfo the above sections
     that are being used by several other documents.</para>
 
-    <para id="CHMVer">2015 Version ${DOC_VERSION}</para>
+    <para id="CHMVer">2016 Version ${DOC_VERSION}</para>
 
     <para>The following line is the code to be put into the document you wish
     to include the above version info in:</para>


### PR DESCRIPTION
FIX HPCC-14733 DOCS:Change copyright date to 2016 for all docs
By changing the date in the Version.xml file
which gets included in all docs.

Signed-off-by: G Panagiotatos greg.panagiotatos@lexisnexis.com

@JamesDeFabia Please review
