### PR TITLE
HPCC-14896 Always fill in destFileOut for getDropZoneInfoByIP()

### DIFF
--- a/esp/services/ws_fs/ws_fsService.cpp
+++ b/esp/services/ws_fs/ws_fsService.cpp
@@ -2280,6 +2280,9 @@ bool CFileSprayEx::onReplicate(IEspContext &context, IEspReplicate &req, IEspRep
 
 void CFileSprayEx::getDropZoneInfoByIP(const char* ip, const char* destFileIn, StringBuffer& destFileOut, StringBuffer& mask)
 {
+    if (destFileIn && *destFileIn)
+        destFileOut.set(destFileIn);
+
     if (!ip || !*ip)
         return;
 


### PR DESCRIPTION
Signed-off-by: Mark Kelly mark.kelly@lexisnexis.com
