### PR TITLE
HPCC-14901 Git hook does not properly update the local bare repository

### DIFF
--- a/ecl/eclccserver/vchooks/git.sh
+++ b/ecl/eclccserver/vchooks/git.sh
@@ -114,10 +114,10 @@ function fetch_repo {
     if [ -n "$fetch_needed" ]; then
         if [ -n "$GIT_VERBOSE" ]; then
             echo "GIT: using directory $git_directory" 1>&2
-            echo "GIT: Running git fetch $git_url" 1>&2
-            git fetch $git_url 1>&2
+            echo "GIT: Running git fetch $git_url +refs/heads/*:refs/heads/* --prune" 1>&2
+            git fetch $git_url +refs/heads/*:refs/heads/* --prune 1>&2
         else
-            git fetch $git_url 2>&1 >/dev/null
+            git fetch $git_url +refs/heads/*:refs/heads/* --prune 2>&1 >/dev/null
         fi
         if [ $? -ne 0 ]; then
             echo "Failed to run git fetch $git_url" 1>&2


### PR DESCRIPTION
It seems that git fetch is not enough - the magic incantation specified here
is what is needed.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
