### PR TITLE
HPCC-14306 ECL Watch remembers checked files

### DIFF
--- a/esp/src/eclwatch/DFUQueryWidget.js
+++ b/esp/src/eclwatch/DFUQueryWidget.js
@@ -446,6 +446,7 @@ define([
             this.listStore = this.params.searchResults ? this.params.searchResults : new ESPLogicalFile.CreateLFQueryStore();
             this.treeStore = new ESPLogicalFile.CreateLFQueryTreeStore();
             this.workunitsGrid = new declare([ESPUtil.Grid(true, true)])({
+                deselectOnRefresh: true,
                 store: this.listStore,
                 columns: {
                     col1: selector({


### PR DESCRIPTION
Whenever a user is using the filtering capabilities of dgrid the files previously checked are still checked. If a user decides to delete a file before the filter was set two files will now be checked. Adding an additional fail-safe that clears selection on refresh.

Signed-off by: Miguel Vazquez miguel.vazquez@lexisnexis.com
