### PR TITLE
HPCC-14956 ConfigMgr crashes when using wizard

### DIFF
--- a/deployment/deployutils/wizardInputs.cpp
+++ b/deployment/deployutils/wizardInputs.cpp
@@ -1092,6 +1092,9 @@ void CWizardInputs::checkForDependencies()
       if((!strcmp(buildSetName,"roxie") && m_roxieNodes == 0 )|| (!strcmp(buildSetName,"thor")&& m_thorNodes == 0)){
           numOfNodesNeeded = 0;
           m_doNotGenComp.append(buildSetName);
+          m_compForTopology.remove("thor_roxie");
+          if (!strcmp(buildSetName,"thor"))
+             m_compForTopology.remove("thor");
       }
 
       if(numOfNodesNeeded == 0 || (m_doNotGenComp.find(buildSetName) != NotFound))


### PR DESCRIPTION
- The clusters defined in genenvrules.conf are the default set that is created when using the wizard.  Some of the default clusters require either or roxie or thor component as part of the cluster.  When a user specifies 0 thors and/or roxies the ConfigMgr will crash when attempting to reference the undefined instances during configuration generation.  This check will remove the default clusters that do not have the available roxie and/or thor components.

Signed-off-by: Gleb Aronsky gleb.aronsky@lexisnexis.com
