### PR TITLE
HPCC-14241  Add wily.cmake for Ubuntu 15.10 support

### DIFF
--- a/cmake_modules/dependencies/wily.cmake
+++ b/cmake_modules/dependencies/wily.cmake
@@ -1,0 +1,1 @@
+SET_DEPENDENCIES ( CPACK_DEBIAN_PACKAGE_DEPENDS g++ openssh-client openssh-server expect rsync libapr1 python )


### PR DESCRIPTION
Add dependencies to support Ubuntu 15.10 amd64 

Signed-off-by: Xiaoming Wang xiaoming.wang@lexisnexi.com 

@Michael-Gardner please review
