### PR TITLE
HPCC-14783 Change ActionType to WUActionType in WsWorkunits.WUAction

### DIFF
--- a/esp/eclwatch/ws_XSLT/index.xslt
+++ b/esp/eclwatch/ws_XSLT/index.xslt
@@ -171,7 +171,7 @@
                             {
                                 if(confirm('Do you want to abort '+wuid+'?'))
                                 {
-                                    document.location="/WsWorkunits/WUAction?ActionType=Abort&Wuids_i1="+wuid;
+                                    document.location="/WsWorkunits/WUAction?WUActionType=Abort&Wuids_i1="+wuid;
                                 }
                             }
 
@@ -179,7 +179,7 @@
                             {
                                 if(confirm('Do you want to pause '+wuid+'?'))
                                 {
-                                    document.location="/WsWorkunits/WUAction?ActionType=Pause&Wuids_i1="+wuid;
+                                    document.location="/WsWorkunits/WUAction?WUActionType=Pause&Wuids_i1="+wuid;
                                 }
                             }
 
@@ -187,7 +187,7 @@
                             {
                                 if(confirm('Do you want to pause '+wuid+' now?'))
                                 {
-                                    document.location="/WsWorkunits/WUAction?ActionType=PauseNow&Wuids_i1="+wuid;
+                                    document.location="/WsWorkunits/WUAction?WUActionType=PauseNow&Wuids_i1="+wuid;
                                 }
                             }
 
@@ -195,7 +195,7 @@
                             {
                                 if(confirm('Do you want to resume '+wuid+'?'))
                                 {
-                                    document.location="/WsWorkunits/WUAction?ActionType=Resume&Wuids_i1="+wuid;
+                                    document.location="/WsWorkunits/WUAction?WUActionType=Resume&Wuids_i1="+wuid;
                                 }
                             }
 

--- a/esp/eclwatch/ws_XSLT/scheduledwus.xslt
+++ b/esp/eclwatch/ws_XSLT/scheduledwus.xslt
@@ -208,7 +208,7 @@
                     <table style="margin:10 0 0 0" id="btnTable" name="btnTable">
                         <tr>
                             <td>
-                                <input type="submit" class="sbutton" name="ActionType" id="deleteBtn" value="Deschedule" disabled="true" onclick="return confirm('Delete selected workunits from schedule list?')"/>
+                                <input type="submit" class="sbutton" name="WUActionType" id="deleteBtn" value="Deschedule" disabled="true" onclick="return confirm('Delete selected workunits from schedule list?')"/>
                             </td>
                         </tr>
                     </table>

--- a/esp/eclwatch/ws_XSLT/workunits.xslt
+++ b/esp/eclwatch/ws_XSLT/workunits.xslt
@@ -391,34 +391,34 @@
                            <xsl:choose>
                                 <xsl:when test="string-length($archived)">
                                    <td>
-                                      <input type="submit" class="sbutton" name="ActionType" id="restoreBtn" value="Restore" disabled="true"/>
+                                      <input type="submit" class="sbutton" name="WUActionType" id="restoreBtn" value="Restore" disabled="true"/>
                                    </td>
                                 </xsl:when>
                                 <xsl:otherwise>
                                    <td>
-                                      <input type="submit" class="sbutton" name="ActionType" id="deleteBtn" value="Delete" disabled="true" onclick="return confirm('Delete selected workunits?')"/>
+                                      <input type="submit" class="sbutton" name="WUActionType" id="deleteBtn" value="Delete" disabled="true" onclick="return confirm('Delete selected workunits?')"/>
                                    </td>
                                    <td width="10"/>
                                    <td>
-                                      <input type="submit" class="sbutton" name="ActionType" id="protectBtn" value="Protect" disabled="true"/>
+                                      <input type="submit" class="sbutton" name="WUActionType" id="protectBtn" value="Protect" disabled="true"/>
                                    </td>
                                    <td width="10"/>
                                    <td>
