### PR TITLE
HPCC-14610 Add umask to create flags for more control of dirs and files

### DIFF
--- a/common/remote/hooks/git/gitfile.cpp
+++ b/common/remote/hooks/git/gitfile.cpp
@@ -236,8 +236,9 @@ public:
     virtual bool setCompression(bool set) { UNIMPLEMENTED; }
     virtual offset_t compressedSize() { UNIMPLEMENTED; }
     virtual unsigned getCRC() { UNIMPLEMENTED; }
-    virtual void setCreateFlags(unsigned cflags) { UNIMPLEMENTED; }
+    virtual void setCreateFlags(unsigned cflags, unsigned _cumask=IFUnone) { UNIMPLEMENTED; }
     virtual void setShareMode(IFSHmode shmode) { UNIMPLEMENTED; }
+    virtual void setFileUmask(unsigned _cumask) { UNIMPLEMENTED; }
     virtual bool createDirectory() { UNIMPLEMENTED; }
     virtual IDirectoryDifferenceIterator *monitorDirectory(
                                   IDirectoryIterator *prev=NULL,    // in (NULL means use current as baseline)

--- a/common/remote/hooks/libarchive/archive.cpp
+++ b/common/remote/hooks/libarchive/archive.cpp
@@ -398,8 +398,9 @@ public:
     virtual bool setCompression(bool set) { UNIMPLEMENTED; }
     virtual offset_t compressedSize() { UNIMPLEMENTED; }
     virtual unsigned getCRC() { UNIMPLEMENTED; }
-    virtual void setCreateFlags(unsigned cflags) { UNIMPLEMENTED; }
+    virtual void setCreateFlags(unsigned cflags, unsigned _cumask=IFUnone) { UNIMPLEMENTED; }
     virtual void setShareMode(IFSHmode shmode) { UNIMPLEMENTED; }
+    virtual void setFileUmask(unsigned _cumask) { UNIMPLEMENTED; }
     virtual bool createDirectory() { UNIMPLEMENTED; }
     virtual IDirectoryDifferenceIterator *monitorDirectory(
                                   IDirectoryIterator *prev=NULL,    // in (NULL means use current as baseline)

--- a/common/remote/sockfile.cpp
+++ b/common/remote/sockfile.cpp
@@ -1518,12 +1518,14 @@ class CRemoteFile : public CRemoteBase, implements IFile
 {
     StringAttr remotefilename;
     unsigned flags;
+    unsigned cumask;
 public:
     IMPLEMENT_IINTERFACE
     CRemoteFile(const SocketEndpoint &_ep, const char * _filename)
         : CRemoteBase(_ep, _filename)
     {
-        flags = ((unsigned)IFSHread)|((S_IRUSR|S_IWUSR)<<16);
+        flags = ((unsigned)IFSHread)|((S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP|S_IROTH|S_IWOTH)<<16);
+        cumask = IFUnone;
     }
 
     bool exists()
@@ -1783,7 +1785,8 @@ public:
         MemoryBuffer sendBuffer;
         initSendBuffer(sendBuffer);
         MemoryBuffer replyBuffer;
-        sendBuffer.append((RemoteFileCommandType)RFCcreatedir).append(filename);
+        // also send cumask
+        sendBuffer.append((RemoteFileCommandType)RFCcreatedir).append(filename).append(cumask);
         sendRemoteCommand(sendBuffer, replyBuffer);
 
         bool ok;
@@ -1913,9 +1916,23 @@ public:
         return crc;
     }
 
-    void setCreateFlags(unsigned cflags)
+    void setCreateFlags(unsigned cflags, unsigned _cumask=IFUnone)
     {
+        flags &= 0xffff;
         flags |= (cflags<<16);
+        setFileUmask(_cumask);
+    }
+
+    void getCreateFlags(unsigned &oflags, unsigned &oumask)
+    {
+        oflags = flags;
+        oumask = cumask;
+    }
+
+    void setFileUmask(unsigned _cumask)
+    {
+        if (_cumask != IFUnone)
+            cumask = _cumask;
     }
 
     void setShareMode(IFSHmode shmode)
@@ -2193,8 +2210,10 @@ public:
         MemoryBuffer replyBuffer;
         const char *localname = parent->queryLocalName();
         localname = skipSpecialPath(localname);
-        // also send _extraFlags
-        sendBuffer.append((RemoteFileCommandType)RFCopenIO).append(localname).append((byte)_mode).append((byte)_compatmode).append((byte)_extraFlags);
+        unsigned eflags, ecumask;
+        parent->getCreateFlags(eflags, ecumask);
+        // also send _extraFlags, eflags, ecumask
+        sendBuffer.append((RemoteFileCommandType)RFCopenIO).append(localname).append((byte)_mode).append((byte)_compatmode).append((byte)_extraFlags).append(eflags).append(ecumask);
         parent->sendRemoteCommand(sendBuffer, replyBuffer);
 
         replyBuffer.read(handle);
@@ -3957,6 +3976,11 @@ public:
         // can revert to previous behavior with conf file setting "allow_pgcache_flush=false"
         if (extraFlags == IFEnone)
             extraFlags = IFEnocache;
+        // also try to recv extra flags and cumask
+        unsigned eflags = IFUnone;
+        unsigned ecumask = IFUnone;
+        if (msg.remaining() >= 2*sizeof(unsigned))
+            msg.read(eflags).read(ecumask);
         Owned<IFile> file = createIFile(name->text);
         switch ((compatIFSHmode)share) {
         case compatIFSHnone:
@@ -3977,8 +4001,14 @@ public:
             file->setShareMode(IFSHfull);
             break;
         }
+        // use true flags if sent
+        if (eflags != IFUnone)
+        {
+            file->setCreateFlags(eflags>>16, ecumask);
+            file->setShareMode((IFSHmode)(eflags & 0xffff));
+        }
         if (TF_TRACE_PRE_IO)
-            PROGLOG("before open file '%s',  (%d,%d,%d)",name->text.get(),(int)mode,(int)share,extraFlags);
+            PROGLOG("before open file '%s',  (%d,%d,%d,%x,%o,%o)",name->text.get(),(int)mode,(int)share,extraFlags,eflags&0xffff,eflags>>16,ecumask);
         IFileIO *fileio = file->open((IFOmode)mode,extraFlags);
         int handle;
         if (fileio) {
@@ -4322,9 +4352,15 @@ public:
         IMPERSONATE_USER(client);
         StringAttr name;
         msg.read(name);
+        // try to recv extra cumask
+        unsigned ecumask = IFUnone;
+        if (msg.remaining() >= sizeof(unsigned))
+            msg.read(ecumask);
         if (TF_TRACE)
             PROGLOG("CreateDir,  '%s'",name.get());
         Owned<IFile> dir=createIFile(name);
+        if (ecumask != IFUnone)
+            dir->setFileUmask(ecumask);
         bool ret = dir->createDirectory();
         reply.append((unsigned)RFEnoerror).append(ret);
         return true;

--- a/initfiles/etc/DIR_NAME/environment.conf.in
+++ b/initfiles/etc/DIR_NAME/environment.conf.in
@@ -12,6 +12,7 @@ pid=${PID_PATH}
 log=${LOG_PATH}
 user=${RUNTIME_USER}
 group=${RUNTIME_GROUP}
+#umask=022
 home=${HOME_DIR}
 environment=${ENV_XML_FILE}
 sourcedir=${CONFIG_SOURCE_PATH}

--- a/system/jlib/jfile.cpp
+++ b/system/jlib/jfile.cpp
@@ -243,12 +243,21 @@ static StringBuffer &getLocalOrRemoteName(StringBuffer &name,const RemoteFilenam
 CFile::CFile(const char * _filename)
 {
     filename.set(_filename);
-    flags = ((unsigned)IFSHread)|((S_IRUSR|S_IWUSR|S_IRGRP|S_IROTH)<<16);
+    flags = ((unsigned)IFSHread)|((S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP|S_IROTH|S_IWOTH)<<16);
+    cumask = IFUnone;
 }
 
-void CFile::setCreateFlags(unsigned cflags)
+void CFile::setCreateFlags(unsigned cflags, unsigned _cumask)
 {
+    flags &= 0xffff;
     flags |= (cflags<<16);
+    setFileUmask(_cumask);
+}
+
+void CFile::setFileUmask(unsigned _cumask)
+{
+    if (_cumask != IFUnone)
+        cumask = _cumask;
 }
 
 void CFile::setShareMode(IFSHmode shmode)
@@ -256,7 +265,6 @@ void CFile::setShareMode(IFSHmode shmode)
     flags &= ~(IFSHfull|IFSHread);
     flags |= (unsigned)(shmode&(IFSHfull|IFSHread));
 }
-
 
 bool CFile::exists()
 {
@@ -294,13 +302,22 @@ bool WindowsCreateDirectory(const char * path)
 
 #else
 
-
-bool LinuxCreateDirectory(const char * path)
+bool LinuxCreateDirectory(const char * path, unsigned _cumask=IFUnone)
 {
     if (!path)
         return false;
     if (CreateDirectory(path, NULL))
+    {
+        if (_cumask != IFUnone)
+        {
+            mode_t newPerms = ~_cumask & (S_IRUSR|S_IWUSR|S_IXUSR|S_IRGRP|S_IWGRP|S_IXGRP|S_IROTH|S_IWOTH|S_IXOTH);
+#ifdef CFILEIOTRACE
+            DBGLOG("createDirectory(%s): _cumask=0%o newPerms=0%o", path, _cumask, newPerms);
+#endif
+            chmod(path, newPerms);
+        }
         return true;
+    }
     else
     {
         if (EEXIST == errno)
@@ -318,7 +335,7 @@ bool LinuxCreateDirectory(const char * path)
 #endif
 
 
-bool localCreateDirectory(const char *name)
+bool localCreateDirectory(const char *name, unsigned _cumask=IFUnone)
 {
     if (!name)
         return false;
@@ -338,7 +355,7 @@ bool localCreateDirectory(const char *name)
 #ifdef _WIN32
     if (WindowsCreateDirectory(name))
 #else
-    if (LinuxCreateDirectory(name))
+    if (LinuxCreateDirectory(name, _cumask))
 #endif
         return true;
     if (isPathSepChar(name[l-1])) l--;
@@ -347,12 +364,12 @@ bool localCreateDirectory(const char *name)
     if (l<=1)
         return true;
     StringAttr parent(name,l-1);
-    if (!localCreateDirectory(parent.get()))
+    if (!localCreateDirectory(parent.get(), _cumask))
         return false;
 #ifdef _WIN32
     return (WindowsCreateDirectory(name));
 #else
-    return (LinuxCreateDirectory(name));
+    return (LinuxCreateDirectory(name, _cumask));
 #endif
 }
 
@@ -361,9 +378,8 @@ bool localCreateDirectory(const char *name)
 
 bool CFile::createDirectory()
 {
-    return localCreateDirectory(filename);
+    return localCreateDirectory(filename, cumask);
 }
-
 
 
 #ifdef _WIN32
@@ -635,6 +651,16 @@ HANDLE CFile::openHandle(IFOmode mode, IFSHmode sharemode, bool async, int stdh)
             throw makeErrnoExceptionV(errno, "CFile::open %s", filename.get());
         return NULLFILE;
     }
+
+    if (cumask != IFUnone)
+    {
+        mode_t newPerms = ~cumask & fileflags;
+#ifdef CFILEIOTRACE
+        DBGLOG("openHandle(%s): fileflags=0%o cumask=0%o newPerms=0%o", filename.get(), fileflags, cumask, newPerms);
+#endif
+        fchmod(handle, newPerms);
+    }
+
     // check not a directory (compatible with windows)
 
     struct stat info;
@@ -1470,11 +1496,10 @@ public:
     }
 
 
-
     bool createDirectory()
     {
         connect();
-        return localCreateDirectory(filename);
+        return localCreateDirectory(filename, cumask);
     }
 
     IDirectoryIterator *directoryFiles(const char *mask,bool sub,bool includedirs)

--- a/system/jlib/jfile.hpp
+++ b/system/jlib/jfile.hpp
@@ -56,6 +56,7 @@ interface IDirectoryIterator : extends IIteratorOf<IFile>
 #define DEFAULT_COPY_BLKSIZE  0x100000
 enum CFflags { CFnone=0x0, CFflush_read=0x1, CFflush_write=0x2, CFflush_rdwr=0x3 };
 
+#define IFUnone 0xffffffff
 
 #define IDDIunchanged   1
 #define IDDImodified    2
@@ -99,8 +100,9 @@ interface IFile :extends IInterface
     virtual bool setCompression(bool set) = 0;
     virtual offset_t compressedSize() = 0;
     virtual unsigned getCRC() = 0;
-    virtual void setCreateFlags(unsigned cflags) =0;    // I_S*
+    virtual void setCreateFlags(unsigned cflags, unsigned _cumask=IFUnone) = 0;    // I_S*
     virtual void setShareMode(IFSHmode shmode) =0;
+    virtual void setFileUmask(unsigned _cumask) = 0;
 
 // Directory functions
     virtual bool createDirectory() = 0;

--- a/system/jlib/jfile.ipp
+++ b/system/jlib/jfile.ipp
@@ -69,8 +69,9 @@ public:
 
     virtual unsigned getCRC();
 
-    virtual void setCreateFlags(unsigned cflags);
+    virtual void setCreateFlags(unsigned cflags, unsigned _cumask=IFUnone);
     virtual void setShareMode(IFSHmode shmode);
+    virtual void setFileUmask(unsigned _cumask);
     virtual bool getInfo(bool &isdir,offset_t &size,CDateTime &modtime);
 
     virtual void copySection(const RemoteFilename &dest, offset_t toOfs, offset_t fromOfs, offset_t size, ICopyFileProgress *progress=NULL, CFflags copyFlags=CFnone);
@@ -90,6 +91,7 @@ public:
 protected:
     StringAttr filename;
     unsigned flags;
+    unsigned cumask;
 };
 
 


### PR DESCRIPTION
Signed-off-by: Mark Kelly mark.kelly@lexisnexis.com

This adds optional umask capability
And sends extra flags and umask to remote on open, which then honors true values to match local.

@jakesmith please review

After this PR is sub-task HPCC-14822 which is ESP changes for despray to set umask if found in config.
