### PR TITLE
HPCC-14967 Improve separator handling in delimited spray

### DIFF
--- a/dali/ft/filecopy.cpp
+++ b/dali/ft/filecopy.cpp
@@ -2597,6 +2597,10 @@ void FileSprayer::setTarget(IDistributedFile * target)
         unknownTargetFormat = false;
     else
     {
+        const char* separator = srcFormat.separate.get();
+        if (separator && (strcmp(separator, ",") == 0))
+            srcFormat.separate.set("\\,");
+
         tgtFormat.set(srcFormat);
         if (!unknownSourceFormat)
         {


### PR DESCRIPTION
Detect simple ',' character and replace it to '\,' in separator parameter
for CSV/UTF spray.

Signed-off-by: Attila Vamos attila.vamos@gmail.com
