### PR TITLE
HPCC-14164 Error: System error: 1000: Key size mismatch on key [merger]

### DIFF
--- a/system/jhtree/jhtree.cpp
+++ b/system/jhtree/jhtree.cpp
@@ -609,6 +609,11 @@ public:
                 throw e;
             }
         }
+        else
+        {
+            keySize = 0;
+            keyedSize = 0;
+        }
     }
 
     virtual void reset(bool crappyHack)
@@ -2545,7 +2550,11 @@ public:
             numkeys = _keyset->numParts();
         }
         else
+        {
+            keySize = 0;
+            keyedSize = 0;
             numkeys = 0;
+        }
         killBuffers();
     }
 
@@ -2694,7 +2703,8 @@ public:
         if (!started)
         {
             started = true;
-            segs.checkSize(keyedSize, "[merger]"); //PG: not sure what keyname to use here
+            if (keyedSize)
+                segs.checkSize(keyedSize, "[merger]"); //PG: not sure what keyname to use here
         }
         if (!crappyHack)
         {


### PR DESCRIPTION
Not been able to reproduce the error, but it's clearly from the symptoms
related to keyedSIze being uninitialized - this could happen if one of the
keys being merged had zero parts - for example an empty index.

Initializing the variable properly and avoiding the check that failed in the
uninitialized case should help (or at least reveal someother bug).

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
