### PR TITLE
HPCC-14727 Allow warnings when removing superfiles.

### DIFF
--- a/dali/base/CMakeLists.txt
+++ b/dali/base/CMakeLists.txt
@@ -62,6 +62,7 @@ include_directories (
          ./../../system/mp 
          ./../../system/include 
          ./../../system/jlib 
+         ./../../rtl/include 
     )
 
 ADD_DEFINITIONS( -DLOGMSGCOMPONENT=3 -D_USRDLL -DDALI_EXPORTS )

--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -4912,7 +4912,13 @@ protected:
                         if (!subfroot->removeProp(oquery.str()))
                         {
                             VStringBuffer s("SubFile %s is not owned by SuperFile %s", name, logicalName.get());
-                            ctx->addWuException(s.str(), 0, SeverityWarning, "DFS[clearSuperOwner]");
+                            if (ctx)
+                                ctx->addWuException(s.str(), 0, SeverityWarning, "DFS[clearSuperOwner]");
+                            else
+                            {
+                                Owned<IException> e = makeStringException(-1, s.str());
+                                EXCLOG(e, "DFS[clearSuperOwner]");
+                            }
                         }
                     }
                 }

--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -1463,8 +1463,6 @@ class CDistributedFileTransaction: public CInterface, implements IDistributedFil
      */
     IDistributedSuperFile *owner;
 
-
-    void validateAddSubFile(IDistributedSuperFile *super, IDistributedFile *sub, const char *subName);
     CTransactionFile *queryCreate(const char *name, IDistributedFile *file, bool recreate=false)
     {
         Owned<CTransactionFile> trackedFile;
@@ -1484,7 +1482,37 @@ class CDistributedFileTransaction: public CInterface, implements IDistributedFil
     {
         return trackedFiles.find(file);
     }
-
+    void commitActions()
+    {
+        while (actions.ordinality())  // if we get here everything should work!
+        {
+            Owned<CDFAction> action = &actions.popGet();
+            action->commit();
+        }
+    }
+    IDistributedFile *findFile(const char *name)
+    {
+        StringBuffer tmp;
+        name = normalizeLFN(name, tmp);
+        CTransactionFile *trackedFile = trackedFilesByName.find(tmp.str());
+        if (!trackedFile)
+            return NULL;
+        return trackedFile->queryFile();
+    }
+    void deleteFiles()      // no rollback at this point
+    {
+        Owned<IMultiException> me = MakeMultiException("Transaction");
+        ForEachItemIn(i,delayeddelete) {
+            try {
+                delayeddelete.item(i).doDelete();
+            } catch (IException *e) {
+                me->append(*e);
+            }
+        }
+        delayeddelete.kill();
+        if (me->ordinality())
+            throw me.getClear();
+    }
 public:
     IMPLEMENT_IINTERFACE;
     CDistributedFileTransaction(IUserDescriptor *user, IDistributedSuperFile *_owner=NULL)
@@ -1500,79 +1528,8 @@ public:
             rollback();
         assert(depth == 0);
     }
