### PR TITLE
HPCC-14791 changing the path for despray can potentially allow user to overwrite file in another system directory

### DIFF
--- a/dali/ft/filecopy.cpp
+++ b/dali/ft/filecopy.cpp
@@ -2623,6 +2623,49 @@ void FileSprayer::setTarget(IDistributedFile * target)
     }
 }
 
+void FileSprayer::checkTargetPath(RemoteFilename & filename)
+{
+    StringBuffer targetFilePath;
+
+    filename.getRemotePath(targetFilePath);
+    // prune the leading "//" from remote path
+    targetFilePath.remove(0, 2);
+
+    StringBuffer netaddress;
+    filename.queryIP().getIpText(netaddress);
+    const char * pnetaddress = netaddress.str();
+
+    if (streq("127.0.0.1", pnetaddress))
+        throwError1(DFTERR_LocalhostAddressUsed, targetFilePath.str());
+
+    //remove ip address from the beginning of the path
+    targetFilePath.remove(0, netaddress.length());
+#ifdef _DEBUG
+    LOG(MCdebugInfo, unknownJob, "Target file path is '%s'", targetFilePath.str());
+#endif
+
+    const char * ptargetFilePath = targetFilePath.str();
+    const char pathSep = filename.getPathSeparator();
+    const char dotString[]    = {pathSep, '.', pathSep, '\0'};
+    const char dotDotString[] = {pathSep, '.', '.', pathSep, '\0'};
+
+    const char * isDotString = strstr(ptargetFilePath, dotString);
+    const char * isDotDotString = strstr(ptargetFilePath, dotDotString);
+    if ((isDotDotString != nullptr) || (isDotString != nullptr))
+        throwError3(DFTERR_InvalidTargetPath, ptargetFilePath, dotDotString, dotString);
+
+    Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
+    if (factory)
+    {
+        Owned<IConstEnvironment> env = factory->openEnvironment();
+        if (env)
+        {
+            Owned<IConstDropZoneInfo> targetDropZone = env->getDropZoneByAddressPath(pnetaddress, ptargetFilePath);
+            if (!targetDropZone)
+                    throwError1(DFTERR_NoMatchingDropzonePath, ptargetFilePath);
+        }
+    }
+}
 
 void FileSprayer::setTarget(IFileDescriptor * target, unsigned copy)
 {
@@ -2639,6 +2682,7 @@ void FileSprayer::setTarget(IFileDescriptor * target, unsigned copy)
     for (unsigned idx=0; idx < numParts; idx++)
     {
         target->getFilename(idx, copy, filename);
+        checkTargetPath(filename);
         targets.append(*new TargetLocation(filename));
     }
 }

--- a/dali/ft/filecopy.ipp
+++ b/dali/ft/filecopy.ipp
@@ -263,6 +263,7 @@ protected:
     void waitForTransferSem(Semaphore & sem);
     void addPrefix(size32_t len, const void * data, unsigned idx, PartitionPointArray & partitionWork);
     bool isSameSizeHeaderFooter();
+    void checkTargetPath(RemoteFilename & filename);
     
 private:
     bool calcUsePull();

--- a/dali/ft/fterror.hpp
+++ b/dali/ft/fterror.hpp
@@ -152,8 +152,8 @@
 #define DFTERR_WrongRECFMvRecordSize_Text       "Invalid RECFMv file Record Size (%d) or the file is not RECFMv format!"
 #define DFTERR_WrongSplitRecordSize_Text        "Invalid Record Size (%d, 0x%08x)!"
 #define DFTERR_InvalidXmlPartSize_Text          "Invalid XML part size:%" I64F "d! Size is less than XML Header (%" I64F "d) + Footer (%" I64F "d)) size!"
-#define DFTERR_InvalidTargetPath_Text           "Invalid target path: '%s'. By security reason it is forbidden to use '%s' or '%s' to build a path!"
-#define DFTERR_NoMatchingDropzonePath_Text      "No matching drop zone path to target path: '%s'!"
+#define DFTERR_InvalidTargetPath_Text           "Invalid target path: '%s'. For security reason it is forbidden to use '%s' or '%s' to build a path!"
+#define DFTERR_NoMatchingDropzonePath_Text      "No matching drop zone path to target path: '%s'."
 #define DFTERR_LocalhostAddressUsed_Text        "Localhost address used in remote file name: '%s'"
 
 

--- a/dali/ft/fterror.hpp
+++ b/dali/ft/fterror.hpp
@@ -81,6 +81,9 @@
 #define DFTERR_WrongSplitRecordSize             8108
 #define DFTERR_CannotFindFirstJsonRecord        8109
 #define DFTERR_InvalidXmlPartSize               8110
+#define DFTERR_InvalidTargetPath                8111
+#define DFTERR_NoMatchingDropzonePath           8112
+#define DFTERR_LocalhostAddressUsed             8113
 
 //Internal errors
 #define DFTERR_UnknownFormatType                8190
@@ -149,6 +152,10 @@
 #define DFTERR_WrongRECFMvRecordSize_Text       "Invalid RECFMv file Record Size (%d) or the file is not RECFMv format!"
 #define DFTERR_WrongSplitRecordSize_Text        "Invalid Record Size (%d, 0x%08x)!"
 #define DFTERR_InvalidXmlPartSize_Text          "Invalid XML part size:%" I64F "d! Size is less than XML Header (%" I64F "d) + Footer (%" I64F "d)) size!"
+#define DFTERR_InvalidTargetPath_Text           "Invalid target path: '%s'. By security reason it is forbidden to use '%s' or '%s' to build a path!"
+#define DFTERR_NoMatchingDropzonePath_Text      "No matching drop zone path to target path: '%s'!"
+#define DFTERR_LocalhostAddressUsed_Text        "Localhost address used in remote file name: '%s'"
+
 
 #define DFTERR_UnknownFormatType_Text           "INTERNAL: Save unknown format type"
 #define DFTERR_OutputOffsetMismatch_Text        "INTERNAL: Output offset does not match expected (%" I64F "d expected %" I64F "d) at %s of block %d"


### PR DESCRIPTION
Check the path
    - doesn't contain any '../' or './' element
    - does start with the path of a valid drop zone on the target machine

This change depend on the HPCC-14857 (PR8222)

Signed-off-by: Attila Vamos attila.vamos@gmail.com
