### PR TITLE
HPCC-8401 Modifications to use dpkg-shlibdeps during packaging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -293,7 +293,7 @@ endif()
 message("-- Base build tag is '${BASE_BUILD_TAG}'")
 configure_file(${HPCC_SOURCE_DIR}/build-config.h.cmake "build-config.h")
 
-#set( CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON )
+set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
 #set( CPACK_DEB_PACKAGE_COMPONENT ON )
 
 if(TOP_LEVEL_PROJECT)
@@ -413,5 +413,18 @@ endif(TOP_LEVEL_PROJECT)
 ###
 if(PLATFORM OR CLIENTTOOLS OR REMBED)
     install(FILES ${HPCC_SOURCE_DIR}/${LICENSE_FILE} DESTINATION "." COMPONENT Runtime)
+endif()
+
+if("${packageManagement}" STREQUAL "DEB")
+    install(CODE "
+            execute_process(COMMAND mkdir -p ${INSTALL_DIR}
+                            WORKING_DIRECTORY ${PREFIX})
+            if(EXISTS \"${INSTALL_DIR}/lib\")
+                execute_process(COMMAND rm -f lib
+                                WORKING_DIRECTORY ${INSTALL_DIR})
+            endif()
+            execute_process(COMMAND ln -sf ${CMAKE_BINARY_DIR}/_CPack_Packages/${CPACK_SYSTEM_NAME}/${CPACK_GENERATOR}/${CPACK_PACKAGE_FILE_NAME}${INSTALL_DIR}/lib lib
+                            WORKING_DIRECTORY ${INSTALL_DIR})"
+    COMPONENT Runtime)
 endif()
 include(CPack)

--- a/cmake_modules/dependencies/el5.cmake
+++ b/cmake_modules/dependencies/el5.cmake
@@ -1,1 +1,1 @@
-SET_DEPENDENCIES ( CPACK_RPM_PACKAGE_REQUIRES boost141-regex openldap libicu m4 libtool libxslt libxml2 gcc-c++ openssh-server openssh-clients expect libarchive rsync apr apr-util zip tbb )
+SET_DEPENDENCIES ( CPACK_RPM_PACKAGE_REQUIRES m4 libtool gcc-c++ openssh-server openssh-clients expect rsync zip )

--- a/cmake_modules/dependencies/el6.cmake
+++ b/cmake_modules/dependencies/el6.cmake
@@ -1,1 +1,1 @@
-SET_DEPENDENCIES ( CPACK_RPM_PACKAGE_REQUIRES boost-regex openldap libicu m4 libtool libxslt libxml2 gcc-c++ openssh-server openssh-clients expect libarchive rsync apr apr-util zip tbb )
+SET_DEPENDENCIES ( CPACK_RPM_PACKAGE_REQUIRES m4 libtool gcc-c++ openssh-server openssh-clients expect rsync zip )

--- a/cmake_modules/dependencies/el7.cmake
+++ b/cmake_modules/dependencies/el7.cmake
@@ -1,1 +1,1 @@
-SET_DEPENDENCIES ( CPACK_RPM_PACKAGE_REQUIRES boost-regex openldap libicu m4 libtool libxslt libxml2 gcc-c++ openssh-server openssh-clients expect libarchive rsync apr apr-util zip tbb )
+SET_DEPENDENCIES ( CPACK_RPM_PACKAGE_REQUIRES m4 libtool gcc-c++ openssh-server openssh-clients expect rsync zip )

--- a/cmake_modules/dependencies/lenny.cmake
+++ b/cmake_modules/dependencies/lenny.cmake
@@ -1,1 +1,1 @@
-SET_DEPENDENCIES ( CPACK_DEBIAN_PACKAGE_DEPENDS libboost-regex1.34.1 libicu38 libxalan110 libxerces-c28 binutils libldap-2.4-2 openssl zlib1g g++ sudo openssh-client openssh-server expect libarchive rsync libapr1 libaprutil1 zip python libtbb2 )
+SET_DEPENDENCIES ( CPACK_DEBIAN_PACKAGE_DEPENDS g++ sudo openssh-client openssh-server expect rsync zip python )

--- a/cmake_modules/dependencies/lucid.cmake
+++ b/cmake_modules/dependencies/lucid.cmake
@@ -1,1 +1,1 @@
-SET_DEPENDENCIES ( CPACK_DEBIAN_PACKAGE_DEPENDS libboost-regex1.40.0 libicu42 libxslt1.1 libxml2 binutils libldap-2.4-2 openssl zlib1g g++ openssh-client openssh-server expect libarchive1 rsync zip python libtbb2 )
+SET_DEPENDENCIES ( CPACK_DEBIAN_PACKAGE_DEPENDS g++ openssh-client openssh-server expect rsync zip python )

--- a/cmake_modules/dependencies/natty.cmake
+++ b/cmake_modules/dependencies/natty.cmake
@@ -1,1 +1,1 @@
-SET_DEPENDENCIES ( CPACK_DEBIAN_PACKAGE_DEPENDS libboost-regex1.42.0 libicu44 libxalan110 libxerces-c28 binutils libldap-2.4-2 openssl zlib1g g++ openssh-client openssh-server expect libarchive1 rsync zip python libtbb2 )
+SET_DEPENDENCIES ( CPACK_DEBIAN_PACKAGE_DEPENDS g++ openssh-client openssh-server expect rsync zip python )

--- a/cmake_modules/dependencies/oneiric.cmake
+++ b/cmake_modules/dependencies/oneiric.cmake
@@ -1,1 +1,1 @@
-SET_DEPENDENCIES ( CPACK_DEBIAN_PACKAGE_DEPENDS libboost-regex1.46.1 libicu44 libxalan110 libxerces-c28 binutils libldap-2.4-2 openssl zlib1g g++ openssh-client openssh-server expect libarchive1 rsync libapr1 libaprutil1 zip python libtbb2 )
+SET_DEPENDENCIES ( CPACK_DEBIAN_PACKAGE_DEPENDS g++ openssh-client openssh-server expect rsync  zip python )

--- a/cmake_modules/dependencies/precise.cmake
+++ b/cmake_modules/dependencies/precise.cmake
@@ -1,1 +1,1 @@
-SET_DEPENDENCIES ( CPACK_DEBIAN_PACKAGE_DEPENDS libboost-regex1.46.1 libicu48 libxslt1.1 libxml2 binutils libldap-2.4-2 openssl zlib1g g++ openssh-client openssh-server expect libarchive12 rsync libapr1 libaprutil1 zip python libtbb2 )
+SET_DEPENDENCIES ( CPACK_DEBIAN_PACKAGE_DEPENDS g++ openssh-client openssh-server expect rsync  zip python )

--- a/cmake_modules/dependencies/quantal.cmake
+++ b/cmake_modules/dependencies/quantal.cmake
@@ -1,1 +1,1 @@
-SET_DEPENDENCIES ( CPACK_DEBIAN_PACKAGE_DEPENDS libboost-regex1.49.0 libicu48 libxalan110 libxerces-c28 binutils libldap-2.4-2 openssl zlib1g g++ openssh-client openssh-server expect libarchive12 rsync libapr1 libaprutil1 zip python libtbb2 )
+SET_DEPENDENCIES ( CPACK_DEBIAN_PACKAGE_DEPENDS g++ openssh-client openssh-server expect rsync  zip python )

--- a/cmake_modules/dependencies/raring.cmake
+++ b/cmake_modules/dependencies/raring.cmake
@@ -1,1 +1,1 @@
-SET_DEPENDENCIES ( CPACK_DEBIAN_PACKAGE_DEPENDS libboost-regex1.49.0 libicu48 libxalan110 libxerces-c28 binutils libldap-2.4-2 openssl zlib1g g++ openssh-client openssh-server expect libarchive13 rsync libapr1 libaprutil1 zip libtbb2 )
+SET_DEPENDENCIES ( CPACK_DEBIAN_PACKAGE_DEPENDS g++ openssh-client openssh-server expect rsync  zip python )

--- a/cmake_modules/dependencies/saucy.cmake
+++ b/cmake_modules/dependencies/saucy.cmake
@@ -1,1 +1,1 @@
-SET_DEPENDENCIES ( CPACK_DEBIAN_PACKAGE_DEPENDS libboost-regex1.53.0 libicu48 libxalan-c111 libxerces-c3.1 binutils libldap-2.4-2 openssl zlib1g g++ openssh-client openssh-server expect libarchive13 rsync libapr1 libaprutil1 zip python libtbb2 )
+SET_DEPENDENCIES ( CPACK_DEBIAN_PACKAGE_DEPENDS g++ openssh-client openssh-server expect rsync  zip python )

--- a/cmake_modules/dependencies/squeeze.cmake
+++ b/cmake_modules/dependencies/squeeze.cmake
@@ -1,1 +1,1 @@
-SET_DEPENDENCIES ( CPACK_DEBIAN_PACKAGE_DEPENDS libboost-regex1.42.0 libicu44 libxalan110 libxerces-c28 binutils libldap-2.4-2 openssl zlib1g g++ openssh-client openssh-server expect libarchive1 rsync libapr1 libaprutil1 zip python libtbb2 )
+SET_DEPENDENCIES ( CPACK_DEBIAN_PACKAGE_DEPENDS g++ openssh-client openssh-server expect rsync  zip python )

--- a/cmake_modules/dependencies/trusty.cmake
+++ b/cmake_modules/dependencies/trusty.cmake
@@ -1,1 +1,1 @@
-SET_DEPENDENCIES ( CPACK_DEBIAN_PACKAGE_DEPENDS libboost-regex1.54.0 libicu52 libxslt1.1 libxml2 binutils libldap-2.4-2 openssl zlib1g g++ openssh-client openssh-server expect libarchive13 rsync libapr1 libaprutil1 zip python libtbb2 )
+SET_DEPENDENCIES ( CPACK_DEBIAN_PACKAGE_DEPENDS g++ openssh-client openssh-server expect rsync  zip python )

--- a/cmake_modules/dependencies/utopic.cmake
+++ b/cmake_modules/dependencies/utopic.cmake
@@ -1,1 +1,1 @@
-SET_DEPENDENCIES ( CPACK_DEBIAN_PACKAGE_DEPENDS libboost-regex1.55.0 libicu52 libxslt1.1 libxml2 binutils libldap-2.4-2 openssl zlib1g g++ openssh-client openssh-server expect libarchive13 rsync libapr1 libaprutil1 python libtbb2 )
+SET_DEPENDENCIES ( CPACK_DEBIAN_PACKAGE_DEPENDS g++ openssh-client openssh-server expect rsync  zip python )

--- a/cmake_modules/dependencies/vivid.cmake
+++ b/cmake_modules/dependencies/vivid.cmake
@@ -1,1 +1,1 @@
-SET_DEPENDENCIES ( CPACK_DEBIAN_PACKAGE_DEPENDS libboost-regex1.55.0 libicu52 libxslt1.1 libxml2 binutils libldap-2.4-2 openssl zlib1g g++ openssh-client openssh-server expect libarchive13 rsync libapr1 libaprutil1 python libtbb2 )
+SET_DEPENDENCIES ( CPACK_DEBIAN_PACKAGE_DEPENDS g++ openssh-client openssh-server expect rsync  zip python )


### PR DESCRIPTION
This change will make cppunit and uriparser automatically visible in the dependency list if we build against them.  A change only had to be made to the debian packaging.  The rpm generator already handles dependencies correctly.

Signed-off-by: Michael Gardner Michael.Gardner@lexisnexis.com