-    void ensureFile(IDistributedFile *file)
-    {
-        if (!trackedFiles.find(file))
-            addFile(file);
-    }
-    void addFile(IDistributedFile *file)
-    {
-        CTransactionFile *trackedFile = queryCreate(file->queryLogicalName(), file, false);
-        // Also add subfiles to cache
-        IDistributedSuperFile *sfile = file->querySuperFile();
-        if (sfile)
-        {
-            Owned<IDistributedFileIterator> iter = sfile->getSubFileIterator();
-            ForEach(*iter)
-            {
-                IDistributedFile *f = &iter->query();
-                trackedFile->noteAddSubFile(f);
-                addFile(f);
-            }
-        }
-    }
-    void noteAddSubFile(IDistributedSuperFile *super, const char *superName, IDistributedFile *sub)
-    {
-        CTransactionFile *trackedSuper = queryCreate(superName, super);
-        trackedSuper->noteAddSubFile(sub);
-    }
-    void noteRemoveSubFile(IDistributedSuperFile *super, IDistributedFile *sub)
-    {
-        CTransactionFile *trackedSuper = lookupTrackedFile(super);
-        if (trackedSuper)
-            trackedSuper->noteRemoveSubFile(sub);
-    }
-    virtual void clearSubFiles(IDistributedSuperFile *super)
-    {
-        CTransactionFile *trackedSuper = lookupTrackedFile(super);
-        if (trackedSuper)
-            trackedSuper->clearSubs();
-    }
-    virtual void noteSuperSwap(IDistributedSuperFile *super1, IDistributedSuperFile *super2)
-    {
-        CTransactionFile *trackedSuper1 = lookupTrackedFile(super1);
-        CTransactionFile *trackedSuper2 = lookupTrackedFile(super2);
-        assertex(trackedSuper1 && trackedSuper2);
-        ICopyArrayOf<IDistributedFile> super1Subs, super2Subs;
-        Owned<IDistributedFileIterator> iter = trackedSuper1->getSubFiles();
-        ForEach(*iter)
-            super1Subs.append(iter->query());
-        trackedSuper1->clearSubs();
-        iter.setown(trackedSuper2->getSubFiles());
-        ForEach(*iter)
-            super2Subs.append(iter->query());
-        trackedSuper2->clearSubs();
-        ForEachItemIn(s, super2Subs)
-            trackedSuper1->noteAddSubFile(&super2Subs.item(s));
-        ForEachItemIn(s2, super1Subs)
-            trackedSuper2->noteAddSubFile(&super1Subs.item(s2));
-    }
-    void noteRename(IDistributedFile *file, const char *newName)
-    {
-        CTransactionFile *trackedFile = lookupTrackedFile(file);
-        if (trackedFile)
-        {
-            trackedFiles.removeExact(trackedFile);
-            trackedFilesByName.removeExact(trackedFile);
-            trackedFile = queryCreate(newName, file);
-        }
-    }
-    void addAction(CDFAction *action)
-    {
-        actions.append(*action); // takes ownership
-        action->setTransaction(this);
-    }
-    void start()
+// IDistributedFileTransaction impl.
+    virtual void start()
     {
         if (isactive)
             throw MakeStringException(-1,"Transaction already started");
@@ -1582,39 +1539,7 @@ public:
         prepared = 0;
         assertex(actions.ordinality()==0);
     }
-    bool prepareActions()
-    {
-        prepared = 0;
-        unsigned toPrepare = actions.ordinality();
-        ForEachItemIn(i0,actions)
-        {
-            if (actions.item(i0).prepare())
-                ++prepared;
-            else
-                break;
-        }
-        return prepared == toPrepare;
-    }
-    void retryActions()
-    {
-        clearFiles(); // clear all previously tracked pending file changes, e.g. renames, super file additions/removals
-        while (prepared) // unlock for retry
-            actions.item(--prepared).retry();
-    }
-    void runActions()
-    {
-        ForEachItemIn(i,actions)
-            actions.item(i).run();
-    }
-    void commitActions()
-    {
-        while (actions.ordinality())  // if we get here everything should work!
-        {
-            Owned<CDFAction> action = &actions.popGet();
-            action->commit();
-        }
-    }
-    void commit()
+    virtual void commit()
     {
         if (!isactive)
             return;
@@ -1642,17 +1567,7 @@ public:
         rollback();
         throw rete;
     }
-    void commitAndClearup()
-    {
-        // =============== COMMIT and CLEANUP
-        commitActions();
-        clearFiles();
-        isactive = false;
-        actions.kill();
-        deleteFiles();
-    }
-
-    void rollback()
+    virtual void rollback()
     {
         // =============== ROLLBACK AND CLEANUP
         while (actions.ordinality())
@@ -1679,8 +1594,51 @@ public:
         // this we only want to do if active
         delayeddelete.kill();
     }
-
-    void autoCommit()
+    virtual bool active()
+    {
+        return isactive;
+    }
+    virtual IDistributedFile *lookupFile(const char *name,unsigned timeout)
+    {
+        IDistributedFile *ret = findFile(name);
+        if (ret)
+            return LINK(ret);
+        else
+        {
+            ret = queryDistributedFileDirectory().lookup(name, udesc, false, false, false, this, timeout);
+            if (ret)
+                queryCreate(name, ret, true);
+            return ret;
+        }
+    }
+    virtual IDistributedSuperFile *lookupSuperFile(const char *name, unsigned timeout)
+    {
+        IDistributedFile *f = findFile(name);
+        if (f)
+            return LINK(f->querySuperFile());
+        else
+        {
+            IDistributedSuperFile *ret = queryDistributedFileDirectory().lookupSuperFile(name,udesc,this,timeout);
+            if (ret)
+                addFile(ret);
+            return ret;
+        }
+    }
+// IDistributedFileTransactionExt impl.
+    virtual IUserDescriptor *queryUser()
+    {
+        return udesc;
+    }
+    virtual void descend() // Call this when you're recurring
+    {
+        depth++;
+    }
+    virtual void ascend() // Call this at the end of the block that started recursion
+    {
+        assertex(depth);
+        depth--;
+    }
+    virtual void autoCommit()
     {
         // Recursive calls to transaction will not commit until
         // all calls have finished (gone back to zero depth)
@@ -1695,79 +1653,33 @@ public:
             }
         }
     }
