### PR TITLE
HPCC-14554 Roxie control:queries messages need to return errors

### DIFF
--- a/roxie/ccd/ccdstate.cpp
+++ b/roxie/ccd/ccdstate.cpp
@@ -3028,6 +3028,11 @@ void mergeStats(IPropertyTree *s1, IPropertyTree *s2)
 
 void mergeQueries(IPropertyTree *dest, IPropertyTree *src)
 {
+    Owned<IPropertyTreeIterator> elems = src->getElements("Exception");
+    ForEach(*elems)
+    {
+        dest->addPropTree("Exception", LINK(&elems->query()));
+    }
     IPropertyTree *destQueries = ensurePTree(dest, "Queries");
     IPropertyTree *srcQueries = src->queryPropTree("Queries");
     if (!srcQueries)


### PR DESCRIPTION
Other roxie control messages are fine, just control:queries.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
