### PR TITLE
HPCC-14984 Prevent follow on crash in distributor

### DIFF
--- a/thorlcr/activities/hashdistrib/thhashdistribslave.cpp
+++ b/thorlcr/activities/hashdistrib/thhashdistribslave.cpp
@@ -77,7 +77,7 @@
 #define HDSendPrintLog5(M,P1,P2,P3,P4)
 #endif
 
-class CDistributorBase : public CSimpleInterface, implements IHashDistributor, implements IExceptionHandler
+class CDistributorBase : public CInterface, implements IHashDistributor, implements IExceptionHandler
 {
     Linked<IRowInterfaces> rowIf;
     IEngineRowAllocator *allocator;
@@ -973,7 +973,7 @@ protected:
     ICompressHandler *compressHandler;
     StringBuffer compressOptions;
 public:
-    IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
+    IMPLEMENT_IINTERFACE_USING(CInterface);
 
     CDistributorBase(CActivityBase *_activity, bool _doDedup, IStopInput *_istop, const char *_id)
         : activity(_activity), recvthread(this), sendthread(this), sender(*this), id(_id)
@@ -1027,7 +1027,7 @@ public:
         ActPrintLog("targetWriterLimit : %d", targetWriterLimit);
     }
 
-    ~CDistributorBase()
+    virtual void beforeDispose()
     {
         try
         {


### PR DESCRIPTION
Some abort sequences that fail to stop a distributor normally can
cause a crash due to a call sequence from a base destructor that
leads to a pure-virtual call exception

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
