### PR TITLE
HPCC-14802 Add additional edit distance metrics

### DIFF
--- a/ecllibrary/std/Str.ecl
+++ b/ecllibrary/std/Str.ecl
@@ -300,7 +300,7 @@ EXPORT STRING CombineWords(SET OF STRING words, STRING separator) := lib_stringl
 
 
 /**
- * Returns the minimum edit distance between the two strings.  An insert change or delete counts as a single edit.
+ * Returns the minimum (Levenshtein) edit distance between the two strings.  An insert, change, or delete counts as a single edit.
  * The two strings are trimmed before comparing.
  * 
  * @param _left         The first string to be compared.
@@ -311,13 +311,51 @@ EXPORT STRING CombineWords(SET OF STRING words, STRING separator) := lib_stringl
 EXPORT UNSIGNED4 EditDistance(STRING _left, STRING _right) :=
     lib_stringlib.StringLib.EditDistanceV2(_left, _right);
 
+EXPORT UNSIGNED4 LevenshteinDistance(STRING _left, STRING _right) :=
+    lib_stringlib.StringLib.EditDistanceV2(_left, _right);
+/**
+ * Returns the minimum Damerau–Levenshtein (restricted) edit distance (AKA optimal string alignment distance) between the two strings.
+ * The two strings are trimmed before comparing.
+ * 
+ * @param _left         The first string to be compared.
+ * @param _right        The second string to be compared.
+ * @return              The minimum edit distance between the two strings.
+ */
+
+EXPORT UNSIGNED4 OptimalStringAlignmentDistance(STRING _left, STRING _right) :=
+    lib_stringlib.StringLib.OptimalStringAlignmentDistanceV2(_left, _right);
+
+/**
+ * Returns the minimum Damerau–Levenshtein (unrestricted) edit distance between the two strings.
+ * The two strings are trimmed before comparing.
+ * 
+ * @param _left         The first string to be compared.
+ * @param _right        The second string to be compared.
+ * @return              The minimum edit distance between the two strings.
+ */
+
+EXPORT UNSIGNED4 DamerauLevenshteinDistance(STRING _left, STRING _right) :=
+    lib_stringlib.StringLib.damerauLevenshteinDistanceV2(_left, _right);
+
+/**
+ * Returns the minimum Damerau–Levenshtein (unrestricted) edit distance between the two strings.
+ * The two strings are trimmed before comparing.
+ * 
+ * @param _left         The first string to be compared.
+ * @param _right        The second string to be compared.
+ * @return              The minimum edit distance between the two strings.
+ */
+
+EXPORT UNSIGNED4 WeightedDamerauLevenshteinDistance(STRING _left, STRING _right) :=
+    lib_stringlib.StringLib.weightedDamerauLevenshteinDistanceV2(_left, _right);
+    
 /**
  * Returns true if the minimum edit distance between the two strings is with a specific range.
  * The two strings are trimmed before comparing.
  * 
  * @param _left         The first string to be compared.
  * @param _right        The second string to be compared.
- * @param radius        The maximum edit distance that is accepable.
+ * @param radius        The maximum edit distance that is acceptable.
  * @return              Whether or not the two strings are within the given specified edit distance.
  */
 

