### PR TITLE
HPCC-14851 Make unknown component error visible in hpcc-init

### DIFF
--- a/initfiles/bash/etc/init.d/hpcc-init.in
+++ b/initfiles/bash/etc/init.d/hpcc-init.in
@@ -233,6 +233,7 @@ while true ; do
                 if [ -z $comp_return ]
                 then
                     log "Unknown component: $comp"
+                    echo "Unknown component: $comp"
                     exit 1
                 fi
                 for (( i=0; i<=${compListLen}; i++ ));do


### PR DESCRIPTION
Signed-off-by: Michael Gardner michael.gardner@lexisnexis.com
