### PR TITLE
HPCC-14858 Give context to OOM if upstream from gathering activity

### DIFF
--- a/roxie/roxiemem/roxiemem.hpp
+++ b/roxie/roxiemem/roxiemem.hpp
@@ -44,7 +44,7 @@
 #define ROXIEMM_INVALID_MEMORY_ALIGNMENT  ROXIEMM_ERROR_START+2
 #define ROXIEMM_HEAP_ERROR                ROXIEMM_ERROR_START+3
 #define ROXIEMM_TOO_MUCH_MEMORY           ROXIEMM_ERROR_START+4
-
+// NB: max ROXIEMM_* error is ROXIEMM_ERROR_END (see errorlist.h)
 
 #ifdef __64BIT__
 #define HEAP_ALIGNMENT_SIZE I64C(0x40000u)                      // 256kb heaplets

--- a/system/include/errorlist.h
+++ b/system/include/errorlist.h
@@ -38,6 +38,7 @@
 #define ECL_WARN_END            1099
 
 #define ROXIEMM_ERROR_START     1300
+#define ROXIEMM_ERROR_END       1349
 
 #define ROXIE_ERROR_START       1400   // roxie is already using this start value
 #define ROXIE_ERROR_END         1799

--- a/thorlcr/activities/filter/thfilterslave.cpp
+++ b/thorlcr/activities/filter/thfilterslave.cpp
@@ -281,10 +281,9 @@ public:
                 return NULL;
             }
             CThorExpandingRowArray rows(*this, this);
-            Owned<IRowStream> rowStream;
             try
             {
-                rowStream.setown(groupLoader->loadGroup(input, abortSoon, &rows));
+                groupLoader->loadGroup(input, abortSoon, &rows);
             }
             catch (IException *e)
             {

--- a/thorlcr/activities/filter/thfilterslave.cpp
+++ b/thorlcr/activities/filter/thfilterslave.cpp
@@ -281,7 +281,18 @@ public:
                 return NULL;
             }
             CThorExpandingRowArray rows(*this, this);
-            Owned<IRowStream> rowStream = groupLoader->loadGroup(input, abortSoon, &rows);
+            Owned<IRowStream> rowStream;
+            try
+            {
+                rowStream.setown(groupLoader->loadGroup(input, abortSoon, &rows));
+            }
+            catch (IException *e)
+            {
+                if (!isOOMException(e))
+                    throw e;
+                IOutputMetaData *inputOutputMeta = input->queryFromActivity()->queryContainer().queryHelper()->queryOutputMeta();
+                throw checkAndCreateOOMContextException(this, e, "loading group for filter group operation", groupLoader->numRows(), inputOutputMeta, groupLoader->probeRow(0));
+            }
             if (rows.ordinality())
             {
                 // JCSMORE - if isValid would take a stream, group wouldn't need to be in mem.
@@ -348,7 +359,17 @@ public:
 #endif
 
         CThorExpandingRowArray rows(*this, this);
-        groupStream.setown(groupLoader->loadGroup(input, abortSoon, &rows));
+        try
+        {
+            groupStream.setown(groupLoader->loadGroup(input, abortSoon, &rows));
+        }
+        catch (IException *e)
+        {
+            if (!isOOMException(e))
+                throw e;
+            IOutputMetaData *inputOutputMeta = input->queryFromActivity()->queryContainer().queryHelper()->queryOutputMeta();
+            throw checkAndCreateOOMContextException(this, e, "loading group for filter group operation", groupLoader->numRows(), inputOutputMeta, groupLoader->probeRow(0));
+        }
         if (rows.ordinality())
         {
             // JCSMORE - if isValid would take a stream, group wouldn't need to be in mem.

--- a/thorlcr/activities/rollup/throllupslave.cpp
+++ b/thorlcr/activities/rollup/throllupslave.cpp
@@ -117,10 +117,9 @@ public:
         rows.kill();
 
         // JCSMORE - could do in chunks and merge if > mem
-        Owned<IRowStream> rowStream;
         try
         {
-            rowStream.setown(groupOp ? rowLoader->loadGroup(in, activity->queryAbortSoon(), &rows) : rowLoader->load(in, activity->queryAbortSoon(), false, &rows));
+            groupOp ? rowLoader->loadGroup(in, activity->queryAbortSoon(), &rows) : rowLoader->load(in, activity->queryAbortSoon(), false, &rows);
         }
         catch (IException *e)
         {
@@ -617,7 +616,7 @@ public:
         {
             loop
             {
-                Owned<IRowStream> rowStream = groupLoader->loadGroup(input, abortSoon, &rows);
+                groupLoader->loadGroup(input, abortSoon, &rows);
                 unsigned count = rows.ordinality();
                 if (0 == count)
                 {

--- a/thorlcr/graph/thgraph.cpp
+++ b/thorlcr/graph/thgraph.cpp
@@ -3064,11 +3064,6 @@ void CActivityBase::processAndThrowOwnedException(IException * _e)
         e = MakeActivityException(this, _e);
         _e->Release();
     }
-    if (!e->queryNotified())
-    {
-        fireException(e);
-        e->setNotified();
-    }
     throw e;
 }
 

--- a/thorlcr/slave/slave.cpp
+++ b/thorlcr/slave/slave.cpp
@@ -109,6 +109,7 @@ void ProcessSlaveActivity::main()
                 e->setActivityKind(container.getKind());
                 e->setActivityId(container.queryId());
             }
+            exception.set(e);
         }
         else
         {
@@ -120,9 +121,9 @@ void ProcessSlaveActivity::main()
                 e = e2;
             }
             _e->Release();
+            exception.setown(e);
         }
         ActPrintLog(e);
-        exception.setown(e);
     }
     catch (std::exception & es)
     {
@@ -140,12 +141,19 @@ void ProcessSlaveActivity::main()
         ActPrintLogEx(&queryContainer(), thorlog_null, MCerror, "Unknown exception thrown in process()");
         exception.setown(MakeThorFatal(NULL, TE_UnknownException, "FATAL: Unknown exception thrown by ProcessThread"));
     }
