### PR TITLE
HPCC-14935 QuerySetQuery not loading

### DIFF
--- a/esp/src/eclwatch/QuerySetQueryWidget.js
+++ b/esp/src/eclwatch/QuerySetQueryWidget.js
@@ -350,7 +350,7 @@ define([
                         }
                     },
                     Name: {
-                        label: this.i18n.Name,
+                        label: this.i18n.Name
                     },
                     QuerySetId:{
                         width: 140,


### PR DESCRIPTION
Remove extra comma within the grid to fix loading issue.

Signed-off by: Miguel Vazquez miguel.vazquez@lexisnexis.com
