### PR TITLE
HPCC-14368 Remove UTF-8 BOM from CMakeLists.txt

### DIFF
--- a/docs/RoxieReference/CMakeLists.txt
+++ b/docs/RoxieReference/CMakeLists.txt
@@ -1,4 +1,4 @@
-﻿################################################################################
+################################################################################
 #    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems®.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