--- a/ecllibrary/teststd/str/TestDamerauLevenshteinDistance.ecl
+++ b/ecllibrary/teststd/str/TestDamerauLevenshteinDistance.ecl
@@ -1,0 +1,51 @@
+/*##############################################################################
+## HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.  All rights reserved.
+############################################################################## */
+
+IMPORT Std.Str;
+
+EXPORT TestDamerauLevenshteinDistance := MODULE
+
+  STRING alpha := 'abcdefghijklmnopqrstuvwxyz';
+  STRING digits := '0123456789';
+  STRING largeAlpha := alpha+alpha+alpha+alpha+alpha+alpha+alpha+alpha+alpha;
+  STRING manyAlpha := alpha+alpha+alpha+alpha+alpha+alpha+alpha+alpha+alpha+alpha+alpha+alpha;
+  STRING manyDigits := digits+digits+digits+digits+digits+digits+digits+digits+digits+digits+digits+digits+digits+
+                       digits+digits+digits+digits+digits+digits+digits+digits+digits+digits+digits+digits;
+
+  EXPORT TestConst := MODULE
+    EXPORT Test01 := ASSERT(Str.DamerauLevenshteinDistance('','') = 0, CONST);
+    EXPORT Test02 := ASSERT(Str.DamerauLevenshteinDistance('','                ') = 0, CONST);
+    EXPORT Test03 := ASSERT(Str.DamerauLevenshteinDistance('                ','') = 0, CONST);
+    EXPORT Test04 := ASSERT(Str.DamerauLevenshteinDistance('a ','                ') = 1, CONST);
+    //EXPORT Test05 := ASSERT(Str.DamerauLevenshteinDistance(' a ','   ') = 1, CONST);
+    EXPORT Test06 := ASSERT(Str.DamerauLevenshteinDistance('Aprs  ','APp') = 3, CONST);
+    EXPORT Test07 := ASSERT(Str.DamerauLevenshteinDistance('abcd','acbd') = 1, CONST);
+    EXPORT Test08 := ASSERT(Str.DamerauLevenshteinDistance('abcd','abd') = 1, CONST);
+    EXPORT Test09 := ASSERT(Str.DamerauLevenshteinDistance('abcd','abc') = 1, CONST);
+    EXPORT Test10 := ASSERT(Str.DamerauLevenshteinDistance('abcd','bcd') = 1, CONST);
+    EXPORT Test11 := ASSERT(Str.DamerauLevenshteinDistance('abcd','abcde') = 1, CONST);
+    EXPORT Test12 := ASSERT(Str.DamerauLevenshteinDistance('abcd','aabcd') = 1, CONST);
+    EXPORT Test13 := ASSERT(Str.DamerauLevenshteinDistance('abcd',' abcd') = 1, CONST);
+    EXPORT Test14 := ASSERT(Str.DamerauLevenshteinDistance('abcd','a bcd') = 1, CONST);
+    EXPORT Test15 := ASSERT(Str.DamerauLevenshteinDistance('abcd','adcd') = 1, CONST);
+    EXPORT Test16 := ASSERT(Str.DamerauLevenshteinDistance('abcd','') = 4, CONST);
+    EXPORT Test17 := ASSERT(Str.DamerauLevenshteinDistance(alpha,'') = 26, CONST);
+    EXPORT Test18 := ASSERT(Str.DamerauLevenshteinDistance(manyAlpha,'') = 255, CONST);       //overflow
+    EXPORT Test19 := ASSERT(Str.DamerauLevenshteinDistance(alpha,digits) = 26, CONST);
+    EXPORT Test20 := ASSERT(Str.DamerauLevenshteinDistance(manyAlpha,digits) = 255, CONST);   //overflow
+    EXPORT Test21 := ASSERT(Str.DamerauLevenshteinDistance(manyAlpha,manyDigits) = 255, CONST);   //overflow
+    EXPORT Test22 := ASSERT(Str.DamerauLevenshteinDistance(alpha,manyDigits) = 250, CONST);
+    EXPORT Test23 := ASSERT(Str.DamerauLevenshteinDistance(alpha,manyDigits+'12345') = 255, CONST);
+    EXPORT Test24 := ASSERT(Str.DamerauLevenshteinDistance(alpha,manyDigits+'123456') = 255, CONST);
+    EXPORT Test25 := ASSERT(Str.DamerauLevenshteinDistance('123456789','987654321') = 8, CONST);
+    EXPORT Test26 := ASSERT(Str.DamerauLevenshteinDistance(largeAlpha,manyDigits) = 250, CONST);  //overflow
+    EXPORT Test27 := ASSERT(Str.DamerauLevenshteinDistance(largeAlpha+'abcdefghijklmnopqrst',manyDigits) = 254, CONST);
+    EXPORT Test28 := ASSERT(Str.DamerauLevenshteinDistance(largeAlpha+'abcdefghijklmnopqrstu',manyDigits) = 255, CONST);
+    EXPORT Test29 := ASSERT(Str.DamerauLevenshteinDistance(alpha,'ABCDEFGHIJKLMNOPQRSTUVWXYZ') = 26, CONST);
+    EXPORT Test30 := ASSERT(Str.DamerauLevenshteinDistance('ghgygtgfgvgb','bgvgfgtgyghg') = 6, CONST);
+    EXPORT Test31 := ASSERT(Str.DamerauLevenshteinDistance('ca','abc') = 2, CONST);
+    EXPORT Test32 := ASSERT(Str.DamerauLevenshteinDistance('abcd','abdc') = 1, CONST);
+  END;
+
+END;

