### PR TITLE
HPCC-14975 Should not copy "Protected" metadata from source to new copy

### DIFF
--- a/dali/ft/filecopy.cpp
+++ b/dali/ft/filecopy.cpp
@@ -3140,8 +3140,11 @@ void FileSprayer::updateTargetProperties()
 
             // and simple (top level) elements
             Owned<IPropertyTreeIterator> iter = srcAttr->getElements("*");
-            ForEach(*iter) {
-                curProps.addPropTree(iter->query().queryName(),createPTreeFromIPT(&iter->query()));
+            ForEach(*iter)
+            {
+                const char *aname = iter->query().queryName();
+                if (stricmp(aname, "Protect") != 0)
+                    curProps.addPropTree(aname, createPTreeFromIPT(&iter->query()));
             }
         }
     }


### PR DESCRIPTION
Prevent to copy 'Protect' attribute to the target file.

Signed-off-by: Attila Vamos attila.vamos@gmail.com
