### PR TITLE
HPCC-14768 Fix spurious error adding empty superfile to super

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -5144,6 +5144,10 @@ public:
 
     void checkFormatAttr(IDistributedFile *sub, const char* exprefix="")
     {
+        IDistributedSuperFile *superSub = sub->querySuperFile();
+        if (superSub && (0 == superSub->numSubFiles(true)))
+            return;
+
         // only check sub files not siblings, which is excessive (format checking is really only debug aid)
         checkSubFormatAttr(sub,exprefix);
     }


### PR DESCRIPTION
An empty superfile can be interpreted as having some default
property attributes, e.g. global vs local.
Adding it could result in spurious errors that complain that the
empty super being added mismatches the attributes of the super
file it's being added to.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
