### PR TITLE
HPCC-14823 LDAP OUs can be modified by any user

### DIFF
--- a/esp/services/ws_access/ws_accessService.cpp
+++ b/esp/services/ws_access/ws_accessService.cpp
@@ -1604,7 +1604,7 @@ bool Cws_accessEx::onResourceAdd(IEspContext &context, IEspResourceAddRequest &r
 
             ISecResource* r = rlist->addResource(namebuf.str());
             r->setDescription(req.getDescription());
-            secmgr->addResourcesEx(rtype, *usr, rlist, PT_DEFAULT, req.getBasedn());
+            secmgr->addResourcesEx(rtype, *usr, rlist, PT_ADMINISTRATORS_ONLY, req.getBasedn());
 
             if(str2type(req.getRtype()) == RT_FILE_SCOPE && newResources.ordinality())
             {

--- a/system/security/LdapSecurity/ldapconnection.cpp
+++ b/system/security/LdapSecurity/ldapconnection.cpp
@@ -1138,13 +1138,13 @@ public:
             {
             }
         }
-        createLdapBasedn(NULL, m_ldapconfig->getResourceBasedn(RT_DEFAULT), PT_DEFAULT);
-        createLdapBasedn(NULL, m_ldapconfig->getResourceBasedn(RT_FILE_SCOPE), PT_DEFAULT);
-        createLdapBasedn(NULL, m_ldapconfig->getResourceBasedn(RT_WORKUNIT_SCOPE), PT_DEFAULT);
-        createLdapBasedn(NULL, m_ldapconfig->getResourceBasedn(RT_SUDOERS), PT_DEFAULT);
+        createLdapBasedn(NULL, m_ldapconfig->getResourceBasedn(RT_DEFAULT), PT_ADMINISTRATORS_ONLY);
+        createLdapBasedn(NULL, m_ldapconfig->getResourceBasedn(RT_FILE_SCOPE), PT_ADMINISTRATORS_ONLY);
+        createLdapBasedn(NULL, m_ldapconfig->getResourceBasedn(RT_WORKUNIT_SCOPE), PT_ADMINISTRATORS_ONLY);
+        createLdapBasedn(NULL, m_ldapconfig->getResourceBasedn(RT_SUDOERS), PT_ADMINISTRATORS_ONLY);
 
-        createLdapBasedn(NULL, m_ldapconfig->getUserBasedn(), PT_DEFAULT);
-        createLdapBasedn(NULL, m_ldapconfig->getGroupBasedn(), PT_DEFAULT);
+        createLdapBasedn(NULL, m_ldapconfig->getUserBasedn(), PT_ADMINISTRATORS_ONLY);
+        createLdapBasedn(NULL, m_ldapconfig->getGroupBasedn(), PT_ADMINISTRATORS_ONLY);
     }
 
     virtual LdapServerType getServerType()
@@ -1160,7 +1160,7 @@ public:
     virtual void setResourceBasedn(const char* rbasedn, SecResourceType rtype)
     {
         m_ldapconfig->setResourceBasedn(rbasedn, rtype);
-        createLdapBasedn(NULL, m_ldapconfig->getResourceBasedn(rtype), PT_DEFAULT);
+        createLdapBasedn(NULL, m_ldapconfig->getResourceBasedn(rtype), PT_ADMINISTRATORS_ONLY);
     }
 
     void calcPWExpiry(CDateTime &dt, unsigned len, char * val)
@@ -3652,7 +3652,7 @@ public:
         
         ISecUser* user = NULL;
         CLdapSecResource resource(newname);
-        addResource(rtype, *user, &resource, PT_DEFAULT, basedn, sd.get(), false);
+        addResource(rtype, *user, &resource, PT_ADMINISTRATORS_ONLY, basedn, sd.get(), false);
     }
 
     void normalizeDn(const char* dn, StringBuffer& ndn)

--- a/system/security/LdapSecurity/ldapsecurity.ipp
+++ b/system/security/LdapSecurity/ldapsecurity.ipp
@@ -363,8 +363,8 @@ public:
     virtual bool authorizeWorkunitScope(ISecUser & user, ISecResourceList * resources);
     virtual bool addResources(ISecUser& sec_user, ISecResourceList * resources);
     virtual int getAccessFlagsEx(SecResourceType rtype, ISecUser & user, const char * resourcename);
-    virtual bool addResourcesEx(SecResourceType rtype, ISecUser &user, ISecResourceList* resources, SecPermissionType ptype = PT_DEFAULT, const char* basedn = NULL);
-    virtual bool addResourceEx(SecResourceType rtype, ISecUser& user, const char* resourcename, SecPermissionType ptype = PT_DEFAULT, const char* basedn = NULL);
+    virtual bool addResourcesEx(SecResourceType rtype, ISecUser &user, ISecResourceList* resources, SecPermissionType ptype = PT_ADMINISTRATORS_ONLY, const char* basedn = NULL);
+    virtual bool addResourceEx(SecResourceType rtype, ISecUser& user, const char* resourcename, SecPermissionType ptype = PT_ADMINISTRATORS_ONLY, const char* basedn = NULL);
     virtual bool updateResources(ISecUser& sec_user, ISecResourceList * resources){return false;}
     virtual bool addUser(ISecUser & user);
     virtual ISecUser * lookupUser(unsigned uid);

--- a/system/security/shared/basesecurity.hpp
+++ b/system/security/shared/basesecurity.hpp
@@ -184,11 +184,11 @@ public:
     {
         return true;
     }
-    bool addResourcesEx(SecResourceType rtype, ISecUser& sec_user, ISecResourceList * resources, SecPermissionType ptype = PT_DEFAULT, const char* basedn=NULL)
+    bool addResourcesEx(SecResourceType rtype, ISecUser& sec_user, ISecResourceList * resources, SecPermissionType ptype = PT_ADMINISTRATORS_ONLY, const char* basedn=NULL)
     {
         return addResources(sec_user, resources);
     }
-    bool addResourceEx(SecResourceType rtype, ISecUser& user, const char* resourcename, SecPermissionType ptype = PT_DEFAULT, const char* basedn=NULL)
+    bool addResourceEx(SecResourceType rtype, ISecUser& user, const char* resourcename, SecPermissionType ptype = PT_ADMINISTRATORS_ONLY, const char* basedn=NULL)
     {
         Owned<ISecResourceList> rlist;
         rlist.setown(createResourceList("resources"));

--- a/system/security/test/ldapsecuritytest/ldapsecuritytest.cpp
+++ b/system/security/test/ldapsecuritytest/ldapsecuritytest.cpp
@@ -350,7 +350,7 @@ int main(int argc, char* argv[])
             if(username != NULL && *username != '\0')
                 usr.setown(secmgr->createUser(username));
 
-            bool ok = secmgr->addResourceEx(rtype, *usr, resource, PT_DEFAULT, NULL);
+            bool ok = secmgr->addResourceEx(rtype, *usr, resource, PT_ADMINISTRATORS_ONLY, NULL);
             if(!ok)
                 printf("resource not added\n");
             else


### PR DESCRIPTION
LDAP OU resources should only be accessed by members of the LDAP Administrators
group. Currently they are created with access to admins and authenticated users

Signed-off-by: Russ Whitehead william.whitehead@lexisnexis.com