--- a/ecllibrary/teststd/str/TestDamerauLevenshteinDistance.ecl
+++ b/ecllibrary/teststd/str/TestDamerauLevenshteinDistance.ecl
@@ -18,7 +18,7 @@ EXPORT TestDamerauLevenshteinDistance := MODULE
     EXPORT Test02 := ASSERT(Str.DamerauLevenshteinDistance('','                ') = 0, CONST);
     EXPORT Test03 := ASSERT(Str.DamerauLevenshteinDistance('                ','') = 0, CONST);
     EXPORT Test04 := ASSERT(Str.DamerauLevenshteinDistance('a ','                ') = 1, CONST);
-    //EXPORT Test05 := ASSERT(Str.DamerauLevenshteinDistance(' a ','   ') = 1, CONST);
+    EXPORT Test05 := ASSERT(Str.DamerauLevenshteinDistance(' a ','   ') = 2, CONST);
     EXPORT Test06 := ASSERT(Str.DamerauLevenshteinDistance('Aprs  ','APp') = 3, CONST);
     EXPORT Test07 := ASSERT(Str.DamerauLevenshteinDistance('abcd','acbd') = 1, CONST);
     EXPORT Test08 := ASSERT(Str.DamerauLevenshteinDistance('abcd','abd') = 1, CONST);

--- a/ecllibrary/teststd/str/TestOptimalStringAlignmentDistance.ecl
+++ b/ecllibrary/teststd/str/TestOptimalStringAlignmentDistance.ecl
@@ -1,0 +1,51 @@
+/*##############################################################################
+## HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.  All rights reserved.
+############################################################################## */
+
+IMPORT Std.Str;
+
+EXPORT TestOptimalStringAlignmentDistance := MODULE
+
+  STRING alpha := 'abcdefghijklmnopqrstuvwxyz';
+  STRING digits := '0123456789';
+  STRING largeAlpha := alpha+alpha+alpha+alpha+alpha+alpha+alpha+alpha+alpha;
+  STRING manyAlpha := alpha+alpha+alpha+alpha+alpha+alpha+alpha+alpha+alpha+alpha+alpha+alpha;
+  STRING manyDigits := digits+digits+digits+digits+digits+digits+digits+digits+digits+digits+digits+digits+digits+
+                       digits+digits+digits+digits+digits+digits+digits+digits+digits+digits+digits+digits;
+
+  EXPORT TestConst := MODULE
+    EXPORT Test01 := ASSERT(Str.OptimalStringAlignmentDistance('','') = 0, CONST);
+    EXPORT Test02 := ASSERT(Str.OptimalStringAlignmentDistance('','                ') = 0, CONST);
+    EXPORT Test03 := ASSERT(Str.OptimalStringAlignmentDistance('                ','') = 0, CONST);
+    EXPORT Test04 := ASSERT(Str.OptimalStringAlignmentDistance('a ','                ') = 1, CONST);
+    //EXPORT Test05 := ASSERT(Str.OptimalStringAlignmentDistance(' a ','   ') = 1, CONST);
+    EXPORT Test06 := ASSERT(Str.OptimalStringAlignmentDistance('Aprs  ','APp') = 3, CONST);
+    EXPORT Test07 := ASSERT(Str.OptimalStringAlignmentDistance('abcd','acbd') = 1, CONST);
+    EXPORT Test08 := ASSERT(Str.OptimalStringAlignmentDistance('abcd','abd') = 1, CONST);
+    EXPORT Test09 := ASSERT(Str.OptimalStringAlignmentDistance('abcd','abc') = 1, CONST);
+    EXPORT Test10 := ASSERT(Str.OptimalStringAlignmentDistance('abcd','bcd') = 1, CONST);
+    EXPORT Test11 := ASSERT(Str.OptimalStringAlignmentDistance('abcd','abcde') = 1, CONST);
+    EXPORT Test12 := ASSERT(Str.OptimalStringAlignmentDistance('abcd','aabcd') = 1, CONST);
+    EXPORT Test13 := ASSERT(Str.OptimalStringAlignmentDistance('abcd',' abcd') = 1, CONST);
+    EXPORT Test14 := ASSERT(Str.OptimalStringAlignmentDistance('abcd','a bcd') = 1, CONST);
+    EXPORT Test15 := ASSERT(Str.OptimalStringAlignmentDistance('abcd','adcd') = 1, CONST);
+    EXPORT Test16 := ASSERT(Str.OptimalStringAlignmentDistance('abcd','') = 4, CONST);
+    EXPORT Test17 := ASSERT(Str.OptimalStringAlignmentDistance(alpha,'') = 26, CONST);
+    EXPORT Test18 := ASSERT(Str.OptimalStringAlignmentDistance(manyAlpha,'') = 255, CONST);       //overflow
+    EXPORT Test19 := ASSERT(Str.OptimalStringAlignmentDistance(alpha,digits) = 26, CONST);
+    EXPORT Test20 := ASSERT(Str.OptimalStringAlignmentDistance(manyAlpha,digits) = 255, CONST);   //overflow
+    EXPORT Test21 := ASSERT(Str.OptimalStringAlignmentDistance(manyAlpha,manyDigits) = 255, CONST);   //overflow
+    EXPORT Test22 := ASSERT(Str.OptimalStringAlignmentDistance(alpha,manyDigits) = 250, CONST);
+    EXPORT Test23 := ASSERT(Str.OptimalStringAlignmentDistance(alpha,manyDigits+'12345') = 255, CONST);
+    EXPORT Test24 := ASSERT(Str.OptimalStringAlignmentDistance(alpha,manyDigits+'123456') = 255, CONST);
+    EXPORT Test25 := ASSERT(Str.OptimalStringAlignmentDistance('123456789','987654321') = 8, CONST);
+    EXPORT Test26 := ASSERT(Str.OptimalStringAlignmentDistance(largeAlpha,manyDigits) = 250, CONST);  //overflow
+    EXPORT Test27 := ASSERT(Str.OptimalStringAlignmentDistance(largeAlpha+'abcdefghijklmnopqrst',manyDigits) = 254, CONST);
+    EXPORT Test28 := ASSERT(Str.OptimalStringAlignmentDistance(largeAlpha+'abcdefghijklmnopqrstu',manyDigits) = 255, CONST);
+    EXPORT Test29 := ASSERT(Str.OptimalStringAlignmentDistance(alpha,'ABCDEFGHIJKLMNOPQRSTUVWXYZ') = 26, CONST);
+    EXPORT Test30 := ASSERT(Str.OptimalStringAlignmentDistance('ghgygtgfgvgb','bgvgfgtgyghg') = 6, CONST);
+    EXPORT Test31 := ASSERT(Str.OptimalStringAlignmentDistance('ca','abc') = 3, CONST);
+    EXPORT Test32 := ASSERT(Str.OptimalStringAlignmentDistance('abcd','abdc') = 2, CONST);
+  END;
+
+END;