-
-    // Call this when you're recurring
-    void descend()
+    virtual void addAction(CDFAction *action)
     {
-        depth++;
+        actions.append(*action); // takes ownership
+        action->setTransaction(this);
     }
-
-    // Call this at the end of the block that started recursion
-    void ascend()
+    virtual void addFile(IDistributedFile *file)
     {
-        assertex(depth);
-        depth--;
-    }
-
-    IDistributedFile *findFile(const char *name)
-    {
-        StringBuffer tmp;
-        name = normalizeLFN(name, tmp);
-        CTransactionFile *trackedFile = trackedFilesByName.find(tmp.str());
-        if (!trackedFile)
-            return NULL;
-        return trackedFile->queryFile();
-    }
-    IDistributedFile *lookupFile(const char *name,unsigned timeout)
-    {
-        IDistributedFile *ret = findFile(name);
-        if (ret)
-            return LINK(ret);
-        else
+        CTransactionFile *trackedFile = queryCreate(file->queryLogicalName(), file, false);
+        // Also add subfiles to cache
+        IDistributedSuperFile *sfile = file->querySuperFile();
+        if (sfile)
         {
-            ret = queryDistributedFileDirectory().lookup(name, udesc, false, false, false, this, timeout);
-            if (ret)
-                queryCreate(name, ret, true);
-            return ret;
+            Owned<IDistributedFileIterator> iter = sfile->getSubFileIterator();
+            ForEach(*iter)
+            {
+                IDistributedFile *f = &iter->query();
+                trackedFile->noteAddSubFile(f);
+                addFile(f);
+            }
         }
     }
-
-    IDistributedSuperFile *lookupSuperFile(const char *name, unsigned timeout)
+    virtual void ensureFile(IDistributedFile *file)
     {
-        IDistributedFile *f = findFile(name);
-        if (f)
-            return LINK(f->querySuperFile());
-        else
-        {
-            IDistributedSuperFile *ret = queryDistributedFileDirectory().lookupSuperFile(name,udesc,this,timeout);
-            if (ret)
-                addFile(ret);
-            return ret;
-        }
+        if (!trackedFiles.find(file))
+            addFile(file);
     }
-
-    virtual bool isSubFile(IDistributedSuperFile *super, const char *subFile, bool sub)
-    {
-        CTransactionFile *trackedSuper = lookupTrackedFile(super);
-        if (!trackedSuper)
-            return false;
-        return trackedSuper->find(subFile, sub);
-    }
-
-public:
-    bool active()
-    {
-        return isactive;
-    }
-
-    void clearFiles()
-    {
-        trackedFiles.kill();
-        trackedFilesByName.kill();
-        if (owner)
-            addFile(owner); // ensure remains tracked
-    }
-    void clearFile(IDistributedFile *file)
+    virtual void clearFile(IDistributedFile *file)
     {
         CTransactionFile *trackedFile = lookupTrackedFile(file);
         IDistributedSuperFile *sfile = file->querySuperFile();
@@ -1783,31 +1695,104 @@ public:
             trackedFilesByName.removeExact(trackedFile);
         }
     }
-
-    IUserDescriptor *queryUser()
+    virtual void clearFiles()
     {
-        return udesc;
+        trackedFiles.kill();
+        trackedFilesByName.kill();
+        if (owner)
+            addFile(owner); // ensure remains tracked
     }
