### PR TITLE
HPCC-14289 add option to pull thorslave logs into ZAP reports

### DIFF
--- a/esp/eclwatch/ws_XSLT/WUZAPInfoForm.xslt
+++ b/esp/eclwatch/ws_XSLT/WUZAPInfoForm.xslt
@@ -67,7 +67,8 @@
                                 var history = document.getElementById("WhatChanged").value;
                                 var timing = document.getElementById("WhereSlow").value;
                                 var password = document.getElementById("Password").value;
-                                opener.createZAPInfo(wuid, espIP, thorIP, buildVersion, desc, history, timing, password);
+                                var thorSlaveLog = document.getElementById("IncludeThorSlaveLog").checked;
+                                opener.createZAPInfo(wuid, espIP, thorIP, buildVersion, desc, history, timing, password, thorSlaveLog);
                             }
                             window.close();
                         }
@@ -175,6 +176,12 @@
                                 </td>
                                 <td>
                                     <textarea rows="10" cols="72" id="WhereSlow" name="WhereSlow">&#160;</textarea>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td></td>
+                                <td>
+                                    <input type="checkbox" title="Include Thor Slave logs" id="IncludeThorSlaveLog" name="IncludeThorSlaveLog">Include Thor Slave logs (It may take a long time to report the logs from multiple Thor Slave nodes.)</input>
                                 </td>
                             </tr>
                             <tr>

--- a/esp/eclwatch/ws_XSLT/wuid.xslt
+++ b/esp/eclwatch/ws_XSLT/wuid.xslt
@@ -751,12 +751,13 @@
                         mywindow.focus();
                         return false;
                     }
-                    function createZAPInfo(wuid, espIP, thorIP, ESPBuildVersion, problemDesciption, history, timingInfo, password)
+                    function createZAPInfo(wuid, espIP, thorIP, ESPBuildVersion, problemDesciption, history, timingInfo, password, thorSlaveLog)
                     {
                         document.getElementById("ESPIPAddress").value=espIP;
                         if (thorIP != '')
                             document.getElementById("ThorIPAddress").value=thorIP;
                         document.getElementById("BuildVersion").value=ESPBuildVersion;
+                        document.getElementById("IncludeThorSlaveLog").value=thorSlaveLog;
                         if (problemDesciption != '')
                             document.getElementById("ProblemDescription").value=problemDesciption;
                         else

--- a/esp/eclwatch/ws_XSLT/wuidcommon.xslt
+++ b/esp/eclwatch/ws_XSLT/wuidcommon.xslt
@@ -828,6 +828,7 @@
               <input type="hidden" id="WhatChanged" name="WhatChanged" value=""/>
               <input type="hidden" id="WhereSlow" name="WhereSlow" value=""/>
               <input type="hidden" id="Password" name="Password" value=""/>
+              <input type="hidden" id="IncludeThorSlaveLog" name="IncludeThorSlaveLog" value="0"/>
               <input type="button" name="Type" value="Save" class="sbutton" onclick="updateWorkunit('{$wuid}');">
                         <xsl:if test="number(AccessFlag) &lt; 7">
                           <xsl:attribute name="disabled">disabled</xsl:attribute>

--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -1639,6 +1639,7 @@ ESPrequest [nil_remove] WUCreateZAPInfoRequest
     string WhatChanged;
     string WhereSlow;
     [min_ver("1.53")] string Password;
+    [min_ver("1.57")] bool IncludeThorSlaveLog(false);
 };
 
 ESPresponse [exceptions_inline] WUCreateZAPInfoResponse

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -4171,6 +4171,71 @@ void CWsWorkunitsEx::addProcessLogfile(Owned<IConstWorkUnit>& cwu, WsWuInfo& win
     }
 }
 
