### PR TITLE
HPCC-14165 LDAP compare on 389 DirectoryServer fails

### DIFF
--- a/system/security/LdapSecurity/ldapconnection.cpp
+++ b/system/security/LdapSecurity/ldapconnection.cpp
@@ -2493,6 +2493,10 @@ public:
         LDAP* ld = ((CLdapConnection*)lconn.get())->getLd();
 
         int rc = LDAP_COMPARE_EXT_S(ld, (const char*)groupdn, (const char*)fldname, (const char*)userdn,0,0,0);
+#ifndef _WIN32
+        if (rc == -3)//389DirectoryServer always seems to return -3
+            rc = ldap_compare_s(ld, groupdn, fldname, userdn);
+#endif
         if(rc == LDAP_COMPARE_TRUE)
             return true;
         else
@@ -2642,9 +2646,17 @@ public:
             Owned<ILdapConnection> lconn = m_connections->getConnection();
             LDAP* ld = ((CLdapConnection*)lconn.get())->getLd();
             int compresult = LDAP_COMPARE_EXT_S(ld, (const char*)userdn.str(), (const char*)"objectclass", (const char*)"posixAccount",0,0,0);
+#ifndef _WIN32
+            if (compresult == -3)//389DirectoryServer always seems to return -3
+                compresult = ldap_compare_s(ld, groupdn, fldname, userdn);
+#endif
             if(compresult != LDAP_COMPARE_TRUE)
                 attrs[ind++] = &oc_attr;
             compresult = LDAP_COMPARE_EXT_S(ld, (const char*)userdn.str(), (const char*)"objectclass", (const char*)"shadowAccount",0,0,0);
+#ifndef _WIN32
+            if (compresult == -3)//389DirectoryServer always seems to return -3
+                compresult = ldap_compare_s(ld, groupdn, fldname, userdn);
+#endif
             if(compresult != LDAP_COMPARE_TRUE)
                 attrs[ind++] = &oc1_attr;
             attrs[ind] = NULL;
@@ -2658,6 +2670,10 @@ public:
             Owned<ILdapConnection> lconn = m_connections->getConnection();
             LDAP* ld = ((CLdapConnection*)lconn.get())->getLd();
             int compresult = LDAP_COMPARE_EXT_S(ld, (const char*)userdn.str(), (const char*)"objectclass", (const char*)"posixAccount",0,0,0);
+#ifndef _WIN32
+            if (compresult == -3)//389DirectoryServer always seems to return -3
+                compresult = ldap_compare_s(ld, groupdn, fldname, userdn);
+#endif
             if(compresult != LDAP_COMPARE_TRUE)
             {
                 rc = LDAP_SUCCESS;


### PR DESCRIPTION
Using 389DirectoryServer, when determining whether or not a user is a member
of a group (user/MemberOf), the security manager calls ldap_compare_ext_s.
However, this call is returning -3, which is not a valid LDAP return code.
This PR checks for that condition (only if not WinLDAP) and if it gets the
-3, it calls the legacy ldap_compare_s which works fine.

Signed-off-by: Russ Whitehead william.whitehead@lexisnexis.com
