### PR TITLE
HPCC-14944 Return PercentCompressed in WsDfu.DFUInfo

### DIFF
--- a/esp/scm/ws_dfu.ecm
+++ b/esp/scm/ws_dfu.ecm
@@ -133,6 +133,7 @@ ESPStruct [nil_remove] DFUFileDetail
     [min_ver("1.09")] string UserPermission;
     [min_ver("1.21")] string ContentType;
     [min_ver("1.22")] int64 CompressedFileSize;
+    [min_ver("1.34")] string PercentCompressed;
     [min_ver("1.22")] bool IsCompressed(false);
     [min_ver("1.28")] bool BrowseData(true);
 };
@@ -699,7 +700,7 @@ ESPresponse [exceptions_inline, nil_remove, http_encode(0)] DFUGetFileMetaDataRe
 
 //  ===========================================================================
 ESPservice [
-    version("1.33"),
+    version("1.34"),
     noforms, 
     exceptions_inline("./smc_xslt/exceptions.xslt")] WsDfu
 {

--- a/esp/services/ws_dfu/CMakeLists.txt
+++ b/esp/services/ws_dfu/CMakeLists.txt
@@ -47,6 +47,7 @@ include_directories (
          ./../ws_topology 
          ./../../../system/jlib 
          ./../../../rtl/eclrtl 
+         ./../../../rtl/nbcd
          ./../../../common/environment 
          ./../../services 
          ./../../../dali/ft 

--- a/esp/services/ws_dfu/ws_dfuService.cpp
+++ b/esp/services/ws_dfu/ws_dfuService.cpp
@@ -44,6 +44,7 @@
 #include "roxiecommlibscm.hpp"
 #include "dfuwu.hpp"
 #include "fverror.hpp"
+#include "nbcd.hpp"
 
 #include "jstring.hpp"
 #include "exception_util.hpp"
@@ -1874,7 +1875,16 @@ void CWsDfuEx::doGetFileDetails(IEspContext &context, IUserDescriptor* udesc, co
         {
             FileDetails.setIsCompressed(true);
             if (df->queryAttributes().hasProp("@compressedSize"))
-                FileDetails.setCompressedFileSize(df->queryAttributes().getPropInt64("@compressedSize"));
+            {
+                __int64 compressedSize = df->queryAttributes().getPropInt64("@compressedSize");
+                FileDetails.setCompressedFileSize(compressedSize);
+                if (version >= 1.34)
+                {
+                    Decimal d(((double) compressedSize)/size*100);
+                    d.round(2);
+                    FileDetails.setPercentCompressed(d.getCString());
+                }
+            }
         }
     }
 


### PR DESCRIPTION
The code is added in WsDfu.DFUInfo to return PercentCompressed
for compressed logical files.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