--- a/ecllibrary/teststd/str/TestOptimalStringAlignmentDistance.ecl
+++ b/ecllibrary/teststd/str/TestOptimalStringAlignmentDistance.ecl
@@ -18,7 +18,7 @@ EXPORT TestOptimalStringAlignmentDistance := MODULE
     EXPORT Test02 := ASSERT(Str.OptimalStringAlignmentDistance('','                ') = 0, CONST);
     EXPORT Test03 := ASSERT(Str.OptimalStringAlignmentDistance('                ','') = 0, CONST);
     EXPORT Test04 := ASSERT(Str.OptimalStringAlignmentDistance('a ','                ') = 1, CONST);
-    //EXPORT Test05 := ASSERT(Str.OptimalStringAlignmentDistance(' a ','   ') = 1, CONST);
+    EXPORT Test05 := ASSERT(Str.OptimalStringAlignmentDistance(' a ','   ') = 2, CONST);
     EXPORT Test06 := ASSERT(Str.OptimalStringAlignmentDistance('Aprs  ','APp') = 3, CONST);
     EXPORT Test07 := ASSERT(Str.OptimalStringAlignmentDistance('abcd','acbd') = 1, CONST);
     EXPORT Test08 := ASSERT(Str.OptimalStringAlignmentDistance('abcd','abd') = 1, CONST);

