### PR TITLE
HPCC-14762 Prevent scope cleanup from invalidating an active record

### DIFF
--- a/ecl/hql/hqlgram2.cpp
+++ b/ecl/hql/hqlgram2.cpp
@@ -2861,8 +2861,14 @@ void HqlGram::releaseScopes()
 
     leftRightScopes.kill();
     
-    while (selfScopes.length()>0)
+    while (selfScopes.length() > 0)
+    {
+        //Ensure that we do not remove any scopes that are still active - otherwise they will be released too early
+        OwnedHqlExpr self = getSelfScope();
+        if (activeRecords.contains(*self))
+            break;
         popSelfScope();
+    }
     modScope.clear();
     outerScopeAccessDepth = 0;
 


### PR DESCRIPTION
Only occurs when cleaning up after a syntax error.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
