### PR TITLE
HPCC-13864 DOCS:Remove Hardware Recomendations from Installing

### DIFF
--- a/docs/Installing_and_RunningTheHPCCPlatform/Installing_and_RunningTheHPCCPlatform.xml
+++ b/docs/Installing_and_RunningTheHPCCPlatform/Installing_and_RunningTheHPCCPlatform.xml
@@ -209,10 +209,6 @@
     </sect1>
   </chapter>
 
-  <xi:include href="Installing_and_RunningTheHPCCPlatform/Inst-Mods/Hardware.xml"
-              xpointer="Hardware-and-Software-Chapter"
-              xmlns:xi="http://www.w3.org/2001/XInclude" />
-
   <chapter id="HPCC-installation-and-startup">
     <title>HPCC Installation and Startup</title>
 


### PR DESCRIPTION
FIX HPCC-13864 DOCS:Remove Hardware Recomendations from Installing
Remove the Hardware Recomendations chapter from the Installing and
Running the HPCC Platform book.

Signed-off-by: G Panagiotatos greg.panagiotatos@lexisnexis.com

@JamesDeFabia please review
