### PR TITLE
HPCC-14547 Add open ability to superfile tab

### DIFF
--- a/esp/src/eclwatch/FileBelongsToWidget.js
+++ b/esp/src/eclwatch/FileBelongsToWidget.js
@@ -18,12 +18,17 @@ define([
     "dojo/i18n",
     "dojo/i18n!./nls/hpcc",
 
+    "dgrid/selector",
+
+    "hpcc/DelayLoadWidget",
     "hpcc/GridDetailsWidget",
     "hpcc/ESPLogicalFile",
-    "hpcc/ESPUtil"
+    "hpcc/ESPUtil",
+    "hpcc/SFDetailsWidget",
 
 ], function (declare, i18n, nlsHPCC,
-                GridDetailsWidget, ESPLogicalFile, ESPUtil) {
+                selector,
+                DelayLoadWidget, GridDetailsWidget, ESPLogicalFile, ESPUtil, SFDetailsWidget) {
     return declare("FileBelongsToWidget", [GridDetailsWidget], {
         i18n: nlsHPCC,
         logicalFile: null,
@@ -42,10 +47,29 @@ define([
             var retVal = new declare([ESPUtil.Grid(false, true)])({
                 store: this.store,
                 columns: {
+                    sel: selector({
+                        width: 27,
+                        selectorType: 'checkbox'
+                    }),
                     Name: { label: this.i18n.Name }
                 }
             }, domID);
             return retVal;
+        },
+
+        createDetail: function (id, row, params) {
+            return new DelayLoadWidget({
+                id: id,
+                title: row.Name,
+                closable: true,
+                delayWidget: "SFDetailsWidget",
+                hpcc: {
+                    type: "SFDetailsWidget",
+                    params: {
+                        Name: row.Name
+                    }
+                }
+            });
         },
 
         refreshGrid: function (args) {

--- a/esp/src/eclwatch/LFDetailsWidget.js
+++ b/esp/src/eclwatch/LFDetailsWidget.js
@@ -331,6 +331,7 @@ define([
                 domClass.add(this.id + "StateIdImage", this.logicalFile.getStateIconClass());
                 domAttr.set(this.id + "Name", "innerHTML", this.logicalFile.Name + (this.logicalFile.isDeleted() ? " (" + this.i18n.Deleted + ")" : "" ));
             } else if (name === "Superfiles") {
+                this.fileBelongsToWidget.set("title", this.i18n.Superfile + " (" + newValue.DFULogicalFile.length + ")");
             } else if (name === "__hpcc_changedCount" && newValue > 0) {
                 this.refreshActionState();
                 //  Force Icon to Show (I suspect its not working due to Circular Reference Loading)


### PR DESCRIPTION
Within logical file details within the superfile tab there was no open ability into superfile details or number of superfiles in the tab.

Signed-off by: Miguel Vazquez miguel.vazquez@lexisnexis.com
