### PR TITLE
HPCC-14950 Add graph name to exceptions

### DIFF
--- a/thorlcr/graph/thgraph.cpp
+++ b/thorlcr/graph/thgraph.cpp
@@ -1309,8 +1309,7 @@ void CGraphBase::executeSubGraph(size32_t parentExtractSz, const byte *parentExt
         }
         catch (IException *e)
         {
-            Owned<IThorException> e2 = MakeThorException(e);
-            e2->setGraphId(graphId);
+            Owned<IThorException> e2 = MakeGraphException(this, e);
             e2->setAction(tea_abort);
             queryJobChannel().fireException(e2);
             throw;
@@ -1408,7 +1407,6 @@ void CGraphBase::doExecute(size32_t parentExtractSz, const byte *parentExtract, 
             {
                 StringBuffer str;
                 Owned<IThorException> e = MakeGraphException(this, exception->errorCode(), "%s", exception->errorMessage(str).str());
-                e->setGraphId(graphId);
                 e->setAction(tea_abort);
                 fireException(e);
             }
@@ -2895,7 +2893,7 @@ IThorResult *CJobChannel::getOwnedResult(graph_id gid, activity_id ownerId, unsi
     if (!graph)
     {
         Owned<IThorException> e = MakeThorException(0, "getOwnedResult: graph not found");
-        e->setGraphId(gid);
+        e->setGraphInfo(queryJob().queryGraphName(), gid);
         throw e.getClear();
     }
     Owned<IThorResult> result;

--- a/thorlcr/graph/thgraphslave.hpp
+++ b/thorlcr/graph/thgraphslave.hpp
@@ -127,8 +127,7 @@ public:
         StringBuffer s;
         if (!te || !te->queryGraphId())
         {
-            Owned<IThorException> e2 = ThorWrapException(e, "CSlaveGraph trapped");         
-            e2->setGraphId(queryGraphId());
+            Owned<IThorException> e2 = MakeGraphException(this, e);
             e2->setAudience(e->errorAudience());
             return CGraphBase::fireException(e2);
         }

--- a/thorlcr/slave/slave.cpp
+++ b/thorlcr/slave/slave.cpp
@@ -105,7 +105,7 @@ void ProcessSlaveActivity::main()
         {
             if (!e->queryActivityId())
             {
-                e->setGraphId(container.queryOwner().queryGraphId());
+                e->setGraphInfo(container.queryJob().queryGraphName(), container.queryOwner().queryGraphId());
                 e->setActivityKind(container.getKind());
                 e->setActivityId(container.queryId());
             }

--- a/thorlcr/slave/slavmain.cpp
+++ b/thorlcr/slave/slavmain.cpp
@@ -461,8 +461,7 @@ public:
                                 Owned<CGraphBase> graph = jobChannel.getGraph(gid);
                                 if (graph)
                                 {
-                                    Owned<IThorException> e = MakeThorException(0, "GraphAbort");
-                                    e->setGraphId(gid);
+                                    Owned<IThorException> e = MakeGraphException(graph, 0, "GraphAbort");
                                     graph->abort(e);
                                 }
                             }

--- a/thorlcr/thorutil/thormisc.cpp
+++ b/thorlcr/thorutil/thormisc.cpp
@@ -225,7 +225,7 @@ protected:
     unsigned slave;
     MemoryBuffer data; // extra exception specific data
     unsigned line, column;
-    StringAttr file, origin;
+    StringAttr file, origin, graphName;
     ErrorSeverity severity;
     Linked<IException> originalException;
 public:
@@ -236,6 +236,7 @@ public:
     {
         mb.read((unsigned &)action);
         mb.read(jobId);
+        mb.read(graphName);
         mb.read(graphId);
         mb.read((unsigned &)kind);
         mb.read(id);
@@ -264,6 +265,7 @@ public:
     virtual ThorExceptionAction queryAction() const { return action; }
     virtual ThorActivityKind queryActivityKind() const { return kind; }
     virtual activity_id queryActivityId() const { return id; }
+    virtual const char *queryGraphName() const { return graphName; }
     virtual graph_id queryGraphId() const { return graphId; }
     virtual const char *queryJobId() const { return jobId; }
     virtual unsigned querySlave() const { return slave; }
@@ -275,7 +277,7 @@ public:
     virtual IException *queryOriginalException() const { return originalException; }
     virtual void setActivityId(activity_id _id) { id = _id; }
     virtual void setActivityKind(ThorActivityKind _kind) { kind = _kind; }
-    virtual void setGraphId(graph_id _graphId) { graphId = _graphId; }
+    virtual void setGraphInfo(const char *_graphName, graph_id _graphId) { graphName.set(_graphName); graphId = _graphId; }
     virtual void setJobId(const char *_jobId) { jobId.set(_jobId); }
     virtual void setAction(ThorExceptionAction _action) { action = _action; }
     virtual void setAudience(MessageAudience _audience) { audience = _audience; }
@@ -293,7 +295,7 @@ public:
         if (!origin.length() || 0 != stricmp("user", origin.get())) // don't report slave in user message
         {
             if (graphId)
-                str.append("Graph[").append(graphId).append("], ");
+                str.append("Graph ").append(graphName).append("[").append(graphId).append("], ");
             if (kind)
                 str.append(activityKindStr(kind));
             if (id)
@@ -385,7 +387,7 @@ void setExceptionActivityInfo(CGraphElementBase &container, IThorException *e)
 {
     e->setActivityKind(container.getKind());
     e->setActivityId(container.queryId());
-    e->setGraphId(container.queryOwner().queryGraphId());
+    e->setGraphInfo(container.queryJob().queryGraphName(), container.queryOwner().queryGraphId());
 }
 
 IThorException *_MakeActivityException(CGraphElementBase &container, int code, const char *format, va_list args) __attribute__((format(printf,3,0)));
@@ -535,9 +537,17 @@ IThorException *MakeGraphException(CGraphBase *graph, int code, const char *form
     va_list args;
     va_start(args, format);
     IThorException *e = _MakeThorException(MSGAUD_user, code, format, args);
-    e->setGraphId(graph->queryGraphId());
+    e->setGraphInfo(graph->queryJob().queryGraphName(), graph->queryGraphId());
     va_end(args);
     return e;
+}
+
+IThorException *MakeGraphException(CGraphBase *graph, IException *e)
+{
+    StringBuffer msg;
+    IThorException *e2 = new CThorException(MSGAUD_user, e->errorCode(), e->errorMessage(msg).str());
+    e2->setGraphInfo(graph->queryJob().queryGraphName(), graph->queryGraphId());
+    return e2;
 }
 
 #if 0
@@ -913,6 +923,7 @@ void serializeThorException(IException *e, MemoryBuffer &out)
     out.append(1);
     out.append((unsigned)te->queryAction());
     out.append(te->queryJobId());
+    out.append(te->queryGraphName());
     out.append(te->queryGraphId());
     out.append((unsigned)te->queryActivityKind());
     out.append(te->queryActivityId());

--- a/thorlcr/thorutil/thormisc.hpp
+++ b/thorlcr/thorutil/thormisc.hpp
@@ -310,6 +310,7 @@ interface IThorException : extends IException
     virtual ThorExceptionAction queryAction() const = 0;
     virtual ThorActivityKind queryActivityKind() const = 0;
     virtual activity_id queryActivityId() const = 0;
+    virtual const char *queryGraphName() const = 0;
     virtual graph_id queryGraphId() const = 0;
     virtual const char *queryJobId() const = 0;
     virtual unsigned querySlave() const = 0;
@@ -322,7 +323,7 @@ interface IThorException : extends IException
     virtual void setAction(ThorExceptionAction _action) = 0;
     virtual void setActivityKind(ThorActivityKind _kind) = 0;
     virtual void setActivityId(activity_id id) = 0;
-    virtual void setGraphId(graph_id id) = 0;
+    virtual void setGraphInfo(const char *graphName, graph_id id) = 0;
     virtual void setJobId(const char *jobId) = 0;
     virtual void setAudience(MessageAudience audience) = 0;
     virtual void setSlave(unsigned slave) = 0;
@@ -415,6 +416,7 @@ extern graph_decl IThorException *MakeActivityException(CGraphElementBase *activ
 extern graph_decl IThorException *MakeActivityWarning(CGraphElementBase *activity, int code, const char *_format, ...) __attribute__((format(printf, 3, 4)));
 extern graph_decl IThorException *MakeActivityWarning(CGraphElementBase *activity, IException *e, const char *format, ...) __attribute__((format(printf, 3, 4)));
 extern graph_decl IThorException *MakeGraphException(CGraphBase *graph, int code, const char *format, ...) __attribute__((format(printf, 3, 4)));
+extern graph_decl IThorException *MakeGraphException(CGraphBase *graph, IException *e);
 extern graph_decl IThorException *MakeThorException(int code, const char *format, ...) __attribute__((format(printf, 2, 3)));
 extern graph_decl IThorException *MakeThorException(IException *e);
 extern graph_decl IThorException *MakeThorAudienceException(LogMsgAudience audience, int code, const char *format, ...) __attribute__((format(printf, 3, 4)));


### PR DESCRIPTION
This is primarily related to issue HPCC-14782, so that EclWatch/
IDE can more easily link to the graph/subgraph/activity that
issue the error.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