-
-    bool addDelayedDelete(CDfsLogicalFileName &lfn,unsigned timeoutms)
+    virtual void noteAddSubFile(IDistributedSuperFile *super, const char *superName, IDistributedFile *sub)
+    {
+        CTransactionFile *trackedSuper = queryCreate(superName, super);
+        trackedSuper->noteAddSubFile(sub);
+    }
+    virtual void noteRemoveSubFile(IDistributedSuperFile *super, IDistributedFile *sub)
+    {
+        CTransactionFile *trackedSuper = lookupTrackedFile(super);
+        if (trackedSuper)
+            trackedSuper->noteRemoveSubFile(sub);
+    }
+    virtual void noteSuperSwap(IDistributedSuperFile *super1, IDistributedSuperFile *super2)
+    {
+        CTransactionFile *trackedSuper1 = lookupTrackedFile(super1);
+        CTransactionFile *trackedSuper2 = lookupTrackedFile(super2);
+        assertex(trackedSuper1 && trackedSuper2);
+        ICopyArrayOf<IDistributedFile> super1Subs, super2Subs;
+        Owned<IDistributedFileIterator> iter = trackedSuper1->getSubFiles();
+        ForEach(*iter)
+            super1Subs.append(iter->query());
+        trackedSuper1->clearSubs();
+        iter.setown(trackedSuper2->getSubFiles());
+        ForEach(*iter)
+            super2Subs.append(iter->query());
+        trackedSuper2->clearSubs();
+        ForEachItemIn(s, super2Subs)
+            trackedSuper1->noteAddSubFile(&super2Subs.item(s));
+        ForEachItemIn(s2, super1Subs)
+            trackedSuper2->noteAddSubFile(&super1Subs.item(s2));
+    }
+    virtual void clearSubFiles(IDistributedSuperFile *super)
+    {
+        CTransactionFile *trackedSuper = lookupTrackedFile(super);
+        if (trackedSuper)
+            trackedSuper->clearSubs();
+    }
+    virtual void noteRename(IDistributedFile *file, const char *newName)
+    {
+        CTransactionFile *trackedFile = lookupTrackedFile(file);
+        if (trackedFile)
+        {
+            trackedFiles.removeExact(trackedFile);
+            trackedFilesByName.removeExact(trackedFile);
+            trackedFile = queryCreate(newName, file);
+        }
+    }
+    virtual void validateAddSubFile(IDistributedSuperFile *super, IDistributedFile *sub, const char *subName);
+    virtual bool isSubFile(IDistributedSuperFile *super, const char *subFile, bool sub)
+    {
+        CTransactionFile *trackedSuper = lookupTrackedFile(super);
+        if (!trackedSuper)
+            return false;
+        return trackedSuper->find(subFile, sub);
+    }
+    virtual bool addDelayedDelete(CDfsLogicalFileName &lfn,unsigned timeoutms)
     {
         delayeddelete.append(*new CDelayedDelete(lfn,udesc,timeoutms));
         return true;
     }
-    
-    void deleteFiles()      // no rollback at this point
+    virtual bool prepareActions()
     {
-        Owned<IMultiException> me = MakeMultiException("Transaction");
-        ForEachItemIn(i,delayeddelete) {
-            try {
-                delayeddelete.item(i).doDelete();
-            } catch (IException *e) {
-                me->append(*e);
-            }
+        prepared = 0;
+        unsigned toPrepare = actions.ordinality();
+        ForEachItemIn(i0,actions)
+        {
+            if (actions.item(i0).prepare())
+                ++prepared;
+            else
+                break;
         }
-        delayeddelete.kill();
-        if (me->ordinality())
-            throw me.getClear();
+        return prepared == toPrepare;
+    }
+    virtual void retryActions()
+    {
+        clearFiles(); // clear all previously tracked pending file changes, e.g. renames, super file additions/removals
+        while (prepared) // unlock for retry
+            actions.item(--prepared).retry();
+    }
+    virtual void runActions()
+    {
+        ForEachItemIn(i,actions)
+            actions.item(i).run();
+    }
+    virtual void commitAndClearup()
+    {
+        // =============== COMMIT and CLEANUP
+        commitActions();
+        clearFiles();
+        isactive = false;
+        actions.kill();
+        deleteFiles();
     }
 };
 

--- a/dali/base/dadfs.hpp
+++ b/dali/base/dadfs.hpp
@@ -290,6 +290,7 @@ interface IDistributedSuperFileIterator: extends IIteratorOf<IDistributedSuperFi
     virtual const char *queryName() = 0;
 };
 
+interface ICodeContext;
 /**
  * A distributed file, composed of one or more DistributedFileParts.
  */
