### PR TITLE
HPCC-14164 Error: System error: 1000: Key size mismatch on key [merger]

### DIFF
--- a/system/jhtree/jhtree.cpp
+++ b/system/jhtree/jhtree.cpp
@@ -531,6 +531,8 @@ public:
         numsegs = 0;
         keyBuffer = NULL;
         keyCursor = NULL;
+        keySize = 0;
+        keyedSize = 0;
         eclKeySize = _eclKeySize;
         started = false;
         setKey(_key);
@@ -608,11 +610,6 @@ public:
                 EXCLOG(e, err.str());
                 throw e;
             }
-        }
-        else
-        {
-            keySize = 0;
-            keyedSize = 0;
         }
     }
 
@@ -2550,11 +2547,7 @@ public:
             numkeys = _keyset->numParts();
         }
         else
-        {
-            keySize = 0;
-            keyedSize = 0;
             numkeys = 0;
-        }
         killBuffers();
     }
 


### PR DESCRIPTION
Previous fix caused regressions in Roxie regression suite, as setKey is called
multiple times in some cases.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