+    if (exception)
+        fireException(exception);
     try { endProcess(); }
-    catch (IException *e)
+    catch (IException *_e)
     {
-        ActPrintLog(e, "Exception calling activity endProcess");
-        fireException(e);
-        exception.setown(e);
+        ActPrintLog(_e, "Exception calling activity endProcess");
+        IThorException *e = QUERYINTERFACE(_e, IThorException);
+        if (e)
+            exception.set(e);
+        else
+            exception.setown(MakeActivityException(this, _e));
+        _e->Release();
+        fireException(exception);
     }
 }
 

--- a/thorlcr/slave/slave.ipp
+++ b/thorlcr/slave/slave.ipp
@@ -32,7 +32,7 @@ interface IRangeCompare;
 class ProcessSlaveActivity : public CSlaveActivity, implements IThreaded
 {
 protected:
-    Owned<IException> exception;
+    Owned<IThorException> exception;
     CThreadedPersistent threaded;
     rowcount_t processed;
     unsigned __int64 lastCycles;

--- a/thorlcr/thorutil/thmem.cpp
+++ b/thorlcr/thorutil/thmem.cpp
@@ -1752,6 +1752,12 @@ public:
         spillableRows.transferFrom(src);
         enableSpillingCallback();
     }
+    virtual const void *probeRow(unsigned r)
+    {
+        if (r>=spillableRows.numCommitted())
+            return NULL;
+        return spillableRows.query(r);
+    }
     virtual void setup(ICompare *_iCompare, StableSortFlag _stableSort, RowCollectorSpillFlags _diskMemMix, unsigned _spillPriority)
     {
         iCompare = _iCompare;
@@ -1856,6 +1862,7 @@ public:
     virtual void transferRowsOut(CThorExpandingRowArray &dst, bool sort) { CThorRowCollectorBase::transferRowsOut(dst, sort); }
     virtual void transferRowsIn(CThorExpandingRowArray &src) { CThorRowCollectorBase::transferRowsIn(src); }
     virtual void transferRowsIn(CThorSpillableRowArray &src) { CThorRowCollectorBase::transferRowsIn(src); }
+    virtual const void *probeRow(unsigned r) { return CThorRowCollectorBase::probeRow(r); }
     virtual void setup(ICompare *iCompare, StableSortFlag stableSort, RowCollectorSpillFlags diskMemMix=rc_mixed, unsigned spillPriority=50)
     {
         CThorRowCollectorBase::setup(iCompare, stableSort, diskMemMix, spillPriority);
@@ -1908,6 +1915,7 @@ public:
     virtual void transferRowsOut(CThorExpandingRowArray &dst, bool sort) { CThorRowCollectorBase::transferRowsOut(dst, sort); }
     virtual void transferRowsIn(CThorExpandingRowArray &src) { CThorRowCollectorBase::transferRowsIn(src); }
     virtual void transferRowsIn(CThorSpillableRowArray &src) { CThorRowCollectorBase::transferRowsIn(src); }
+    virtual const void *probeRow(unsigned r) { return CThorRowCollectorBase::probeRow(r); }
     virtual void setup(ICompare *iCompare, StableSortFlag stableSort, RowCollectorSpillFlags diskMemMix=rc_mixed, unsigned spillPriority=50)
     {
         CThorRowCollectorBase::setup(iCompare, stableSort, diskMemMix, spillPriority);

--- a/thorlcr/thorutil/thmem.hpp
+++ b/thorlcr/thorutil/thmem.hpp
@@ -514,6 +514,7 @@ interface IThorRowCollectorCommon : extends IInterface
     virtual void transferRowsOut(CThorExpandingRowArray &dst, bool sort=true) = 0;
     virtual void transferRowsIn(CThorExpandingRowArray &src) = 0;
     virtual void transferRowsIn(CThorSpillableRowArray &src) = 0;
+    virtual const void *probeRow(unsigned r) = 0;
     virtual void setup(ICompare *iCompare, StableSortFlag stableSort=stableSort_none, RowCollectorSpillFlags diskMemMix=rc_mixed, unsigned spillPriority=50) = 0;
     virtual void resize(rowidx_t max) = 0;
     virtual void setOptions(unsigned options) = 0;

--- a/thorlcr/thorutil/thormisc.cpp
+++ b/thorlcr/thorutil/thormisc.cpp
@@ -1372,17 +1372,17 @@ bool isOOMException(IException *_e)
         IThorException *e = QUERYINTERFACE(_e, IThorException);
         IException *oe = e && e->queryOriginalException() ? e->queryOriginalException() : _e;
         int ecode = oe->errorCode();
-        if (ecode >= ROXIEMM_ERROR_START && ecode <= ROXIEMM_ERROR_START) // should have ROXIEMM_ERROR_END marker probably
+        if (ecode >= ROXIEMM_ERROR_START && ecode <= ROXIEMM_ERROR_END)
             return true;
     }
     return false;
 }
 
-IThorException *checkAndCreateOOMContextException(CActivityBase *activity, IException *e, const char *msg, unsigned numRows, IOutputMetaData *meta, const void *row)
+IThorException *checkAndCreateOOMContextException(CActivityBase *activity, IException *e, const char *msg, rowcount_t numRows, IOutputMetaData *meta, const void *row)
 {
     VStringBuffer errorMsg("Out of memory whilst %s", msg);
-    if (NotFound != numRows)
-        errorMsg.appendf(", group/set size = %d", numRows);
+    if (RCUNSET != numRows)
+        errorMsg.appendf(", group/set size = %" RCPF "u", numRows);
     if (meta)
     {
         if (meta->isFixedSize())

--- a/thorlcr/thorutil/thormisc.cpp
+++ b/thorlcr/thorutil/thormisc.cpp
@@ -222,16 +222,16 @@ protected:
     int errorcode;
     StringAttr msg;
     LogMsgAudience audience;
-    unsigned node;
+    unsigned slave;
     MemoryBuffer data; // extra exception specific data
-    bool notified;
     unsigned line, column;
     StringAttr file, origin;
     ErrorSeverity severity;
+    Linked<IException> originalException;
 public:
     IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
     CThorException(LogMsgAudience _audience,int code, const char *str) 
-        : audience(_audience), errorcode(code), msg(str), action(tea_null), graphId(0), id(0), node(0), line(0), column(0), severity(SeverityInformation), kind(TAKnone), notified(false) { };
+        : audience(_audience), errorcode(code), msg(str), action(tea_null), graphId(0), id(0), slave(0), line(0), column(0), severity(SeverityInformation), kind(TAKnone) { };
     CThorException(MemoryBuffer &mb)
     {
         mb.read((unsigned &)action);
@@ -239,6 +239,7 @@ public:
         mb.read(graphId);
         mb.read((unsigned &)kind);
         mb.read(id);
+        mb.read(slave);
         mb.read((unsigned &)audience);
         mb.read(errorcode);
         mb.read(msg);
@@ -249,6 +250,10 @@ public:
         mb.read(origin);
         if (0 == origin.length()) // simpler to clear serialized 0 length terminated string here than check on query
             origin.clear();
+        bool oe;
+        mb.read(oe);
+        if (oe)
+            originalException.setown(deserializeThorException(mb));
         size32_t sz;
         mb.read(sz);
         if (sz)
@@ -256,29 +261,30 @@ public:
     }
 
 // IThorException
-    ThorExceptionAction queryAction() { return action; }
-    ThorActivityKind queryActivityKind() { return kind; }
-    activity_id queryActivityId() { return id; }
-    graph_id queryGraphId() { return graphId; }
-    const char *queryJobId() { return jobId; }
-    void getAssert(StringAttr &_file, unsigned &_line, unsigned &_column) { _file.set(file); _line = line; _column = column; }
-    const char *queryOrigin() { return origin; }
-    const char *queryMessage() { return msg; }
-    ErrorSeverity querySeverity() { return severity; }
-    bool queryNotified() const { return notified; }
-    MemoryBuffer &queryData() { return data; }
-    void setNotified() { notified = true; }
-    void setActivityId(activity_id _id) { id = _id; }
-    void setActivityKind(ThorActivityKind _kind) { kind = _kind; }
-    void setGraphId(graph_id _graphId) { graphId = _graphId; }
-    void setJobId(const char *_jobId) { jobId.set(_jobId); }
-    void setAction(ThorExceptionAction _action) { action = _action; }
-    void setAudience(MessageAudience _audience) { audience = _audience; }
-    void setSlave(unsigned _node) { node = _node; }
-    void setMessage(const char *_msg) { msg.set(_msg); }
-    void setAssert(const char *_file, unsigned _line, unsigned _column) { file.set(_file); line = _line; column = _column; }
-    void setOrigin(const char *_origin) { origin.set(_origin); }
-    void setSeverity(ErrorSeverity _severity) { severity = _severity; }
+    virtual ThorExceptionAction queryAction() const { return action; }
+    virtual ThorActivityKind queryActivityKind() const { return kind; }
+    virtual activity_id queryActivityId() const { return id; }
+    virtual graph_id queryGraphId() const { return graphId; }
+    virtual const char *queryJobId() const { return jobId; }
+    virtual unsigned querySlave() const { return slave; }
+    virtual void getAssert(StringAttr &_file, unsigned &_line, unsigned &_column) const { _file.set(file); _line = line; _column = column; }
+    virtual const char *queryOrigin() const { return origin; }
+    virtual const char *queryMessage() const { return msg; }
+    virtual ErrorSeverity querySeverity() const { return severity; }
+    virtual MemoryBuffer &queryData() { return data; }
+    virtual IException *queryOriginalException() const { return originalException; }
+    virtual void setActivityId(activity_id _id) { id = _id; }
+    virtual void setActivityKind(ThorActivityKind _kind) { kind = _kind; }
+    virtual void setGraphId(graph_id _graphId) { graphId = _graphId; }
+    virtual void setJobId(const char *_jobId) { jobId.set(_jobId); }
+    virtual void setAction(ThorExceptionAction _action) { action = _action; }
+    virtual void setAudience(MessageAudience _audience) { audience = _audience; }
+    virtual void setSlave(unsigned _slave) { slave = _slave; }
+    virtual void setMessage(const char *_msg) { msg.set(_msg); }
+    virtual void setAssert(const char *_file, unsigned _line, unsigned _column) { file.set(_file); line = _line; column = _column; }
+    virtual void setOrigin(const char *_origin) { origin.set(_origin); }
+    virtual void setSeverity(ErrorSeverity _severity) { severity = _severity; }
+    virtual void setOriginalException(IException *e) { originalException.set(e); }
 
 // IException
     int errorCode() const { return errorcode; }
@@ -297,21 +303,31 @@ public:
                 if (kind) str.append(']');
                 str.append(": ");
             }
-            if (node)
+            if (slave)
             {
-                str.appendf("SLAVE #%d [", node);
-                queryClusterGroup().queryNode(node).endpoint().getUrlStr(str);
+                str.appendf("SLAVE #%d [", slave);
+                queryClusterGroup().queryNode(slave).endpoint().getUrlStr(str);
                 str.append("]: ");
             }
         }
         str.append(msg);
+        if (originalException)
+        {
+            if (msg.length())
+                str.append(" - ");
+            str.append("caused by (");
+            str.append(originalException->errorCode());
+            str.append(", ");
+            originalException->errorMessage(str);
+            str.append(")");
+        }
         return str;
     }
     MessageAudience errorAudience() const { return audience; }
 };
 
 CThorException *_MakeThorException(LogMsgAudience audience,int code, const char *format, va_list args) __attribute__((format(printf,3,0)));