-                                      <input type="submit" class="sbutton" name="ActionType" id="unprotectBtn" value="Unprotect" disabled="true"/>
+                                      <input type="submit" class="sbutton" name="WUActionType" id="unprotectBtn" value="Unprotect" disabled="true"/>
                                    </td>
                                 </xsl:otherwise>
                             </xsl:choose>
                            <td width="10"/>
                            <td>
-                              <input type="submit" class="sbutton" name="ActionType" id="scheduleBtn" value="Reschedule" disabled="true"/>
+                              <input type="submit" class="sbutton" name="WUActionType" id="scheduleBtn" value="Reschedule" disabled="true"/>
                            </td>
                            <td width="10"/>
                            <td>
-                              <input type="submit" class="sbutton" name="ActionType" id="descheduleBtn" value="Deschedule" disabled="true"/>
+                              <input type="submit" class="sbutton" name="WUActionType" id="descheduleBtn" value="Deschedule" disabled="true"/>
                            </td>
                            <td width="10"/>
                            <td>
-                              <input type="submit" class="sbutton" name="ActionType" id="changeStateBtn" value="SetToFailed" disabled="true"/>
+                              <input type="submit" class="sbutton" name="WUActionType" id="changeStateBtn" value="SetToFailed" disabled="true"/>
                            </td>
                         </tr>
                      </table>

--- a/esp/eclwatch/ws_XSLT/wuidcommon.xslt
+++ b/esp/eclwatch/ws_XSLT/wuidcommon.xslt
@@ -854,7 +854,7 @@
       <xsl:when test="number(Archived)">
         <form action="/WsWorkunits/WUAction?PageFrom=WUID" method="post">
           <input type="hidden" name="Wuids_i1" value="{$wuid}"/>
-          <input type="submit" class="sbutton" name="ActionType" id="restoreBtn" value="Restore"/>
+          <input type="submit" class="sbutton" name="WUActionType" id="restoreBtn" value="Restore"/>
         </form>
       </xsl:when>
         <xsl:when test="number(ClusterFlag)=2">
@@ -870,12 +870,12 @@
                   </xsl:choose>
                 </xsl:variable>
                 <input type="hidden" name="Wuids_i1" value="{$wuid}"/>
-                <input type="submit" name="ActionType" value="Abort" class="sbutton" title="Abort workunit" onclick="return confirm('Abort workunit?')">
+                <input type="submit" name="WUActionType" value="Abort" class="sbutton" title="Abort workunit" onclick="return confirm('Abort workunit?')">
                   <xsl:if test="number(AccessFlag) &lt; 7 or State='aborting' or State='aborted' or State='failed' or State='completed' or $ScheduledAborting!=0">
                     <xsl:attribute name="disabled">disabled</xsl:attribute>
                   </xsl:if>
                 </input>
-                <input type="submit" name="ActionType" value="Delete" class="sbutton" title="Delete workunit" onclick="return confirm('Delete workunit?')">
+                <input type="submit" name="WUActionType" value="Delete" class="sbutton" title="Delete workunit" onclick="return confirm('Delete workunit?')">
                   <xsl:if test="number(AccessFlag) &lt; 7 or number(Protected)">
                     <xsl:attribute name="disabled">disabled</xsl:attribute>
                   </xsl:if>
@@ -891,7 +891,7 @@
             <td></td>
             <xsl:if test="number(ThorLCR)">
                 <td>
-                  <form action="/WsWorkunits/WUAction?ActionType=Pause&amp;Wuids_i1={$wuid}" method="post">
+                  <form action="/WsWorkunits/WUAction?WUActionType=Pause&amp;Wuids_i1={$wuid}" method="post">
                     <input type="submit" name="Pause" value="Pause" class="sbutton" title="Pause workunit">
                       <xsl:if test="number(AccessFlag) &lt; 7 or State!='running'">
                         <xsl:attribute name="disabled">disabled</xsl:attribute>
@@ -900,7 +900,7 @@
                   </form>
                 </td>
                 <td>
