### PR TITLE
HPCC-14280 Access rights checks should include SERVICE calls

### DIFF
--- a/ecl/eclcc/eclcc.cpp
+++ b/ecl/eclcc/eclcc.cpp
@@ -1333,7 +1333,7 @@ void EclCC::processDefinitions(EclRepositoryArray & repositories)
         }
 
         //Create a repository with just that attribute.
-        Owned<IFileContents> contents = createFileContentsFromText(value, NULL);
+        Owned<IFileContents> contents = createFileContentsFromText(value, NULL, false);
         repositories.append(*createSingleDefinitionEclRepository(module, attr, contents));
     }
 }
@@ -1410,7 +1410,7 @@ void EclCC::processXmlFile(EclCompileInstance & instance, const char *archiveXML
     {
         const char * sourceFilename = archiveTree->queryProp("Query/@originalFilename");
         Owned<ISourcePath> sourcePath = createSourcePath(sourceFilename);
-        contents.setown(createFileContentsFromText(queryText, sourcePath));
+        contents.setown(createFileContentsFromText(queryText, sourcePath, false));
         if (queryAttributePath && queryText && *queryText)
         {
             Owned<IEclSourceCollection> inputFileCollection = createSingleDefinitionEclCollection(queryAttributePath, contents);
@@ -1431,7 +1431,7 @@ void EclCC::processXmlFile(EclCompileInstance & instance, const char *archiveXML
         queryAttributePath = fullPath.str();
 
         //Create a repository with just that attribute, and place it before the archive in the resolution order.
-        Owned<IFileContents> contents = createFileContentsFromText(queryText, NULL);
+        Owned<IFileContents> contents = createFileContentsFromText(queryText, NULL, false);
         repositories.append(*createSingleDefinitionEclRepository(syntaxCheckModule, syntaxCheckAttribute, contents));
     }
 
@@ -1455,7 +1455,7 @@ void EclCC::processFile(EclCompileInstance & instance)
     assertex(curFilename);
 
     Owned<ISourcePath> sourcePath = optNoSourcePath ? NULL : createSourcePath(curFilename);
-    Owned<IFileContents> queryText = createFileContentsFromFile(curFilename, sourcePath);
+    Owned<IFileContents> queryText = createFileContentsFromFile(curFilename, sourcePath, false);
     const char * queryTxt = queryText->getText();
     if (optArchive || optGenerateDepend)
         instance.archive.setown(createAttributeArchive());

--- a/ecl/hql/hqlcollect.hpp
+++ b/ecl/hql/hqlcollect.hpp
@@ -56,8 +56,6 @@ interface IEclSource : public IInterface
         EclSourceType type = queryType();
         return (type==ESTlibrary) || (type==ESTplugin);
     }
-    //virtual bool isPluginDllScope(IHqlScope * scope)
-    //virtual bool allowImplicitImport(IHqlScope * scope)
 };
 
 typedef IIteratorOf<IEclSource> IEclSourceIterator;

--- a/ecl/hql/hqlexpr.hpp
+++ b/ecl/hql/hqlexpr.hpp
@@ -836,6 +836,7 @@ public:
     virtual ISourcePath * querySourcePath() = 0;
     virtual const char * getText() = 0;
     virtual size32_t length() = 0;
+    virtual bool isImplicitlySigned() = 0;
 };
 
 //This class ensures that the pointer to the owner is cleared before both links are released, which allows
