### PR TITLE
HPCC-14210 Deprecate the iplanet directory server

### DIFF
--- a/initfiles/componentfiles/configxml/ldapserver.xsd
+++ b/initfiles/componentfiles/configxml/ldapserver.xsd
@@ -255,7 +255,6 @@
                             <xs:enumeration value="OpenLDAP"/>
                             <xs:enumeration value="389DirectoryServer"/>
                             <xs:enumeration value="Fedora389"/>
-			    <xs:enumeration value="iPlanet"/>
                         </xs:restriction>
                     </xs:simpleType>
             </xs:attribute>


### PR DESCRIPTION
FIX HPCC-14210 Deprecate the iplanet directory server  
To Remove the reference for the iplanet directory server from 
the documentation, remove it from the component XSD file. 
This documentation is built directly from the components source files. 

@garonsky please review 
@JamesDeFabia FYI
