### PR TITLE
HPCC-14730 Fix issue with conditional null inputs in child queries

### DIFF
--- a/thorlcr/graph/thgraph.cpp
+++ b/thorlcr/graph/thgraph.cpp
@@ -326,7 +326,7 @@ bool isDiskInput(ThorActivityKind kind)
 
 void CIOConnection::connect(unsigned which, CActivityBase *destActivity)
 {
-    destActivity->setInput(which, activity->queryActivity(), index);
+    destActivity->setInput(which, activity->queryActivity(true), index);
 }
 
 /////////////////////////////////// 

--- a/thorlcr/graph/thgraph.hpp
+++ b/thorlcr/graph/thgraph.hpp
@@ -342,7 +342,7 @@ public:
     }
     virtual bool prepareContext(size32_t parentExtractSz, const byte *parentExtract, bool checkDependencies, bool shortCircuit, bool async);
 //
-    virtual CActivityBase *queryActivity() { return activity; }
+    virtual CActivityBase *queryActivity(bool checkNull=false) { return activity; }
     virtual void initActivity();
     virtual CActivityBase *factory(ThorActivityKind kind) { assertex(false); return NULL; }
     virtual CActivityBase *factory() { return factory(getKind()); }

--- a/thorlcr/slave/slave.cpp
+++ b/thorlcr/slave/slave.cpp
@@ -289,9 +289,9 @@ public:
         }
         haveCreateCtx = true;
     }
-    virtual CActivityBase *queryActivity()
+    virtual CActivityBase *queryActivity(bool checkNull)
     {
-        if (hasNullInput)
+        if (checkNull && hasNullInput)
         {
             CriticalBlock b(nullActivityCs);
             if (!nullActivity)


### PR DESCRIPTION
If a child query has an activity whose input could be evaluated
to null (an example is Filter with !canMatchAny()), if that
activity calculates that it has a null input on the 1st execution
but not on subsequent exections, Thor hits a runtime assertion
whilst connecting the graph, specifically: "assert(outLink)"

This was because once the input was deemed as null, the acitivty
wasn't fully initialized. When subsequent executions of the child
query relied on the activitiy, it was still not initialized and
consequently had not added it's output to be connected in the
graph.

Fix is to treat the activity normally during initialization and
special case the null activity connection during connect only.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
