### PR TITLE
HPCC-14515 Issues sorting logical files

### DIFF
--- a/esp/src/eclwatch/DFUQueryWidget.js
+++ b/esp/src/eclwatch/DFUQueryWidget.js
@@ -502,7 +502,15 @@ define([
                     Description: { label: this.i18n.Description, width: 153 },
                     NodeGroup: { label: this.i18n.Cluster, width: 108 },
                     RecordCount: { label: this.i18n.Records, width: 72},
-                    IntSize: { label: this.i18n.Size, width: 72},
+                    IntSize: { label: this.i18n.Size, width: 72,
+                        formatter: function (intsize, row) {
+                            if (intsize === null) {
+                                return ""
+                            } else {
+                                return intsize.toLocaleString();
+                            }
+                        }
+                    },
                     Parts: { label: this.i18n.Parts, width: 45},
                     Modified: { label: this.i18n.ModifiedUTCGMT, width: 155}
                 }

--- a/esp/src/eclwatch/ESPLogicalFile.js
+++ b/esp/src/eclwatch/ESPLogicalFile.js
@@ -66,7 +66,7 @@ define([
                 case "RecordCount":
                     request.Sortby = "Records";
                     break;
-                case "Totalsize":
+                case "IntSize":
                     request.Sortby = "FileSize";
                     break;
             }


### PR DESCRIPTION
There was previous issues sorting within the SearchResultsWidget we issues a fix for that which in turn caused issues in our DFUQueryWidget. Modified the service call to accomodate both areas. Also, "null" is returned at times for certain files which causes sorting issues. Will assign to 0 on a per row basis but not display 0.

Signed-off by: Miguel Vazquez miguel.vazquez@lexisnexis.com