@@ -1840,11 +1841,11 @@ extern HQL_API ITypeInfo * getPromotedECLCompareType(ITypeInfo * lType, ITypeInf
 extern HQL_API void extendAdd(SharedHqlExpr & value, IHqlExpression * expr);
 inline bool isOmitted(IHqlExpression * actual) { return !actual || actual->getOperator() == no_omitted; }
 
-extern HQL_API IFileContents * createFileContentsFromText(unsigned len, const char * text, ISourcePath * sourcePath);
-extern HQL_API IFileContents * createFileContentsFromText(const char * text, ISourcePath * sourcePath);
-extern HQL_API IFileContents * createFileContentsFromFile(const char * filename, ISourcePath * sourcePath);
+extern HQL_API IFileContents * createFileContentsFromText(unsigned len, const char * text, ISourcePath * sourcePath, bool isSigned);
+extern HQL_API IFileContents * createFileContentsFromText(const char * text, ISourcePath * sourcePath, bool isSigned);
+extern HQL_API IFileContents * createFileContentsFromFile(const char * filename, ISourcePath * sourcePath, bool isSigned);
 extern HQL_API IFileContents * createFileContentsSubset(IFileContents * contents, size32_t offset, size32_t len);
-extern HQL_API IFileContents * createFileContents(IFile * file, ISourcePath * sourcePath);
+extern HQL_API IFileContents * createFileContents(IFile * file, ISourcePath * sourcePath, bool isSigned);
 
 void addForwardDefinition(IHqlScope * scope, IIdAtom * symbolName, IIdAtom * moduleName, IFileContents * contents,
                           unsigned symbolFlags, bool isExported, unsigned startLine, unsigned startColumn);

--- a/ecl/hql/hqlexpr.ipp
+++ b/ecl/hql/hqlexpr.ipp
@@ -461,11 +461,12 @@ private:
     MemoryAttr fileContents;
     Linked<ISourcePath> sourcePath;
     bool delayedRead;
+    bool implicitlySigned;
 
 public:
-    CFileContents(IFile * _file, ISourcePath * _sourcePath);
-    CFileContents(const char *query, ISourcePath * _sourcePath);
-    CFileContents(unsigned len, const char *query, ISourcePath * _sourcePath);
+    CFileContents(IFile * _file, ISourcePath * _sourcePath, bool _isSigned);
+    CFileContents(const char *query, ISourcePath * _sourcePath, bool _isSigned);
+    CFileContents(unsigned len, const char *query, ISourcePath * _sourcePath, bool _isSigned);
 
     virtual IFile * queryFile() { return file; }
     virtual ISourcePath * querySourcePath() { return sourcePath; }
@@ -480,7 +481,10 @@ public:
         ensureLoaded();
         return (size32_t)(fileContents.length()-1);
     }
-
+    virtual bool isImplicitlySigned()
+    {
+        return implicitlySigned;
+    }
 private:
     bool preloadFromFile();
     void ensureLoaded();

