### PR TITLE
HPCC-14780 rmtssh call changed to use UserKnownHostsFile

### DIFF
--- a/common/remote/rmtssh.cpp
+++ b/common/remote/rmtssh.cpp
@@ -400,7 +400,7 @@ public:
             }
             if (cmdline.length()==0) {
                 // ssh
-                cmdline.appendf("%s -n -o LogLevel=QUIET -o StrictHostKeyChecking=%s ",usepssh?"pssh":"ssh",strict?"yes":"no");
+                cmdline.appendf("%s -n -o LogLevel=QUIET -o StrictHostKeyChecking=%s ",usepssh?"pssh":"ssh",strict?"yes":"no -o UserKnownHostsFile=/dev/null");
                 if (!usepssh)
                     cmdline.append("-o BatchMode=yes ");
                 if (!identityfile.isEmpty())


### PR DESCRIPTION
Added UserKnownHostsFile=/dev/null for cases where we don't want strict host key checking

Signed-off-by: Michael Gardner michael.gardner@lexisnexis.com
