### PR TITLE
HPCC-14935 Encapsulate TxSummary logging in a new interface

### DIFF
--- a/esp/bindings/SOAP/soaplib/CMakeLists.txt
+++ b/esp/bindings/SOAP/soaplib/CMakeLists.txt
@@ -29,6 +29,7 @@ set (    SRCS
          ../../../platform/espcontext.cpp 
          ../../../platform/espprotocol.cpp 
          ../../../platform/espthread.cpp 
+         ../../../platform/esptxsummary.cpp
          ../../../platform/sechandler.cpp 
          ../../../protocols/http/mapinfo.cpp 
          ../../bindutil.cpp 

--- a/esp/platform/espcontext.cpp
+++ b/esp/platform/espcontext.cpp
@@ -25,6 +25,7 @@
 
 #include "jliball.hpp"
 #include "espcontext.hpp"
+#include "esptxsummary.hpp"
 #include "http/platform/httptransport.ipp"
 #include "sechandler.hpp"
 #include "espprotocol.hpp"
@@ -67,7 +68,7 @@ private:
     SecHandler m_SecurityHandler;
     BoolHash  m_optGroups;
 
-    StringArray m_traceValues;
+    Owned<IEspTxSummary> m_txSummary;
     unsigned    m_active;
     unsigned    m_creationTime;
     unsigned    m_processingTime;
@@ -83,9 +84,15 @@ public:
     CEspContext() : m_servPort(0), m_bindingValue(0), m_serviceValue(0), m_toBeAuthenticated(false), options(0), m_clientVer(-1)
     {
         m_hasException =  false;
+        m_exceptionTime = 0;
+        m_exceptionCode = 0;
         m_creationTime = msTick();
+        m_processingTime = 0;
         m_active=ActiveRequests::getCount();
         respSerializationFormat=ESPSerializationANY;
+
+        m_txSummary.setown(createEspTxSummary(m_creationTime));
+        updateTraceSummaryHeader();
     }
 
     ~CEspContext()
@@ -187,10 +194,6 @@ public:
         return m_servName.str();
     }
 
-    virtual void setCreationTime()
-    {
-        m_creationTime = msTick();
-    }
     virtual const unsigned queryCreationTime()
     {
         return m_creationTime;
@@ -408,72 +411,44 @@ public:
         m_custom_headers.append(StringBuffer(name).appendf(": %s", val?val:"").str());
     }
 
+    virtual IEspTxSummary* getTxSummary()
+    {
+        return m_txSummary.get();
+    }
+
     virtual void addTraceSummaryValue(const char *name, const char *value)
     {
-        StringBuffer str;
-        if (name && *name)
-            str.append(name).append('=');
-        if (value && *value)
-            str.append(value);
-        m_traceValues.append(str.str());
+        if (m_txSummary)
+            m_txSummary->append(name, value);
     }
 
     virtual void addTraceSummaryValue(const char *name, __int64 value)
     {
-        StringBuffer str;
-        if (name && *name)
-            str.append(name).append('=');
-        str.append(value);
-        m_traceValues.append(str.str());
+        if (m_txSummary)
+            m_txSummary->append(name, value);
     }
 
     virtual void addTraceSummaryTimeStamp(const char *name)
     {
-        if (name && *name)
-        {
-            unsigned timeval=msTick()-m_creationTime;
-            StringBuffer value;
-            value.append(name).append('=').appendulong(timeval).append("ms");
-            m_traceValues.append(value.str());
-        }
+        if (m_txSummary && name && *name)
+            m_txSummary->append(name, m_txSummary->getTimestamp(), "ms");
     }
     virtual void flushTraceSummary()
     {
-        StringBuffer logstr;
-        logstr.appendf("activeReqs=").append(m_active).append(';');
-        logstr.append("user=").append(queryUserId());
-        if (m_peer.length())
-            logstr.append('@').append(m_peer.get());
-        logstr.append(';');
-
-        if (m_hasException)
+        if (m_txSummary)
         {
-            logstr.appendf("exception@%dms=%d;", m_exceptionTime, m_exceptionCode);
-        }
+            if (!m_hasException && (getEspLogLevel() <= LogNormal))
+                m_txSummary->clear();
 
-        StringBuffer value;
-        value.append("total=").appendulong(m_processingTime).append("ms");
-        if (m_hasException || (getEspLogLevel() > LogNormal))
-        {
-            m_traceValues.append(value.str());
-
-            if (m_traceValues.length())
-            {
-                ForEachItemIn(idx, m_traceValues)
-                    logstr.append(m_traceValues.item(idx)).append(";");
-                m_traceValues.kill();
-            }
+            updateTraceSummaryHeader();
+            m_txSummary->append("total", m_processingTime, "ms");
         }
-        else
-        {
-            logstr.appendf("%s;", value.str());
-        }
-
-        DBGLOG("TxSummary[%s]", logstr.str());
     }
 
     virtual ESPSerializationFormat getResponseFormat(){return respSerializationFormat;}
     virtual void setResponseFormat(ESPSerializationFormat fmt){respSerializationFormat = fmt;}
