### PR TITLE
HPCC-14809 Ensure temporary fields are marked as link counted if required

### DIFF
--- a/ecl/hql/hqlexpr.cpp
+++ b/ecl/hql/hqlexpr.cpp
@@ -10601,6 +10601,28 @@ extern IHqlExpression *createField(IIdAtom *id, ITypeInfo *type, IHqlExpression 
     return expr->closeExpr();
 }
 
+extern IHqlExpression *createFieldFromValue(IIdAtom *id, IHqlExpression * expr)
+{
+    HqlExprArray args;
+    if (expr->getOperator() == no_select)
+        expr = expr->queryChild(1);
+    if (expr->getOperator() == no_field)
+    {
+        inheritAttribute(args, expr, _linkCounted_Atom);
+    }
+    else
+    {
+        IHqlExpression * record = expr->queryRecord();
+        if (record)
+        {
+            if (recordRequiresLinkCount(record))
+                args.append(*createAttribute(_linkCounted_Atom));
+        }
+    }
+    return createField(id, expr->getType(), args);
+}
+
+
 extern HQL_API IHqlExpression *createQuoted(const char * text, ITypeInfo *type)
 {
     return CHqlVariable::makeVariable(no_quoted, text, type);

--- a/ecl/hql/hqlexpr.hpp
+++ b/ecl/hql/hqlexpr.hpp
@@ -1255,6 +1255,7 @@ extern HQL_API IHqlExpression *createLeftBinaryList(node_operator op, HqlExprArr
 
 extern HQL_API IHqlExpression *createField(IIdAtom * name, ITypeInfo *type, IHqlExpression *defaultValue, IHqlExpression *attrs=NULL);
 extern HQL_API IHqlExpression *createField(IIdAtom *name, ITypeInfo *type, HqlExprArray & args);
+extern HQL_API IHqlExpression *createFieldFromValue(IIdAtom *id, IHqlExpression * expr);
 extern HQL_API IHqlExpression *createConstant(bool constant);
 extern HQL_API IHqlExpression *createConstant(__int64 constant);
 extern HQL_API IHqlExpression *createConstant(const char *constant);

--- a/ecl/hqlcpp/hqlckey.cpp
+++ b/ecl/hqlcpp/hqlckey.cpp
@@ -796,7 +796,7 @@ IHqlExpression * KeyedJoinInfo::optimizeTransfer(HqlExprArray & fields, HqlExprA
                         //Check same field isn't used in two different nested records.
                         StringBuffer name;
                         name.append("__unnamed__").append(fields.ordinality());
-                        field.setown(createField(createIdAtom(name), field->getType(), NULL, NULL));
+                        field.setown(createFieldFromValue(createIdAtom(name), field));
                     }
 
                     fields.append(*LINK(field));

--- a/ecl/hqlcpp/hqlcpputil.cpp
+++ b/ecl/hqlcpp/hqlcpputil.cpp
@@ -397,7 +397,7 @@ IHqlExpression * projectCreateSetDataset(IHqlExpression * expr)
         if (select->getOperator() == no_select)
             targetField.set(select->queryChild(1));
         else
-            targetField.setown(createField(valueId, select->getType(), NULL));
+            targetField.setown(createFieldFromValue(valueId, select));
         IHqlExpression * newRecord = createRecord(targetField);
         assigns.append(*createAssign(createSelectExpr(getSelf(newRecord), LINK(targetField)), LINK(select)));
         IHqlExpression * newTransform = createValue(no_newtransform, makeTransformType(LINK(newRecord->queryRecordType())), assigns);

--- a/ecl/hqlcpp/hqlhtcpp.cpp
+++ b/ecl/hqlcpp/hqlhtcpp.cpp
@@ -14111,7 +14111,7 @@ ABoundActivity * HqlCppTranslator::doBuildActivityDedup(BuildCtx & ctx, IHqlExpr
             {
                 StringBuffer name;
                 name.append("_expression_").append(idx);
-                field = createField(createIdAtom(name.str()), cur.getType(), NULL);
+                field = createFieldFromValue(createIdAtom(name.str()), &cur);
             }
             fields.append(*field);
             selects.append(*createSelectExpr(getActiveTableSelector(), LINK(field)));

--- a/ecl/hqlcpp/hqlresource.cpp
+++ b/ecl/hqlcpp/hqlresource.cpp
@@ -321,7 +321,7 @@ public:
                 if (selected->getOperator() == no_select)
                     field.set(selected->queryChild(1));
                 else
-                    field.setown(createField(valueId, selected->getType(), NULL));
+                    field.setown(createFieldFromValue(valueId, selected));
                 OwnedHqlExpr record = createRecord(field);
                 OwnedHqlExpr self = getSelf(record);
                 OwnedHqlExpr assign = createAssign(createSelectExpr(LINK(self), LINK(field)), LINK(selected));

--- a/ecl/hqlcpp/hqlttcpp.cpp
+++ b/ecl/hqlcpp/hqlttcpp.cpp
@@ -1664,7 +1664,7 @@ protected:
                 {
                     StringBuffer temp;
                     temp.append("_agg_").append(assigns.ordinality());
-                    targetField = createField(createIdAtom(temp.str()), expr->getType(), NULL);
+                    targetField = createFieldFromValue(createIdAtom(temp.str()), expr);
                     extraSelectNeeded = true;
                 }
                 fields.append(*targetField);
@@ -3338,7 +3338,7 @@ static IHqlExpression * extractPrefetchFields(HqlExprArray & fields, HqlExprArra
         match = fields.ordinality();
         StringBuffer name;
         name.append("_f").append(match).append("_");
-        IHqlExpression * field = createField(createIdAtom(name.str()), expr->getType(), NULL);
+        IHqlExpression * field = createFieldFromValue(createIdAtom(name.str()), expr);
         fields.append(*field);
         values.append(*LINK(expr));
     }
@@ -3656,7 +3656,7 @@ IHqlExpression * ThorHqlTransformer::normalizeTableToAggregate(IHqlExpression * 
             {
                 StringBuffer temp;
                 temp.append("_agg_").append(aggregateAssigns.ordinality());
-                IHqlExpression * targetField = createField(createIdAtom(temp.str()), curGroup->getType(), NULL);
+                IHqlExpression * targetField = createFieldFromValue(createIdAtom(temp.str()), curGroup);
                 aggregateFields.append(*targetField);
                 aggregateAssigns.append(*createAssign(createSelectExpr(getActiveTableSelector(), LINK(targetField)), LINK(curGroup)));
                 extraSelectNeeded = true;
@@ -11181,7 +11181,7 @@ IHqlExpression * HqlTreeNormalizer::transformEvaluate(IHqlExpression * expr)
                 else
                 {
                     //EVALUATE(t[n], e)          -> table(t,{f1 := e})[n].f1;
-                    OwnedHqlExpr field = createField(valueId, expr->getType(), NULL);
+                    OwnedHqlExpr field = createFieldFromValue(valueId, expr);
                     IHqlExpression * aggregateRecord = createRecord(field);
 
                     IHqlExpression * newAttr = replaceSelector(attr, activeTable, baseDs);


### PR DESCRIPTION
Clone the attribute from fields being aliases, and ensure that a field
is marked as link counted if it requires it (e.g., a link counted child row).

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