-                  <form action="/WsWorkunits/WUAction?ActionType=PauseNow&amp;Wuids_i1={$wuid}" method="post">
+                  <form action="/WsWorkunits/WUAction?WUActionType=PauseNow&amp;Wuids_i1={$wuid}" method="post">
                     <input type="submit" name="PauseNow" value="PauseNow" class="sbutton" title="Pause workunit now">
                       <xsl:if test="number(AccessFlag) &lt; 7 or State!='running'">
                         <xsl:attribute name="disabled">disabled</xsl:attribute>
@@ -909,7 +909,7 @@
                   </form>
                 </td>
                 <td>
-                  <form action="/WsWorkunits/WUAction?ActionType=Resume&amp;Wuids_i1={$wuid}" method="post">
+                  <form action="/WsWorkunits/WUAction?WUActionType=Resume&amp;Wuids_i1={$wuid}" method="post">
                     <input type="submit" name="Resume" value="Resume" class="sbutton" title="Resume workunit">
                       <xsl:if test="number(AccessFlag) &lt; 7 or State!='paused'">
                         <xsl:attribute name="disabled">disabled</xsl:attribute>
@@ -927,25 +927,25 @@
                   </xsl:choose>
                 </xsl:variable>
                 <input type="hidden" name="Wuids_i1" value="{$wuid}"/>
-                <input type="submit" name="ActionType" value="Abort" class="sbutton" title="Abort workunit" onclick="return confirm('Abort workunit?')">
+                <input type="submit" name="WUActionType" value="Abort" class="sbutton" title="Abort workunit" onclick="return confirm('Abort workunit?')">
                   <xsl:if test="number(AccessFlag) &lt; 7 or State='aborting' or State='aborted' or State='failed' or State='completed' or $ScheduledAborting!=0">
                     <xsl:attribute name="disabled">disabled</xsl:attribute>
                   </xsl:if>
                 </input>
-                <input type="submit" name="ActionType" value="Delete" class="sbutton" title="Delete workunit" onclick="return confirm('Delete workunit?')">
+                <input type="submit" name="WUActionType" value="Delete" class="sbutton" title="Delete workunit" onclick="return confirm('Delete workunit?')">
                   <xsl:if test="number(AccessFlag) &lt; 7 or number(Protected)">
                     <xsl:attribute name="disabled">disabled</xsl:attribute>
                   </xsl:if>
                 </input>
                 <xsl:if test="number(EventSchedule) = 1">
-                  <input type="submit" name="ActionType" value="Reschedule" class="sbutton" title="Reschedule workunit">
+                  <input type="submit" name="WUActionType" value="Reschedule" class="sbutton" title="Reschedule workunit">
                             <xsl:if test="number(AccessFlag) &lt; 7">
                               <xsl:attribute name="disabled">disabled</xsl:attribute>
                             </xsl:if>
                          </input>
                 </xsl:if>
                 <xsl:if test="number(EventSchedule) = 2">
-                  <input type="submit" name="ActionType" value="Deschedule" class="sbutton" title="Deschedule workunit">
+                  <input type="submit" name="WUActionType" value="Deschedule" class="sbutton" title="Deschedule workunit">
                             <xsl:if test="number(AccessFlag) &lt; 7">
                               <xsl:attribute name="disabled">disabled</xsl:attribute>
                             </xsl:if>

--- a/esp/src/eclwatch/WsWorkunits.js
+++ b/esp/src/eclwatch/WsWorkunits.js
@@ -227,7 +227,7 @@ define([
         WUAction: function (workunits, actionType, callback) {
             var request = {
                 Wuids: workunits,
-                ActionType: actionType
+                WUActionType: actionType
             };
             ESPRequest.flattenArray(request, "Wuids", "Wuid");
 


### PR DESCRIPTION
This is UI changes for https://track.hpccsystems.com/browse/HPCC-14717.
Recently, the ActionType has been changed to WUActionType for better
versioning. Inside the ESP calls from ECLWatch UI, old ActionType has to be 
replaced by WUActionType.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
