### PR TITLE
HPCC-14937 Remove old permission type: ExecuteAccess

### DIFF
--- a/docs/Installing_and_RunningTheHPCCPlatform/Inst-Mods/UserSecurityMaint.xml
+++ b/docs/Installing_and_RunningTheHPCCPlatform/Inst-Mods/UserSecurityMaint.xml
@@ -1406,14 +1406,6 @@
 
                   <entry>Read</entry>
                 </row>
-
-                <row>
-                  <entry>ExecuteAccess</entry>
-
-                  <entry>Access to Remote Execution in ECL Watch</entry>
-
-                  <entry>Full</entry>
-                </row>
               </tbody>
             </tgroup>
           </informaltable></para>

--- a/esp/scm/ws_machine.ecm
+++ b/esp/scm/ws_machine.ecm
@@ -393,14 +393,6 @@ ESPservice [version("1.13")] ws_machine
 
     ESPmethod [resp_xsl_default("./smc_xslt/ws_machine/metrics.xslt"), exceptions_inline("./smc_xslt/exceptions.xslt")] 
        GetMetrics(MetricsRequest, MetricsResponse);
-
-    ESPmethod [resp_xsl_default("./smc_xslt/ws_machine/StartStopBegin.xslt"), exceptions_inline("./smc_xslt/exceptions.xslt")]
-       StartStopBegin(StartStopBeginRequest, StartStopBeginResponse);
-
-    ESPmethod [resp_xsl_default("./smc_xslt/ws_machine/StartStopDone.xslt"), exceptions_inline("./smc_xslt/exceptions.xslt")]
-        StartStopDone(StartStopDoneRequest, StartStopResponse);
-
-    ESPmethod StartStop(StartStopRequest, StartStopResponse);
 };
 
 

--- a/esp/services/ws_smc/espsmc_permissions.txt
+++ b/esp/services/ws_smc/espsmc_permissions.txt
@@ -74,8 +74,6 @@ ws_machine:
         Read - GetMachineInfo
     MetricsAccess: 
         Read - Access to SNMP metrics information
-    ExecuteAccess: 
-        Full - access to remote execution of commands and start/stop
 
 ws_workunits:
     OwnWorkunitsAccess: 

--- a/initfiles/componentfiles/configxml/buildsetCC.xml.in
+++ b/initfiles/componentfiles/configxml/buildsetCC.xml.in
@@ -137,10 +137,6 @@
                           path="MetricsAccess"
                           resource="MetricsAccess"
                           service="ws_machine"/>
-     <AuthenticateFeature description="Access to remote execution"
-                          path="ExecuteAccess"
-                          resource="ExecuteAccess"
-                          service="ws_machine"/>
      <AuthenticateFeature description="Access to DFU workunits"
                           path="DfuWorkunitsAccess"
                           resource="DfuWorkunitsAccess"


### PR DESCRIPTION
Remote Execution via ECL Watch was removed. But, ECLWatch
still shows its feature authentication type due to old
code inside configuration scripts.

This fix also removes three ExecuteAccess related methods from
ws_machine wsdl: StartStop, StartStopBegin, StartStopDone.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