--- a/ecllibrary/teststd/str/TestWeightedDamerauLevenshteinDistance.ecl
+++ b/ecllibrary/teststd/str/TestWeightedDamerauLevenshteinDistance.ecl
@@ -1,0 +1,49 @@
+/*##############################################################################
+## HPCC SYSTEMS software Copyright (C) 2015 HPCC Systems®.  All rights reserved.
+############################################################################## */
+
+IMPORT Std.Str;
+
+EXPORT TestWeightedDamerauLevenshteinDistance := MODULE
+
+  STRING alpha := 'abcdefghijklmnopqrstuvwxyz';
+  STRING digits := '0123456789';
+  STRING largeAlpha := alpha+alpha+alpha+alpha+alpha+alpha+alpha+alpha+alpha;
+  STRING manyAlpha := alpha+alpha+alpha+alpha+alpha+alpha+alpha+alpha+alpha+alpha+alpha+alpha;
+  STRING manyDigits := digits+digits+digits+digits+digits+digits+digits+digits+digits+digits+digits+digits+digits+
+                       digits+digits+digits+digits+digits+digits+digits+digits+digits+digits+digits+digits;
+
+  EXPORT TestConst := MODULE
+    EXPORT Test01 := ASSERT(Str.WeightedDamerauLevenshteinDistance('','') = 0, CONST);
+    EXPORT Test02 := ASSERT(Str.WeightedDamerauLevenshteinDistance('','                ') = 0, CONST);
+    EXPORT Test03 := ASSERT(Str.WeightedDamerauLevenshteinDistance('                ','') = 0, CONST);
+    EXPORT Test04 := ASSERT(Str.WeightedDamerauLevenshteinDistance('a ','                ') = 1, CONST);
+    //EXPORT Test05 := ASSERT(Str.WeightedDamerauLevenshteinDistance(' a ','   ') = 1, CONST);
+    EXPORT Test06 := ASSERT(Str.WeightedDamerauLevenshteinDistance('Aprs  ','APp') = 2, CONST);//default confusion matrix is case insensitive.
+    EXPORT Test07 := ASSERT(Str.WeightedDamerauLevenshteinDistance('abcd','acbd') = 1, CONST);
+    EXPORT Test08 := ASSERT(Str.WeightedDamerauLevenshteinDistance('abcd','abd') = 1, CONST);
+    EXPORT Test09 := ASSERT(Str.WeightedDamerauLevenshteinDistance('abcd','abc') = 1, CONST);
+    EXPORT Test10 := ASSERT(Str.WeightedDamerauLevenshteinDistance('abcd','bcd') = 1, CONST);
+    EXPORT Test11 := ASSERT(Str.WeightedDamerauLevenshteinDistance('abcd','abcde') = 1, CONST);
+    EXPORT Test12 := ASSERT(Str.WeightedDamerauLevenshteinDistance('abcd','aabcd') = 1, CONST);
+    EXPORT Test13 := ASSERT(Str.WeightedDamerauLevenshteinDistance('abcd',' abcd') = 1, CONST);
+    EXPORT Test14 := ASSERT(Str.WeightedDamerauLevenshteinDistance('abcd','a bcd') = 1, CONST);
+    EXPORT Test15 := ASSERT(Str.WeightedDamerauLevenshteinDistance('abcd','adcd') = 0, CONST);
+    EXPORT Test16 := ASSERT(Str.WeightedDamerauLevenshteinDistance('abcd','') = 4, CONST);
+    EXPORT Test17 := ASSERT(Str.WeightedDamerauLevenshteinDistance(alpha,'') = 26, CONST);
+    EXPORT Test18 := ASSERT(Str.WeightedDamerauLevenshteinDistance(manyAlpha,'') = 255, CONST);       //overflow
+    EXPORT Test19 := ASSERT(Str.WeightedDamerauLevenshteinDistance(alpha,digits) = 26, CONST);
+    EXPORT Test20 := ASSERT(Str.WeightedDamerauLevenshteinDistance(manyAlpha,digits) = 255, CONST);   //overflow
+    EXPORT Test21 := ASSERT(Str.WeightedDamerauLevenshteinDistance(manyAlpha,manyDigits) = 255, CONST);   //overflow
+    EXPORT Test22 := ASSERT(Str.WeightedDamerauLevenshteinDistance(alpha,manyDigits) = 250, CONST);
+    EXPORT Test23 := ASSERT(Str.WeightedDamerauLevenshteinDistance(alpha,manyDigits+'12345') = 255, CONST);
+    EXPORT Test24 := ASSERT(Str.WeightedDamerauLevenshteinDistance(alpha,manyDigits+'123456') = 255, CONST);
+    EXPORT Test25 := ASSERT(Str.WeightedDamerauLevenshteinDistance('123456789','987654321') = 8, CONST);
+    EXPORT Test26 := ASSERT(Str.WeightedDamerauLevenshteinDistance(largeAlpha,manyDigits) = 250, CONST);  //overflow
+    EXPORT Test27 := ASSERT(Str.WeightedDamerauLevenshteinDistance(largeAlpha+'abcdefghijklmnopqrst',manyDigits) = 254, CONST);
+    EXPORT Test28 := ASSERT(Str.WeightedDamerauLevenshteinDistance(largeAlpha+'abcdefghijklmnopqrstu',manyDigits) = 255, CONST);
+    EXPORT Test29 := ASSERT(Str.WeightedDamerauLevenshteinDistance(alpha,'ABCDEFGHIJKLMNOPQRSTUVWXYZ') = 0, CONST);
+    EXPORT Test30 := ASSERT(Str.WeightedDamerauLevenshteinDistance('ghgygtgfgvgb','bgvgfgtgyghg') = 0, CONST);
+  END;
+
+END;

