### PR TITLE
HPCC-14924 Fixes for dpkg-shlibdeps conflicting with imported libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -419,16 +419,4 @@ if(PLATFORM OR CLIENTTOOLS OR REMBED)
     install(FILES ${HPCC_SOURCE_DIR}/${LICENSE_FILE} DESTINATION "." COMPONENT Runtime)
 endif()
 
-if(USE_SHLIBDEPS AND "${packageManagement}" STREQUAL "DEB")
-    install(CODE "
-            execute_process(COMMAND mkdir -p ${INSTALL_DIR}
-                            WORKING_DIRECTORY ${PREFIX})
-            if(EXISTS \"${INSTALL_DIR}/lib\")
-                execute_process(COMMAND rm -f lib
-                                WORKING_DIRECTORY ${INSTALL_DIR})
-            endif()
-            execute_process(COMMAND ln -sf ${CMAKE_BINARY_DIR}/_CPack_Packages/${CPACK_SYSTEM_NAME}/${CPACK_GENERATOR}/${CPACK_PACKAGE_FILE_NAME}${INSTALL_DIR}/lib lib
-                            WORKING_DIRECTORY ${INSTALL_DIR})"
-    COMPONENT Runtime)
-endif()
 include(CPack)

--- a/cmake_modules/commonSetup.cmake
+++ b/cmake_modules/commonSetup.cmake
@@ -221,8 +221,8 @@ IF ("${COMMONSETUP_DONE}" STREQUAL "")
       set(DEVEL OFF)
   endif()
 
-    # Leave REMBED OFF for compliance with licensing
     if(TEST_PLUGINS)
+        set(REMBED ON)
         set(V8EMBED ON)
         set(MEMCACHED ON)
         set(PYEMBED ON)
@@ -474,70 +474,68 @@ IF ("${COMMONSETUP_DONE}" STREQUAL "")
 
   set ( SCM_GENERATED_DIR ${CMAKE_BINARY_DIR}/generated )
 
-  ###############################################################
-  # Macro for Logging Plugin build in CMake
+    ###############################################################
+    # Macro for Logging Plugin build in CMake
 
-  macro(LOG_PLUGIN)
-    PARSE_ARGUMENTS(pLOG
-      "OPTION;MDEPS"
-      ""
-      ${ARGN}
-    )
-    LIST(GET pLOG_DEFAULT_ARGS 0 PLUGIN_NAME)
-    if ( ${pLOG_OPTION} )
-        message(STATUS "Building Plugin: ${PLUGIN_NAME}" )
-    else()
-      message("---- WARNING -- Not Building Plugin: ${PLUGIN_NAME}")
-      foreach (dep ${pLOG_MDEPS})
-        MESSAGE("---- WARNING -- Missing dependency: ${dep}")
-      endforeach()
-      if (NOT USE_OPTIONAL)
-        message(FATAL_ERROR "Optional dependencies missing and USE_OPTIONAL not set")
-      endif()
-    endif()
-  endmacro()
-
-  ###############################################################
-  # Macro for adding an optional plugin to the CMake build.
-
-  macro(ADD_PLUGIN)
-    PARSE_ARGUMENTS(PLUGIN
-        "PACKAGES;OPTION;MINVERSION;MAXVERSION"
+    macro(LOG_PLUGIN)
+        PARSE_ARGUMENTS(pLOG
+        "OPTION;MDEPS"
         ""
-        ${ARGN}
-    )
-    LIST(GET PLUGIN_DEFAULT_ARGS 0 PLUGIN_NAME)
-    string(TOUPPER ${PLUGIN_NAME} name)
-    set(ALL_PLUGINS_FOUND 1)
-    set(PLUGIN_MDEPS ${PLUGIN_NAME}_mdeps)
-    set(${PLUGIN_MDEPS} "")
-
-    FOREACH(package ${PLUGIN_PACKAGES})
-      set(findvar ${package}_FOUND)
-      string(TOUPPER ${findvar} PACKAGE_FOUND)
-      if ("${PLUGIN_MINVERSION}" STREQUAL "")
-        find_package(${package})
-      else()
-        set(findvar ${package}_VERSION_STRING)
-        string(TOUPPER ${findvar} PACKAGE_VERSION_STRING)
-        find_package(${package} ${PLUGIN_MINVERSION} )
-        if ("${${PACKAGE_VERSION_STRING}}" VERSION_GREATER "${PLUGIN_MAXVERSION}")
-          set(${ALL_PLUGINS_FOUND} 0)
+        ${ARGN})
+        LIST(GET pLOG_DEFAULT_ARGS 0 PLUGIN_NAME)
+        if(${pLOG_OPTION})
+            message(STATUS "Building Plugin: ${PLUGIN_NAME}" )
+        else()
+            message(WARNING "Not Building Plugin: ${PLUGIN_NAME}")
+            foreach (dep ${pLOG_MDEPS})
+                message(WARNING "Missing dependency: ${dep}")
+            endforeach()
+            if(NOT USE_OPTIONAL)
+                message(FATAL_ERROR "Optional dependencies missing and USE_OPTIONAL OFF")
+            endif()
         endif()
-      endif()
-      if (NOT ${PACKAGE_FOUND})
-        set(ALL_PLUGINS_FOUND 0)
-        set(${PLUGIN_MDEPS} ${${PLUGIN_MDEPS}} ${package})
-      endif()
-    ENDFOREACH()
-    option(${PLUGIN_OPTION} "Turn on optional plugin based on availability of dependencies" ${ALL_PLUGINS_FOUND})
-    LOG_PLUGIN(${PLUGIN_NAME} OPTION ${PLUGIN_OPTION} MDEPS ${${PLUGIN_MDEPS}})
-    if(${ALL_PLUGINS_FOUND})
-      set(bPLUGINS ${bPLUGINS} ${PLUGIN_NAME})
-    else()
-      set(nbPLUGINS ${nbPLUGINS} ${PLUGIN_NAME})
-    endif()
-  endmacro()
+    endmacro()
+
+    ###############################################################
+    # Macro for adding an optional plugin to the CMake build.
+
+    macro(ADD_PLUGIN)
+        PARSE_ARGUMENTS(PLUGIN
+            "PACKAGES;MINVERSION;MAXVERSION"
+            ""
+            ${ARGN})
+        LIST(GET PLUGIN_DEFAULT_ARGS 0 PLUGIN_NAME)
+        string(TOUPPER ${PLUGIN_NAME} name)
+        set(ALL_PLUGINS_FOUND 1)
+        set(PLUGIN_MDEPS ${PLUGIN_NAME}_mdeps)
+        set(${PLUGIN_MDEPS} "")
+
+        foreach(package ${PLUGIN_PACKAGES})
+            set(findvar ${package}_FOUND)
+            string(TOUPPER ${findvar} PACKAGE_FOUND)
+            if("${PLUGIN_MINVERSION}" STREQUAL "")
+                find_package(${package})
+            else()
+                set(findvar ${package}_VERSION_STRING)
+                string(TOUPPER ${findvar} PACKAGE_VERSION_STRING)
+                find_package(${package} ${PLUGIN_MINVERSION} )
+                if ("${${PACKAGE_VERSION_STRING}}" VERSION_GREATER "${PLUGIN_MAXVERSION}")
+                    set(${ALL_PLUGINS_FOUND} 0)
+                endif()
+            endif()
+            if(NOT ${PACKAGE_FOUND})
+                set(ALL_PLUGINS_FOUND 0)
+                set(${PLUGIN_MDEPS} ${${PLUGIN_MDEPS}} ${package})
+            endif()
+        endforeach()
+        set(MAKE_${name} ${ALL_PLUGINS_FOUND})
+        LOG_PLUGIN(${PLUGIN_NAME} OPTION ${ALL_PLUGINS_FOUND} MDEPS ${${PLUGIN_MDEPS}})
+        if(${ALL_PLUGINS_FOUND})
+            set(bPLUGINS ${bPLUGINS} ${PLUGIN_NAME})
+        else()
+            set(nbPLUGINS ${nbPLUGINS} ${PLUGIN_NAME})
+        endif()
+    endmacro()
 
   ##################################################################
 
@@ -560,13 +558,13 @@ IF ("${COMMONSETUP_DONE}" STREQUAL "")
 
   ###########################################################################
 
-  if (USE_OPTIONAL)
-    message ("-- USE_OPTIONAL set - missing dependencies for optional features will automatically disable them")
-  endif()
+    if(USE_OPTIONAL)
+        message(WARNING "USE_OPTIONAL set - missing dependencies for optional features will automatically disable them")
+    endif()
 
-  if (NOT "${EXTERNALS_DIRECTORY}" STREQUAL "")
-    message ("-- Using externals directory at ${EXTERNALS_DIRECTORY}")
-  endif()
+    if(NOT "${EXTERNALS_DIRECTORY}" STREQUAL "")
+        message(STATUS "Using externals directory at ${EXTERNALS_DIRECTORY}")
+    endif()
 
   IF ( NOT MAKE_DOCS_ONLY )
       IF ("${EXTERNALS_DIRECTORY}" STREQUAL "")

--- a/plugins/Rembed/CMakeLists.txt
+++ b/plugins/Rembed/CMakeLists.txt
@@ -25,7 +25,7 @@
 project(Rembed)
 
 if(REMBED)
-    ADD_PLUGIN(Rembed PACKAGES R OPTION MAKE_REMBED)
+    ADD_PLUGIN(Rembed PACKAGES R)
     if(MAKE_REMBED)
         set(
             SRCS

--- a/plugins/cassandra/CMakeLists.txt
+++ b/plugins/cassandra/CMakeLists.txt
@@ -27,112 +27,116 @@ project(cassandraembed)
 if(CASSANDRAEMBED)
     # There is not yet a standard package for cassandra cpp client, and only very modern distros have libuv-dev
     # When there is (and the distros catch up) we may want to add them as dependencies here
-    ADD_PLUGIN(cassandraembed PACKAGES OPTION MAKE_CASSANDRAEMBED)
+    ADD_PLUGIN(cassandraembed)
     if(MAKE_CASSANDRAEMBED)
 
-        # until then, we build the required libraries from source
-        # Build libuv, required by the cassandra driver but not available on all distros
-        if(APPLE)
-            add_custom_command(
-                OUTPUT ${PROJECT_BINARY_DIR}/libuv.dylib
-                COMMAND make builddir_name=${PROJECT_BINARY_DIR}
-                WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/libuv)
-            add_custom_target(
-                libuv ALL
-                DEPENDS ${PROJECT_BINARY_DIR}/libuv.dylib)
-            set(LIBUV_LIBRARY ${PROJECT_BINARY_DIR}/libuv.dylib)
-        else()
-            add_custom_command(
-                OUTPUT ${PROJECT_BINARY_DIR}/libuv.so
-                COMMAND make builddir_name=${PROJECT_BINARY_DIR}
-                COMMAND mv ${PROJECT_BINARY_DIR}/libuv.so ${PROJECT_BINARY_DIR}/libuv.so.0.10
-                COMMAND ln -s ${PROJECT_BINARY_DIR}/libuv.so.0.10 ${PROJECT_BINARY_DIR}/libuv.so
-                WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/libuv)
-            add_custom_target(
-                libuv ALL
-                DEPENDS ${PROJECT_BINARY_DIR}/libuv.so)
-            set(LIBUV_LIBRARY ${PROJECT_BINARY_DIR}/libuv.so)
-        endif()
-        set(LIBUV_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/libuv/include/)
+    set(
+        LIBUV_SRCS
+        libuv/src/unix/async.c
+        libuv/src/unix/core.c
+        libuv/src/unix/dl.c
+        libuv/src/unix/error.c
+        libuv/src/unix/fs.c
+        libuv/src/unix/getaddrinfo.c
+        libuv/src/unix/loop.c
+        libuv/src/unix/loop-watcher.c
+        libuv/src/unix/pipe.c
+        libuv/src/unix/poll.c
+        libuv/src/unix/process.c
+        libuv/src/unix/signal.c
+        libuv/src/unix/stream.c
+        libuv/src/unix/tcp.c
+        libuv/src/unix/thread.c
+        libuv/src/unix/threadpool.c
+        libuv/src/unix/timer.c
+        libuv/src/unix/tty.c
+        libuv/src/unix/udp.c
+        libuv/src/fs-poll.c
+        libuv/src/uv-common.c
+        libuv/src/inet.c
+        libuv/src/version.c
+        libuv/src/unix/linux-core.c
+        libuv/src/unix/linux-inotify.c
+        libuv/src/unix/linux-syscalls.c
+        libuv/src/unix/proctitle.c)
 
-        # Build the Cassandra cpp driver, only presently available as source
-        if(NOT EXISTS "${PROJECT_SOURCE_DIR}/cpp-driver/CMakeLists.txt")
-            message(FATAL_ERROR
+    HPCC_ADD_LIBRARY(uv SHARED ${LIBUV_SRCS})
+    target_compile_options(uv PRIVATE --std=c89 -pedantic -Wall -Wextra -Wno-unused-parameter -g -fPIC -c)
+    target_compile_definitions(uv PRIVATE -D_GNU_SOURCE -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64)
+    set(LIBUV_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/libuv/include/)
+    set(LIBUV_LIBRARY $<TARGET_FILE:uv>)
+
+    # Build the Cassandra cpp driver, only presently available as source
+    if(NOT EXISTS "${PROJECT_SOURCE_DIR}/cpp-driver/CMakeLists.txt")
+        message(FATAL_ERROR
 "   The cpp-driver submodule is not available.
    This normally indicates that the git submodule has not been fetched.
    Please run git submodule update --init --recursive")
+    endif()
+
+    option(CASS_INSTALL_HEADER "Install header file" OFF)
+    option(CASS_BUILD_STATIC "Build static library" OFF)
+    option(CASS_BUILD_EXAMPLES "Build examples" OFF)
+    set_property(GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS FALSE)
+    set(_SAVE_CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+    if(NOT WIN32)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-format-nonliteral") # Work around cassandra build error
+    endif()
+    add_subdirectory(cpp-driver)
+    add_dependencies(cassandra uv)
+    set(CMAKE_CXX_FLAGS "${_SAVE_CMAKE_CXX_FLAGS}")
+
+    set(
+        SRCS
+        cassandraembed.cpp
+        cassandrawu.cpp)
+
+    include_directories(
+        ./../../system/include
+        ./../../rtl/eclrtl
+        ./../../roxie/roxiemem
+        ./../../rtl/include
+        ./../../rtl/nbcd
+        ./../../common/deftype
+        ./../../common/workunit
+        ./../../system/jlib
+        ./../../system/security/shared 
+        ./../../system/mp
+        ./../../dali/base 
+        ./cpp-driver/include
+        ./libuv/src
+        ./libuv/include
+        ./libuv/include/uv-private)
+
+    add_definitions(-D_USRDLL -DCASSANDRAEMBED_EXPORTS)
+
+    HPCC_ADD_LIBRARY(cassandraembed SHARED ${SRCS})
+    if(NOT FORCE_WORKUNITS_TO_CASSANDRA)
+        if(${CMAKE_VERSION} VERSION_LESS "2.8.9")
+            message(WARNING "Cannot set NO_SONAME. shlibdeps will give warnings when package is installed")
+        elseif(NOT APPLE)
+            set_target_properties(cassandraembed PROPERTIES NO_SONAME 1)
         endif()
+    endif()
 
-        option(CASS_INSTALL_HEADER "Install header file" OFF)
-        option(CASS_BUILD_STATIC "Build static library" OFF)
-        option(CASS_BUILD_EXAMPLES "Build examples" OFF)
-        set_property(GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS FALSE)
-        set(_SAVE_CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-        if(NOT WIN32)
-            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-format-nonliteral") # Work around cassandra build error
-        endif()
-        add_subdirectory(cpp-driver ${PROJECT_BINARY_DIR}/cassandra)
-        add_dependencies(cassandra libuv)
-        set(CMAKE_CXX_FLAGS "${_SAVE_CMAKE_CXX_FLAGS}")
+    install(
+        TARGETS cassandraembed
+        DESTINATION plugins
+        COMPONENT Runtime)
+    install(
+        TARGETS uv
+        DESTINATION ${LIB_DIR}
+        COMPONENT Runtime)
 
-        set(
-            SRCS
-            cassandraembed.cpp
-            cassandrawu.cpp)
-
-        include_directories(
-            ./../../system/include
-            ./../../rtl/eclrtl
-            ./../../roxie/roxiemem
-            ./../../rtl/include
-            ./../../rtl/nbcd
-            ./../../common/deftype
-            ./../../common/workunit
-            ./../../system/jlib
-            ./../../system/security/shared 
-            ./../../system/mp
-            ./../../dali/base 
-            ./cpp-driver/include)
-
-        add_definitions(-D_USRDLL -DCASSANDRAEMBED_EXPORTS)
-
-        HPCC_ADD_LIBRARY(cassandraembed SHARED ${SRCS})
-        if(NOT FORCE_WORKUNITS_TO_CASSANDRA)
-            if(${CMAKE_VERSION} VERSION_LESS "2.8.9")
-                message(WARNING "Cannot set NO_SONAME. shlibdeps will give warnings when package is installed")
-            elseif(NOT APPLE)
-                set_target_properties(cassandraembed PROPERTIES NO_SONAME 1)
-            endif()
-        endif()
-
-        install(
-            TARGETS cassandraembed
-            DESTINATION plugins
-            COMPONENT Runtime )
-        # until such time as the cassandra cpp driver and libuv are available as standard in all distros we want to support,
-        # include them in our rpm
-        # Note that the cassandra driver CMake file already includes the relevant install commands
-
-        if(APPLE)
-            install(
-                FILES ${PROJECT_BINARY_DIR}/libuv.dylib
-                DESTINATION ${LIB_DIR}
-                COMPONENT Runtime)
-        else()
-            install(
-                FILES ${PROJECT_BINARY_DIR}/libuv.so.0.10
-                DESTINATION ${LIB_DIR}
-                COMPONENT Runtime)
-        endif()
-
-        target_link_libraries(
-            cassandraembed
-            cassandra
-            eclrtl
-            roxiemem
-            dalibase
-            workunit
-            jlib)
+    target_link_libraries(
+        cassandraembed
+        uv
+        cassandra
+        eclrtl
+        roxiemem
+        dalibase
+        workunit
+        jlib)
     endif()
 endif()
 

--- a/plugins/javaembed/CMakeLists.txt
+++ b/plugins/javaembed/CMakeLists.txt
@@ -26,7 +26,7 @@
 project(javaembed)
 
 if(JAVAEMBED)
-    ADD_PLUGIN(javaembed PACKAGES JNI OPTION MAKE_JAVAEMBED)
+    ADD_PLUGIN(javaembed PACKAGES JNI)
     if(MAKE_JAVAEMBED)
         set(
             SRCS

--- a/plugins/kafka/CMakeLists.txt
+++ b/plugins/kafka/CMakeLists.txt
@@ -25,9 +25,8 @@
 project(kafka)
 
 if(KAFKA)
-    ADD_PLUGIN(kafka PACKAGES OPTION MAKE_KAFKA)
+    ADD_PLUGIN(kafka)
     if(MAKE_KAFKA)
-
         # librdkafka packages do not include everything we need to properly
         # build against it; until/if they are ever fixed we will need to build
         # our own version of librdkafka from source and include it ourselves
@@ -39,40 +38,36 @@ if(KAFKA)
    Please run git submodule update --init --recursive")
         endif()
 
-        if(APPLE)
-            set(LIBRDKAFKA_LIB ${PROJECT_BINARY_DIR}/lib/librdkafka.dylib)
-            set(LIBRDKAFKA_LIB_REAL ${PROJECT_BINARY_DIR}/lib/librdkafka.1.dylib)
-            set(LIBRDKAFKACPP_LIB ${PROJECT_BINARY_DIR}/lib/librdkafka++.dylib)
-            set(LIBRDKAFKACPP_LIB_REAL ${PROJECT_BINARY_DIR}/lib/librdkafka++.1.dylib)
-        else()
-            set(LIBRDKAFKA_LIB ${PROJECT_BINARY_DIR}/lib/librdkafka.so)
-            set(LIBRDKAFKA_LIB_REAL ${PROJECT_BINARY_DIR}/lib/librdkafka.so.1)
-            set(LIBRDKAFKACPP_LIB ${PROJECT_BINARY_DIR}/lib/librdkafka++.so)
-            set(LIBRDKAFKACPP_LIB_REAL ${PROJECT_BINARY_DIR}/lib/librdkafka++.so.1)
-        endif()
+        set(
+            LIBRDKAFKA_SRCS
+            librdkafka/src/rdkafka.c
+            librdkafka/src/rdkafka_broker.c
+            librdkafka/src/rdkafka_msg.c
+            librdkafka/src/rdkafka_topic.c
+            librdkafka/src/rdkafka_defaultconf.c
+            librdkafka/src/rdkafka_timer.c
+            librdkafka/src/rdkafka_offset.c
+            librdkafka/src/rdcrc32.c
+            librdkafka/src/rdgz.c
+            librdkafka/src/rdaddr.c
+            librdkafka/src/rdrand.c
+            librdkafka/src/rdthread.c
+            librdkafka/src/rdqueue.c
+            librdkafka/src/rdlog.c
+            librdkafka/src/snappy.c
+            librdkafka/src/rdkafka.h)
 
-        # librdkafka does not support out-of-source builds, so let's copy all
-        # of its source code to our binary directory and build there; further,
-        # we need to pull some working directory shenanigans for each command
-        # in order to make the built scripts function correctly
-
-        add_custom_command(
-            OUTPUT ${LIBRDKAFKA_LIB}
-            COMMAND cp -r ${PROJECT_SOURCE_DIR}/librdkafka ${PROJECT_BINARY_DIR}/src
-            COMMAND cd ${PROJECT_BINARY_DIR}/src && ./configure --prefix=${PROJECT_BINARY_DIR}
-            COMMAND cd ${PROJECT_BINARY_DIR}/src && make && make install
-            COMMENT Copying and building librdkafka)
-
-        add_custom_target(librdkafka-build ALL DEPENDS ${LIBRDKAFKA_LIB})
-
-        # Add both libraries from librdkafka
-        add_library(librdkafka SHARED IMPORTED)
-        set_property(TARGET librdkafka PROPERTY IMPORTED_LOCATION ${LIBRDKAFKA_LIB})
-        add_dependencies(librdkafka librdkafka-build)
-
-        add_library(librdkafkacpp STATIC IMPORTED)
-        set_property(TARGET librdkafkacpp PROPERTY IMPORTED_LOCATION ${LIBRDKAFKACPP_LIB})
-        add_dependencies(librdkafkacpp librdkafka-build)
+	set(
+            LIBRDKAFKACPP_SRCS
+            librdkafka/src-cpp/RdKafka.cpp
+            librdkafka/src-cpp/ConfImpl.cpp
+            librdkafka/src-cpp/HandleImpl.cpp
+            librdkafka/src-cpp/ConsumerImpl.cpp
+            librdkafka/src-cpp/ProducerImpl.cpp
+            librdkafka/src-cpp/QueueImpl.cpp
+            librdkafka/src-cpp/TopicImpl.cpp
+            librdkafka/src-cpp/MessageImpl.cpp
+            librdkafka/src-cpp/rdkafkacpp.h)
 
         set(
             SRCS
@@ -87,7 +82,26 @@ if(KAFKA)
             ./../../system/jlib
             ${PROJECT_BINARY_DIR}/include
             ${CMAKE_BINARY_DIR}
-            ${CMAKE_BINARY_DIR}/oss)
+            ${CMAKE_BINARY_DIR}/oss
+            ${CMAKE_CURRENT_SOURCE_DIR}/librdkafka
+            ${CMAKE_CURRENT_SOURCE_DIR}/librdkafka/src
+            ${CMAKE_CURRENT_SOURCE_DIR}/librdkafka/src-cpp)
+
+	execute_process(
+            COMMAND ./configure
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/librdkafka
+            OUTPUT_QUIET)
+
+	add_custom_target(librdkafka-config ALL DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/librdkafka/config.h)
+
+	HPCC_ADD_LIBRARY(librdkafka SHARED ${LIBRDKAFKA_SRCS})
+        HPCC_ADD_LIBRARY(librdkafkacpp SHARED ${LIBRDKAFKACPP_SRCS})
+	add_dependencies(librdkafka librdkafka-config)
+	add_dependencies(librdkafkacpp librdkafka-config)
+
+	install(
+            TARGETS librdkafka librdkafkacpp
+            DESTINATION lib)
 
         add_definitions(-D_USRDLL -DECL_KAFKA_EXPORTS)
         HPCC_ADD_LIBRARY(kafka SHARED ${SRCS})
@@ -101,12 +115,6 @@ if(KAFKA)
         install(
             TARGETS kafka
             DESTINATION plugins)
-
-        # Install our built librdkafka libraries into the RPM
-        install(
-            FILES ${LIBRDKAFKA_LIB} ${LIBRDKAFKA_LIB_REAL} ${LIBRDKAFKACPP_LIB} ${LIBRDKAFKACPP_LIB_REAL}
-            DESTINATION ${LIB_DIR}
-            COMPONENT Runtime)
 
         target_link_libraries(
             kafka

--- a/plugins/kafka/kafka.cpp
+++ b/plugins/kafka/kafka.cpp
@@ -24,7 +24,7 @@
 #include "jfile.hpp"
 #include "build-config.h"
 
-#include "librdkafka/rdkafka.h"
+#include "librdkafka/src/rdkafka.h"
 
 #include <map>
 #include <fstream>

--- a/plugins/kafka/kafka.hpp
+++ b/plugins/kafka/kafka.hpp
@@ -40,7 +40,7 @@
 #include <string>
 #include <time.h>
 
-#include "librdkafka/rdkafkacpp.h"
+#include "librdkafka/src-cpp/rdkafkacpp.h"
 
 #ifdef ECL_KAFKA_EXPORTS
 extern "C"

--- a/plugins/memcached/CMakeLists.txt
+++ b/plugins/memcached/CMakeLists.txt
@@ -25,7 +25,7 @@
 project( memcached )
 
 if (MEMCACHED)
-    ADD_PLUGIN(memcached PACKAGES MEMCACHED OPTION MAKE_MEMCACHED)
+    ADD_PLUGIN(memcached PACKAGES MEMCACHED)
     if(MAKE_MEMCACHED)
         set(
             SRCS

--- a/plugins/mysql/CMakeLists.txt
+++ b/plugins/mysql/CMakeLists.txt
@@ -25,7 +25,7 @@
 project(mysqlembed)
 
 if(MYSQLEMBED)
-    ADD_PLUGIN(mysqlembed PACKAGES MYSQL OPTION MAKE_MYSQLEMBED)
+    ADD_PLUGIN(mysqlembed PACKAGES MYSQL)
     if(MAKE_MYSQLEMBED)
         set(
             SRCS

--- a/plugins/pyembed/CMakeLists.txt
+++ b/plugins/pyembed/CMakeLists.txt
@@ -29,7 +29,7 @@ set(DEBUG_PYTHON_LIBRARY "/usr/lib/libpython2.7_d.so")
 project(pyembed)
 
 if(PYEMBED)
-    ADD_PLUGIN(pyembed PACKAGES PythonLibs OPTION MAKE_PYEMBED MINVERSION 2.6 MAXVERSION 2.7)
+    ADD_PLUGIN(pyembed PACKAGES PythonLibs MINVERSION 2.6 MAXVERSION 2.7)
     if(MAKE_PYEMBED)
         set(
             SRCS

--- a/plugins/redis/CMakeLists.txt
+++ b/plugins/redis/CMakeLists.txt
@@ -25,7 +25,7 @@
 project(redis)
 
 if(REDIS)
-    ADD_PLUGIN(redis PACKAGES REDIS OPTION MAKE_REDIS)
+    ADD_PLUGIN(redis PACKAGES REDIS)
     if(MAKE_REDIS)
         set(
             SRCS

--- a/plugins/sqlite3/CMakeLists.txt
+++ b/plugins/sqlite3/CMakeLists.txt
@@ -25,8 +25,8 @@
 project(sqlite3embed)
 
 if(SQLITE3EMBED)
-    ADD_PLUGIN(sqlite3embed PACKAGES SQLITE3 OPTION MAKE_SQLITEEMBED)
-    if(MAKE_SQLITEEMBED)
+    ADD_PLUGIN(sqlite3embed PACKAGES SQLITE3)
+    if(MAKE_SQLITE3EMBED)
         set(
             SRCS
             sqlite3.cpp)

--- a/plugins/v8embed/CMakeLists.txt
+++ b/plugins/v8embed/CMakeLists.txt
@@ -25,7 +25,7 @@
 project(v8embed)
 
 if(V8EMBED)
-    ADD_PLUGIN(v8embed PACKAGES V8 OPTION MAKE_V8EMBED)
+    ADD_PLUGIN(v8embed PACKAGES V8)
     if(MAKE_V8EMBED)
         set(
             SRCS


### PR DESCRIPTION
ADD_PLUGIN No longer uses OPTION.  We now automatically generate a MAKE_{PLUGINNAME} variable to be used by the caller, similar to how Find generates PACKAGE_FOUND variables.

LOG_PLUGIN causes a fatal error if USE_OPTIONAL is set to OFF.

Kafka - librdkafka now is generated as a shared object by the kafka cmake file

Cassandra - libuv is now generated as a shared object by the cassandra cmake file.  The cassandra library generation done by the code in cpp-driver had to be modified in regards to it's installation location and soname version for dpkg-shlibdeps to work correctly.  I have forked our cpp-driver repo and will be updating it shortly with a PR.

Signed-off-by: Michael Gardner michael.gardner@lexisnexis.com
