### PR TITLE
HPCC-14678 Check/abort WU when WUSyntaxCheck times out

### DIFF
--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -1021,6 +1021,7 @@ ESPrequest WUSyntaxCheckRequest
 ESPresponse [exceptions_inline] WUSyntaxCheckResponse
 {
     ESParray<ESPstruct ECLException> Errors;
+    [min_ver("1.57")] string Message;
 };
 
 


### PR DESCRIPTION
When ESP performs an ECL syntax check using WUSyntaxCheck, it
submits a workunit. If that workunit takes greater than the
timeout period (default 60 seconds), the existing code tries
to delete the workunit. The workunit deletion may fail if the
workunit is still in a submitted state. In this fix, the code
is added to check the workunit state. If the state is allowed,
deleteWorkUnit() will be called. If not, secAbortWorkUnit()
will be called and inform user to delete the workunit after
aborting.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
