### PR TITLE
HPCC-14915 Set USE_OPTIONAL to OFF if building a plugin

### DIFF
--- a/cmake_modules/commonSetup.cmake
+++ b/cmake_modules/commonSetup.cmake
@@ -121,6 +121,7 @@ IF ("${COMMONSETUP_DONE}" STREQUAL "")
         set(CLIENTTOOLS OFF)
         set(PLATFORM OFF)
         set(TEST_PLUGINS OFF)
+        set(USE_OPTIONAL OFF) # Force failure if we can't find the plugin dependencies
     endif()
 
     if(REMBED)


### PR DESCRIPTION
Building a plugin, but failing to find the necessary dependency packages for that plugin, will now cause a fatal error.  Before it was possible to build a plugin package containing no shared object for the specified plugin.

Signed-off-by: Michael Gardner michael.gardner@lexisnexis.com