-CThorException *_MakeThorException(LogMsgAudience audience,int code, const char *format, va_list args)
+CThorException *_MakeThorException(LogMsgAudience audience, int code, const char *format, va_list args)
 {
     StringBuffer eStr;
     eStr.limited_valist_appendf(1024, format, args);
@@ -388,6 +404,7 @@ IThorException *_MakeActivityException(CGraphElementBase &container, IException 
     if (_format)
         msg.append(", ").limited_valist_appendf(1024, _format, args);
     IThorException *e2 = new CThorException(e->errorAudience(), e->errorCode(), msg.str());
+    e2->setOriginalException(e);
     setExceptionActivityInfo(container, e2);
     return e2;
 }
@@ -899,6 +916,7 @@ void serializeThorException(IException *e, MemoryBuffer &out)
     out.append(te->queryGraphId());
     out.append((unsigned)te->queryActivityKind());
     out.append(te->queryActivityId());
+    out.append(te->querySlave());
     out.append((unsigned)te->errorAudience());
     out.append(te->errorCode());
     out.append(te->queryMessage());
@@ -910,6 +928,14 @@ void serializeThorException(IException *e, MemoryBuffer &out)
     out.append(column);
     out.append(te->querySeverity());
     out.append(te->queryOrigin());
+    IException *oe = te->queryOriginalException();
+    if (oe)
+    {
+        out.append(true);
+        serializeThorException(oe, out);
+    }
+    else
+        out.append(false);
     MemoryBuffer &data = te->queryData();
     out.append((size32_t)data.length());
     if (data.length())
@@ -1337,5 +1363,40 @@ IPerfMonHook *createThorMemStatsPerfMonHook(CJobBase &job, int maxLevel, IPerfMo
     return new CPerfMonHook(job, maxLevel, chain);
 }
 
-
 const StatisticsMapping spillStatistics(StTimeSpillElapsed, StTimeSortElapsed, StNumSpills, StSizeSpillFile, StKindNone);
+
+bool isOOMException(IException *_e)
+{
+    if (_e)
+    {
+        IThorException *e = QUERYINTERFACE(_e, IThorException);
+        IException *oe = e && e->queryOriginalException() ? e->queryOriginalException() : _e;
+        int ecode = oe->errorCode();
+        if (ecode >= ROXIEMM_ERROR_START && ecode <= ROXIEMM_ERROR_START) // should have ROXIEMM_ERROR_END marker probably
+            return true;
+    }
+    return false;
+}
+
+IThorException *checkAndCreateOOMContextException(CActivityBase *activity, IException *e, const char *msg, unsigned numRows, IOutputMetaData *meta, const void *row)
+{
+    VStringBuffer errorMsg("Out of memory whilst %s", msg);
+    if (NotFound != numRows)
+        errorMsg.appendf(", group/set size = %d", numRows);
+    if (meta)
+    {
+        if (meta->isFixedSize())
+            errorMsg.appendf(", Fixed rows, size = %d", meta->getFixedSize());
+        else
+            errorMsg.appendf(", Variable rows, min. size = %d", meta->getMinRecordSize());
+        if (row && meta->hasXML())
+        {
+            CommonXmlWriter xmlwrite(0);
+            meta->toXML((byte *) row, xmlwrite);
+            errorMsg.newline().append("Leading row of group: ").append(xmlwrite.str());
+        }
+    }
+    Owned<IThorException> te = MakeActivityException(activity, e, "%s", errorMsg.str());
+    e->Release();
+    return te.getClear();
+}

--- a/thorlcr/thorutil/thormisc.hpp
+++ b/thorlcr/thorutil/thormisc.hpp
@@ -307,18 +307,18 @@ extern graph_decl IBarrierException *createBarrierAbortException();
 
 interface IThorException : extends IException
 {
-    virtual ThorExceptionAction queryAction() = 0;
-    virtual ThorActivityKind queryActivityKind() = 0;
-    virtual activity_id queryActivityId() = 0;
-    virtual graph_id queryGraphId() = 0;
-    virtual const char *queryJobId() = 0;
-    virtual void getAssert(StringAttr &file, unsigned &line, unsigned &column) = 0;
-    virtual const char *queryOrigin() = 0;
-    virtual ErrorSeverity querySeverity() = 0;
-    virtual const char *queryMessage() = 0;
-    virtual bool queryNotified() const = 0;
+    virtual ThorExceptionAction queryAction() const = 0;
+    virtual ThorActivityKind queryActivityKind() const = 0;
+    virtual activity_id queryActivityId() const = 0;
+    virtual graph_id queryGraphId() const = 0;
+    virtual const char *queryJobId() const = 0;
+    virtual unsigned querySlave() const = 0;
+    virtual void getAssert(StringAttr &file, unsigned &line, unsigned &column) const = 0;
+    virtual const char *queryOrigin() const = 0;
+    virtual ErrorSeverity querySeverity() const = 0;
+    virtual const char *queryMessage() const = 0;
     virtual MemoryBuffer &queryData() = 0;
-    virtual void setNotified() = 0;
+    virtual IException *queryOriginalException() const = 0;
     virtual void setAction(ThorExceptionAction _action) = 0;
     virtual void setActivityKind(ThorActivityKind _kind) = 0;
     virtual void setActivityId(activity_id id) = 0;
@@ -330,6 +330,7 @@ interface IThorException : extends IException
     virtual void setAssert(const char *file, unsigned line, unsigned column) = 0;
     virtual void setOrigin(const char *origin) = 0;
     virtual void setSeverity(ErrorSeverity severity) = 0;
+    virtual void setOriginalException(IException *e) = 0;
 };
 
 class CGraphElementBase;
@@ -486,6 +487,9 @@ extern graph_decl IPerfMonHook *createThorMemStatsPerfMonHook(CJobBase &job, int
 
 //statistics gathered by the different activities
 extern const graph_decl StatisticsMapping spillStatistics;
+
+extern graph_decl bool isOOMException(IException *e);
+extern graph_decl IThorException *checkAndCreateOOMContextException(CActivityBase *activity, IException *e, const char *msg, unsigned numRows, IOutputMetaData *meta, const void *row);
 
 #endif
 

--- a/thorlcr/thorutil/thormisc.hpp
+++ b/thorlcr/thorutil/thormisc.hpp
@@ -489,7 +489,7 @@ extern graph_decl IPerfMonHook *createThorMemStatsPerfMonHook(CJobBase &job, int
 extern const graph_decl StatisticsMapping spillStatistics;
 
 extern graph_decl bool isOOMException(IException *e);
-extern graph_decl IThorException *checkAndCreateOOMContextException(CActivityBase *activity, IException *e, const char *msg, unsigned numRows, IOutputMetaData *meta, const void *row);
+extern graph_decl IThorException *checkAndCreateOOMContextException(CActivityBase *activity, IException *e, const char *msg, rowcount_t numRows, IOutputMetaData *meta, const void *row);
 
 #endif
 


### PR DESCRIPTION
If a upstream activity requires a group or set of rows to be in
memory and cannot spill. Give some context to a OOM exception
that it catches.

This also changes the way the original encountered exception is
reported. Before this commit, the activity that hit the exception
would fire the exception to the master asap and abort the query.
To catch and add context, that had to change.
Now the exception is propagated up the activity chain (was before)
before firing the exception back to the master.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