@@ -313,7 +314,7 @@ interface IDistributedFile: extends IInterface
     virtual const char *queryPartMask() = 0;                                    // default part name mask
 
     virtual void attach(const char *logicalname,IUserDescriptor *user) = 0;     // attach to name in DFS
-    virtual void detach(unsigned timeoutms=INFINITE) = 0;                       // no longer attached to name in DFS
+    virtual void detach(unsigned timeoutms=INFINITE, ICodeContext *ctx=NULL) = 0; // no longer attached to name in DFS
 
     virtual IPropertyTree &queryAttributes() = 0;                               // DFile attributes
 
@@ -761,7 +762,7 @@ extern da_decl bool removeClusterSpares(const char *clusterName, const char *typ
 extern da_decl StringBuffer &getClusterGroupName(IPropertyTree &cluster, StringBuffer &groupName);
 extern da_decl StringBuffer &getClusterSpareGroupName(IPropertyTree &cluster, StringBuffer &groupName);
 
-extern da_decl IDistributedFileTransaction *createDistributedFileTransaction(IUserDescriptor *user);
+extern da_decl IDistributedFileTransaction *createDistributedFileTransaction(IUserDescriptor *user, ICodeContext *ctx=NULL);
 
 extern da_decl const char *normalizeLFN(const char *s, StringBuffer &normalized);
 

--- a/dali/base/dadfs.hpp
+++ b/dali/base/dadfs.hpp
@@ -295,7 +295,6 @@ interface IDistributedSuperFileIterator: extends IIteratorOf<IDistributedSuperFi
  */
 interface IDistributedFile: extends IInterface
 {
-
     virtual unsigned numParts() = 0;
     virtual IDistributedFilePart &queryPart(unsigned idx) = 0;
     virtual IDistributedFilePart* getPart(unsigned idx) = 0;

--- a/ecl/eclagent/eclagent.cpp
+++ b/ecl/eclagent/eclagent.cpp
@@ -2999,7 +2999,7 @@ void EclAgent::reportProgress(const char *progress, unsigned flags)
 IDistributedFileTransaction *EclAgent::querySuperFileTransaction()
 {
     if (!superfiletransaction.get())
-        superfiletransaction.setown(createDistributedFileTransaction(queryUserDescriptor()));
+        superfiletransaction.setown(createDistributedFileTransaction(queryUserDescriptor(), this));
     return superfiletransaction.get();
 }
 

--- a/roxie/ccd/ccdcontext.cpp
+++ b/roxie/ccd/ccdcontext.cpp
@@ -3750,7 +3750,7 @@ public:
     {
         CriticalBlock b(contextCrit);
         if (!superfileTransaction.get())
-            superfileTransaction.setown(createDistributedFileTransaction(queryUserDescriptor()));
+            superfileTransaction.setown(createDistributedFileTransaction(queryUserDescriptor(), queryCodeContext()));
         return superfileTransaction.get();
     }
     virtual void flush(unsigned seqNo) { throwUnexpected(); }

--- a/thorlcr/graph/thgraphmaster.cpp
+++ b/thorlcr/graph/thgraphmaster.cpp
@@ -1216,7 +1216,7 @@ public:
     virtual IDistributedFileTransaction *querySuperFileTransaction()
     {
         if (!superfiletransaction.get())
-            superfiletransaction.setown(createDistributedFileTransaction(userDesc));
+            superfiletransaction.setown(createDistributedFileTransaction(userDesc, this));
         return superfiletransaction.get();
     }
     virtual char *getJobName()

--- a/thorlcr/graph/thgraphslave.cpp
+++ b/thorlcr/graph/thgraphslave.cpp
@@ -1005,7 +1005,7 @@ public:
     {
         // NB: shouldn't really have fileservice being called on slaves
         if (!superfiletransaction.get())
-            superfiletransaction.setown(createDistributedFileTransaction(userDesc));
+            superfiletransaction.setown(createDistributedFileTransaction(userDesc, this));
         return superfiletransaction.get();
     }
     virtual void getResultStringF(unsigned tlen, char * tgt, const char * name, unsigned sequence) { throwUnexpected(); }


### PR DESCRIPTION
Pass ICodeContext to transactions, so that superfile ops. can
issue warnings.
Issue warning when superfile is removed and subfile is not marked
as belonging to the superfile.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
