### PR TITLE
HPCC-14787 Use && instead of the more modern and

### DIFF
--- a/system/jlib/jscm.hpp
+++ b/system/jlib/jscm.hpp
@@ -94,7 +94,7 @@ public:
     inline Shared()                              { ptr = NULL; }
     inline Shared(CLASS * _ptr, bool owned)      { ptr = _ptr; if (!owned && _ptr) _ptr->Link(); }
     inline Shared(const Shared & other)          { ptr = other.getLink(); }
-#if defined(__cplusplus) and __cplusplus >= 201100
+#if defined(__cplusplus) && __cplusplus >= 201100
     inline Shared(Shared && other)               { ptr = other.getClear(); }
 #endif
     inline ~Shared()                             { ::Release(ptr); }


### PR DESCRIPTION
Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
