### PR TITLE
HPCC-14795 XREF - Tolerate physical files that do not conform

### DIFF
--- a/dali/base/dautils.cpp
+++ b/dali/base/dautils.cpp
@@ -1103,8 +1103,7 @@ bool CDfsLogicalFileName::setFromMask(const char *fname,const char *rootdir)
                             if (memicmp(fname,"_of_",4)==0) {
                                 if (!fname[4])
                                     return false;
-                                set(logicalName.str());
-                                return true;
+                                return setValidate(logicalName.str());
                             }
                         }
                     }


### PR DESCRIPTION
If XREF finds orphaned physical files, it tries to deduce the
logical file name they come from. In doing so it may create an
illegal logical filename.
Avoid an illegal logical filename excpetion and instead
validate the deduced logical filenames during XREF.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
