### PR TITLE
HPCC-14821 Throw exception in WsWorkunits when ECLWU cannot be deleted

### DIFF
--- a/esp/services/ecldirect/EclDirectService.cpp
+++ b/esp/services/ecldirect/EclDirectService.cpp
@@ -143,7 +143,8 @@ inline void deleteEclDirectWorkunit(IWorkUnitFactory *factory, const char *wuid)
 {
     try
     {
-        factory->deleteWorkUnit(wuid);
+        if (!factory->deleteWorkUnit(wuid))
+            throw MakeStringException(-1, "%s: Workunit cannot be deleted. Please check ESP log.", wuid);
     }
     catch (IException *e)
     {

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -200,7 +200,8 @@ bool doAction(IEspContext& context, StringArray& wuids, CECLWUActions action, IP
                     ensureWsWorkunitAccess(context, *cw, SecAccess_Full);
                     {
                         cw.clear();
-                        factory->deleteWorkUnit(wuid);
+                        if (!factory->deleteWorkUnit(wuid))
+                            throw MakeStringException(ECLWATCH_CANNOT_DELETE_WORKUNIT, "%s: Workunit cannot be deleted. Please check ESP log.", wuid);
                         AuditSystemAccess(context.queryUserId(), true, "Deleted %s", wuid);
                     }
                     break;
@@ -1122,7 +1123,8 @@ bool CWsWorkunitsEx::onWUSyntaxCheckECL(IEspContext &context, IEspWUSyntaxCheckR
         resp.setErrors(errors);
         cw.clear();
 
-        factory->deleteWorkUnit(wuid.str());
+        if (!factory->deleteWorkUnit(wuid.str()))
+            throw MakeStringException(ECLWATCH_CANNOT_DELETE_WORKUNIT, "%s: Workunit cannot be deleted. Please check ESP log.", wuid.str());
     }
     catch(IException* e)
     {
@@ -1210,7 +1212,8 @@ bool CWsWorkunitsEx::onWUCompileECL(IEspContext &context, IEspWUCompileECLReques
             resp.setDependencies(dependencies);
         }
         cw.clear();
-        factory->deleteWorkUnit(wuid.str());
+        if (!factory->deleteWorkUnit(wuid.str()))
+            throw MakeStringException(ECLWATCH_CANNOT_DELETE_WORKUNIT, "%s: Workunit cannot be deleted. Please check ESP log.", wuid.str());
     }
     catch(IException* e)
     {
@@ -1281,7 +1284,8 @@ bool CWsWorkunitsEx::onWUGetDependancyTrees(IEspContext& context, IEspWUGetDepen
         wu->commit();
         wu.clear();
 
-        factory->deleteWorkUnit(wuid.str());
+        if (!factory->deleteWorkUnit(wuid.str()))
+            throw MakeStringException(ECLWATCH_CANNOT_DELETE_WORKUNIT, "%s: Workunit cannot be deleted. Please check ESP log.", wuid.str());
     }
     catch(IException* e)
     {


### PR DESCRIPTION
In 6.0.0, CWorkUnitFactory::deleteWorkUnit() returns false (not throw
an exception any more) when a WU cannot be deleted. WsWorkunits/
ECLDirect have to check the return and throw exceptions.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