--- a/ecl/hql/hqlgram2.cpp
+++ b/ecl/hql/hqlgram2.cpp
@@ -343,7 +343,8 @@ HqlGram::HqlGram(IHqlScope * _globalScope, IHqlScope * _containerScope, IFileCon
     moduleName = _containerScope->queryId();
     forceResult = false;
     parsingTemplateAttribute = false;
-    inSignedModule = false;
+    inSignedModule = _text->isImplicitlySigned();
+;
 
     lexObject = new HqlLex(this, _text, xmlScope, NULL);
 
@@ -369,7 +370,7 @@ HqlGram::HqlGram(HqlGramCtx & parent, IHqlScope * _containerScope, IFileContents
     for (unsigned i=0;i<parent.defaultScopes.length();i++)
         defaultScopes.append(*LINK(&parent.defaultScopes.item(i)));
     sourcePath.set(parent.sourcePath);
-    inSignedModule = parent.inSignedModule;
+    inSignedModule = parent.inSignedModule || _text->isImplicitlySigned();
     errorHandler = lookupCtx.errs;
     moduleName = containerScope->queryId();
 
@@ -11619,7 +11620,7 @@ IHqlExpression * reparseTemplateFunction(IHqlExpression * funcdef, IHqlScope *sc
     text.append("=>").append(contents->length(), contents->getText());
 
     //Could use a merge string implementation of IFileContents instead of expanding...
-    Owned<IFileContents> parseContents = createFileContentsFromText(text.str(), contents->querySourcePath());
+    Owned<IFileContents> parseContents = createFileContentsFromText(text.str(), contents->querySourcePath(), contents->isImplicitlySigned());
     HqlGram parser(scope, scope, parseContents, ctx, NULL, hasFieldMap, true);
     unsigned startLine = funcdef->getStartLine();
 
@@ -11743,7 +11744,7 @@ extern HQL_API IHqlExpression * parseQuery(const char * text, IErrorReceiver * e
 {
     Owned<IHqlScope> scope = createScope();
     HqlDummyLookupContext ctx(errs);
-    Owned<IFileContents> contents = createFileContentsFromText(text, NULL);
+    Owned<IFileContents> contents = createFileContentsFromText(text, NULL, false);
     return parseQuery(scope, contents, ctx, NULL, NULL, true);
 }
 

--- a/ecl/hql/hqllex.l
+++ b/ecl/hql/hqllex.l
@@ -32,6 +32,7 @@
 #include "hqlgram.h"
 
 #define YY_DECL int HqlLex::doyyFlex(YYSTYPE & returnToken, yyscan_t yyscanner, HqlLex * lexer, bool lookup, const short * activeState)
+#define register
 
 //#define DEBUG_TOKEN 
 
@@ -1456,7 +1457,7 @@ FUNCTIONMACRO|MACRO {
                         Owned<IFileContents> macroContents;
                         if (!isFunctionMacro)
                         {
-                            macroContents.setown(createFileContentsFromText(len, lexer->yyBuffer+startpos, lexer->sourcePath));
+                            macroContents.setown(createFileContentsFromText(len, lexer->yyBuffer+startpos, lexer->sourcePath, lexer->yyParser->inSignedModule));
                         }
                         else
                         {
@@ -1470,7 +1471,7 @@ FUNCTIONMACRO|MACRO {
                             memcpy(macroBuf, prefix, lenPrefix);
                             memcpy(macroBuf + lenPrefix, lexer->yyBuffer+startpos, len);
                             memcpy(macroBuf + lenPrefix + len, suffix, lenSuffix);
-                            macroContents.setown(createFileContentsFromText(lenSuffix + len + lenPrefix, macroBuf, lexer->sourcePath));
+                            macroContents.setown(createFileContentsFromText(lenSuffix + len + lenPrefix, macroBuf, lexer->sourcePath,lexer->yyParser->inSignedModule));
                             free(macroBuf);
                         }
 

--- a/ecl/hql/hqlparse.cpp
+++ b/ecl/hql/hqlparse.cpp
@@ -317,7 +317,7 @@ void HqlLex::pushText(IFileContents * text, int startLineNo, int startColumn)
 
 void HqlLex::pushText(const char *s, int startLineNo, int startColumn)
 {
-    Owned<IFileContents> macroContents = createFileContentsFromText(s, sourcePath);
+    Owned<IFileContents> macroContents = createFileContentsFromText(s, sourcePath, yyParser->inSignedModule);
     pushText(macroContents, startLineNo, startColumn);
 }
 
@@ -327,7 +327,7 @@ void HqlLex::pushText(const char *s)
 #ifdef TIMING_DEBUG
     MTIME_SECTION(timer, "HqlLex::pushText");
 #endif
-    Owned<IFileContents> macroContents = createFileContentsFromText(s, sourcePath);
+    Owned<IFileContents> macroContents = createFileContentsFromText(s, sourcePath, yyParser->inSignedModule);
     inmacro = new HqlLex(yyParser, macroContents, NULL, NULL);
     inmacro->set_yyLineNo(yyLineNo);
     inmacro->set_yyColumn(yyColumn);
@@ -659,7 +659,7 @@ void HqlLex::processEncrypted()
     decryptEclAttribute(decrypted, encoded64.str());
     decrypted.append(0);    // add a null terminator to the string...
     Owned<ISourcePath> sourcePath = createSourcePath("<encrypted>");
-    Owned<IFileContents> decryptedContents = createFileContentsFromText((const char *)decrypted.toByteArray(), sourcePath);
+    Owned<IFileContents> decryptedContents = createFileContentsFromText((const char *)decrypted.toByteArray(), sourcePath, yyParser->inSignedModule);
     inmacro = new HqlLex(yyParser, decryptedContents, NULL, NULL);
     inmacro->setParentLex(this);
     inmacro->encrypted = true;
@@ -1077,7 +1077,7 @@ void HqlLex::doExport(YYSTYPE & returnToken, bool toXml)
         try
         {
             HqlLookupContext ctx(yyParser->lookupCtx);
-            Owned<IFileContents> exportContents = createFileContentsFromText(curParam.str(), sourcePath);
+            Owned<IFileContents> exportContents = createFileContentsFromText(curParam.str(), sourcePath, yyParser->inSignedModule);
             expr.setown(parseQuery(scope, exportContents, ctx, xmlScope, NULL, true));
 
             if (expr && (expr->getOperator() == no_sizeof))
@@ -1219,8 +1219,8 @@ void HqlLex::doFor(YYSTYPE & returnToken, bool doAll)
 
     forLoop = getSubScopes(returnToken, str(name), doAll);
     if (forFilterText.length())
-        forFilter.setown(createFileContentsFromText(forFilterText, sourcePath));
-    forBody.setown(createFileContentsFromText(forBodyText, sourcePath));
+        forFilter.setown(createFileContentsFromText(forFilterText, sourcePath, yyParser->inSignedModule));
+    forBody.setown(createFileContentsFromText(forBodyText, sourcePath, yyParser->inSignedModule));
 
     loopTimes = 0;
     if (forLoop && forLoop->first()) // more - check filter
@@ -1269,7 +1269,7 @@ void HqlLex::doLoop(YYSTYPE & returnToken)
     ::Release(forLoop);
     forLoop = new CDummyScopeIterator(ensureTopXmlScope());
     forFilter.clear();
-    forBody.setown(createFileContentsFromText(forBodyText, sourcePath));
+    forBody.setown(createFileContentsFromText(forBodyText, sourcePath, yyParser->inSignedModule));
     loopTimes = 0;
     if (forLoop->first()) // more - check filter
         checkNextLoop(returnToken, true,startLine,startCol);
@@ -1510,7 +1510,7 @@ void HqlLex::doIsValid(YYSTYPE & returnToken)
     {
         HqlLookupContext ctx(yyParser->lookupCtx);
         ctx.errs.clear();   //Deliberately ignore any errors
-        Owned<IFileContents> contents = createFileContentsFromText(curParam.str(), sourcePath);
+        Owned<IFileContents> contents = createFileContentsFromText(curParam.str(), sourcePath, yyParser->inSignedModule);
         expr = parseQuery(scope, contents, ctx, xmlScope, NULL, true);
 
         if(expr)
@@ -1788,7 +1788,7 @@ IHqlExpression *HqlLex::parseECL(IFileContents * contents, IXmlScope *xmlScope, 
 
 IHqlExpression *HqlLex::parseECL(const char * text, IXmlScope *xmlScope, int startLine, int startCol)
 {
-    Owned<IFileContents> contents = createFileContentsFromText(text, querySourcePath());
+    Owned<IFileContents> contents = createFileContentsFromText(text, querySourcePath(), yyParser->inSignedModule);
     return parseECL(contents, xmlScope, startLine, startCol);
 }
 

--- a/ecl/hql/hqlutil.cpp
+++ b/ecl/hql/hqlutil.cpp
@@ -8710,7 +8710,7 @@ IHqlExpression * expandMacroDefinition(IHqlExpression * expr, HqlLookupContext &
     //This might be cleaner if it was implemented by parsing the text myModule.myAttribute().
     //It would make implementing default parameters easy.  However it could introduce other problems
     //with implicitly importing myModule.
-    Owned<IFileContents> mappedContents = createFileContentsFromText(macroText.length(), macroText.str(), macroContents->querySourcePath());
+    Owned<IFileContents> mappedContents = createFileContentsFromText(macroText.length(), macroText.str(), macroContents->querySourcePath(), false);
     Owned<IHqlScope> scope = createPrivateScope();
     if (queryLegacyImportSemantics())
         importRootModulesToScope(scope, ctx);

--- a/ecl/hqlcpp/hqlcerrors.hpp
+++ b/ecl/hqlcpp/hqlcerrors.hpp
@@ -220,6 +220,7 @@
 #define HQLERR_InvalidXmlnsPrefix               4200
 #define HQLERR_ConditionalAggregateVarOffset    4201
 #define HQLERR_AggregateDynamicOffset           4202
+#define HQLERR_ServiceDefinitionNotAllowed      4203
 
 //Warnings....
 #define HQLWRN_PersistDataNotLikely             4500
@@ -515,6 +516,7 @@
 #define HQLERR_InvalidXmlnsPrefix_Text          "Invalid XMLNS prefix: %s"
 #define HQLERR_ConditionalAggregateVarOffset_Text "Conditional aggregate '%s' cannot follow a variable length field"
 #define HQLERR_AggregateDynamicOffset_Text      "Aggregate assignment to '%s' cannot follow variable size aggregate"
+#define HQLERR_ServiceDefinitionNotAllowed_Text "Insufficient access rights to use SERVICE"
 
 //Warnings.
 #define HQLWRN_CannotRecreateDistribution_Text  "Cannot recreate the distribution for a persistent dataset"

--- a/ecl/hqlcpp/hqlcpp.cpp
+++ b/ecl/hqlcpp/hqlcpp.cpp
@@ -1396,7 +1396,7 @@ HqlCppTranslator::HqlCppTranslator(IErrorReceiver * _errors, const char * _soNam
             HqlDummyLookupContext ctx(&errs);
             cppSystemScope = createScope();
             Owned<ISourcePath> sysPath = createSourcePath("<system-definitions>");
-            Owned<IFileContents> systemContents = createFileContentsFromText(systemText.str(), sysPath);
+            Owned<IFileContents> systemContents = createFileContentsFromText(systemText.str(), sysPath, true);
             OwnedHqlExpr query = parseQuery(cppSystemScope, systemContents, ctx, NULL, NULL, false);
             if (errs.errCount())
             {

--- a/ecl/hqlcpp/hqlwcpp.cpp
+++ b/ecl/hqlcpp/hqlwcpp.cpp
@@ -590,6 +590,8 @@ bool HqlCppWriter::generateFunctionPrototype(IHqlExpression * funcdef, const cha
 {
     IHqlExpression *body = funcdef->queryChild(0);
     IHqlExpression *formals = funcdef->queryChild(1);
+    if (body->hasAttribute(_disallowed_Atom))
+        throwError(HQLERR_ServiceDefinitionNotAllowed);
 
     if (body->hasAttribute(includeAtom) || body->hasAttribute(ctxmethodAtom) || body->hasAttribute(gctxmethodAtom) || body->hasAttribute(methodAtom) || body->hasAttribute(sysAtom) || body->hasAttribute(omethodAtom))
         return false;


### PR DESCRIPTION
This seems to be working ok, but will require either that we sign all plugins
explicitly, or that we make code loaded from plugins to be considered
"trusted" explicitly before it can be used.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
