### PR TITLE
HPCC-14742 Roxie may core if keyed join limit transform references RHS row

### DIFF
--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -24632,7 +24632,7 @@ public:
         if (keepLimit == 0) keepLimit = (unsigned)-1;
         getLimitType(joinFlags, limitFail, limitOnFail);
         cloneLeft = (joinFlags & JFtransformmatchesleft) != 0;
-        if (joinFlags & JFleftouter)
+        if (joinFlags & JFleftouter || limitOnFail)
             createDefaultRight();
     }
 


### PR DESCRIPTION
Ensure defaultRight is set up if there is a fail transform.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
