### PR TITLE
HPCC-14503 STD.system.Thorlib.group() errors out on roxie platform

### DIFF
--- a/roxie/ccd/ccdcontext.cpp
+++ b/roxie/ccd/ccdcontext.cpp
@@ -3767,7 +3767,10 @@ public:
                 Owned<IConstWUClusterInfo> clusterInfo = getTargetClusterInfo(cluster);
                 if (!clusterInfo)
                     throw MakeStringException(-1, "Unknown cluster '%s'", cluster);
-                clusterWidth = clusterInfo->getSize();
+                if (clusterInfo->getPlatform() == RoxieCluster)
+                    clusterWidth = numChannels;  // We assume it's the current roxie - that's ok so long as roxie's don't call other roxies.
+                else
+                    clusterWidth = clusterInfo->getSize();
             }
             return clusterWidth;
         }


### PR DESCRIPTION
Make sure Roxie returns numChannels for nodes() as before.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
