### PR TITLE
HPCC-1628 Check network address before listing files

### DIFF
--- a/esp/services/ws_fs/ws_fsService.cpp
+++ b/esp/services/ws_fs/ws_fsService.cpp
@@ -2813,6 +2813,8 @@ bool CFileSprayEx::onFileList(IEspContext &context, IEspFileListRequest &req, IE
 
         double version = context.getClientVersion();
         const char* netaddr = req.getNetaddr();
+        if (!netaddr || !*netaddr)
+            throw MakeStringException(ECLWATCH_INVALID_INPUT, "Network address not specified.");
         const char* mask = req.getMask();
         bool directoryOnly = req.getDirectoryOnly();
 


### PR DESCRIPTION
The network address is needed for listing files on one machine.
The code is added to check the address input before using it to
list files.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
