### PR TITLE
HPCC-15000 Unchecked malloc in udp memory allocation

### DIFF
--- a/roxie/udplib/udptrs.cpp
+++ b/roxie/udplib/udptrs.cpp
@@ -1100,7 +1100,7 @@ public:
             if (mem_buffer_size < len)
             {
                 free(mem_buffer);
-                mem_buffer = malloc(len);
+                mem_buffer = checked_malloc(len, ROXIE_MEMORY_ERROR);
                 mem_buffer_size = len;
             }
             packed_request = false;


### PR DESCRIPTION
When returning rows larger than 1K, getBuffer::getBuffer uses a temporary
memory buffer allocated from the heap, but does not check that the allocation
succeeds.

If it does not, code accessing the buffer subsequently is liable to core. This
was observed where (due to bugs elsewhere) a ridiculously large size was being
requested, but could in theory also happen when returning genuinely large rows
from a Roxie slave.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
