### PR TITLE
HPCC-14913 Ignore deprecated warnings in OSX

### DIFF
--- a/system/security/LdapSecurity/CMakeLists.txt
+++ b/system/security/LdapSecurity/CMakeLists.txt
@@ -24,6 +24,10 @@
 
 project( LdapSecurity ) 
 
+if (APPLE AND CMAKE_COMPILER_IS_CLANG)
+  SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
+endif()
+
 set (    SRCS 
          ../shared/authmap.cpp 
          ../shared/caching.cpp 

--- a/tools/initldap/CMakeLists.txt
+++ b/tools/initldap/CMakeLists.txt
@@ -25,6 +25,10 @@
 
 project( initldap )
 
+if (APPLE AND CMAKE_COMPILER_IS_CLANG)
+  SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
+endif()
+
 set (    SRCS
          initldap.cpp
     )


### PR DESCRIPTION
This doesn't remove ALL deprecated warnings, but it kills the vast majority.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
