### PR TITLE
HPCC-14760 Depreciate DFUArrayActionResult from WsDfu.DFUArrayAction

### DIFF
--- a/dali/dfuplus/dfuplus.cpp
+++ b/dali/dfuplus/dfuplus.cpp
@@ -1035,26 +1035,38 @@ int CDfuPlusHelper::remove()
         return -1;
     }
 
-    const char* result = resp->getDFUArrayActionResult();
     StringBuffer resultbuf;
-    if(result != NULL && *result != '\0')
+    IArrayOf<IConstDFUActionInfo>& actionResults = resp->getActionResults();
+    if (actionResults.ordinality())
     {
-        if(*result != '<')
-            resultbuf.append(result);
-        else
+        ForEachItemIn(i, actionResults)
         {
-            bool intag = false;
-            int i = 0;
-            char c;
-            while((c = result[i]) != '\0')
+            IConstDFUActionInfo& actionResult = actionResults.item(i);
+            resultbuf.append(actionResult.getActionResult()).append("\n");
+        }
+    }
+    else
+    {
+        const char* result = resp->getDFUArrayActionResult();
+        if(result != NULL && *result != '\0')
+        {
+            if(*result != '<')
+                resultbuf.append(result);
+            else
             {
-                if(c == '<')
-                    intag = true;
-                else if(c == '>')
-                    intag = false;
-                else if(!intag)
-                    resultbuf.append(c);
-                i++;
+                bool intag = false;
+                int i = 0;
+                char c;
+                while((c = result[i]) != '\0')
+                {
+                    if(c == '<')
+                        intag = true;
+                    else if(c == '>')
+                        intag = false;
+                    else if(!intag)
+                        resultbuf.append(c);
+                    i++;
+                }
             }
         }
     }

--- a/esp/eclwatch/ws_XSLT/action.xslt
+++ b/esp/eclwatch/ws_XSLT/action.xslt
@@ -70,16 +70,9 @@
                 <b>Action status:</b>
             </tr>
             <table>
-                <xsl:for-each select="//Message">
-                    <xsl:choose>             
-                        <xsl:when test="string-length(href)">
-                            <a href="{href}"><xsl:value-of select="Value"/></a>
-                        </xsl:when>
-                        <xsl:otherwise>
-                            <xsl:value-of select="Value"/>
-                        </xsl:otherwise>
-                    </xsl:choose>
+                <xsl:for-each select="//ActionResults/*">
                     <br/>
+                    <xsl:value-of select="ActionResult"/>
                 </xsl:for-each>
             </table>
             <xsl:choose>             

--- a/esp/scm/ws_dfu.ecm
+++ b/esp/scm/ws_dfu.ecm
@@ -267,7 +267,7 @@ DFUArrayActionResponse
 {
     [min_ver("1.04")] string BackToPage;
     [min_ver("1.18")] string RedirectTo;
-    string DFUArrayActionResult; //used by legacy eclwatch
+    [depr_ver("1.33")] string DFUArrayActionResult;
     [min_ver("1.27")] ESParray<ESPstruct DFUActionInfo> ActionResults;
 };
 
@@ -699,7 +699,7 @@ ESPresponse [exceptions_inline, nil_remove, http_encode(0)] DFUGetFileMetaDataRe
 
 //  ===========================================================================
 ESPservice [
-    version("1.32"),
+    version("1.33"),
     noforms, 
     exceptions_inline("./smc_xslt/exceptions.xslt")] WsDfu
 {


### PR DESCRIPTION
The DFUArrayActionResult in the WsDfu.DFUArrayActionResponse contains
un-encoded xml, which breaks clients based on the declared WSDL.
In this fix, the DFUArrayActionResult is depreciated since the same
information has been replaced by the ActionResults in the
WsDfu.DFUArrayActionResponse.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
