### PR TITLE
HPCC-14698 Security Manager code needed to support plug-in sec managers

### DIFF
--- a/system/security/shared/seclib.hpp
+++ b/system/security/shared/seclib.hpp
@@ -324,8 +324,6 @@ interface IRestartManager : extends IInterface
     virtual void setRestartHandler(IRestartHandler * pRestartHandler) = 0;
 };
 
-extern "C" SECLIB_API ISecManager *createSecManager(const char *model_name, const char *serviceName, IPropertyTree &config);
-extern "C" SECLIB_API IAuthMap *createDefaultAuthMap(IPropertyTree* config);
 
 
 #endif

--- a/system/security/shared/secloader.hpp
+++ b/system/security/shared/secloader.hpp
@@ -21,10 +21,53 @@
 
 typedef IAuthMap* (*createDefaultAuthMap_t_)(IPropertyTree* config);
 typedef ISecManager* (*newSecManager_t_)(const char *serviceName, IPropertyTree &config);
+typedef ISecManager* (*newPluggableSecManager_t_)(const char *serviceName, IPropertyTree &secMgrCfg, IPropertyTree &authCfg);
 
 class SecLoader
 {
 public:
+    ///
+    /// Method:  loadPluggableSecManager
+    ///
+    /// Using the given configuration property trees, this method loads the specified
+    /// Security Manager DLL/SO implemented in the specified library file and calls
+    /// its instance factory to create and return an ISecManager security manager instance
+    /// for the given ESP service
+    ///
+    /// @param  svcName         Service name ie 'WsTopology_smc_myesp'
+    /// @param  secMgrCfg       'SecurityManager' IPropertyTree from component config file
+    /// @param  authCfg         'Authenticate' IPropertyTree from EspService component binding
+    ///
+    /// @return an ISecManager Security Manager instance
+    ///
+    static ISecManager* loadPluggableSecManager(const char * svcName, IPropertyTree* authCfg, IPropertyTree* secMgrCfg)
+    {
+        const char * lsm = "Load Security Manager :";
+
+        StringBuffer libName, instFactory;
+        secMgrCfg->getProp("@LibName", libName);
+        if (libName.isEmpty())
+            throw MakeStringException(-1, "%s library name not specified for %s", lsm, svcName);
+        //TODO Search for LibName in plugins folder, or in specified location
+
+        instFactory.set(secMgrCfg->queryProp("@InstanceFactoryName"));
+        if (instFactory.isEmpty())
+            instFactory.set("createInstance");
+
+        //Load the DLL/SO
+        HINSTANCE pluggableSecLib = LoadSharedObject(libName.str(), true, false);
+        if(pluggableSecLib == NULL)
+            throw MakeStringException(-1, "%s can't load library %s for %s", lsm, libName.str(), svcName);
+
+        //Retrieve address of exported ISecManager instance factory
+        newPluggableSecManager_t_ xproc = NULL;
+        xproc = (newPluggableSecManager_t_)GetSharedProcedure(pluggableSecLib, instFactory.str());
+        if (xproc == NULL)
+            throw MakeStringException(-1, "%s cannot locate procedure %s of '%s'", lsm, instFactory.str(), libName.str());
+
+        //Call ISecManager instance factory and return the new instance
+        return xproc(svcName, *secMgrCfg, *authCfg);
+    }
     static ISecManager* loadSecManager(const char* model_name, const char* servicename, IPropertyTree* cfg)
     {
         if (!model_name || !*model_name)

--- a/system/security/shared/secloader.hpp
+++ b/system/security/shared/secloader.hpp
@@ -34,20 +34,20 @@ public:
     /// its instance factory to create and return an ISecManager security manager instance
     /// for the given ESP service
     ///
-    /// @param  svcName         Service name ie 'WsTopology_smc_myesp'
+    /// @param  bindingName     Binding name ie 'WsTopology_smc_myesp'
     /// @param  secMgrCfg       'SecurityManager' IPropertyTree from component config file
     /// @param  authCfg         'Authenticate' IPropertyTree from EspService component binding
     ///
     /// @return an ISecManager Security Manager instance
     ///
-    static ISecManager* loadPluggableSecManager(const char * svcName, IPropertyTree* authCfg, IPropertyTree* secMgrCfg)
+    static ISecManager* loadPluggableSecManager(const char * bindingName, IPropertyTree* authCfg, IPropertyTree* secMgrCfg)
     {
         const char * lsm = "Load Security Manager :";
 
         StringBuffer libName, instFactory;
         secMgrCfg->getProp("@LibName", libName);
         if (libName.isEmpty())
-            throw MakeStringException(-1, "%s library name not specified for %s", lsm, svcName);
+            throw MakeStringException(-1, "%s library name not specified for %s", lsm, bindingName);
         //TODO Search for LibName in plugins folder, or in specified location
 
         instFactory.set(secMgrCfg->queryProp("@InstanceFactoryName"));
@@ -57,7 +57,7 @@ public:
         //Load the DLL/SO
         HINSTANCE pluggableSecLib = LoadSharedObject(libName.str(), true, false);
         if(pluggableSecLib == NULL)
-            throw MakeStringException(-1, "%s can't load library %s for %s", lsm, libName.str(), svcName);
+            throw MakeStringException(-1, "%s can't load library %s for %s", lsm, libName.str(), bindingName);
 
         //Retrieve address of exported ISecManager instance factory
         newPluggableSecManager_t_ xproc = NULL;
@@ -66,8 +66,9 @@ public:
             throw MakeStringException(-1, "%s cannot locate procedure %s of '%s'", lsm, instFactory.str(), libName.str());
 
         //Call ISecManager instance factory and return the new instance
-        return xproc(svcName, *secMgrCfg, *authCfg);
+        return xproc(bindingName, *secMgrCfg, *authCfg);
     }
+
     static ISecManager* loadSecManager(const char* model_name, const char* servicename, IPropertyTree* cfg)
     {
         if (!model_name || !*model_name)


### PR DESCRIPTION
This PR implements a new "pluggable" security manager feature, while maintaining
backward camptibility for environment files that continue to specify the legacy
configuration methodologies . If the "<SecurityManager> tag is found, it is
assumed this is a dynamic/pluggable manager, and the SO/DLL will be loaded
and the ISecManager factory method specified in the config will be invoked to
instantiate an instance.

Signed-off-by: Russ Whitehead william.whitehead@lexisnexis.com