+
+    void updateTraceSummaryHeader();
 };
 
 //---------------------------------------------------------
@@ -553,6 +528,17 @@ bool CEspContext::isMethodAllowed(double version, const char* optional, const ch
         return false;
 
     return true;
+}
+
+void CEspContext::updateTraceSummaryHeader()
+{
+    if (m_txSummary)
+    {
+        m_txSummary->set("activeReqs", m_active);
+        m_txSummary->set("user", VStringBuffer(m_peer.length() ? "%s@%s" : "%s", (queryUserId() ? queryUserId() : ""), m_peer.str()).str());
+        if (m_hasException)
+            m_txSummary->set(VStringBuffer("exception@%ums", m_exceptionTime), m_exceptionCode);
+    }
 }
 
 IEspContext* createEspContext()

--- a/esp/platform/esptxsummary.cpp
+++ b/esp/platform/esptxsummary.cpp
@@ -1,0 +1,131 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2016 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include "esptxsummary.hpp"
+#include <algorithm>
+#include <list>
+#include <sstream>
+
+using std::find_if;
+using std::stringstream;
+
+#define VALIDATE_KEY(k) if (!(k) || !(*k)) return false
+#define MATCH_KEY       [&](const Entry& entry) { return stricmp(entry.key.str(), key) == 0; }
+
+class CEspTxSummary : public CInterface, implements IEspTxSummary
+{
+private:
+    struct Entry
+    {
+        StringBuffer key;
+        StringBuffer value;
+    };
+
+    using Entries = std::list<Entry>;
+
+    Entries   m_entries;
+    unsigned  m_creationTime;
+
+public:
+    IMPLEMENT_IINTERFACE;
+
+    CEspTxSummary(unsigned creationTime)
+    : m_creationTime(creationTime ? creationTime : msTick())
+    {
+    }
+
+    ~CEspTxSummary()
+    {
+        log();
+        clear();
+    }
+
+    virtual unsigned __int64 size() const override
+    {
+        return m_entries.size();
+    }
+
+    virtual void clear() override
+    {
+        m_entries.clear();
+    }
+
+    virtual unsigned getTimestamp() const override
+    {
+        return msTick() - m_creationTime;
+    }
+
+    bool contains(const char* key) const
+    {
+        return find_if(m_entries.begin(), m_entries.end(), MATCH_KEY) != m_entries.end();
+    }
+
+    virtual bool append(const char* key, const char* value) override
+    {
+        VALIDATE_KEY(key);
+
+        if (contains(key))
+            return false;
+
+        m_entries.push_back({key, value});
+        return true;
+    }
+
+    virtual bool set(const char* key, const char* value) override
+    {
+        VALIDATE_KEY(key);
+
+        Entries::iterator it = find_if(m_entries.begin(), m_entries.end(), MATCH_KEY);
+
+        if (it != m_entries.end())
+            it->value.set(value);
+        else
+            m_entries.push_back({key, value});
+
+        return true;
+    }
+
+    virtual void serialize(StringBuffer& buffer) const override
+    {
+        for (auto&& entry : m_entries)
+        {
+            buffer.appendf((entry.value.length() > 0 ? "%s=%s;" : "%s;"), entry.key.str(), entry.value.str());
+        }
+    }
+
+private:
+    void log()
+    {
+        if (size())
+        {
+            StringBuffer summary;
+            serialize(summary);
+            DBGLOG("TxSummary[%s]", summary.str());
+        }
+    }
+
+    template <class T>
+    static T find_key(T begin, T end, const char* key)
+    {
+        return std::find_if(begin, end, [&](const Entry& entry) { return stricmp(entry.key.str(), key) == 0; });
+    }
+};
+
+IEspTxSummary* createEspTxSummary(unsigned creationTime)
+{
+    return new CEspTxSummary(creationTime);
+}

