### PR TITLE
HPCC-15009 QuerySetQuery not displaying icon

### DIFF
--- a/esp/src/eclwatch/ESPQuery.js
+++ b/esp/src/eclwatch/ESPQuery.js
@@ -78,7 +78,7 @@ define([
             item[this.idProperty] = item.QuerySetId + ":" + item.Id;
             if (lang.exists("Clusters", item)) {
                 arrayUtil.some(item.Clusters.ClusterQueryState, function(cqs, idx){
-                    if (lang.exists("Errors", cqs) && cqs.Errors) {
+                    if (lang.exists("Errors", cqs) && cqs.Errors || cqs.State !== "Available") {
                         ErrorCount++;
                         StatusMessage = context.i18n.SuspendedByCluster;
                         return false;


### PR DESCRIPTION
Within the QueryDetails area when a query is suspended by cluster the icon appears correctly but not in the query page. We check for a string in the Errors key but, sometimes there is no error string reported from ClusterQueryState. Therefore, adding a check to verify both error key and as long as query status is !Available string inside of State key.

Signed-off by: Miguel Vazquez miguel.vazquez@lexisnexis.com