+void CWsWorkunitsEx::addThorSlaveLogfile(Owned<IConstWorkUnit>& cwu, WsWuInfo& winfo, const char* path)
+{
+    if (cwu->getWuidVersion() <= 0)
+        return;
+    StringAttr clusterName(cwu->queryClusterName());
+    if (clusterName.isEmpty()) //Cluster name may not be set yet
+        return;
+    Owned<IConstWUClusterInfo> clusterInfo = getTargetClusterInfo(clusterName.str());
+    if (!clusterInfo)
+    {
+        WARNLOG("Cannot find TargetClusterInfo for workunit %s", cwu->queryWuid());
+        return;
+    }
+
+    unsigned numberOfSlaves = clusterInfo->getSize();
+    BoolHash uniqueProcesses;
+    Owned<IStringIterator> thorInstances = cwu->getProcesses("Thor");
+    ForEach (*thorInstances)
+    {
+        SCMStringBuffer processName;
+        thorInstances->str(processName);
+        if (processName.length() == 0)
+            continue;
+
+        bool* found = uniqueProcesses.getValue(processName.str());
+        if (found && *found)
+            continue;
+        uniqueProcesses.setValue(processName.str(), true);
+
+        StringBuffer groupName, logDir;
+        getClusterThorGroupName(groupName, processName.str());
+        getConfigurationDirectory(directories, "log", "thor", processName.str(), logDir);
+        Owned<IStringIterator> thorLogs = cwu->getLogs("Thor", processName.str());
+        ForEach (*thorLogs)
+        {
+            SCMStringBuffer logName;
+            thorLogs->str(logName);
+            if (logName.length() == 0)
+                continue;
+
+            const char* pStr = logName.str();
+            const char* ppStr = strstr(pStr, "/thormaster.");
+            if (!ppStr)
+            {
+                WARNLOG("Invalid thorlog entry in workunit xml: %s", logName.str());
+                continue;
+            }
+            ppStr += 12;
+            StringBuffer logDate = ppStr;
+            logDate.setLength(10);
+
+            for (unsigned i = 0; i < numberOfSlaves; i++)
+            {
+                MemoryBuffer mb;
+                winfo.getWorkunitThorSlaveLog(groupName.str(), NULL, logDate.str(), logDir.str(), i+1, mb, false);
+                if (!mb.length())
+                    continue;
+
+                VStringBuffer fileName("%s%c%s_thorslave.%d.%s.log", path, PATHSEPCHAR, processName.str(), i+1, logDate.str());
+                createZAPFile(fileName.str(), mb.length(), mb.bufferBase());
+            }
+        }
+    }
+}
+
 void CWsWorkunitsEx::createZAPWUInfoFile(IEspWUCreateZAPInfoRequest &req, Owned<IConstWorkUnit>& cwu, const char* pathNameStr)
 {
     StringBuffer sb;
@@ -4325,6 +4390,8 @@ bool CWsWorkunitsEx::onWUCreateZAPInfo(IEspContext &context, IEspWUCreateZAPInfo
         createZAPWUGraphProgressFile(req.getWuid(), pathNameStr.str());
         addProcessLogfile(cwu, winfo, "EclAgent", folderToZIP.str());
         addProcessLogfile(cwu, winfo, "Thor", folderToZIP.str());
+        if (req.getIncludeThorSlaveLog())
+            addThorSlaveLogfile(cwu, winfo, folderToZIP.str());
 
         //Write out to ZIP file
         zipFileName.append(nameStr.str()).append(".zip");

--- a/esp/services/ws_workunits/ws_workunitsService.hpp
+++ b/esp/services/ws_workunits/ws_workunitsService.hpp
@@ -263,6 +263,7 @@ public:
     bool onWUGetArchiveFile(IEspContext &context, IEspWUGetArchiveFileRequest &req, IEspWUGetArchiveFileResponse &resp);
 private:
     void addProcessLogfile(Owned<IConstWorkUnit> &cwu, WsWuInfo &winfo, const char * process, const char* path);
+    void addThorSlaveLogfile(Owned<IConstWorkUnit> &cwu,WsWuInfo& winfo, const char* path);
     void createZAPWUInfoFile(IEspWUCreateZAPInfoRequest &req, Owned<IConstWorkUnit>& cwu, const char* pathNameStr);
     void createZAPWUXMLFile(WsWuInfo &winfo, const char* pathNameStr);
     void createZAPWUGraphProgressFile(const char* wuid, const char* pathNameStr);


### PR DESCRIPTION
Also add a checkbox into legacy ECLWatch UI and default it to
unchecked. If it is checked, thorslave logs will be added
into ZAP report.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