--- a/esp/platform/esptxsummary.hpp
+++ b/esp/platform/esptxsummary.hpp
@@ -1,0 +1,30 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2016 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef ESPTXSUMMARY_HPP
+#define ESPTXSUMMARY_HPP
+
+#include "esp.hpp"
+#include "esphttp.hpp"
+
+// Creates a standard instance of the IEspTxSummary interface. The
+// 'creationTime' parameter allows the summary's time-stamp to be synchronized
+// with that of the owning object. If zero or omitted, time-stamps will be
+// based on the instance's time of construction.
+ESPHTTP_API IEspTxSummary* createEspTxSummary(unsigned creationTime = 0);
+
+#endif // ESPTXSUMMARY_HPP

--- a/esp/protocols/http/CMakeLists.txt
+++ b/esp/protocols/http/CMakeLists.txt
@@ -44,6 +44,7 @@ set (    SRCS
          ../../platform/espcontext.cpp 
          ../../platform/espprotocol.cpp 
          ../../platform/espthread.cpp 
+         ../../platform/esptxsummary.cpp
          ../../platform/sechandler.cpp 
          mapinfo.cpp 
          plugin.cpp 

--- a/esp/scm/esp.ecm
+++ b/esp/scm/esp.ecm
@@ -18,6 +18,7 @@
 #include "seclib.hpp"
 #include "esplog.hpp"
 #include "mapinfo.hpp"
+#include <sstream>
 
 SCMinterface IEspStringIntMap(IInterface)
 {
@@ -59,6 +60,83 @@ typedef enum ESPSerializationFormat_
 #define ESPCTX_WSDL_EXT         0x00000100
 #define ESPCTX_NO_ANNOTATION    0x00001000
 #define ESPCTX_ALL_ANNOTATION   0x00010000
+
+interface IEspTxSummary : extends IInterface
+{
+    // Returns the number of summary entries.
+    virtual unsigned __int64 size() const = 0;
+
+    // Purges all summary entries.
+    virtual void clear() = 0;
+
+    // Returns true if an entry exists for the key.
+    virtual bool contains(const char* key) const = 0;
+
+    // Returns the number of milliseconds elapsed since the construction of
+    // the summary.
+    virtual unsigned getTimestamp() const = 0;
+
+    // Appends all summary entries to the given buffer.
+    virtual void serialize(StringBuffer& buffer) const = 0;
+
+    // Adds the unique key and value to the end of the summary and returns
+    // true. If the key is not unique, the summary is unchanged and false
+    // is returned.
+    virtual bool append(const char* key, const char* value) = 0;
+
+    // Convenience method to add any value representable as text to the summary.
+    // Note that the value type must support the stream output operator (<<).
+    template <typename TValue>
+    bool append(const char* key, const TValue& value)
+    {
+        std::stringstream ss;
+
+        ss << value;
+        return append(key, ss.str().c_str());
+    }
+
+    // Convenience method to add any value representable as text, along with
+    // a text suffix, to the summary. An example suffix might be "ms", to
+    // represent the units of a milli-seconds time measurement.
+    // Note that the value and suffix types both must support the stream output
+    // operator (<<).
+    template <typename TValue, typename TSuffix>
+    bool append(const char* key, const TValue& value, const TSuffix& suffix)
+    {
+        std::stringstream ss;
+
+        ss << value << suffix;
+        return append(key, ss.str().c_str());
+    }
+
+    // Updates the value associated with an existing key, or appends the key
+    // and value to the summary if it is not already found.
+    virtual bool set(const char* key, const char* value) = 0;
+
+    // Convenience method to set any value representable as text.
+    // Note that the value type must support the stream output operator (<<).
+    template <typename TValue>
+    bool set(const char* key, const TValue& value)
+    {
+        std::stringstream ss;
+
+        ss << value;
+        return set(key, ss.str().c_str());
+    }
+
+    // Convenience method to set any value representable as text, along with a
+    // text suffix, to the summary.
+    // Note that the value and suffix types both must support the stream output
+    // operator (<<).
+    template <typename TValue, typename TSuffix>
+    bool set(const char* key, const TValue& value, const TSuffix& suffix)
+    {
+        std::stringstream ss;
+
+        ss << value << suffix;
+        return set(key, ss.str().c_str());
+    }
+};
 
 interface IEspContext : extends IInterface
 {
@@ -109,7 +187,6 @@ interface IEspContext : extends IInterface
 
     virtual void setServiceName(const char *name)=0;
     virtual const char * queryServiceName(const char *name)=0;
-    virtual void setCreationTime()=0;
     virtual const unsigned queryCreationTime()=0;
     virtual void setProcessingTime()=0;
     virtual const unsigned queryProcessingTime()=0;
@@ -144,10 +221,10 @@ interface IEspContext : extends IInterface
     virtual StringArray& queryCustomHeaders() = 0;
     virtual void addCustomerHeader(const char* name, const char* val) = 0;
 
+    virtual IEspTxSummary* getTxSummary()=0;
     virtual void addTraceSummaryValue(const char *name, const char *value)=0;
     virtual void addTraceSummaryValue(const char *name, __int64 value)=0;
     virtual void addTraceSummaryTimeStamp(const char *name)=0;
-    virtual void flushTraceSummary()=0;
 
     virtual ESPSerializationFormat getResponseFormat()=0;
     virtual void setResponseFormat(ESPSerializationFormat fmt)=0;


### PR DESCRIPTION
Define the IEspTxSummary interface to encapsulate the transaction summary
funcionality found in IEspContext. Provide a simplified yet generalized
interface to manage a collection of key-value pairs, including these
capabilities:
- Insert values into the collection for unique keys, in insertion order.
- Update values for existing keys in the collection.
- Interrogate the size of the collection.
- Purge the collection.
- Test the existance of a key in the collection.
- Interrogate the elapsed time since the collection's creation.
- Serialize the collection into a StringBuffer. 

Retain the existing IEspContext interface for summary content additions so
existing usage is unaffected. The requirement for unique keys is new, but does
not affect current usage.

Expose IEspContext's encapsulation for content additions in situations when the
context is not and cannot be available. Any function with access to a context
may continue to use the context's existing interface. 

Remove IEspContext methods that distort the log or have no effect. These
removals do not impact current usage.
- setCreationTime alters subsequent timestamp values. Timing values that are
  not relative to the start of request processing have limited to no value.
- flushTraceSummary only prepares the summary to be logged. It does not
  generate a new log entry.

Signed-off-by: Tim Klemm Tim.Klemm@lexisnexis.com
