### PR TITLE
HPCC-15008 Logical files tab not showing all files

### DIFF
--- a/esp/src/eclwatch/QuerySetLogicalFilesWidget.js
+++ b/esp/src/eclwatch/QuerySetLogicalFilesWidget.js
@@ -50,7 +50,7 @@ define([
 
         createGrid: function (domID) {
             var context = this;
-            var retVal = new declare([ESPUtil.Grid(false, true)])({
+            var retVal = new declare([ESPUtil.Grid(true, true)])({
                 store: this.store,
                 columns: {
                     col1: selector({ width: 27, selectorType: 'checkbox' }),


### PR DESCRIPTION
Within Queries/Logical Files tab the page not having pagination did not allow the user to see more than 25 files at a time.

Signed-off by: Miguel Vazquez miguel.vazquez@lexisnexis.com
