### PR TITLE
HPCC-14398 ESP process core when plugin contains invalid ECL

### DIFF
--- a/ecl/hql/hqlerror.cpp
+++ b/ecl/hql/hqlerror.cpp
@@ -228,7 +228,7 @@ class HQL_API ThrowingErrorReceiver : public ErrorReceiverSink
 
 void ThrowingErrorReceiver::report(IError* error)
 {
-    throw error;
+    throw LINK(error);
 }
 
 IErrorReceiver * createThrowingErrorReceiver()


### PR DESCRIPTION
Signed-off-by: Richard Chapman rchapman@hpccsystems.com
