### PR TITLE
HPCC-14749 Ensure HPCC generates core dump if abort condition sensed.

### DIFF
--- a/ecl/eclagent/eclagent.cpp
+++ b/ecl/eclagent/eclagent.cpp
@@ -3113,7 +3113,9 @@ void EclAgent::fatalAbort(bool userabort,const char *excepttext)
 #ifdef _WIN32
     TerminateProcess(GetCurrentProcess(), 1);
 #else
-    kill(getpid(), SIGKILL);
+   if (userabort)
+       kill(getpid(), SIGKILL);
+
 #endif
 }
 

--- a/ecl/eclagent/eclagent.ipp
+++ b/ecl/eclagent/eclagent.ipp
@@ -424,7 +424,7 @@ private:
             StringBuffer text;
             e->errorMessage(text);
             parent.fatalAbort(false,text.str());
-            return true; // won't return hopefully!
+            return false; // It returns to excsighandler() to abort!
         }
     } *abortmonitor;
 

--- a/roxie/ccd/ccdmain.cpp
+++ b/roxie/ccd/ccdmain.cpp
@@ -374,7 +374,7 @@ public:
         {
             socketListeners.item(idx).stopListening();
         }
-        return false;
+        return false; // It returns to excsighandler() to abort!
     }
 } abortHandler;
 
@@ -1004,6 +1004,7 @@ int STARTQUERY_API start_query(int argc, const char *argv[])
         tmpFlag |= _CRTDBG_CHECK_ALWAYS_DF;
         _CrtSetDbgFlag( tmpFlag );
 #endif
+        EnableSEHtoExceptionMapping();
         setSEHtoExceptionHandler(&abortHandler);
         if (runOnce)
         {

--- a/system/jlib/jexcept.cpp
+++ b/system/jlib/jexcept.cpp
@@ -993,6 +993,7 @@ void excsighandler(int signum, siginfo_t *info, void *extra)
     signal(SIGBUS, SIG_DFL);
     signal(SIGILL, SIG_DFL);
     signal(SIGFPE, SIG_DFL);
+    signal(SIGABRT, SIG_DFL);
 #endif
     StringBuffer s;
 
@@ -1200,8 +1201,14 @@ void excsighandler(int signum, siginfo_t *info, void *extra)
     *spp = ip;
     sigsegv_exc = new CSEHException(signum,s.str());
 #else
-    if (SEHHandler && SEHHandler->fireException(new CSEHException(signum,s.str()))) 
-        return;
+    if (SEHHandler)
+    {
+        if ( SEHHandler->fireException(new CSEHException(signum,s.str())) )
+            return;
+        else
+            kill(getpid(), SIGABRT);
+    }
+
 #endif
     nested--;
 }
@@ -1264,6 +1271,7 @@ void jlib_decl enableSEHtoExceptionMapping()
     sigaction(SIGILL, &act, NULL);
     sigaction(SIGBUS, &act, NULL);
     sigaction(SIGFPE, &act, NULL);
+    sigaction(SIGABRT, &act, NULL);
 #endif
 }
 
@@ -1286,6 +1294,7 @@ void  jlib_decl disableSEHtoExceptionMapping()
     signal(SIGBUS, SIG_DFL);
     signal(SIGILL, SIG_DFL);
     signal(SIGFPE, SIG_DFL);
+    signal(SIGABRT, SIG_DFL);
 #endif
 }
 


### PR DESCRIPTION
Add SIGBABRT to handled signals set.

Ensure to create core dump after we caught an abort like signal.

Signed-off-by: Attila Vamos attila.vamos@gmail.com
