### PR TITLE
HPCC-14698 Security Manager code needed to support plug-in sec managers

### DIFF
--- a/esp/bindings/http/platform/httpbinding.cpp
+++ b/esp/bindings/http/platform/httpbinding.cpp
@@ -174,12 +174,49 @@ EspHttpBinding::EspHttpBinding(IPropertyTree* tree, const char *bindname, const 
         if (strnicmp(m_wsdlAddress.str(), "http", 4))
             m_wsdlAddress.insert(0, (m_port!=443) ? "http://" : "https://");
         
+
         Owned<IPropertyTree> authcfg = bnd_cfg->getPropTree("Authenticate");
         if(authcfg != NULL)
         {
+#ifdef _DEBUG
+            StringBuffer authXml;
+            toXML(authcfg, authXml);
+            PROGLOG("\nAUTHENTICATE(%s) PROPS\n%s\n", bindname, authXml.str());
+#endif
+            //Instantiate a Security Manager
             m_authtype.set(authcfg->queryProp("@type"));
             m_authmethod.set(authcfg->queryProp("@method"));
-            PROGLOG("Authenticate method=%s", m_authmethod.str());
+            if (!m_authmethod.isEmpty())
+            {
+                PROGLOG("Authenticate method=%s", m_authmethod.str());
+                Owned<IPropertyTree> process_config = getProcessConfig(tree, procname);
+
+                Owned<IPropertyTree> secMgrCfg;
+                if(process_config.get() != NULL)
+                    secMgrCfg.setown(process_config->getPropTree("SecurityManager"));//Is this a Pluggable Security Manager
+                if (secMgrCfg)
+                {
+#ifdef _DEBUG
+                    StringBuffer secMgrXml;
+                    toXML(secMgrCfg, secMgrXml);
+                    PROGLOG("\nSECURITY MANAGER(%s) PROPS\n%s\n", bindname, secMgrXml.str());
+#endif
+                    //This is a Pluggable Security Manager
+                    StringBuffer secMgrType;
+                    secMgrCfg->getProp("@type", secMgrType);
+                    if (!secMgrType.isEmpty() && 0==strcmp(secMgrType.str(), m_authmethod.str()))
+                    {
+                        m_secmgr.setown(SecLoader::loadPluggableSecManager(bindname, authcfg, secMgrCfg));
+                        m_authmap.setown(m_secmgr->createAuthMap(authcfg));//???
+                    }
+                    else
+                    {
+                        throw MakeStringException(-1, "Authorization type %s not found in SecurityManager configuration for %s", m_authmethod.str(), bindname);
+                    }
+                }
+                else
+                {
+            //Legacy Security Manager
             if(stricmp(m_authmethod.str(), "LdapSecurity") == 0)
             {
                 StringBuffer lsname;
@@ -187,7 +224,6 @@ EspHttpBinding::EspHttpBinding(IPropertyTree* tree, const char *bindname, const 
                 Owned<IPropertyTree> lscfg = bnd_cfg->getPropTree(StringBuffer(".//ldapSecurity[@name=").appendf("\"%s\"]", lsname.str()).str());
                 if(lscfg == NULL)
                 {
-                    Owned<IPropertyTree> process_config = getProcessConfig(tree, procname);
                     if(process_config.get() != NULL)
                         lscfg.setown(process_config->getPropTree(StringBuffer("ldapSecurity[@name=").appendf("\"%s\"]", lsname.str()).str()));
                     if(lscfg == NULL)
@@ -202,7 +238,7 @@ EspHttpBinding::EspHttpBinding(IPropertyTree* tree, const char *bindname, const 
                 {
                     throw MakeStringException(-1, "error generating SecManager");
                 }
-                
+
                 StringBuffer basednbuf;
                 authcfg->getProp("@resourcesBasedn", basednbuf);
                 m_secmgr->setExtraParam("resourcesBasedn", basednbuf.str());
@@ -221,7 +257,6 @@ EspHttpBinding::EspHttpBinding(IPropertyTree* tree, const char *bindname, const 
             else if(stricmp(m_authmethod.str(), "htpasswd") == 0)
             {
                 Owned<IPropertyTree> cfg;
-                Owned<IPropertyTree> process_config = getProcessConfig(tree, procname);
                 if(process_config.get() != NULL)
                     cfg.setown(process_config->getPropTree("htpasswdSecurity"));
                 if(cfg == NULL)
@@ -239,6 +274,8 @@ EspHttpBinding::EspHttpBinding(IPropertyTree* tree, const char *bindname, const 
                 IRestartHandler* pHandler = dynamic_cast<IRestartHandler*>(getESPContainer());
                 if(pHandler!=NULL)
                     restartManager->setRestartHandler(pHandler);
+            }
+            }
             }
         }
     }

--- a/system/security/shared/seclib.hpp
+++ b/system/security/shared/seclib.hpp
@@ -324,8 +324,4 @@ interface IRestartManager : extends IInterface
     virtual void setRestartHandler(IRestartHandler * pRestartHandler) = 0;
 };
 
-extern "C" SECLIB_API ISecManager *createSecManager(const char *model_name, const char *serviceName, IPropertyTree &config);
-extern "C" SECLIB_API IAuthMap *createDefaultAuthMap(IPropertyTree* config);
-
-
 #endif


### PR DESCRIPTION
This PR implements a new "pluggable" security manager feature, while maintaining
backward camptibility for enironment files that continue to specify the legacy
configuration methodologies . If the "<SecurityManager> tag is found, it is
assumed this is a dynamic/pluggable manager, and the SO/DLL will be loaded
and the ISecManager factory method specified in the config will be invoked to
instantiate an instance.

Signed-off-by: Russ Whitehead william.whitehead@lexisnexis.com
