### PR TITLE
HPCC-13774 Remove information not provided

### DIFF
--- a/esp/src/eclwatch/TopologyDetailsWidget.js
+++ b/esp/src/eclwatch/TopologyDetailsWidget.js
@@ -142,13 +142,20 @@ define([
                 for (var key in this.params.__hpcc_treeItem) {
                     if (this.params.__hpcc_treeItem.hasOwnProperty(key) && !(this.params.__hpcc_treeItem[key] instanceof Object)) {
                         if (key.indexOf("__") !== 0) {
-                            var tr = domConstruct.create("tr", {}, table);
-                            domConstruct.create("td", {
-                                innerHTML: "<b>" + key + ":&nbsp;&nbsp;</b>"
-                            }, tr);
-                            domConstruct.create("td", {
-                                innerHTML: this.params.__hpcc_treeItem[key]
-                            }, tr);
+                            switch (key) {
+                                case "Port":
+                                case "Path":
+                                case "ProcessNumber":
+                                break;
+                            default:
+                                var tr = domConstruct.create("tr", {}, table);
+                                domConstruct.create("td", {
+                                    innerHTML: "<b>" + key + ":&nbsp;&nbsp;</b>"
+                                }, tr);
+                                domConstruct.create("td", {
+                                    innerHTML: this.params.__hpcc_treeItem[key]
+                                }, tr);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Whenever navigating into a cluster/node within topology some portions of the response never reach the user therefore omitting the labels and values.

Signed-off by: Miguel Vazquez miguel.vazquez@lexisnexis.com
