### PR TITLE
HPCC-14932 CMake does not validate build type properly

### DIFF
--- a/cmake_modules/commonSetup.cmake
+++ b/cmake_modules/commonSetup.cmake
@@ -248,7 +248,7 @@ IF ("${COMMONSETUP_DONE}" STREQUAL "")
 
   if ("${CMAKE_BUILD_TYPE}" STREQUAL "")
     set ( CMAKE_BUILD_TYPE "Release" )
-  elseif (NOT "${CMAKE_BUILD_TYPE}" MATCHES "Debug|Release|RelWithDebInfo")
+  elseif (NOT "${CMAKE_BUILD_TYPE}" MATCHES "^Debug$|^Release$|^RelWithDebInfo$")
     message (FATAL_ERROR "Unknown build type ${CMAKE_BUILD_TYPE}")
   endif ()
   message ("-- Making ${CMAKE_BUILD_TYPE} system")


### PR DESCRIPTION
Signed-off-by: Richard Chapman rchapman@hpccsystems.com