--- a/ecllibrary/teststd/str/TestWeightedDamerauLevenshteinDistance.ecl
+++ b/ecllibrary/teststd/str/TestWeightedDamerauLevenshteinDistance.ecl
@@ -18,7 +18,7 @@ EXPORT TestWeightedDamerauLevenshteinDistance := MODULE
     EXPORT Test02 := ASSERT(Str.WeightedDamerauLevenshteinDistance('','                ') = 0, CONST);
     EXPORT Test03 := ASSERT(Str.WeightedDamerauLevenshteinDistance('                ','') = 0, CONST);
     EXPORT Test04 := ASSERT(Str.WeightedDamerauLevenshteinDistance('a ','                ') = 1, CONST);
-    //EXPORT Test05 := ASSERT(Str.WeightedDamerauLevenshteinDistance(' a ','   ') = 1, CONST);
+    EXPORT Test05 := ASSERT(Str.WeightedDamerauLevenshteinDistance(' a ','   ') = 2, CONST);
     EXPORT Test06 := ASSERT(Str.WeightedDamerauLevenshteinDistance('Aprs  ','APp') = 2, CONST);//default confusion matrix is case insensitive.
     EXPORT Test07 := ASSERT(Str.WeightedDamerauLevenshteinDistance('abcd','acbd') = 1, CONST);
     EXPORT Test08 := ASSERT(Str.WeightedDamerauLevenshteinDistance('abcd','abd') = 1, CONST);

--- a/plugins/stringlib/stringlib.hpp
+++ b/plugins/stringlib/stringlib.hpp
@@ -77,6 +77,9 @@ STRINGLIB_API bool STRINGLIB_CALL slStringContains(unsigned srcLen, const char *
 STRINGLIB_API void STRINGLIB_CALL slStringExtractMultiple(unsigned & tgtLen, char * & tgt, unsigned srcLen, const char * src, unsigned __int64 mask);
 STRINGLIB_API unsigned STRINGLIB_CALL slEditDistanceV2(unsigned leftLen, const char * left, unsigned rightLen, const char * right);
 STRINGLIB_API bool STRINGLIB_CALL slEditDistanceWithinRadiusV2(unsigned leftLen, const char * left, unsigned rightLen, const char * right, unsigned radius);
+STRINGLIB_API unsigned STRINGLIB_CALL slDamerauLevenshteinDistanceV2(unsigned leftLen, const char * left, unsigned rightLen, const char * right);
+STRINGLIB_API unsigned STRINGLIB_CALL slWeightedDamerauLevenshteinDistanceV2(unsigned leftLen, const char * left, unsigned rightLen, const char * right);
+STRINGLIB_API unsigned STRINGLIB_CALL slOptimalStringAlignmentDistanceV2(unsigned leftLen, const char * left, unsigned rightLen, const char * right);
 STRINGLIB_API void STRINGLIB_CALL slStringGetNthWord(unsigned & tgtLen, char * & tgt, unsigned srcLen, const char * src, unsigned n);
 STRINGLIB_API unsigned STRINGLIB_CALL slStringWordCount(unsigned srcLen, const char * src);
 STRINGLIB_API void STRINGLIB_CALL slStringExcludeLastWord(unsigned & tgtLen, char * & tgt, unsigned srcLen, const char * src);


### PR DESCRIPTION
Add both the restricted (optimal string alignment - OSA) and unrestricted (full)
Damerau-Levenshtein metrics.
Add a weighted version of the full Damerau-Levenshtein.

NOTE: this doesn't currently contain the service entry for passing user
defined weight-matrices nor wrappers for passing dataset/tables etc.

Signed-off-by: James Noss james.noss@lexisnexis.com
