### PR TITLE
HPCC-14914 - Unused variable ucmCrit in eclrtl.cpp

### DIFF
--- a/rtl/eclrtl/eclrtl.cpp
+++ b/rtl/eclrtl/eclrtl.cpp
@@ -309,7 +309,6 @@ private:
 typedef MapStringTo<RTLUnicodeConverter, char const *> MapStrToUnicodeConverter;
 static __thread MapStrToUnicodeConverter *unicodeConverterMap = NULL;
 static __thread ThreadTermFunc prevThreadTerminator = NULL;
-CriticalSection ucmCrit;
 
 static void clearUnicodeConverterMap()
 {


### PR DESCRIPTION
Signed-off-by: Richard Chapman rchapman@hpccsystems.com
