### PR TITLE
HPCC-14764 Roxie protocol encapsulation

### DIFF
--- a/common/thorhelper/roxiedebug.cpp
+++ b/common/thorhelper/roxiedebug.cpp
@@ -46,10 +46,9 @@ bool CDebugCommandHandler::checkCommand(IXmlWriter &out, const char *&supplied, 
     }
 }
 
-void CDebugCommandHandler::doDebugCommand(IPropertyTree *query, IDebuggerContext *debugContext, FlushingStringBuffer &output)
+void CDebugCommandHandler::doDebugCommand(IPropertyTree *query, IDebuggerContext *debugContext, IXmlWriter &out)
 {
     const char *commandName = query->queryName();
-    CommonXmlWriter out(0, 1);
     if (strnicmp(commandName, "b", 1)==0 && checkCommand(out, commandName, "breakpoint"))
     {
         const char *mode = query->queryProp("@mode");
@@ -207,7 +206,6 @@ void CDebugCommandHandler::doDebugCommand(IPropertyTree *query, IDebuggerContext
     else
         throw MakeStringException(THORHELPER_DEBUG_ERROR, "Unknown command %s", commandName);
     out.outputEndNested(commandName);
-    output.append(out.str());
 }
 
 //=======================================================================================

--- a/common/thorhelper/roxiedebug.hpp
+++ b/common/thorhelper/roxiedebug.hpp
@@ -39,7 +39,13 @@ class THORHELPER_API CDebugCommandHandler : public CInterface, implements IInter
 public:
     IMPLEMENT_IINTERFACE;
     static bool checkCommand(IXmlWriter &out, const char *&supplied, const char *expected);
-    void doDebugCommand(IPropertyTree *query, IDebuggerContext *debugContext, FlushingStringBuffer &output);
+    void doDebugCommand(IPropertyTree *query, IDebuggerContext *debugContext, IXmlWriter &out);
+    void doDebugCommand(IPropertyTree *query, IDebuggerContext *debugContext, FlushingStringBuffer &output)
+    {
+        CommonXmlWriter out(0, 1);
+        doDebugCommand(query, debugContext, out);
+        output.append(out.str());
+    }
 };
 
 //=======================================================================================

--- a/common/thorhelper/roxiehelper.hpp
+++ b/common/thorhelper/roxiehelper.hpp
@@ -231,7 +231,6 @@ protected:
     UnsignedArray lengths;
 
     bool needsFlush(bool closing);
-    void startBlock();
 public:
     TextMarkupFormat mlFmt;      // controls whether xml/json elements are output
     bool isRaw;      // controls whether output as binary or ascii
@@ -260,11 +259,13 @@ public:
     virtual void flush(bool closing) ;
     virtual void addPayload(StringBuffer &s, unsigned int reserve=0);
     virtual void *getPayload(size32_t &length);
+    virtual void startBlock();
     virtual void startDataset(const char *elementName, const char *resultName, unsigned sequence, bool _extend = false, const IProperties *xmlns=NULL);
     virtual void startScalar(const char *resultName, unsigned sequence);
     virtual void setScalarInt(const char *resultName, unsigned sequence, __int64 value, unsigned size);
     virtual void setScalarUInt(const char *resultName, unsigned sequence, unsigned __int64 value, unsigned size);
     virtual void incrementRowCount();
+    void setTail(const char *value){tail.set(value);}
 };
 
 class THORHELPER_API FlushingJsonBuffer : public FlushingStringBuffer

--- a/roxie/ccd/CMakeLists.txt
+++ b/roxie/ccd/CMakeLists.txt
@@ -36,6 +36,7 @@ set (   SRCS
         ccdkey.cpp 
         ccdlistener.cpp
         ccdmain.cpp
+        ccdprotocol.cpp
         ccdquery.cpp
         ccdqueue.cpp
         ccdsnmp.cpp 
@@ -50,10 +51,12 @@ set (   SRCS
         ccdfile.hpp
         ccdkey.hpp
         ccdlistener.hpp
+        ccdprotocol.hpp
         ccdquery.hpp
         ccdqueue.ipp
         ccdsnmp.hpp
         ccdstate.hpp 
+        hpccprotocol.hpp
         
                 sourcedoc.xml
     )

--- a/roxie/ccd/ccdcontext.cpp
+++ b/roxie/ccd/ccdcontext.cpp
@@ -1123,8 +1123,6 @@ protected:
     const IRoxieContextLogger &logctx;
 
 protected:
-    CriticalSection resultsCrit;
-    IPointerArrayOf<FlushingStringBuffer> resultMap;
     bool exceptionLogged;
     bool aborted;
     CriticalSection abortLock; // NOTE: we don't bother to get lock when just reading to see whether to abort
@@ -2546,10 +2544,12 @@ public:
 class CRoxieServerContext : public CRoxieContextBase, implements IRoxieServerContext, implements IGlobalCodeContext
 {
     const IQueryFactory *serverQueryFactory;
+    IHpccProtocolResponse *protocol;
+    IHpccProtocolResultsWriter *results;
+    IHpccNativeProtocolResponse *nativeProtocol;
     CriticalSection daliUpdateCrit;
     StringAttr querySetName;
 
-    TextMarkupFormat mlFmt;
     bool isRaw;
     bool sendHeartBeats;
     unsigned lastSocketCheckTime;
@@ -2559,34 +2559,23 @@ protected:
     Owned<CRoxieWorkflowMachine> workflow;
     Owned<ITimeReporter> myTimer;
     mutable MapStringToMyClass<IResolvedFile> fileCache;
-    SafeSocket *client;
     StringArray clusterNames;
     int clusterWidth = -1;
 
     bool isBlocked;
-    bool isHttp;
+    bool isNative;
     bool trim;
 
     void doPostProcess()
     {
-        CriticalBlock b(resultsCrit); // Probably not needed
+        if (!protocol)
+            return;
+
         if (!isRaw && !isBlocked)
-        {
-            ForEachItemIn(seq, resultMap)
-            {
-                FlushingStringBuffer *result = resultMap.item(seq);
-                if (result)
-                    result->flush(true);
-            }
-        }
+            protocol->flush();
 
         if (probeQuery)
         {
-            FlushingStringBuffer response(client, isBlocked, MarkupFmt_XML, false, isHttp, *this);
-
-            // create output stream
-            response.startDataset("_Probe", NULL, (unsigned) -1);  // initialize it
-
             // loop through all of the graphs and create a _Probe to output each xgmml
             Owned<IPropertyTreeIterator> graphs = probeQuery->getElements("Graph");
             ForEach(*graphs)
@@ -2595,8 +2584,7 @@ protected:
 
                 StringBuffer xgmml;
                 _toXML(&graph, xgmml, 0);
-                response.append("\n");
-                response.append(xgmml.str());
+                protocol->appendProbeGraph(xgmml.str());
             }
         }
     }
@@ -2608,13 +2596,10 @@ protected:
 
     void init()
     {
-        client = NULL;
         totSlavesReplyLen = 0;
-        mlFmt = MarkupFmt_XML;
         isRaw = false;
         isBlocked = false;
-        isHttp = false;
-        trim = false;
+        isNative = true;
         sendHeartBeats = false;
 
         lastSocketCheckTime = startTime;
@@ -2628,7 +2613,7 @@ protected:
         wu->subscribe(SubscribeOptionAbort);
         addTimeStamp(wu, SSTglobal, NULL, StWhenQueryStarted);
         if (!context->getPropBool("@outputToSocket", false))
-            client = NULL;
+            protocol = NULL;
         updateSuppliedXmlParams(wu);
         SCMStringBuffer wuParams;
         if (workUnit->getXmlParams(wuParams, false).length())
@@ -2657,9 +2642,9 @@ protected:
 
     void initDebugMode(bool breakAtStart, const char *debugUID)
     {
-        if (!debugPermitted || !ownEP.port)
+        if (!debugPermitted || !ownEP.port || !nativeProtocol)
             throw MakeStringException(ROXIE_ACCESS_ERROR, "Debug queries are not permitted on this system");
-        debugContext.setown(new CRoxieServerDebugContext(this, logctx, factory->cloneQueryXGMML(), *client));
+        debugContext.setown(new CRoxieServerDebugContext(this, logctx, factory->cloneQueryXGMML(), *nativeProtocol->querySafeSocket()));
         debugContext->debugInitialize(debugUID, factory->queryQueryName(), breakAtStart);
         if (workUnit)
         {
@@ -2677,7 +2662,7 @@ public:
     IMPLEMENT_IINTERFACE;
 
     CRoxieServerContext(const IQueryFactory *_factory, const IRoxieContextLogger &_logctx)
-        : CRoxieContextBase(_factory, _logctx), serverQueryFactory(_factory)
+        : CRoxieContextBase(_factory, _logctx), serverQueryFactory(_factory), results(NULL)
     {
         init();
         rowManager->setMemoryLimit(options.memoryLimit);
@@ -2686,7 +2671,7 @@ public:
     }
 
     CRoxieServerContext(IConstWorkUnit *_workUnit, const IQueryFactory *_factory, const ContextLogger &_logctx)
-        : CRoxieContextBase(_factory, _logctx), serverQueryFactory(_factory)
+        : CRoxieContextBase(_factory, _logctx), serverQueryFactory(_factory), results(NULL)
     {
         init();
         workUnit.set(_workUnit);
@@ -2700,18 +2685,20 @@ public:
         startWorkUnit();
     }
 
-    CRoxieServerContext(IPropertyTree *_context, const IQueryFactory *_factory, SafeSocket &_client, TextMarkupFormat _mlFmt, bool _isRaw, bool _isBlocked, HttpHelper &httpHelper, bool _trim, const ContextLogger &_logctx, PTreeReaderOptions _xmlReadFlags, const char *_querySetName)
-        : CRoxieContextBase(_factory, _logctx), serverQueryFactory(_factory), querySetName(_querySetName)
+    CRoxieServerContext(IPropertyTree *_context, IHpccProtocolResponse *_protocol, const IQueryFactory *_factory, unsigned flags, const ContextLogger &_logctx, PTreeReaderOptions _xmlReadFlags, const char *_querySetName)
+        : CRoxieContextBase(_factory, _logctx), serverQueryFactory(_factory), querySetName(_querySetName), protocol(_protocol), results(NULL)
     {
         init();
+        if (protocol)
+        {
+            nativeProtocol = dynamic_cast<IHpccNativeProtocolResponse*>(protocol);
+            results = protocol->queryHpccResultsSection();
+        }
         context.set(_context);
         options.setFromContext(context);
-        client = &_client;
-        mlFmt = _mlFmt;
-        isRaw = _isRaw;
-        isBlocked = _isBlocked;
-        isHttp = httpHelper.isHttp();
-        trim = _trim;
+        isNative = (flags & HPCC_PROTOCOL_NATIVE);
+        isRaw = (flags & HPCC_PROTOCOL_NATIVE_RAW);
+        isBlocked = (flags & HPCC_PROTOCOL_BLOCKED);
         xmlStoredDatasetReadFlags = _xmlReadFlags;
         sendHeartBeats = enableHeartBeat && isRaw && isBlocked && options.priority==0;
 
@@ -2738,7 +2725,7 @@ public:
         // MORE some of these might be appropriate in wu case too?
         rowManager->setActivityTracking(context->getPropBool("_TraceMemory", false));
         rowManager->setMemoryLimit(options.memoryLimit);
-        authToken.append(httpHelper.queryAuthToken());
+
         workflow.setown(_factory->createWorkflowMachine(workUnit, false, logctx));
     }
 
@@ -2805,14 +2792,14 @@ public:
                 }
             }
         }
-        if (client)
+        if (protocol)
         {
             if (socketCheckInterval)
             {
                 if (ticksNow - lastSocketCheckTime > socketCheckInterval)
                 {
                     CriticalBlock b(abortLock);
-                    if (!client->checkConnection())
+                    if (!protocol->checkConnection())
                         throw MakeStringException(ROXIE_CLIENT_CLOSED, "Client socket closed");
                     lastSocketCheckTime = ticksNow;
                 }
@@ -2823,7 +2810,7 @@ public:
                 if (hb > 30000)
                 {
                     lastHeartBeat = msTick();
-                    client->sendHeartBeat(*this);
+                    protocol->sendHeartBeat();
                 }
             }
         }
@@ -2945,30 +2932,14 @@ public:
         return this;
     }
 
-    // interface ICodeContext
-    virtual FlushingStringBuffer *queryResult(unsigned sequence)
-    {
-        if (!client && workUnit)
-            return NULL;    // when outputting to workunit only, don't output anything to stdout
-        CriticalBlock procedure(resultsCrit);
-        while (!resultMap.isItem(sequence))
-            resultMap.append(NULL);
-        FlushingStringBuffer *result = resultMap.item(sequence);
-        if (!result)
-        {
-            result = new FlushingStringBuffer(client, isBlocked, mlFmt, isRaw, isHttp, *this);
-            result->isSoap = isHttp;
-            result->trim = trim;
-            result->queryName.set(context->queryName());
-            resultMap.replace(result, sequence);
-        }
-        return result;
-    }
-
     virtual char *getDaliServers()
     {
         //MORE: Should this now be implemented using IRoxieDaliHelper?
         throwUnexpected();
+    }
+    virtual IHpccProtocolResponse *queryProtocol()
+    {
+        return protocol;
     }
 
     virtual void setResultBool(const char *name, unsigned sequence, bool value)
@@ -2978,18 +2949,11 @@ public:
             CriticalBlock b(contextCrit);
             useContext(sequence).setPropBool(name, value);
         }
-        else
+        else if (results)
         {
-            FlushingStringBuffer *r = queryResult(sequence);
-            if (r)
-            {
-                r->startScalar(name, sequence);
-                if (isRaw)
-                    r->append(sizeof(value), (char *)&value);
-                else
-                    r->append(value ? "true" : "false");
-            }
+            results->setResultBool(name, sequence, value);
         }
+
         if (workUnit)
         {
             try
@@ -3024,14 +2988,9 @@ public:
             IPropertyTree &ctx = useContext(sequence);
             ctx.setProp(name, s.str());
         }
-        else
+        else if (results)
         {
-            FlushingStringBuffer *r = queryResult(sequence);
-            if (r)
-            {
-                r->startScalar(name, sequence);
-                r->encodeData(data, len);
-            }
+            results->setResultData(name, sequence, len, data);
         }
         if (workUnit)
         {
@@ -3125,17 +3084,9 @@ public:
             ctx.setPropBin(name, len, data);
             ctx.queryPropTree(name)->setProp("@format", "raw");
         }
-        else
+        else if (results)
         {
-            FlushingStringBuffer *r = queryResult(sequence);
-            if (r)
-            {
-                r->startScalar(name, sequence);
-                if (isRaw)
-                    r->append(len, (const char *) data);
-                else
-                    UNIMPLEMENTED;
-            }
+            results->setResultRaw(name, sequence, len, data);
         }
 
         if (workUnit)
@@ -3169,42 +3120,9 @@ public:
             ctx.queryPropTree(name)->setProp("@format", "raw");
             ctx.queryPropTree(name)->setPropBool("@isAll", isAll);
         }
-        else
+        else if (results)
         {
-            FlushingStringBuffer *r = queryResult(sequence);
-            if (r)
-            {
-                r->startScalar(name, sequence);
-                if (isRaw)
-                    r->append(len, (char *)data);
-                else if (mlFmt==MarkupFmt_XML)
-                {
-                    assertex(transformer);
-                    CommonXmlWriter writer(getXmlFlags()|XWFnoindent, 0);
-                    transformer->toXML(isAll, len, (byte *)data, writer);
-                    r->append(writer.str());
-                }
-                else if (mlFmt==MarkupFmt_JSON)
-                {
-                    assertex(transformer);
-                    CommonJsonWriter writer(getXmlFlags()|XWFnoindent, 0);
-                    transformer->toXML(isAll, len, (byte *)data, writer);
-                    r->append(writer.str());
-                }
-                else
-                {
-                    assertex(transformer);
-                    r->append('[');
-                    if (isAll)
-                        r->appendf("*]");
-                    else
-                    {
-                        SimpleOutputWriter x;
-                        transformer->toXML(isAll, len, (const byte *) data, x);
-                        r->appendf("%s]", x.str());
-                    }
-                }
-            }
+            results->setResultSet(name, sequence, isAll, len, data, transformer);
         }
 
         if (workUnit)
@@ -3243,24 +3161,9 @@ public:
             CriticalBlock b(contextCrit);
             useContext(sequence).setPropBin(name, m.length(), m.toByteArray());
         }
-        else
+        else if (results)
         {
-            FlushingStringBuffer *r = queryResult(sequence);
-            if (r)
-            {
-                r->startScalar(name, sequence);
-                if (isRaw)
-                    r->append(len, (char *)val);
-                else
-                {
-                    StringBuffer s;
-                    if (isSigned)
-                        outputXmlDecimal(val, len, precision, NULL, s);
-                    else
-                        outputXmlUDecimal(val, len, precision, NULL, s);
-                    r->append(s);
-                }
-            }
+            results->setResultDecimal(name, sequence, len, precision, isSigned, val);
         }
         if (workUnit)
         {
@@ -3290,21 +3193,10 @@ public:
             CriticalBlock b(contextCrit);
             useContext(sequence).setPropInt64(name, value);
         }
-        else
+        else if (results)
         {
-            FlushingStringBuffer *r = queryResult(sequence);
-            if (r)
-            {
-                if (isRaw)
-                {
-                    r->startScalar(name, sequence);
-                    r->append(sizeof(value), (char *)&value);
-                }
-                else
-                    r->setScalarInt(name, sequence, value, size);
-            }
+            results->setResultInt(name, sequence, value, size);
         }
-
         if (workUnit)
         {
             try
@@ -3334,19 +3226,9 @@ public:
             CriticalBlock b(contextCrit);
             useContext(sequence).setPropInt64(name, value);
         }
-        else
+        else if (results)
         {
-            FlushingStringBuffer *r = queryResult(sequence);
-            if (r)
-            {
-                if (isRaw)
-                {
-                    r->startScalar(name, sequence);
-                    r->append(sizeof(value), (char *)&value);
-                }
-                else
-                    r->setScalarUInt(name, sequence, value, size);
-            }
+            results->setResultUInt(name, sequence, value, size);
         }
 
         if (workUnit)
@@ -3378,14 +3260,9 @@ public:
             CriticalBlock b(contextCrit);
             useContext(sequence).setPropBin(name, sizeof(value), &value);
         }
-        else
+        else if (results)
         {
-            FlushingStringBuffer *r = queryResult(sequence);
-            if (r)
-            {
-                r->startScalar(name, sequence);
-                r->append(value);
-            }
+            results->setResultReal(name, sequence, value);
         }
         if (workUnit)
         {
@@ -3415,23 +3292,10 @@ public:
             CriticalBlock b(contextCrit);
             useContext(sequence).setPropBin(name, len, str);
         }
-        else
+        else if (results)
         {
-            FlushingStringBuffer *r = queryResult(sequence);
-            if (r)
-            {
-                r->startScalar(name, sequence);
-                if (r->isRaw)
-                {
-                    r->append(len, str);
-                }
-                else
-                {
-                    r->encodeString(str, len);
-                }
-            }
+            results->setResultString(name, sequence, len, str);
         }
-
         if (workUnit)
         {
             try
@@ -3463,26 +3327,10 @@ public:
             CriticalBlock b(contextCrit);
             useContext(sequence).setPropBin(name, bufflen, buff.getstr());
         }
-        else
+        else if (results)
         {
-            FlushingStringBuffer *r = queryResult(sequence);
-            if (r)
-            {
-                r->startScalar(name, sequence);
-                if (r->isRaw)
-                {
-                    r->append(len*2, (const char *) str);
-                }
-                else
-                {
-                    rtlDataAttr buff;
-                    unsigned bufflen = 0;
-                    rtlUnicodeToCodepageX(bufflen, buff.refstr(), len, str, "utf-8");
-                    r->encodeString(buff.getstr(), bufflen, true); // output as UTF-8
-                }
-            }
+            results->setResultUnicode(name, sequence, len, str);
         }
-
         if (workUnit)
         {
             try
@@ -3519,7 +3367,9 @@ public:
 
     virtual IWorkUnitRowReader *createStreamedRawRowReader(IEngineRowAllocator *rowAllocator, bool isGrouped, const char *id)
     {
-        return new StreamedRawDataReader(this, rowAllocator, isGrouped, logctx, *client, id);
+        if (!nativeProtocol)
+            throwUnexpected();
+        return new StreamedRawDataReader(this, rowAllocator, isGrouped, logctx, *nativeProtocol->querySafeSocket(), id);
     }
 
     virtual void printResults(IXmlWriter *output, const char *name, unsigned sequence)
@@ -3885,10 +3735,15 @@ public:
             superfileTransaction.setown(createDistributedFileTransaction(queryUserDescriptor(), queryCodeContext()));
         return superfileTransaction.get();
     }
-    virtual void flush(unsigned seqNo) { throwUnexpected(); }
+    virtual void finalize(unsigned seqNo)
+    {
+        if (!protocol)
+            throwUnexpected();
+        protocol->finalize(seqNo);
+    }
     virtual unsigned getPriority() const { return options.priority; }
     virtual IConstWorkUnit *queryWorkUnit() const { return workUnit; }
-    virtual bool outputResultsToSocket() const { return client != NULL; }
+    virtual bool outputResultsToSocket() const { return protocol != NULL; }
 
     virtual void selectCluster(const char * newCluster)
     {
@@ -3927,8 +3782,8 @@ private:
     StringAttr queryName;
 
 public:
-    CSoapRoxieServerContext(IPropertyTree *_context, const IQueryFactory *_factory, SafeSocket &_client, HttpHelper &httpHelper, const ContextLogger &_logctx, PTreeReaderOptions xmlReadFlags, const char *_querySetName)
-        : CRoxieServerContext(_context, _factory, _client, MarkupFmt_XML, false, false, httpHelper, httpHelper.getTrim(), _logctx, xmlReadFlags, _querySetName)
+    CSoapRoxieServerContext(IPropertyTree *_context, IHpccProtocolResponse *_protocol, const IQueryFactory *_factory, unsigned flags, const ContextLogger &_logctx, PTreeReaderOptions xmlReadFlags, const char *_querySetName)
+        : CRoxieServerContext(_context, _protocol, _factory, flags, _logctx, xmlReadFlags, _querySetName)
     {
         queryName.set(_context->queryName());
     }
@@ -3942,139 +3797,13 @@ public:
         else
             p->perform(this, 0);
     }
-
-    virtual void flush(unsigned seqNo)
-    {
-        CriticalBlock b(resultsCrit);
-        CriticalBlock b1(client->queryCrit());
-
-        StringBuffer responseHead, responseTail;
-        responseHead.append("<").append(queryName).append("Response");
-        responseHead.append(" sequence=\"").append(seqNo).append("\"");
-        responseHead.append(" xmlns=\"urn:hpccsystems:ecl:").appendLower(queryName.length(), queryName.str()).append("\">");
-        responseHead.append("<Results><Result>");
-        unsigned len = responseHead.length();
-        client->write(responseHead.detach(), len, true);
-
-        ForEachItemIn(seq, resultMap)
-        {
-            FlushingStringBuffer *result = resultMap.item(seq);
-            if (result)
-            {
-                result->flush(true);
-                for(;;)
-                {
-                    size32_t length;
-                    void *payload = result->getPayload(length);
-                    if (!length)
-                        break;
-                    client->write(payload, length, true);
-                }
-            }
-        }
-
-        responseTail.append("</Result></Results>");
-        responseTail.append("</").append(queryName).append("Response>");
-        len = responseTail.length();
-        client->write(responseTail.detach(), len, true);
-    }
 };
 
-class CJsonRoxieServerContext : public CRoxieServerContext
+IRoxieServerContext *createRoxieServerContext(IPropertyTree *context, IHpccProtocolResponse *protocol, const IQueryFactory *factory, unsigned flags, const ContextLogger &_logctx, PTreeReaderOptions readFlags, const char *querySetName)
 {
-private:
-    StringAttr queryName;
-
-public:
-    CJsonRoxieServerContext(IPropertyTree *_context, const IQueryFactory *_factory, SafeSocket &_client, HttpHelper &httpHelper, const ContextLogger &_logctx, PTreeReaderOptions xmlReadFlags, const char *_querySetName)
-        : CRoxieServerContext(_context, _factory, _client, MarkupFmt_JSON, false, false, httpHelper, httpHelper.getTrim(), _logctx, xmlReadFlags, _querySetName)
-    {
-        queryName.set(_context->queryName());
-    }
-
-    virtual void process()
-    {
-        EclProcessFactory pf = (EclProcessFactory) factory->queryDll()->getEntry("createProcess");
-        Owned<IEclProcess> p = pf();
-        if (workflow)
-            workflow->perform(this, p);
-        else
-            p->perform(this, 0);
-    }
-
-    virtual void flush(unsigned seqNo)
-    {
-        CriticalBlock b(resultsCrit);
-        CriticalBlock b1(client->queryCrit());
-
-        StringBuffer responseHead, responseTail;
-        appendfJSONName(responseHead, "%sResponse", queryName.get()).append(" {");
-        appendJSONValue(responseHead, "sequence", seqNo);
-        appendJSONName(responseHead, "Results").append(" {");
-
-        unsigned len = responseHead.length();
-        client->write(responseHead.detach(), len, true);
-
-        bool needDelimiter = false;
-        ForEachItemIn(seq, resultMap)
-        {
-            FlushingStringBuffer *result = resultMap.item(seq);
-            if (result)
-            {
-                result->flush(true);
-                for(;;)
-                {
-                    size32_t length;
-                    void *payload = result->getPayload(length);
-                    if (!length)
-                        break;
-                    if (needDelimiter)
-                    {
-                        StringAttr s(","); //write() will take ownership of buffer
-                        size32_t len = s.length();
-                        client->write((void *)s.detach(), len, true);
-                        needDelimiter=false;
-                    }
-                    client->write(payload, length, true);
-                }
-                needDelimiter=true;
-            }
-        }
-
-        responseTail.append("}}");
-        len = responseTail.length();
-        client->write(responseTail.detach(), len, true);
-    }
-
-    virtual FlushingStringBuffer *queryResult(unsigned sequence)
-    {
-        if (!client && workUnit)
-            return NULL;    // when outputting to workunit only, don't output anything to stdout
-        CriticalBlock procedure(resultsCrit);
-        while (!resultMap.isItem(sequence))
-            resultMap.append(NULL);
-        FlushingStringBuffer *result = resultMap.item(sequence);
-        if (!result)
-        {
-            result = new FlushingJsonBuffer(client, isBlocked, isHttp, *this);
-            result->trim = trim;
-            result->queryName.set(context->queryName());
-            resultMap.replace(result, sequence);
-        }
-        return result;
-    }
-};
-
-IRoxieServerContext *createRoxieServerContext(IPropertyTree *context, const IQueryFactory *factory, SafeSocket &client, bool isXml, bool isRaw, bool isBlocked, HttpHelper &httpHelper, bool trim, const ContextLogger &_logctx, PTreeReaderOptions readFlags, const char *querySetName)
-{
-    if (httpHelper.isHttp())
-    {
-        if (httpHelper.queryContentFormat()==MarkupFmt_JSON)
-            return new CJsonRoxieServerContext(context, factory, client, httpHelper, _logctx, readFlags, querySetName);
-        return new CSoapRoxieServerContext(context, factory, client, httpHelper, _logctx, readFlags, querySetName);
-    }
-    else
-        return new CRoxieServerContext(context, factory, client, isXml ? MarkupFmt_XML : MarkupFmt_Unknown, isRaw, isBlocked, httpHelper, trim, _logctx, readFlags, querySetName);
+    if (flags & HPCC_PROTOCOL_NATIVE)
+        return new CRoxieServerContext(context, protocol, factory, flags, _logctx, readFlags, querySetName);
+    return new CSoapRoxieServerContext(context, protocol, factory, flags, _logctx, readFlags, querySetName);
 }
 
 IRoxieServerContext *createOnceServerContext(const IQueryFactory *factory, const IRoxieContextLogger &_logctx)

--- a/roxie/ccd/ccdcontext.hpp
+++ b/roxie/ccd/ccdcontext.hpp
@@ -76,7 +76,6 @@ interface IRoxieSlaveContext : extends IRoxieContextLogger
 interface IRoxieServerContext : extends IInterface
 {
     virtual IGlobalCodeContext *queryGlobalCodeContext() = 0;
-    virtual FlushingStringBuffer *queryResult(unsigned sequence) = 0;
     virtual void setResultXml(const char *name, unsigned sequence, const char *xml) = 0;
     virtual void appendResultDeserialized(const char *name, unsigned sequence, size32_t count, byte **data, bool extend, IOutputMetaData *meta) = 0;
     virtual void appendResultRawContext(const char *name, unsigned sequence, int len, const void * data, int numRows, bool extend, bool saveInContext) = 0;
@@ -84,7 +83,7 @@ interface IRoxieServerContext : extends IInterface
 
     virtual void process() = 0;
     virtual void done(bool failed) = 0;
-    virtual void flush(unsigned seqNo) = 0;
+    virtual void finalize(unsigned seqNo) = 0;
     virtual unsigned getMemoryUsage() = 0;
     virtual unsigned getSlavesReplyLen() = 0;
 
@@ -94,6 +93,7 @@ interface IRoxieServerContext : extends IInterface
 
     virtual IRoxieDaliHelper *checkDaliConnection() = 0;
     virtual const IProperties *queryXmlns(unsigned seqNo) = 0;
+    virtual IHpccProtocolResponse *queryProtocol() = 0;
 };
 
 interface IDeserializedResultStore : public IInterface
@@ -109,7 +109,7 @@ class CRoxieWorkflowMachine;
 
 extern IDeserializedResultStore *createDeserializedResultStore();
 extern IRoxieSlaveContext *createSlaveContext(const IQueryFactory *factory, const SlaveContextLogger &logctx, IRoxieQueryPacket *packet, bool hasRemoteChildren);
-extern IRoxieServerContext *createRoxieServerContext(IPropertyTree *context, const IQueryFactory *factory, SafeSocket &client, bool isXml, bool isRaw, bool isBlocked, HttpHelper &httpHelper, bool trim, const ContextLogger &logctx, PTreeReaderOptions xmlReadFlags, const char *querySetName);
+extern IRoxieServerContext *createRoxieServerContext(IPropertyTree *context, IHpccProtocolResponse *protocol, const IQueryFactory *factory, unsigned flags, const ContextLogger &logctx, PTreeReaderOptions xmlReadFlags, const char *querySetName);
 extern IRoxieServerContext *createOnceServerContext(const IQueryFactory *factory, const IRoxieContextLogger &_logctx);
 extern IRoxieServerContext *createWorkUnitServerContext(IConstWorkUnit *wu, const IQueryFactory *factory, const ContextLogger &logctx);
 extern CRoxieWorkflowMachine *createRoxieWorkflowMachine(IPropertyTree *_workflowInfo, IConstWorkUnit *wu, bool doOnce, const IRoxieContextLogger &_logctx);

--- a/roxie/ccd/ccdlistener.cpp
+++ b/roxie/ccd/ccdlistener.cpp
@@ -58,72 +58,6 @@ static void controlException(StringBuffer &response, IException *E, const IRoxie
 
 //================================================================================================================
 
-class CHttpRequestAsyncFor : public CInterface, public CAsyncFor
-{
-private:
-    const char *queryName, *queryText, *querySetName;
-    const ContextLogger &logctx;
-    IArrayOf<IPropertyTree> &requestArray;
-    Linked<IQueryFactory> f;
-    SafeSocket &client;
-    HttpHelper &httpHelper;
-    PTreeReaderOptions xmlReadFlags;
-    unsigned &memused;
-    unsigned &slaveReplyLen;
-    CriticalSection crit;
-
-public:
-    CHttpRequestAsyncFor(const char *_queryName, IQueryFactory *_f, IArrayOf<IPropertyTree> &_requestArray, SafeSocket &_client, HttpHelper &_httpHelper, unsigned &_memused,
-                            unsigned &_slaveReplyLen, const char *_queryText, const ContextLogger &_logctx, PTreeReaderOptions _xmlReadFlags, const char *_querySetName)
-    : f(_f), requestArray(_requestArray), client(_client), httpHelper(_httpHelper), memused(_memused),
-      slaveReplyLen(_slaveReplyLen), logctx(_logctx), xmlReadFlags(_xmlReadFlags), querySetName(_querySetName)
-    {
-        queryName = _queryName;
-        queryText = _queryText;
-    }
-
-    IMPLEMENT_IINTERFACE;
-
-    void onException(IException *E)
-    {
-        if (!logctx.isBlind())
-            logctx.CTXLOG("FAILED: %s", queryText);
-        StringBuffer error("EXCEPTION: ");
-        E->errorMessage(error);
-        DBGLOG("%s", error.str());
-        client.checkSendHttpException(httpHelper, E, queryName);
-        E->Release();
-    }
-
-    void Do(unsigned idx)
-    {
-        try
-        {
-            IPropertyTree &request = requestArray.item(idx);
-            Owned<IRoxieServerContext> ctx = f->createContext(&request, client, httpHelper.queryContentFormat(), false, false, httpHelper, httpHelper.getTrim(), logctx, xmlReadFlags, querySetName);
-            ctx->process();
-            ctx->flush(idx);
-            CriticalBlock b(crit);
-            memused += ctx->getMemoryUsage();
-            slaveReplyLen += ctx->getSlavesReplyLen();
-        }
-        catch (WorkflowException * E)
-        {
-            onException(E);
-        }
-        catch (IException * E)
-        {
-            onException(E);
-        }
-        catch (...)
-        {
-            onException(MakeStringException(ROXIE_INTERNAL_ERROR, "Unknown exception"));
-        }
-    }
-};
-
-//================================================================================================================
-
 class CascadeManager : public CInterface
 {
     static Semaphore globalLock;
@@ -365,12 +299,11 @@ public:
         logctx.Release();
     }
 
-    void doLockChild(const char *queryText, StringBuffer &reply)
+    void doLockChild(IPropertyTree *xml, const char *logText, StringBuffer &reply)
     {
         if (traceLevel > 5)
-            DBGLOG("doLockChild: %s", queryText);
+            DBGLOG("doLockChild: %s", logText);
         isMaster = false;
-        Owned<IPropertyTree> xml = createPTreeFromXMLString(queryText);
         bool unlock = xml->getPropBool("@unlock", false);
         if (unlock)
         {
@@ -403,6 +336,12 @@ public:
                 reply.append("<Lock>0</Lock>");
             }
         }
+    }
+
+    void doLockChild(const char *queryText, StringBuffer &reply)
+    {
+        Owned<IPropertyTree> xml = createPTreeFromXMLString(queryText);
+        doLockChild(xml, queryText, reply);
     }
 
     bool doLockGlobal(StringBuffer &reply, bool lockAll)
@@ -456,14 +395,21 @@ public:
 
     void doControlQuery(SocketEndpoint &ep, const char *queryText, StringBuffer &reply)
     {
+        Owned<IPropertyTree> xml = createPTreeFromXMLString(queryText); // control queries are case sensitive
+        doControlQuery(ep, xml, queryText, reply);
+    }
+
+    void doControlQuery(SocketEndpoint &ep, IPropertyTree *xml, const char *queryText, StringBuffer &reply)
+    {
         if (logctx.queryTraceLevel() > 5)
             logctx.CTXLOG("doControlQuery (%d): %.80s", isMaster, queryText);
         // By this point we should have cascade-connected thanks to a prior <control:lock>
         // So do the query ourselves and in all child threads;
+        const char *name = xml->queryName();
         CascadeMergeType mergeType=CascadeMergeNone;
-        if (strstr(queryText, "querystats"))
+        if (strstr(name, "querystats"))
             mergeType=CascadeMergeStats;
-        else if (strstr(queryText, ":queries"))
+        else if (strstr(name, "queries"))
             mergeType=CascadeMergeQueries;
         Owned<IPropertyTree> mergedReply;
         if (mergeType!=CascadeMergeNone)
@@ -480,11 +426,12 @@ public:
             SocketEndpoint &ep;
             unsigned numChildren;
             const IRoxieContextLogger &logctx;
+            IPropertyTree *xml;
 
         public:
-            casyncfor(const char *_queryText, CascadeManager *_parent, IPropertyTree *_mergedReply, CascadeMergeType _mergeType,
+            casyncfor(IPropertyTree *_xml, const char *_queryText, CascadeManager *_parent, IPropertyTree *_mergedReply, CascadeMergeType _mergeType,
                       StringBuffer &_reply, SocketEndpoint &_ep, unsigned _numChildren, const IRoxieContextLogger &_logctx)
-                : queryText(_queryText), parent(_parent), mergedReply(_mergedReply), mergeType(_mergeType), reply(_reply), ep(_ep), numChildren(_numChildren), logctx(_logctx)
+                : xml(_xml), queryText(_queryText), parent(_parent), mergedReply(_mergedReply), mergeType(_mergeType), reply(_reply), ep(_ep), numChildren(_numChildren), logctx(_logctx)
             {
             }
             void Do(unsigned i)
@@ -497,15 +444,15 @@ public:
                 {
                     StringBuffer childReply;
                     parent->doChildQuery(i, queryText, childReply);
-                    Owned<IPropertyTree> xml = createPTreeFromXMLString(childReply);
-                    if (!xml)
+                    Owned<IPropertyTree> replyXML = createPTreeFromXMLString(childReply);
+                    if (!replyXML)
                     {
                         StringBuffer err;
                         err.appendf("doControlQuery::do (%d of %d): %.80s received invalid response %s", i, numChildren, queryText, childReply.str());
                         logctx.CTXLOG("%s", err.str());
                         throw MakeStringException(ROXIE_INTERNAL_ERROR, "%s", err.str());
                     }
-                    Owned<IPropertyTreeIterator> meat = xml->getElements("Endpoint");
+                    Owned<IPropertyTreeIterator> meat = replyXML->getElements("Endpoint");
                     ForEach(*meat)
                     {
                         CriticalBlock cb(crit);
@@ -529,7 +476,6 @@ public:
                 myReply.append("'>\n");
                 try
                 {
-                    Owned<IPropertyTree> xml = createPTreeFromXMLString(queryText); // control queries are case sensitive
                     globalPackageSetManager->doControlMessage(xml, myReply, logctx);
                 }
                 catch(IException *E)
@@ -544,16 +490,16 @@ public:
                 CriticalBlock cb(crit);
                 if (mergedReply)
                 {
-                    Owned<IPropertyTree> xml = createPTreeFromXMLString(myReply);
+                    Owned<IPropertyTree> replyXML = createPTreeFromXMLString(myReply);
                     if (mergeType == CascadeMergeStats)
-                        mergeStats(mergedReply, xml);
+                        mergeStats(mergedReply, replyXML);
                     else if (mergeType == CascadeMergeQueries)
-                        mergeQueries(mergedReply, xml);
+                        mergeQueries(mergedReply, replyXML);
                 }
                 else
                     reply.append(myReply);
             }
-        } afor(queryText, this, mergedReply, mergeType, reply, ep, activeChildren.ordinality(), logctx);
+        } afor(xml, queryText, this, mergedReply, mergeType, reply, ep, activeChildren.ordinality(), logctx);
         afor.For(activeChildren.ordinality()+(isMaster ? 0 : 1), 10);
         activeChildren.kill();
         if (mergedReply)
@@ -644,7 +590,74 @@ public:
 
 //================================================================================================================================
 
-class RoxieListener : public Thread, implements IRoxieListener, implements IThreadFactory
+class ActiveQueryLimiter : public CInterface, implements IActiveQueryLimiter
+{
+    IHpccProtocolListener *parent;
+    IHpccProtocolMsgSink *sink;
+    bool accepted;
+public:
+    IMPLEMENT_IINTERFACE;
+    ActiveQueryLimiter(IHpccProtocolListener *_parent) : parent(_parent)
+    {
+        sink = parent->queryMsgSink();
+        CriticalBlock b(sink->getActiveCrit());
+        if (sink->getIsSuspended())
+        {
+            accepted = false;
+            if (traceLevel > 1)
+                DBGLOG("Rejecting query since Roxie server pool %d is suspended ", parent->queryPort());
+        }
+        else
+        {
+            unsigned threadsActive = sink->getActiveThreadCount();
+            unsigned poolSize = sink->getPoolSize();
+            accepted = (threadsActive < poolSize);
+            if (accepted && threadsActive > sink->getMaxActiveThreads())
+            {
+                sink->setMaxActiveThreads(threadsActive);
+                if (traceLevel > 1)
+                    DBGLOG("Maximum queries active %d of %d for pool %d", threadsActive, poolSize, parent->queryPort());
+            }
+            if (!accepted && traceLevel > 5)
+                DBGLOG("Too many active queries (%d >= %d)", threadsActive, poolSize);
+        }
+        sink->incActiveThreadCount();
+    }
+    ~ActiveQueryLimiter()
+    {
+        CriticalBlock b(sink->getActiveCrit());
+        sink->decActiveThreadCount();
+    }
+    virtual bool isAccepted(){return accepted;}
+};
+
+IActiveQueryLimiter *createActiveQueryLimiter(IHpccProtocolListener *listener)
+{
+    return new ActiveQueryLimiter(listener);
+}
+
+class CActiveQueryLimiterFactory : public CInterface, implements IActiveQueryLimiterFactory
+{
+public:
+    IMPLEMENT_IINTERFACE;
+    CActiveQueryLimiterFactory(){}
+    IActiveQueryLimiter *create(IHpccProtocolListener *listener)
+    {
+        return createActiveQueryLimiter(listener);
+    }
+};
+
+static Owned<IActiveQueryLimiterFactory> queryLimiterFactory;
+IActiveQueryLimiterFactory *ensureLimiterFactory()
+{
+    if (!queryLimiterFactory)
+        queryLimiterFactory.setown(new CActiveQueryLimiterFactory());
+    return queryLimiterFactory;
+}
+
+//================================================================================================================================
+
+class RoxieListener : public Thread, implements IHpccProtocolListener, implements IHpccProtocolMsgSink, implements IThreadFactory
 {
 public:
     IMPLEMENT_IINTERFACE;
@@ -655,6 +668,42 @@ public:
         poolSize = _poolSize;
         threadsActive = 0;
         maxThreadsActive = 0;
+    }
+    virtual IHpccProtocolMsgSink *queryMsgSink()
+    {
+        return this;
+    }
+    virtual CriticalSection &getActiveCrit()
+    {
+        return activeCrit;
+    }
+    virtual bool getIsSuspended()
+    {
+        return suspended;
+    }
+    virtual unsigned getActiveThreadCount()
+    {
+        return threadsActive;
+    }
+    virtual unsigned getPoolSize()
+    {
+        return poolSize;
+    }
+    virtual unsigned getMaxActiveThreads()
+    {
+        return maxThreadsActive;
+    }
+    virtual void setMaxActiveThreads(unsigned val)
+    {
+        maxThreadsActive=val;
+    }
+    virtual void incActiveThreadCount()
+    {
+        threadsActive++;
+    }
+    virtual void decActiveThreadCount()
+    {
+        threadsActive--;
     }
 
     static void updateAffinity()
@@ -825,7 +874,6 @@ protected:
     unsigned threadsActive;
     unsigned maxThreadsActive;
     CriticalSection activeCrit;
-    friend class ActiveQueryLimiter;
 
 #ifdef CPU_ZERO
     static cpu_set_t cpuMask;
@@ -896,11 +944,30 @@ public:
         return 0;
     }
 
-    virtual void runOnce(const char*)
+    virtual StringArray &getTargetNames(StringArray &targets)
+    {
+        CloneArray(targets, allQuerySetNames);
+        return targets;
+    }
+
+    virtual IHpccProtocolMsgContext *createMsgContext(time_t startTime)
     {
         UNIMPLEMENTED;
     }
 
+    virtual void runOnce(const char *query)
+    {
+        UNIMPLEMENTED;
+    }
+
+    virtual void noteQuery(IHpccProtocolMsgContext *msgctx, const char *peer, bool failed, unsigned bytesOut, unsigned elapsed, unsigned priority, unsigned memused, unsigned slavesReplyLen, bool continuationNeeded)
+    {
+    }
+
+    virtual void onQueryMsg(IHpccProtocolMsgContext *msgctx, IPropertyTree *msg, IHpccProtocolResponse *protocol, unsigned flags, PTreeReaderOptions readFlags, const char *target, unsigned idx, unsigned &memused, unsigned &slaveReplyLen)
+    {
+        UNIMPLEMENTED;
+    }
     virtual bool stop(unsigned timeout)
     {
         if (queue)
@@ -986,117 +1053,6 @@ public:
     virtual IPooledThread* createNew();
 };
 
-class RoxieSocketListener : public RoxieListener
-{
-    unsigned port;
-    unsigned listenQueue;
-    Owned<ISocket> socket;
-    SocketEndpoint ep;
-
-public:
-    RoxieSocketListener(unsigned _port, unsigned _poolSize, unsigned _listenQueue, bool _suspended)
-      : RoxieListener(_poolSize, _suspended)
-    {
-        port = _port;
-        listenQueue = _listenQueue;
-        ep.set(port, queryHostIP());
-    }
-
-    virtual bool stop(unsigned timeout)
-    {
-        if (socket)
-            socket->cancel_accept();
-        return RoxieListener::stop(timeout);
-    }
-
-    virtual void disconnectQueue()
-    {
-        // This is for dali queues only
-    }
-
-    virtual void stopListening()
-    {
-        // Not threadsafe, but we only call this when generating a core file... what's the worst that can happen?
-        try
-        {
-            DBGLOG("Closing listening socket %d", port);
-            socket.clear();
-            DBGLOG("Closed listening socket %d", port);
-        }
-        catch(...)
-        {
-        }
-    }
-
-    virtual void runOnce(const char *query);
-
-    virtual int run()
-    {
-        DBGLOG("RoxieSocketListener (%d threads) listening to socket on port %d", poolSize, port);
-        socket.setown(ISocket::create(port, listenQueue));
-        running = true;
-        started.signal();
-        while (running)
-        {
-            ISocket *client = socket->accept(true);
-            if (client)
-            {
-                client->set_linger(-1);
-                pool->start(client);
-            }
-        }
-        DBGLOG("RoxieSocketListener closed query socket");
-        return 0;
-    }
-
-    virtual IPooledThread *createNew();
-
-    virtual const SocketEndpoint &queryEndpoint() const
-    {
-        return ep;
-    }
-
-    virtual unsigned queryPort() const
-    {
-        return port;
-    }
-};
-
-class ActiveQueryLimiter
-{
-    RoxieListener *parent;
-public:
-    bool accepted;
-    ActiveQueryLimiter(RoxieListener *_parent) : parent(_parent)
-    {
-        CriticalBlock b(parent->activeCrit);
-        if (parent->suspended)
-        {
-            accepted = false;
-            if (traceLevel > 1)
-                DBGLOG("Rejecting query since Roxie server pool %d is suspended ", parent->queryPort());
-        }
-        else
-        {
-            accepted = (parent->threadsActive < parent->poolSize);
-            if (accepted && parent->threadsActive > parent->maxThreadsActive)
-            {
-                parent->maxThreadsActive = parent->threadsActive;
-                if (traceLevel > 1)
-                    DBGLOG("Maximum queries active %d of %d for pool %d", parent->threadsActive, parent->poolSize, parent->queryPort());
-            }
-            if (!accepted && traceLevel > 5)
-                DBGLOG("Too many active queries (%d >= %d)", parent->threadsActive, parent->poolSize);
-        }
-        parent->threadsActive++;
-    }
-
-    ~ActiveQueryLimiter()
-    {
-        CriticalBlock b(parent->activeCrit);
-        parent->threadsActive--;
-    }
-};
 
 class RoxieQueryWorker : public CInterface, implements IPooledThread
 {
@@ -1230,8 +1186,8 @@ public:
             if (pool)
             {
                 pool->checkWuAccess(isBlind);
-                ActiveQueryLimiter l(pool);
-                if (!l.accepted)
+                Owned<IActiveQueryLimiter> l = createActiveQueryLimiter(pool);
+                if (!l->isAccepted())
                 {
                     IException *e = MakeStringException(ROXIE_TOO_MANY_QUERIES, "Too many active queries");
                     if (trapTooManyActiveQueries)
@@ -1318,693 +1274,494 @@ private:
     StringAttr wuid;
 };
 
-class RoxieSocketWorker : public RoxieQueryWorker
+class RoxieProtocolMsgContext : public CInterface, implements IHpccProtocolMsgContext
 {
-    Owned<SafeSocket> client;
-    Owned<CDebugCommandHandler> debugCmdHandler;
-    SocketEndpoint ep;
-
 public:
-    RoxieSocketWorker(RoxieListener *_pool, SocketEndpoint &_ep)
-        : RoxieQueryWorker(_pool), ep(_ep)
+    StringAttr queryName;
+    StringAttr uid;
+    Owned<CascadeManager> cascade;
+    Owned<IDebuggerContext> debuggerContext;
+    Owned<CDebugCommandHandler> debugCmdHandler;
+    Owned<StringContextLogger> logctx;
+    Owned<IQueryFactory> queryFactory;
+
+    SocketEndpoint ep;
+    time_t startTime;
+public:
+    IMPLEMENT_IINTERFACE;
+
+    RoxieProtocolMsgContext(const SocketEndpoint &_ep, time_t _startTime) : startTime(_startTime)
+    {
+        ep.set(_ep);
+        unknownQueryStats.noteActive();
+        atomic_inc(&queryCount);
+    }
+    ~RoxieProtocolMsgContext()
     {
     }
 
-    //  interface IPooledThread
-    virtual void init(void *_r)
+    inline ContextLogger &ensureContextLogger()
     {
-        client.setown(new CSafeSocket((ISocket *) _r));
-        RoxieQueryWorker::init(_r);
+        if (!logctx)
+        {
+            unsigned instanceId = getNextInstanceId();
+            StringBuffer ctxstr;
+            logctx.setown(new StringContextLogger(ep.getIpText(ctxstr).appendf(":%u{%u}", ep.port, instanceId).str()));
+        }
+        return *logctx;
     }
-
-    virtual void main()
+    virtual bool initQuery(StringBuffer &target, const char *name)
     {
-        doMain("");
-    }
-
-    virtual void runOnce(const char *query)
-    {
-        doMain(query);
-    }
-
-private:
-    static void sendHttpServerTooBusy(SafeSocket &client, const IRoxieContextLogger &logctx)
-    {
-        StringBuffer message;
-
-        message.append("HTTP/1.0 503 Server Too Busy\r\n\r\n");
-        message.append("Server too busy, please try again later");
-
-        StringBuffer err("Too many active queries");  // write out Too many active queries - make searching for this error consistent
-        if (!trapTooManyActiveQueries)
+        queryName.set(name);
+        queryFactory.setown(globalPackageSetManager->getQuery(name, &target, NULL, *logctx));
+        if (!queryFactory)
         {
-            err.appendf("  %s", message.str());
-            logctx.CTXLOG("%s", err.str());
-        }
-        else
-        {
-            IException *E = MakeStringException(ROXIE_TOO_MANY_QUERIES, "%s", err.str());
-            logctx.logOperatorException(E, __FILE__, __LINE__, "%s", message.str());
-            E->Release();
-        }
-
-        try
-        {
-            client.write(message.str(), message.length());
-        }
-        catch (IException *E)
-        {
-            logctx.logOperatorException(E, __FILE__, __LINE__, "Exception caught in sendHttpServerTooBusy");
-            E->Release();
-        }
-        catch (...)
-        {
-            logctx.logOperatorException(NULL, __FILE__, __LINE__, "sendHttpServerTooBusy write failed (Unknown exception)");
-        }
-    }
-
-    void sanitizeQuery(Owned<IPropertyTree> &queryXML, StringAttr &queryName, StringBuffer &saniText, HttpHelper &httpHelper, const char *&uid, bool &isRequest, bool &isRequestArray, bool &isBlind, bool &isDebug)
-    {
-        if (queryXML)
-        {
-            queryName.set(queryXML->queryName());
-            isRequest = false;
-            isRequestArray = false;
-            if (httpHelper.isHttp())
+            logctx->logOperatorException(NULL, NULL, 0, "Unknown query %s", name);
+            if (globalPackageSetManager->getActivePackageCount())
             {
-                if (httpHelper.queryContentFormat()==MarkupFmt_JSON)
-                {
-                    if (strieq(queryName, "__object__"))
-                    {
-                        queryXML.setown(queryXML->getPropTree("*[1]"));
-                        queryName.set(queryXML->queryName());
-                        isRequest = true;
-                        if (!queryXML)
-                            throw MakeStringException(ROXIE_DATA_ERROR, "Malformed JSON request (missing Body)");
-                    }
-                    else if (strieq(queryName, "__array__"))
-                        throw MakeStringException(ROXIE_DATA_ERROR, "JSON request array not implemented");
-                    else
-                        throw MakeStringException(ROXIE_DATA_ERROR, "Malformed JSON request");
-                }
-                else
-                {
-                    if (strieq(queryName, "envelope"))
-                        queryXML.setown(queryXML->getPropTree("Body/*"));
-                    else if (!strnicmp(httpHelper.queryContentType(), "application/soap", strlen("application/soap")))
-                        throw MakeStringException(ROXIE_DATA_ERROR, "Malformed SOAP request");
-                    else
-                        httpHelper.setUseEnvelope(false);
-                    if (!queryXML)
-                        throw MakeStringException(ROXIE_DATA_ERROR, "Malformed SOAP request (missing Body)");
-                    String reqName(queryXML->queryName());
-                    queryXML->removeProp("@xmlns:m");
-
-                    // following code is moved from main() - should be no performance hit
-                    String requestString("Request");
-                    String requestArrayString("RequestArray");
-
-                    if (reqName.endsWith(requestArrayString))
-                    {
-                        isRequestArray = true;
-                        queryName.set(reqName.str(), reqName.length() - requestArrayString.length());
-                    }
-                    else if (reqName.endsWith(requestString))
-                    {
-                        isRequest = true;
-                        queryName.set(reqName.str(), reqName.length() - requestString.length());
-                    }
-                    else
-                        queryName.set(reqName.str());
-
-                    queryXML->renameProp("/", queryName.get());  // reset the name of the tree
-                }
-            }
-
-            // convert to XML with attribute values in single quotes - makes replaying queries easier
-            uid = queryXML->queryProp("@uid");
-            if (!uid)
-                uid = queryXML->queryProp("_TransactionId");
-            isBlind = queryXML->getPropBool("@blind", false) || queryXML->getPropBool("_blind", false);
-            isDebug = queryXML->getPropBool("@debug") || queryXML->getPropBool("_Probe", false);
-            toXML(queryXML, saniText, 0, isBlind ? (XML_SingleQuoteAttributeValues | XML_Sanitize) : XML_SingleQuoteAttributeValues);
-        }
-        else
-            throw MakeStringException(ROXIE_DATA_ERROR, "Malformed request");
-    }
-    void parseQueryPTFromString(Owned<IPropertyTree> &queryPT, HttpHelper &httpHelper, const char *text, PTreeReaderOptions options)
-    {
-        if (strieq(httpHelper.queryContentType(), "application/json"))
-            queryPT.setown(createPTreeFromJSONString(text, ipt_caseInsensitive, options));
-        else
-            queryPT.setown(createPTreeFromXMLString(text, ipt_caseInsensitive, options));
-    }
-    void doMain(const char *runQuery)
-    {
-        StringBuffer rawText(runQuery);
-        unsigned priority = (unsigned) -2;
-        unsigned memused = 0;
-        Owned<CascadeManager> cascade;
-        IpAddress peer;
-        bool continuationNeeded = false;
-        bool isStatus = false;
-readAnother:
-        Owned<IDebuggerContext> debuggerContext;
-        unsigned slavesReplyLen = 0;
-        HttpHelper httpHelper(&allQuerySetNames);
-        try
-        {
-            if (client)
-            {
-                client->querySocket()->getPeerAddress(peer);
-                if (!client->readBlock(rawText, WAIT_FOREVER, &httpHelper, continuationNeeded, isStatus, maxBlockSize))
-                {
-                    if (traceLevel > 8)
-                    {
-                        StringBuffer b;
-                        DBGLOG("No data reading query from socket");
-                    }
-                    client.clear();
-                    return;
-                }
-            }
-            if (continuationNeeded)
-            {
-                qstart = msTick();
-                time(&startTime);
-            }
-            unknownQueryStats.noteActive();
-            atomic_inc(&queryCount);
-        }
-        catch (IException * E)
-        {
-            if (traceLevel > 0)
-            {
-                StringBuffer b;
-                DBGLOG("Error reading query from socket: %s", E->errorMessage(b).str());
-            }
-            E->Release();
-            client.clear();
-            return;
-        }
-
-        TextMarkupFormat mlFmt = MarkupFmt_XML;
-        bool isRaw = false;
-        bool isHTTP = httpHelper.isHttp();
-        bool isBlocked = false;
-        bool trim = false;
-        bool failed = false;
-        Owned<IPropertyTree> queryXml;
-        Owned<IQueryFactory> queryFactory;
-        StringBuffer sanitizedText;
-        StringAttr queryName;
-        StringBuffer peerStr;
-        peer.getIpText(peerStr);
-        const char *uid = "-";
-        unsigned instanceId = getNextInstanceId();
-        StringBuffer ctxstr;
-        Owned<StringContextLogger> _logctx = new StringContextLogger(ep.getIpText(ctxstr).appendf(":%u{%u}", ep.port, instanceId).str());
-        StringContextLogger &logctx = *_logctx.get();
-        try
-        {
-            // Note - control queries have to be formatted without spaces..
-            if (strnicmp(rawText.str(), "<control:lock", 13)==0 && !isalpha(rawText.charAt(13)))
-            {
-                if (logctx.queryTraceLevel() > 8)
-                    logctx.CTXLOG("Got lock request %s", rawText.str());
-                FlushingStringBuffer response(client, false, MarkupFmt_XML, false, false, logctx);
-                response.startDataset("Control", NULL, (unsigned) -1);
-                if (!cascade)
-                    cascade.setown(new CascadeManager(logctx));
-                StringBuffer s;
-                cascade->doLockGlobal(s, false);
-                response.append(s);
-                if (logctx.queryTraceLevel() > 8)
-                    logctx.CTXLOG("lock reply %s", s.str());
-                response.flush(true);
-                unsigned replyLen = 0;
-                client->write(&replyLen, sizeof(replyLen));
-                rawText.clear();
-                unknownQueryStats.noteComplete();
-                goto readAnother;
-            }
-            else if (strnicmp(rawText.str(), "<control:childlock", 18)==0 && !isalpha(rawText.charAt(18)))
-            {
-                if (logctx.queryTraceLevel() > 8)
-                    logctx.CTXLOG("Got childlock request %s", rawText.str());
-                FlushingStringBuffer response(client, false, MarkupFmt_XML, false, false, logctx);
-                response.startDataset("Control", NULL, (unsigned) -1);
-                if (!cascade)
-                    cascade.setown(new CascadeManager(logctx));
-                StringBuffer s;
-                cascade->doLockChild(rawText.str(), s);
-                response.append(s);
-                if (logctx.queryTraceLevel() > 8)
-                    logctx.CTXLOG("childlock reply %s", s.str());
-                response.flush(true);
-                unsigned replyLen = 0;
-                client->write(&replyLen, sizeof(replyLen));
-                rawText.clear();
-                unknownQueryStats.noteComplete();
-                goto readAnother;
-            }
-            else if (strnicmp(rawText.str(), "<control:", 9)==0)
-            {
-                Owned<IPropertyTree> queryXML = createPTreeFromXMLString(rawText.str()); // This is just done to check it is valid XML and make error reporting better...
-                queryXML.clear();
-                bool doControlQuery = true;
-
-                FlushingStringBuffer response(client, false, MarkupFmt_XML, false, isHTTP, logctx);
-                response.startDataset("Control", NULL, (unsigned) -1);
-
-                if (strnicmp(rawText.str(), "<control:aclupdate", 18)==0 && !isalpha(rawText.charAt(18)))
-                {
-                    queryXml.setown(createPTreeFromXMLString(rawText.str(), ipt_caseInsensitive, (PTreeReaderOptions)(ptr_ignoreWhiteSpace|ptr_ignoreNameSpaces)));
-                    IPropertyTree *aclTree = queryXml->queryPropTree("ACL");
-                    if (aclTree)
-                    {
-                        Owned<IPropertyTreeIterator> accesses = aclTree->getElements("Access");
-                        ForEach(*accesses)
-                        {
-                            IPropertyTree &access = accesses->query();
-                            try
-                            {
-                                pool->addAccess(access.getPropBool("@allow", true), access.getPropBool("@allowBlind", true), access.queryProp("@ip"), access.queryProp("@mask"), access.queryProp("@query"), access.queryProp("@error"), access.getPropInt("@errorCode", -1));
-                            }
-                            catch (IException *E)
-                            {
-                                StringBuffer s, x;
-                                E->errorMessage(s);
-                                E->Release();
-                                toXML(&access, x, 0, 0);
-                                throw MakeStringException(ROXIE_ACL_ERROR, "Error in access statement %s: %s", x.str(), s.str());
-                            }
-                        }
-
-                    }
-                }
-                else if (strnicmp(rawText.str(), "<control:queryaclinfo", 21)==0 && !isalpha(rawText.charAt(21)))
-                {
-                    StringBuffer info;
-                    info.append("<Endpoint ep='");
-                    ep.getUrlStr(info);
-                    info.append("'>\n");
-
-                    pool->queryAccessInfo(info);
-                    info.append("</Endpoint>\n");
-                    response.append(info.str());
-                    doControlQuery = false;
-                }
-
-                if (doControlQuery)
-                {
-                    if(!cascade)
-                        cascade.setown(new CascadeManager(logctx));
-                    StringBuffer s;
-                    cascade->doControlQuery(ep, rawText, s);
-                    response.append(s);
-                }
-            }
-            else if (isStatus)
-            {
-                client->write("OK", 2);
+                StringBuffer targetMsg;
+                if (target.length())
+                    targetMsg.append(", in target ").append(target);
+                throw MakeStringException(ROXIE_UNKNOWN_QUERY, "Unknown query %s%s", queryName.get(), targetMsg.str());
             }
             else
-            {
-                try
-                {
-                    parseQueryPTFromString(queryXml, httpHelper, rawText.str(), (PTreeReaderOptions)(defaultXmlReadFlags | ptr_ignoreNameSpaces));
-                }
-                catch (IException *E)
-                {
-                    logctx.logOperatorException(E, __FILE__, __LINE__, "Invalid XML received from %s:%d - %s", peerStr.str(), pool->queryPort(), rawText.str());
-                    logctx.CTXLOG("ERROR: Invalid XML received from %s:%d - %s", peerStr.str(), pool->queryPort(), rawText.str());
-                    throw;
-                }
-                bool isRequest = false;
-                bool isRequestArray = false;
-                bool isBlind = false;
-                bool isDebug = false;
-                const char *uid = NULL;
-                sanitizeQuery(queryXml, queryName, sanitizedText, httpHelper, uid, isRequest, isRequestArray, isBlind, isDebug);
-                if (uid)
-                {
-                    logctx.set(ep.getIpText(ctxstr).appendf(":%u{%s}", ep.port, uid).str());
-                    ctxstr.clear();
-                }
-                else
-                    uid = "-";
-                pool->checkAccess(peer, queryName, sanitizedText, isBlind);
-                if (isDebug)
-                {
-                    if (!debugPermitted || !ownEP.port)
-                        throw MakeStringException(ROXIE_ACCESS_ERROR, "Debug queries are not permitted on this system");
-                }
-                isBlind = isBlind || blindLogging;
-                logctx.setBlind(isBlind);
-                if (logFullQueries)
-                {
-                    StringBuffer soapStr;
-                    (isRequest) ? soapStr.append("SoapRequest") : (isRequestArray) ? soapStr.append("SoapRequest") : soapStr.clear();
-                    logctx.CTXLOG("%s %s:%d %s %s %s", isBlind ? "BLIND:" : "QUERY:", peerStr.str(), pool->queryPort(), uid, soapStr.str(), sanitizedText.str());
-                }
-                if (strnicmp(rawText.str(), "<debug:", 7)==0)
-                {
-                    if (!debugPermitted || !ownEP.port)
-                        throw MakeStringException(ROXIE_ACCESS_ERROR, "Debug queries are not permitted on this system");
-                    if (!debuggerContext)
-                    {
-                        if (!uid)
-#ifdef _DEBUG
-                            uid="*";
-#else
-                            throw MakeStringException(ROXIE_DEBUG_ERROR, "Debug id not specified");
-#endif
-                        debuggerContext.setown(queryRoxieDebugSessionManager().lookupDebuggerContext(uid));
-                        if (!debuggerContext)
-                            throw MakeStringException(ROXIE_DEBUG_ERROR, "No active query matching context %s found", uid);
-                        if (!debugCmdHandler.get())
-                            debugCmdHandler.setown(new CDebugCommandHandler);
-                    }
-                    FlushingStringBuffer response(client, false, MarkupFmt_XML, false, isHTTP, logctx);
-                    response.startDataset("Debug", NULL, (unsigned) -1);
-                    debugCmdHandler->doDebugCommand(queryXml, debuggerContext, response);
-                }
-                else
-                {
-                    ActiveQueryLimiter l(pool);
-                    if (!l.accepted)
-                    {
-                        if (isHTTP)
-                        {
-                            sendHttpServerTooBusy(*client, logctx);
-                            logctx.CTXLOG("FAILED: %s", sanitizedText.str());
-                            logctx.CTXLOG("EXCEPTION: Too many active queries");
-                        }
-                        else
-                        {
-                            IException *e = MakeStringException(ROXIE_TOO_MANY_QUERIES, "Too many active queries");
-                            if (trapTooManyActiveQueries)
-                                logctx.logOperatorException(e, __FILE__, __LINE__, NULL);
-                            throw e;
-                        }
-                    }
-                    else
-                    {
-                        StringBuffer querySetName;
-                        if (isHTTP)
-                        {
-                            client->setHttpMode(queryName, isRequestArray, httpHelper);
-                            querySetName.set(httpHelper.queryTarget());
-                            if (querySetName.length())
-                            {
-                                const char *target = targetAliases->queryProp(querySetName.str());
-                                if (target)
-                                    querySetName.set(target);
-                            }
-                        }
-                        queryFactory.setown(globalPackageSetManager->getQuery(queryName, &querySetName, NULL, logctx));
-                        if (queryFactory)
-                        {
-                            queryFactory->checkSuspended();
-                            int bindCores = queryFactory->queryOptions().bindCores;
-                            bindCores = queryXml->getPropInt("@bindCores", bindCores);
-                            if (bindCores > 0)
-                                pool->setThreadAffinity(bindCores);
-                            bool stripWhitespace = queryFactory->queryOptions().stripWhitespaceFromStoredDataset;
-                            stripWhitespace = queryXml->getPropBool("_stripWhitespaceFromStoredDataset", stripWhitespace);
-                            PTreeReaderOptions xmlReadFlags = (PTreeReaderOptions)((defaultXmlReadFlags & ~ptr_ignoreWhiteSpace) |
-                                                                               (stripWhitespace ? ptr_ignoreWhiteSpace : ptr_none));
-                            if (xmlReadFlags != defaultXmlReadFlags)
-                            {
-                                // we need to reparse input xml, as global whitespace setting has been overridden
-                                parseQueryPTFromString(queryXml, httpHelper, rawText.str(), (PTreeReaderOptions)(xmlReadFlags | ptr_ignoreNameSpaces));
-                                const char *dummy;
-                                sanitizeQuery(queryXml, queryName, sanitizedText, httpHelper, dummy, isRequest, isRequestArray, isBlind, isDebug);
-                            }
-                            IArrayOf<IPropertyTree> requestArray;
-                            if (isHTTP)
-                            {
-                                if (isRequestArray)
-                                {
-                                    StringBuffer reqIterString;
-                                    reqIterString.append(queryName).append("Request");
+                throw MakeStringException(ROXIE_NO_PACKAGES_ACTIVE, "Unknown query %s (no packages active)", queryName.get());
+            return false;
+        }
+        queryFactory->checkSuspended();
+        return true;
+    }
+    virtual void noteQueryActive()
+    {
+        unsigned priority = getQueryPriority();
+        switch (priority)
+        {
+        case 0: loQueryStats.noteActive(); break;
+        case 1: hiQueryStats.noteActive(); break;
+        case 2: slaQueryStats.noteActive(); break;
+        }
+        unknownQueryStats.noteComplete();
+        combinedQueryStats.noteActive();
+    }
+    IQueryFactory *queryQueryFactory(){return queryFactory;}
+    virtual IContextLogger *queryLogContext()
+    {
+        return &ensureContextLogger();
+    }
+    inline CascadeManager &ensureCascadeManager()
+    {
+        if (!cascade)
+            cascade.setown(new CascadeManager(ensureContextLogger()));
+        return *cascade;
+    }
 
-                                    Owned<IPropertyTreeIterator> reqIter = queryXml->getElements(reqIterString.str());
-                                    ForEach(*reqIter)
-                                    {
-                                        IPropertyTree *fixedreq = createPTree(queryName, ipt_caseInsensitive);
-                                        Owned<IPropertyTreeIterator> iter = reqIter->query().getElements("*");
-                                        ForEach(*iter)
-                                        {
-                                            fixedreq->addPropTree(iter->query().queryName(), LINK(&iter->query()));
-                                        }
-                                        requestArray.append(*fixedreq);
-                                    }
-                                }
-                                else
-                                {
-                                    IPropertyTree *fixedreq = createPTree(queryName, ipt_caseInsensitive);
-                                    Owned<IPropertyTreeIterator> iter = queryXml->getElements("*");
-                                    ForEach(*iter)
-                                    {
-                                        fixedreq->addPropTree(iter->query().queryName(), LINK(&iter->query()));
-                                    }
-                                    requestArray.append(*fixedreq);
-                                }
-                                trim = true;
-                            }
-                            else
-                            {
-                                const char *format = queryXml->queryProp("@format");
-                                if (format)
-                                {
-                                    if (stricmp(format, "raw") == 0)
-                                    {
-                                        isRaw = true;
-                                        mlFmt = MarkupFmt_Unknown;
-                                        isBlocked = (client != NULL);
-                                    }
-                                    else if (stricmp(format, "bxml") == 0)
-                                    {
-                                        isBlocked = true;
-                                    }
-                                    else if (stricmp(format, "ascii") == 0)
-                                    {
-                                        isRaw = false;
-                                        mlFmt = MarkupFmt_Unknown;
-                                    }
-                                    else if (stricmp(format, "xml") != 0) // xml is the default
-                                        throw MakeStringException(ROXIE_INVALID_INPUT, "Unsupported format specified: %s", format);
-                                }
-                                trim = queryXml->getPropBool("@trim", false);;
-                                logctx.setIntercept(queryXml->getPropBool("@log", false));
-                                logctx.setTraceLevel(queryXml->getPropInt("@traceLevel", traceLevel));
-                            }
+    inline IDebuggerContext &ensureDebuggerContext(const char *id)
+    {
+        if (!debuggerContext)
+        {
+            if (!id)
+    #ifdef _DEBUG
+                id="*";
+    #else
+                throw MakeStringException(ROXIE_DEBUG_ERROR, "Debug id not specified");
+    #endif
+            uid.set(id);
+            debuggerContext.setown(queryRoxieDebugSessionManager().lookupDebuggerContext(id));
+            if (!debuggerContext)
+                throw MakeStringException(ROXIE_DEBUG_ERROR, "No active query matching context %s found", id);
+        }
+        return *debuggerContext;
+    }
+    inline CDebugCommandHandler &ensureDebugCommandHandler()
+    {
+        if (!debugCmdHandler.get())
+            debugCmdHandler.setown(new CDebugCommandHandler);
+        return *debugCmdHandler;
+    }
 
-                            priority = queryFactory->queryOptions().priority;
-                            switch (priority)
-                            {
-                            case 0: loQueryStats.noteActive(); break;
-                            case 1: hiQueryStats.noteActive(); break;
-                            case 2: slaQueryStats.noteActive(); break;
-                            }
-                            unknownQueryStats.noteComplete();
-                            combinedQueryStats.noteActive();
-                            if (isHTTP)
-                            {
-                                CHttpRequestAsyncFor af(queryName, queryFactory, requestArray, *client, httpHelper, memused, slavesReplyLen, sanitizedText, logctx, xmlReadFlags, querySetName);
-                                af.For(requestArray.length(), numRequestArrayThreads);
-                            }
-                            else
-                            {
-                                Owned<IRoxieServerContext> ctx = queryFactory->createContext(queryXml, *client, mlFmt, isRaw, isBlocked, httpHelper, trim, logctx, xmlReadFlags, querySetName);
-                                if (client && !ctx->outputResultsToSocket())
-                                {
-                                    unsigned replyLen = 0;
-                                    client->write(&replyLen, sizeof(replyLen));
-                                    client.clear();
-                                }
-                                try
-                                {
-                                    ctx->process();
-                                    memused = ctx->getMemoryUsage();
-                                    slavesReplyLen = ctx->getSlavesReplyLen();
-                                    ctx->done(false);
-                                }
-                                catch(...)
-                                {
-                                    memused = ctx->getMemoryUsage();
-                                    slavesReplyLen = ctx->getSlavesReplyLen();
-                                    ctx->done(true);
-                                    throw;
-                                }
-                            }
-                        }
-                        else
-                        {
-                            pool->reportBadQuery(queryName.get(), logctx);
-                            if (globalPackageSetManager->getActivePackageCount())
-                            {
-                                StringBuffer targetMsg;
-                                const char *target = httpHelper.queryTarget();
-                                if (target && *target)
-                                    targetMsg.append(", in target ").append(target);
-                                throw MakeStringException(ROXIE_UNKNOWN_QUERY, "Unknown query %s%s", queryName.get(), targetMsg.str());
-                            }
-                            else
-                                throw MakeStringException(ROXIE_NO_PACKAGES_ACTIVE, "Unknown query %s (no packages active)", queryName.get());
-                        }
-                    }
-                }
-            }
-        }
-        catch (WorkflowException * E)
-        {
-            failed = true;
-            logctx.CTXLOG("FAILED: %s", sanitizedText.str());
-            StringBuffer error;
-            E->errorMessage(error);
-            logctx.CTXLOG("EXCEPTION: %s", error.str());
-            unsigned code = E->errorCode();
-            if (QUERYINTERFACE(E, ISEH_Exception))
-                code = ROXIE_INTERNAL_ERROR;
-            else if (QUERYINTERFACE(E, IOutOfMemException))
-                code = ROXIE_MEMORY_ERROR;
-            if (client)
-            {
-                if (isHTTP)
-                    client->checkSendHttpException(httpHelper, E, queryName);
-                else
-                    client->sendException("Roxie", code, error.str(), isBlocked, logctx);
-            }
-            else
-            {
-                fprintf(stderr, "EXCEPTION: %s", error.str());
-            }
-            E->Release();
-        }
-        catch (IException * E)
-        {
-            failed = true;
-            logctx.CTXLOG("FAILED: %s", sanitizedText.str());
-            StringBuffer error;
-            E->errorMessage(error);
-            logctx.CTXLOG("EXCEPTION: %s", error.str());
-            unsigned code = E->errorCode();
-            if (QUERYINTERFACE(E, ISEH_Exception))
-                code = ROXIE_INTERNAL_ERROR;
-            else if (QUERYINTERFACE(E, IOutOfMemException))
-                code = ROXIE_MEMORY_ERROR;
-            if (client)
-            {
-                if (isHTTP)
-                    client->checkSendHttpException(httpHelper, E, queryName);
-                else
-                    client->sendException("Roxie", code, error.str(), isBlocked, logctx);
-            }
-            else
-            {
-                fprintf(stderr, "EXCEPTION: %s\n", error.str());
-            }
-            E->Release();
-        }
-#ifndef _DEBUG
-        catch(...)
-        {
-            failed = true;
-            logctx.CTXLOG("FAILED: %s", sanitizedText.str());
-            logctx.CTXLOG("EXCEPTION: Unknown exception");
-            {
-                if (isHTTP)
-                {
-                    Owned<IException> E = MakeStringException(ROXIE_INTERNAL_ERROR, "Unknown exception");
-                    client->checkSendHttpException(httpHelper, E, queryName);
-                }
-                else
-                    client->sendException("Roxie", ROXIE_INTERNAL_ERROR, "Unknown exception", isBlocked, logctx);
-            }
-        }
-#endif
-        if (isHTTP)
-        {
-            try
-            {
-                client->flush();
-            }
-            catch (IException * E)
-            {
-                StringBuffer error("RoxieSocketWorker failed to write to socket ");
-                E->errorMessage(error);
-                logctx.CTXLOG("%s", error.str());
-                E->Release();
+    virtual bool checkSetBlind(bool blind)
+    {
+        blind = blind || blindLogging;
+        ensureContextLogger().setBlind(blind);
+        return blind;
+    }
+    virtual void verifyAllowDebug()
+    {
+        if (!debugPermitted || !ep.port)
+            throw MakeStringException(ROXIE_ACCESS_ERROR, "Debug queries are not permitted on this system");
+    }
+    virtual bool logFullQueries()
+    {
+        return ::logFullQueries;
+    }
+    virtual bool trapTooManyActiveQueries()
+    {
+        return ::trapTooManyActiveQueries;
+    }
+    virtual bool getStripWhitespace()
+    {
+        return queryFactory ? queryFactory->queryOptions().stripWhitespaceFromStoredDataset : (defaultXmlReadFlags & ptr_ignoreWhiteSpace);
+    }
+    virtual int getBindCores()
+    {
+        return queryFactory ? queryFactory->queryOptions().bindCores : 0;
+    }
+    virtual void setTraceLevel(unsigned traceLevel)
+    {
+        if (logctx)
+            logctx->setTraceLevel(traceLevel);
+    }
+    virtual void setIntercept(bool intercept)
+    {
+        if (logctx)
+            logctx->setIntercept(intercept);
+    }
+    virtual bool getIntercept()
+    {
+        return (logctx) ? logctx->intercept : false;
+    }
+    virtual void outputLogXML(IXmlStreamFlusher &out)
+    {
+        if (logctx)
+            logctx->outputXML(out);
+    }
 
-            }
-//#ifndef _DEBUG
-            catch(...)
-            {
-                logctx.CTXLOG("RoxieSocketWorker failed to write to socket (Unknown exception)");
-            }
-//#endif
+    virtual unsigned getQueryPriority()
+    {
+        return queryFactory ? queryFactory->queryOptions().priority : (unsigned) -2;
+    }
+    void noteQueryStats(bool failed, unsigned elapsedTime, unsigned priority)
+    {
+        Owned <IJlibDateTime> now = createDateTimeNow();
+        unsigned y,mo,d,h,m,s,n;
+        now->getLocalTime(h, m, s, n);
+        now->getLocalDate(y, mo, d);
+        lastQueryTime = h*10000 + m * 100 + s;
+        lastQueryDate = y*10000 + mo * 100 + d;
+
+        switch(priority)
+        {
+        case 0: loQueryStats.noteQuery(failed, elapsedTime); break;
+        case 1: hiQueryStats.noteQuery(failed, elapsedTime); break;
+        case 2: slaQueryStats.noteQuery(failed, elapsedTime); break;
+        default: unknownQueryStats.noteQuery(failed, elapsedTime); return; // Don't include unknown in the combined stats
         }
-        unsigned bytesOut = client? client->bytesOut() : 0;
-        unsigned elapsed = msTick() - qstart;
-        noteQuery(failed, elapsed, priority);
+        combinedQueryStats.noteQuery(failed, elapsedTime);
+    }
+    void noteQuery(const char *peer, bool failed, unsigned elapsed, unsigned memused, unsigned slavesReplyLen, unsigned bytesOut, unsigned priority, bool continuationNeeded)
+    {
+        noteQueryStats(failed, elapsed, priority);
         if (queryFactory)
         {
             queryFactory->noteQuery(startTime, failed, elapsed, memused, slavesReplyLen, bytesOut);
             queryFactory.clear();
         }
-        if (logctx.queryTraceLevel() && (logctx.queryTraceLevel() > 2 || logFullQueries || logctx.intercept))
+        if (logctx && logctx->queryTraceLevel() && (logctx->queryTraceLevel() > 2 || logFullQueries() || logctx->intercept))
+        {
             if (queryName.get())
             {
                 StringBuffer s;
-                logctx.getStats(s);
-                logctx.CTXLOG("COMPLETE: %s %s from %s complete in %d msecs memory=%d Mb priority=%d slavesreply=%d resultsize=%d continue=%d%s", queryName.get(), uid, peerStr.str(), elapsed, memused, priority, slavesReplyLen, bytesOut, continuationNeeded, s.str());
+                logctx->getStats(s);
+                logctx->CTXLOG("COMPLETE: %s %s from %s complete in %d msecs memory=%d Mb priority=%d slavesreply=%d resultsize=%d continue=%d%s", queryName.get(), uid.get(), peer, elapsed, memused, priority, slavesReplyLen, bytesOut, continuationNeeded, s.str());
             }
-        if (continuationNeeded)
+        }
+    }
+};
+
+
+class RoxieProtocolMsgSink : public CInterface, implements IHpccNativeProtocolMsgSink
+{
+    CriticalSection activeCrit;
+    SocketEndpoint ep;
+    CIArrayOf<AccessTableEntry> accessTable;
+    unsigned threadsActive;
+    unsigned maxThreadsActive;
+    unsigned poolSize;
+    bool suspended;
+
+public:
+    IMPLEMENT_IINTERFACE;
+
+    RoxieProtocolMsgSink(const SocketEndpoint &_ep, unsigned _poolSize, bool _suspended)
+    {
+        ep.set(_ep);
+        threadsActive = 0;
+        maxThreadsActive = 0;
+        suspended = _suspended;
+        poolSize = _poolSize;
+    }
+    virtual CriticalSection &getActiveCrit()
+    {
+        return activeCrit;
+    }
+    virtual bool getIsSuspended()
+    {
+        return suspended;
+    }
+    virtual unsigned getActiveThreadCount()
+    {
+        return threadsActive;
+    }
+    virtual unsigned getPoolSize()
+    {
+        return poolSize;
+    }
+    virtual unsigned getMaxActiveThreads()
+    {
+        return maxThreadsActive;
+    }
+    virtual void setMaxActiveThreads(unsigned val)
+    {
+        maxThreadsActive=val;
+    }
+    virtual void incActiveThreadCount()
+    {
+        threadsActive++;
+    }
+    virtual void decActiveThreadCount()
+    {
+        threadsActive--;
+    }
+    virtual bool suspend(bool suspendIt)
+    {
+        CriticalBlock b(activeCrit);
+        bool ret = suspended;
+        suspended = suspendIt;
+        return ret;
+    }
+    virtual void addAccess(bool allow, bool allowBlind, const char *ip, const char *mask, const char *query, const char *errorMsg, int errorCode)
+    {
+        accessTable.append(*new AccessTableEntry(allow, allowBlind, ip, mask, query, errorMsg, errorCode));
+    }
+
+    virtual void checkAccess(IpAddress &peer, const char *queryName, const char *queryText, bool isBlind)
+    {
+        bool allowed = true;
+        StringBuffer errorMsg;
+        int errorCode = -1;
+        ForEachItemIn(idx, accessTable)
         {
-            rawText.clear();
-            goto readAnother;
+            AccessTableEntry &item = accessTable.item(idx);
+            item.match(peer, queryName, isBlind, allowed, errorMsg, errorCode);
+            item.match(peer, queryText, isBlind, allowed, errorMsg, errorCode);
+        }
+        if (!allowed)
+        {
+            StringBuffer peerStr;
+            peer.getIpText(peerStr);
+            StringBuffer qText;
+            if (queryText && *queryText)
+                decodeXML(queryText, qText);
+
+            StringBuffer errText;
+            if (errorCode != -1)
+                errText.appendf("errorCode = %d : ", errorCode);
+            else
+                errorCode = ROXIE_ACCESS_ERROR;
+
+            if (errorMsg.length())
+                throw MakeStringException(errorCode, "Cannot run %s : %s from host %s because %s %s", queryName, qText.str(), peerStr.str(), errText.str(), errorMsg.str());
+            else
+                throw MakeStringException(errorCode, "Access to %s : %s from host %s is not allowed %s", queryName, qText.str(), peerStr.str(), errText.str());
+        }
+    }
+
+    virtual void queryAccessInfo(StringBuffer &info)
+    {
+        info.append("<ACCESSINFO>\n");
+        ForEachItemIn(idx, accessTable)
+        {
+            AccessTableEntry &item = accessTable.item(idx);
+            item.queryAccessTableEntryInfo(info);
+        }
+        info.append("</ACCESSINFO>\n");
+    }
+
+    IHpccProtocolMsgContext *createMsgContext(time_t startTime)
+    {
+        return new RoxieProtocolMsgContext(ep, startTime);
+    }
+    virtual StringArray &getTargetNames(StringArray &targets)
+    {
+        CloneArray(targets, allQuerySetNames);
+        return targets;
+    }
+
+    inline RoxieProtocolMsgContext * checkGetRoxieMsgContext(IHpccProtocolMsgContext *msgctx)
+    {
+        if (!msgctx)
+            throw MakeStringExceptionDirect(ROXIE_INTERNAL_ERROR, "Protocol message context cannot be null"); //if protocols become plugins have to be cautious
+        RoxieProtocolMsgContext *roxieMsgCtx = dynamic_cast<RoxieProtocolMsgContext*>(msgctx);
+        if (!roxieMsgCtx)
+            throw MakeStringExceptionDirect(ROXIE_INTERNAL_ERROR, "Invalid protocol message context");
+        return roxieMsgCtx;
+    }
+
+    inline RoxieProtocolMsgContext * checkGetRoxieMsgContext(IHpccProtocolMsgContext *msgctx, IPropertyTree *msg)
+    {
+        if (!msg)
+            throw MakeStringExceptionDirect(ROXIE_INTERNAL_ERROR, "Protocol message cannot be null"); //if protocols become plugins have to be cautious
+        return checkGetRoxieMsgContext(msgctx);
+    }
+
+    virtual void onQueryMsg(IHpccProtocolMsgContext *msgctx, IPropertyTree *msg, IHpccProtocolResponse *protocol, unsigned flags, PTreeReaderOptions xmlReadFlags, const char *target, unsigned idx, unsigned &memused, unsigned &slavesReplyLen)
+    {
+        RoxieProtocolMsgContext *roxieMsgCtx = checkGetRoxieMsgContext(msgctx, msg);
+        IQueryFactory *f = roxieMsgCtx->queryQueryFactory();
+        Owned<IRoxieServerContext> ctx = f->createContext(msg, protocol, flags, *roxieMsgCtx->logctx, xmlReadFlags, target);
+        if (!(flags & HPCC_PROTOCOL_NATIVE))
+        {
+            ctx->process();
+            protocol->finalize(idx);
+            memused += ctx->getMemoryUsage();
+            slavesReplyLen += ctx->getSlavesReplyLen();
         }
         else
         {
             try
             {
-                if (client && !isHTTP && !isStatus)
-                {
-                    if (logctx.intercept)
-                    {
-                        FlushingStringBuffer response(client, isBlocked, mlFmt, isRaw, false, logctx);
-                        response.startDataset("Tracing", NULL, (unsigned) -1);
-                        logctx.outputXML(response);
-                    }
-                    unsigned replyLen = 0;
-                    client->write(&replyLen, sizeof(replyLen));
-                }
-                client.clear();
+                ctx->process();
+                memused = ctx->getMemoryUsage();
+                slavesReplyLen = ctx->getSlavesReplyLen();
+                ctx->done(false);
             }
-            catch (IException * E)
-            {
-                StringBuffer error("RoxieSocketWorker failed to close socket ");
-                E->errorMessage(error);
-                logctx.CTXLOG("%s", error.str()); // MORE - audience?
-                E->Release();
-
-            }
-//#ifndef _DEBUG
             catch(...)
             {
-                logctx.CTXLOG("RoxieSocketWorker failed to close socket (Unknown exception)"); // MORE - audience?
+                memused = ctx->getMemoryUsage();
+                slavesReplyLen = ctx->getSlavesReplyLen();
+                ctx->done(true);
+                throw;
             }
-//#endif
         }
     }
+    virtual void onControlMsg(IHpccProtocolMsgContext *msgctx, IPropertyTree *msg, IHpccProtocolResponse *protocol)
+    {
+        StringBuffer reply;
+        RoxieProtocolMsgContext *roxieMsgCtx = checkGetRoxieMsgContext(msgctx, msg);
+        const char *name = msg->queryName();
+        IContextLogger &logctx = *msgctx->queryLogContext();
+
+        StringBuffer xml;
+        toXML(msg, xml, 0, 0);
+
+        if (strieq(name, "control:lock"))
+        {
+            if (logctx.queryTraceLevel() > 8)
+                logctx.CTXLOG("Got lock request %s", xml.str());
+            roxieMsgCtx->ensureCascadeManager().doLockGlobal(reply, false);
+            if (logctx.queryTraceLevel() > 8)
+                logctx.CTXLOG("lock reply %s", reply.str());
+            unknownQueryStats.noteComplete();
+        }
+        else if (strieq(name, "control:childlock"))
+        {
+            if (logctx.queryTraceLevel() > 8)
+                logctx.CTXLOG("Got childlock request %s", xml.str());
+            roxieMsgCtx->ensureCascadeManager().doLockChild(msg, xml.str(), reply);
+            if (logctx.queryTraceLevel() > 8)
+                logctx.CTXLOG("childlock reply %s", reply.str());
+            unknownQueryStats.noteComplete();
+        }
+        else
+        {
+            bool doControlQuery = true;
+            if (strieq(name, "control:aclupdate"))
+            {
+                IPropertyTree *aclTree = msg->queryPropTree("ACL");
+                if (aclTree)
+                {
+                    Owned<IPropertyTreeIterator> accesses = aclTree->getElements("Access");
+                    ForEach(*accesses)
+                    {
+                        IPropertyTree &access = accesses->query();
+                        try
+                        {
+                            addAccess(access.getPropBool("@allow", true), access.getPropBool("@allowBlind", true), access.queryProp("@ip"), access.queryProp("@mask"), access.queryProp("@query"), access.queryProp("@error"), access.getPropInt("@errorCode", -1));
+                        }
+                        catch (IException *E)
+                        {
+                            StringBuffer s, x;
+                            E->errorMessage(s);
+                            E->Release();
+                            toXML(&access, x, 0, 0);
+                            throw MakeStringException(ROXIE_ACL_ERROR, "Error in access statement %s: %s", x.str(), s.str());
+                        }
+                    }
+                }
+            }
+            else if (strieq(name, "control:queryaclinfo"))
+            {
+                reply.append("<Endpoint ep='");
+                ep.getUrlStr(reply);
+                reply.append("'>\n");
+
+                queryAccessInfo(reply);
+                reply.append("</Endpoint>\n");
+                doControlQuery = false;
+            }
+
+            if (doControlQuery)
+            {
+                roxieMsgCtx->ensureCascadeManager().doControlQuery(ep, msg, xml.str(), reply);
+            }
+        }
+        if (reply.length())
+            protocol->appendContent(MarkupFmt_XML, reply.str(), "Control");
+
+    }
+
+    virtual void onDebugMsg(IHpccProtocolMsgContext *msgctx, const char *uid, IPropertyTree *msg, IXmlWriter &out)
+    {
+        RoxieProtocolMsgContext *roxieMsgCtx = checkGetRoxieMsgContext(msgctx, msg);
+        roxieMsgCtx->ensureDebugCommandHandler().doDebugCommand(msg, &roxieMsgCtx->ensureDebuggerContext(uid), out);
+    }
+
+    virtual void noteQuery(IHpccProtocolMsgContext *msgctx, const char *peer, bool failed, unsigned bytesOut, unsigned elapsed, unsigned priority, unsigned memused, unsigned slavesReplyLen, bool continuationNeeded)
+    {
+        RoxieProtocolMsgContext *roxieMsgCtx = checkGetRoxieMsgContext(msgctx);
+        roxieMsgCtx->noteQuery(peer, failed, elapsed, memused, slavesReplyLen, bytesOut, priority, continuationNeeded);
+    }
+
 };
+
+extern IHpccProtocolMsgSink *createRoxieProtocolMsgSink(const IpAddress &ip, unsigned short port, unsigned poolSize, bool suspended)
+{
+    SocketEndpoint ep(port, ip);
+    return new RoxieProtocolMsgSink(ep, poolSize, suspended);
+}
 
 //=================================================================================
 
-IArrayOf<IRoxieListener> socketListeners;
+IArrayOf<IHpccProtocolListener> socketListeners;
+MapStringToMyClass<SharedObject> protocolDlls;
+MapStringToMyClass<IHpccProtocolPlugin> protocolPlugins;
+
+IHpccProtocolPlugin *ensureProtocolPlugin(IHpccProtocolPluginContext &protocolCtx, const char *soname)
+{
+    IHpccProtocolPlugin *plugin = protocolPlugins.getValue(soname ? soname : "native");
+    if (plugin)
+        return plugin;
+    if (!soname)
+    {
+        Owned<IHpccProtocolPlugin> protocolPlugin = loadHpccProtocolPlugin(&protocolCtx, ensureLimiterFactory());
+        protocolPlugins.setValue("native", protocolPlugin.getLink());
+        return protocolPlugin.getClear();
+    }
+    Owned<SharedObject> so = new SharedObject();
+    if (!so->load(soname, true, true))
+        throw MakeStringException(-1, "Failed to load protocol library %s", soname);
+
+    protocolDlls.setValue(soname, so.getLink());
+
+    HpccProtocolInstallFunction *protocolInstall = (HpccProtocolInstallFunction *) GetSharedProcedure(so->getInstanceHandle(), "loadHpccProtocolPlugin");
+    if (!protocolInstall)
+        throw MakeStringException(-1, "Failed to load protocol library %s loadHpccProtocolPlugin function", soname);
+    Owned<IHpccProtocolPlugin> protocolPlugin = protocolInstall(&protocolCtx, ensureLimiterFactory());
+    if (!protocolPlugin)
+        throw MakeStringException(-1, "Protocol library %s loadHpccProtocolPlugin function failed", soname);
+    protocolPlugins.setValue(soname, protocolPlugin.getLink());
+    return protocolPlugin.getClear();
+}
 
 extern void disconnectRoxieQueues()
 {
@@ -2019,25 +1776,7 @@ IPooledThread *RoxieWorkUnitListener::createNew()
     return new RoxieWorkUnitWorker(this);
 }
 
-IPooledThread *RoxieSocketListener::createNew()
-{
-    return new RoxieSocketWorker(this, ep);
-}
-
-void RoxieSocketListener::runOnce(const char *query)
-{
-    Owned<RoxieSocketWorker> p = new RoxieSocketWorker(this, ep);
-    p->runOnce(query);
-}
-
-IRoxieListener *createRoxieSocketListener(unsigned port, unsigned poolSize, unsigned listenQueue, bool suspended)
-{
-    if (traceLevel)
-        DBGLOG("Creating Roxie socket listener, pool size %d, listen queue %d%s", poolSize, listenQueue, suspended?" SUSPENDED":"");
-    return new RoxieSocketListener(port, poolSize, listenQueue, suspended);
-}
-
-IRoxieListener *createRoxieWorkUnitListener(unsigned poolSize, bool suspended)
+IHpccProtocolListener *createRoxieWorkUnitListener(unsigned poolSize, bool suspended)
 {
     if (traceLevel)
         DBGLOG("Creating Roxie workunit listener, pool size %d%s", poolSize, suspended?" SUSPENDED":"");
@@ -2048,7 +1787,7 @@ bool suspendRoxieListener(unsigned port, bool suspended)
 {
     ForEachItemIn(idx, socketListeners)
     {
-        IRoxieListener &listener = socketListeners.item(idx);
+        IHpccProtocolListener &listener = socketListeners.item(idx);
         if (listener.queryPort()==port)
             return listener.suspend(suspended);
     }

--- a/roxie/ccd/ccdlistener.hpp
+++ b/roxie/ccd/ccdlistener.hpp
@@ -19,25 +19,19 @@
 #define _CCDLISTENER_INCL
 
 #include <jlib.hpp>
+#include "ccdprotocol.hpp"
 
-interface IRoxieListener : extends IInterface
-{
-    virtual void start() = 0;
-    virtual bool stop(unsigned timeout) = 0;
-    virtual void stopListening() = 0;
-    virtual void disconnectQueue() = 0;
-    virtual void addAccess(bool allow, bool allowBlind, const char *ip, const char *mask, const char *query, const char *errMsg, int errCode) = 0;
-    virtual unsigned queryPort() const = 0;
-    virtual const SocketEndpoint &queryEndpoint() const = 0;
-    virtual bool suspend(bool suspendIt) = 0;
+extern IHpccProtocolMsgSink *createRoxieProtocolMsgSink(const IpAddress &ip, unsigned short port, unsigned poolSize, bool suspended);
 
-    virtual void runOnce(const char *query) = 0;
-};
-
-extern IRoxieListener *createRoxieSocketListener(unsigned port, unsigned poolSize, unsigned listenQueue, bool suspended);
-extern IRoxieListener *createRoxieWorkUnitListener(unsigned poolSize, bool suspended);
+extern IHpccProtocolListener *createRoxieWorkUnitListener(unsigned poolSize, bool suspended);
 extern bool suspendRoxieListener(unsigned port, bool suspended);
-extern IArrayOf<IRoxieListener> socketListeners;
+
+extern MapStringToMyClass<SharedObject> protocolDlls;
+extern MapStringToMyClass<IHpccProtocolPlugin> protocolPlugins;
+extern IArrayOf<IHpccProtocolListener> socketListeners;
+
+extern IHpccProtocolPlugin *ensureProtocolPlugin(IHpccProtocolPluginContext &protocolCtx, const char *soname);
+
 extern void disconnectRoxieQueues();
 extern void updateAffinity(unsigned __int64 affinity);
 

--- a/roxie/ccd/ccdmain.cpp
+++ b/roxie/ccd/ccdmain.cpp
@@ -409,6 +409,24 @@ void saveTopology()
     }
 }
 
+class CHpccProtocolPluginCtx : public CInterface, implements IHpccProtocolPluginContext
+{
+public:
+    IMPLEMENT_IINTERFACE;
+    virtual int ctxGetPropInt(const char *propName, int defaultValue) const
+    {
+        return topology->getPropInt(propName, defaultValue);
+    }
+    virtual bool ctxGetPropBool(const char *propName, bool defaultValue) const
+    {
+        return topology->getPropBool(propName, defaultValue);
+    }
+    virtual const char *ctxQueryProp(const char *propName) const
+    {
+        return topology->queryProp(propName);
+    }
+};
+
 int STARTQUERY_API start_query(int argc, const char *argv[])
 {
     EnableSEHtoExceptionMapping();
@@ -1010,9 +1028,11 @@ int STARTQUERY_API start_query(int argc, const char *argv[])
 #endif
         EnableSEHtoExceptionMapping();
         setSEHtoExceptionHandler(&abortHandler);
+        Owned<IHpccProtocolPluginContext> protocolCtx = new CHpccProtocolPluginCtx();
         if (runOnce)
         {
-            Owned <IRoxieListener> roxieServer = createRoxieSocketListener(0, 1, 0, false);
+            Owned<IHpccProtocolPlugin> protocolPlugin = loadHpccProtocolPlugin(protocolCtx, NULL);
+            Owned<IHpccProtocolListener> roxieServer = protocolPlugin->createListener("runOnce", createRoxieProtocolMsgSink(getNodeAddress(myNodeIndex), 0, 1, false), 0, 0, NULL);
             try
             {
                 const char *format = globals->queryProp("format");
@@ -1048,18 +1068,26 @@ int STARTQUERY_API start_query(int argc, const char *argv[])
                 unsigned numThreads = roxieFarm.getPropInt("@numThreads", numServerThreads);
                 unsigned port = roxieFarm.getPropInt("@port", ROXIE_SERVER_PORT);
                 unsigned requestArrayThreads = roxieFarm.getPropInt("@requestArrayThreads", 5);
+                const IpAddress &ip = getNodeAddress(myNodeIndex);
                 if (!roxiePort)
                 {
                     roxiePort = port;
-                    ownEP.set(roxiePort, getNodeAddress(myNodeIndex));
+                    ownEP.set(roxiePort, ip);
                 }
                 bool suspended = roxieFarm.getPropBool("@suspended", false);
-                Owned <IRoxieListener> roxieServer;
+                Owned <IHpccProtocolListener> roxieServer;
                 if (port)
-                    roxieServer.setown(createRoxieSocketListener(port, numThreads, listenQueue, suspended));
+                {
+                    const char *protocol = roxieFarm.queryProp("@protocol");
+                    const char *soname =  roxieFarm.queryProp("@so");
+                    const char *config  = roxieFarm.queryProp("@config");
+                    Owned<IHpccProtocolPlugin> protocolPlugin = ensureProtocolPlugin(*protocolCtx, soname);
+                    roxieServer.setown(protocolPlugin->createListener(protocol ? protocol : "native", createRoxieProtocolMsgSink(ip, port, numThreads, suspended), port, listenQueue, config));
+                }
                 else
                     roxieServer.setown(createRoxieWorkUnitListener(numThreads, suspended));
 
+                IHpccProtocolMsgSink *sink = roxieServer->queryMsgSink();
                 const char *aclName = roxieFarm.queryProp("@aclName");
                 if (aclName && *aclName)
                 {
@@ -1071,7 +1099,7 @@ int STARTQUERY_API start_query(int argc, const char *argv[])
                         IPropertyTree &access = accesses->query();
                         try
                         {
-                            roxieServer->addAccess(access.getPropBool("@allow", true), access.getPropBool("@allowBlind", true), access.queryProp("@ip"), access.queryProp("@mask"), access.queryProp("@query"), access.queryProp("@error"), access.getPropInt("@errorCode"));
+                            sink->addAccess(access.getPropBool("@allow", true), access.getPropBool("@allowBlind", true), access.queryProp("@ip"), access.queryProp("@mask"), access.queryProp("@query"), access.queryProp("@error"), access.getPropInt("@errorCode"));
                         }
                         catch (IException *E)
                         {

--- a/roxie/ccd/ccdprotocol.cpp
+++ b/roxie/ccd/ccdprotocol.cpp
@@ -1,0 +1,1819 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2016 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include "platform.h"
+#include "jlib.hpp"
+#include "jthread.hpp"
+
+#include "roxie.hpp"
+#include "roxiehelper.hpp"
+#include "ccdprotocol.hpp"
+
+//================================================================================================================================
+
+IHpccProtocolListener *createProtocolListener(const char *protocol, IHpccProtocolMsgSink *sink, unsigned port, unsigned listenQueue);
+
+class CHpccProtocolPlugin : public CInterface, implements IHpccProtocolPlugin
+{
+public:
+    IMPLEMENT_IINTERFACE;
+    CHpccProtocolPlugin(IHpccProtocolPluginContext &ctx)
+    {
+        targetNames.appendListUniq(ctx.ctxQueryProp("@querySets"), ",");
+        targetAliases.setown(createProperties());
+        StringArray tempList;
+        tempList.appendListUniq(ctx.ctxQueryProp("@targetAliases"), ",");
+        ForEachItemIn(i, tempList)
+        {
+            const char *alias = tempList.item(i);
+            const char *eq = strchr(alias, '=');
+            if (eq)
+            {
+                StringAttr name(alias, eq-alias);
+                if (!targetNames.contains(name))
+                    targetAliases->setProp(name.str(), ++eq);
+            }
+        }
+
+        maxBlockSize = ctx.ctxGetPropInt("@maxBlockSize", 10000000);
+        defaultXmlReadFlags = ctx.ctxGetPropBool("@defaultStripLeadingWhitespace", true) ? ptr_ignoreWhiteSpace : ptr_none;
+        trapTooManyActiveQueries = ctx.ctxGetPropBool("@trapTooManyActiveQueries", true);
+        numRequestArrayThreads = ctx.ctxGetPropInt("@requestArrayThreads", 5);
+    }
+    IHpccProtocolListener *createListener(const char *protocol, IHpccProtocolMsgSink *sink, unsigned port, unsigned listenQueue, const char *config)
+    {
+        return createProtocolListener(protocol, sink, port, listenQueue);
+    }
+public:
+    StringArray targetNames;
+    Owned<IProperties> targetAliases;
+    PTreeReaderOptions defaultXmlReadFlags;
+    unsigned maxBlockSize;
+    unsigned numRequestArrayThreads;
+    bool trapTooManyActiveQueries;
+};
+
+Owned<CHpccProtocolPlugin> global;
+
+class ProtocolListener : public Thread, implements IHpccProtocolListener, implements IThreadFactory
+{
+public:
+    IMPLEMENT_IINTERFACE;
+    ProtocolListener(IHpccProtocolMsgSink *_sink) : Thread("RoxieListener")
+    {
+        running = false;
+        sink.set(dynamic_cast<IHpccNativeProtocolMsgSink*>(_sink));
+    }
+    virtual IHpccProtocolMsgSink *queryMsgSink()
+    {
+        return sink;
+    }
+    static void updateAffinity()
+    {
+#ifdef CPU_ZERO
+        if (sched_getaffinity(0, sizeof(cpu_set_t), &cpuMask))
+        {
+            if (traceLevel)
+                DBGLOG("Unable to get CPU affinity - thread affinity settings will be ignored");
+            cpuCores = 0;
+            lastCore = 0;
+            CPU_ZERO(&cpuMask);
+        }
+        else
+        {
+#if __GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 6)
+            cpuCores = CPU_COUNT(&cpuMask);
+#else
+            cpuCores = 0;
+            unsigned setSize = CPU_SETSIZE;
+            while (setSize--)
+            {
+                if (CPU_ISSET(setSize, &cpuMask))
+                    ++cpuCores;
+            }
+#endif /* GLIBC */
+            if (traceLevel)
+                traceAffinity(&cpuMask);
+        }
+#endif
+    }
+
+    virtual void start()
+    {
+        // Note we allow a few additional threads than requested - these are the threads that return "Too many active queries" responses
+        pool.setown(createThreadPool("RoxieSocketWorkerPool", this, NULL, sink->getPoolSize()+5, INFINITE));
+        assertex(!running);
+        Thread::start();
+        started.wait();
+    }
+
+    virtual bool stop(unsigned timeout)
+    {
+        if (running)
+        {
+            running = false;
+            join();
+            Release();
+        }
+        return pool->joinAll(false, timeout);
+    }
+
+    virtual bool suspend(bool suspendIt)
+    {
+        return sink->suspend(suspendIt);
+    }
+
+    void setThreadAffinity(int numCores)
+    {
+#ifdef CPU_ZERO
+        // Note - strictly speaking not threadsafe but any race conditions are (a) unlikely and (b) harmless
+        if (cpuCores)
+        {
+            if (numCores > 0 && numCores < cpuCores)
+            {
+                cpu_set_t threadMask;
+                CPU_ZERO(&threadMask);
+                unsigned cores = 0;
+                unsigned offset = lastCore;
+                unsigned core;
+                for (core = 0; core < CPU_SETSIZE; core++)
+                {
+                    unsigned useCore = (core + offset) % CPU_SETSIZE;
+                    if (CPU_ISSET(useCore, &cpuMask))
+                    {
+                        CPU_SET(useCore, &threadMask);
+                        cores++;
+                        if (cores == numCores)
+                        {
+                            lastCore = useCore+1;
+                            break;
+                        }
+                    }
+                }
+                if (traceLevel > 3)
+                    traceAffinity(&threadMask);
+                pthread_setaffinity_np(GetCurrentThreadId(), sizeof(cpu_set_t), &threadMask);
+            }
+            else
+            {
+                if (traceLevel > 3)
+                    traceAffinity(&cpuMask);
+                pthread_setaffinity_np(GetCurrentThreadId(), sizeof(cpu_set_t), &cpuMask);
+            }
+        }
+#endif
+    }
+
+protected:
+    bool running;
+    Semaphore started;
+    Owned<IThreadPool> pool;
+
+    Linked<IHpccNativeProtocolMsgSink> sink;
+
+#ifdef CPU_ZERO
+    static cpu_set_t cpuMask;
+    static unsigned cpuCores;
+    static unsigned lastCore;
+
+private:
+    static void traceAffinity(cpu_set_t *mask)
+    {
+        StringBuffer trace;
+        for (unsigned core = 0; core < CPU_SETSIZE; core++)
+        {
+            if (CPU_ISSET(core, mask))
+                trace.appendf(",%d", core);
+        }
+        if (trace.length())
+            DBGLOG("Process affinity is set to use core(s) %s", trace.str()+1);
+    }
+#endif
+
+};
+
+#ifdef CPU_ZERO
+cpu_set_t ProtocolListener::cpuMask;
+unsigned ProtocolListener::cpuCores;
+unsigned ProtocolListener::lastCore;
+#endif
+
+class ProtocolSocketListener : public ProtocolListener
+{
+    unsigned port;
+    unsigned listenQueue;
+    Owned<ISocket> socket;
+    SocketEndpoint ep;
+
+public:
+    ProtocolSocketListener(IHpccProtocolMsgSink *_sink, unsigned _port, unsigned _listenQueue)
+      : ProtocolListener(_sink)
+    {
+        port = _port;
+        listenQueue = _listenQueue;
+        ep.set(port, queryHostIP());
+    }
+
+    IHpccProtocolMsgSink *queryMsgSink()
+    {
+        return sink.get();
+    }
+
+    virtual bool stop(unsigned timeout)
+    {
+        if (socket)
+            socket->cancel_accept();
+        return ProtocolListener::stop(timeout);
+    }
+
+    virtual void disconnectQueue()
+    {
+        // This is for dali queues only
+    }
+
+    virtual void stopListening()
+    {
+        // Not threadsafe, but we only call this when generating a core file... what's the worst that can happen?
+        try
+        {
+            DBGLOG("Closing listening socket %d", port);
+            socket.clear();
+            DBGLOG("Closed listening socket %d", port);
+        }
+        catch(...)
+        {
+        }
+    }
+
+    virtual void runOnce(const char *query);
+
+    virtual int run()
+    {
+        DBGLOG("ProtocolSocketListener (%d threads) listening to socket on port %d", sink->getPoolSize(), port);
+        socket.setown(ISocket::create(port, listenQueue));
+        running = true;
+        started.signal();
+        while (running)
+        {
+            ISocket *client = socket->accept(true);
+            if (client)
+            {
+                client->set_linger(-1);
+                pool->start(client);
+            }
+        }
+        DBGLOG("ProtocolSocketListener closed query socket");
+        return 0;
+    }
+
+    virtual IPooledThread *createNew();
+
+    virtual const SocketEndpoint &queryEndpoint() const
+    {
+        return ep;
+    }
+
+    virtual unsigned queryPort() const
+    {
+        return port;
+    }
+};
+
+class ProtocolQueryWorker : public CInterface, implements IPooledThread
+{
+public:
+    IMPLEMENT_IINTERFACE;
+
+    ProtocolQueryWorker(ProtocolListener *_listener) : listener(_listener)
+    {
+        qstart = msTick();
+        time(&startTime);
+    }
+
+    //  interface IPooledThread
+    virtual void init(void *)
+    {
+        qstart = msTick();
+        time(&startTime);
+    }
+
+    virtual bool canReuse()
+    {
+        return true;
+    }
+
+    virtual bool stop()
+    {
+        ERRLOG("RoxieQueryWorker stopped with queries active");
+        return true;
+    }
+
+protected:
+    ProtocolListener *listener;
+    unsigned qstart;
+    time_t startTime;
+
+};
+
+//================================================================================================================
+
+class CHpccNativeResultsWriter : public CInterface, implements IHpccNativeProtocolResultsWriter
+{
+protected:
+    SafeSocket *client;
+    CriticalSection resultsCrit;
+    IPointerArrayOf<FlushingStringBuffer> resultMap;
+
+    StringAttr queryName;
+    const IContextLogger &logctx;
+    Owned<FlushingStringBuffer> probe;
+    TextMarkupFormat mlFmt;
+    PTreeReaderOptions xmlReadFlags;
+    bool isBlocked;
+    bool isRaw;
+    bool isHTTP;
+    bool trim;
+    bool failed;
+
+public:
+    IMPLEMENT_IINTERFACE;
+    CHpccNativeResultsWriter(const char *queryname, SafeSocket *_client, bool _isBlocked, TextMarkupFormat _mlFmt, bool _isRaw, bool _isHTTP, const IContextLogger &_logctx, PTreeReaderOptions _xmlReadFlags) :
+        client(_client), queryName(queryname), logctx(_logctx), mlFmt(_mlFmt), xmlReadFlags(_xmlReadFlags), isBlocked(_isBlocked), isRaw(_isRaw), isHTTP(_isHTTP)
+    {
+    }
+    ~CHpccNativeResultsWriter()
+    {
+    }
+    virtual FlushingStringBuffer *queryResult(unsigned sequence)
+    {
+        CriticalBlock procedure(resultsCrit);
+        while (!resultMap.isItem(sequence))
+            resultMap.append(NULL);
+        FlushingStringBuffer *result = resultMap.item(sequence);
+        if (!result)
+        {
+            if (mlFmt==MarkupFmt_JSON)
+                result = new FlushingJsonBuffer(client, isBlocked, isHTTP, logctx);
+            else
+                result = new FlushingStringBuffer(client, isBlocked, mlFmt, isRaw, isHTTP, logctx);
+            result->isSoap = isHTTP;
+            result->trim = trim;
+            result->queryName.set(queryName);
+            resultMap.replace(result, sequence);
+        }
+        return result;
+    }
+    virtual FlushingStringBuffer *createFlushingBuffer()
+    {
+        return new FlushingStringBuffer(client, isBlocked, mlFmt, isRaw, isHTTP, logctx);
+    }
+    virtual IXmlWriter *addDataset(const char *name, unsigned sequence, const char *elementName, bool &appendRawData, unsigned writeFlags, bool _extend, const IProperties *xmlns)
+    {
+        FlushingStringBuffer *response = queryResult(sequence);
+        if (response)
+        {
+            appendRawData = response->isRaw;
+            response->startDataset(elementName, name, sequence, _extend, xmlns);
+            if (response->mlFmt==MarkupFmt_XML || response->mlFmt==MarkupFmt_JSON)
+            {
+                if (response->mlFmt==MarkupFmt_JSON)
+                    writeFlags |= XWFnoindent;
+                Owned<IXmlWriter> xmlwriter = createIXmlWriterExt(writeFlags, 1, response, (response->mlFmt==MarkupFmt_JSON) ? WTJSON : WTStandard);
+                xmlwriter->outputBeginArray("Row");
+                return xmlwriter.getClear();
+            }
+        }
+        return NULL;
+    }
+    virtual void finalizeXmlRow(unsigned sequence)
+    {
+        if (mlFmt==MarkupFmt_XML || mlFmt==MarkupFmt_JSON)
+        {
+            FlushingStringBuffer *r = queryResult(sequence);
+            if (r)
+            {
+                r->incrementRowCount();
+                r->flush(false);
+            }
+        }
+    }
+    virtual void appendRaw(unsigned sequence, unsigned len, const char *data)
+    {
+        FlushingStringBuffer *r = queryResult(sequence);
+        if (r)
+            r->append(len, data);
+    }
+    virtual void appendRawRow(unsigned sequence, unsigned len, const char *data)
+    {
+        FlushingStringBuffer *r = queryResult(sequence);
+        if (r)
+        {
+            r->append(len, data);
+            r->incrementRowCount();
+            r->flush(false);
+        }
+    }
+    virtual void appendSimpleRow(unsigned sequence, const char *str)
+    {
+        FlushingStringBuffer *r = queryResult(sequence);
+        if (r)
+            r->append(str);
+    }
+
+    virtual void setResultBool(const char *name, unsigned sequence, bool value)
+    {
+        FlushingStringBuffer *r = queryResult(sequence);
+        if (r)
+        {
+            r->startScalar(name, sequence);
+            if (isRaw)
+                r->append(sizeof(value), (char *)&value);
+            else
+                r->append(value ? "true" : "false");
+        }
+    }
+    virtual void setResultData(const char *name, unsigned sequence, int len, const void * data)
+    {
+        FlushingStringBuffer *r = queryResult(sequence);
+        if (r)
+        {
+            r->startScalar(name, sequence);
+            r->encodeData(data, len);
+        }
+    }
+    virtual void setResultRaw(const char *name, unsigned sequence, int len, const void * data)
+    {
+        FlushingStringBuffer *r = queryResult(sequence);
+        if (r)
+        {
+            r->startScalar(name, sequence);
+            if (isRaw)
+                r->append(len, (const char *) data);
+            else
+                UNIMPLEMENTED;
+        }
+    }
+    virtual void setResultSet(const char *name, unsigned sequence, bool isAll, size32_t len, const void * data, ISetToXmlTransformer * transformer)
+    {
+        FlushingStringBuffer *r = queryResult(sequence);
+        if (r)
+        {
+            r->startScalar(name, sequence);
+            if (isRaw)
+                r->append(len, (char *)data);
+            else if (mlFmt==MarkupFmt_XML)
+            {
+                assertex(transformer);
+                CommonXmlWriter writer(xmlReadFlags|XWFnoindent, 0);
+                transformer->toXML(isAll, len, (byte *)data, writer);
+                r->append(writer.str());
+            }
+            else if (mlFmt==MarkupFmt_JSON)
+            {
+                assertex(transformer);
+                CommonJsonWriter writer(xmlReadFlags|XWFnoindent, 0);
+                transformer->toXML(isAll, len, (byte *)data, writer);
+                r->append(writer.str());
+            }
+            else
+            {
+                assertex(transformer);
+                r->append('[');
+                if (isAll)
+                    r->appendf("*]");
+                else
+                {
+                    SimpleOutputWriter x;
+                    transformer->toXML(isAll, len, (const byte *) data, x);
+                    r->appendf("%s]", x.str());
+                }
+            }
+        }
+    }
+
+    virtual void setResultDecimal(const char *name, unsigned sequence, int len, int precision, bool isSigned, const void *val)
+    {
+        FlushingStringBuffer *r = queryResult(sequence);
+        if (r)
+        {
+            r->startScalar(name, sequence);
+            if (isRaw)
+                r->append(len, (char *)val);
+            else
+            {
+                StringBuffer s;
+                if (isSigned)
+                    outputXmlDecimal(val, len, precision, NULL, s);
+                else
+                    outputXmlUDecimal(val, len, precision, NULL, s);
+                r->append(s);
+            }
+        }
+    }
+    virtual void setResultInt(const char *name, unsigned sequence, __int64 value, unsigned size)
+    {
+        FlushingStringBuffer *r = queryResult(sequence);
+        if (r)
+        {
+            if (isRaw)
+            {
+                r->startScalar(name, sequence);
+                r->append(sizeof(value), (char *)&value);
+            }
+            else
+                r->setScalarInt(name, sequence, value, size);
+        }
+    }
+
+    virtual void setResultUInt(const char *name, unsigned sequence, unsigned __int64 value, unsigned size)
+    {
+        FlushingStringBuffer *r = queryResult(sequence);
+        if (r)
+        {
+            if (isRaw)
+            {
+                r->startScalar(name, sequence);
+                r->append(sizeof(value), (char *)&value);
+            }
+            else
+                r->setScalarUInt(name, sequence, value, size);
+        }
+    }
+
+    virtual void setResultReal(const char *name, unsigned sequence, double value)
+    {
+        FlushingStringBuffer *r = queryResult(sequence);
+        if (r)
+        {
+            r->startScalar(name, sequence);
+            r->append(value);
+        }
+    }
+    virtual void setResultString(const char *name, unsigned sequence, int len, const char * str)
+    {
+        FlushingStringBuffer *r = queryResult(sequence);
+        if (r)
+        {
+            r->startScalar(name, sequence);
+            if (r->isRaw)
+            {
+                r->append(len, str);
+            }
+            else
+            {
+                r->encodeString(str, len);
+            }
+        }
+    }
+    virtual void setResultUnicode(const char *name, unsigned sequence, int len, UChar const * str)
+    {
+        FlushingStringBuffer *r = queryResult(sequence);
+        if (r)
+        {
+            r->startScalar(name, sequence);
+            if (r->isRaw)
+            {
+                r->append(len*2, (const char *) str);
+            }
+            else
+            {
+                rtlDataAttr buff;
+                unsigned bufflen = 0;
+                rtlUnicodeToCodepageX(bufflen, buff.refstr(), len, str, "utf-8");
+                r->encodeString(buff.getstr(), bufflen, true); // output as UTF-8
+            }
+        }
+    }
+    virtual void setResultVarString(const char * name, unsigned sequence, const char * value)
+    {
+        setResultString(name, sequence, strlen(value), value);
+    }
+    virtual void setResultVarUnicode(const char * name, unsigned sequence, UChar const * value)
+    {
+        setResultUnicode(name, sequence, rtlUnicodeStrlen(value), value);
+    }
+    virtual void flush()
+    {
+        ForEachItemIn(seq, resultMap)
+        {
+            FlushingStringBuffer *result = resultMap.item(seq);
+            if (result)
+                result->flush(true);
+        }
+    }
+    virtual void finalize(unsigned seqNo)
+    {
+        ForEachItemIn(seq, resultMap)
+        {
+            FlushingStringBuffer *result = resultMap.item(seq);
+            if (result)
+            {
+                result->flush(true);
+                for(;;)
+                {
+                    size32_t length;
+                    void *payload = result->getPayload(length);
+                    if (!length)
+                        break;
+                    client->write(payload, length, true);
+                }
+            }
+        }
+    }
+    virtual void appendProbeGraph(const char *xml)
+    {
+        if (!xml)
+        {
+            if (probe)
+                probe.clear();
+            return;
+        }
+        if (!probe)
+        {
+            probe.setown(new FlushingStringBuffer(client, isBlocked, MarkupFmt_XML, false, isHTTP, logctx));
+            probe->startDataset("_Probe", NULL, (unsigned) -1);  // initialize it
+        }
+
+        probe->append("\n");
+        probe->append(xml);
+    }
+
+};
+
+class CHpccXmlResultsWriter : public CHpccNativeResultsWriter
+{
+public:
+    CHpccXmlResultsWriter(const char *queryname, SafeSocket *_client, bool _isHTTP, const IContextLogger &_logctx, PTreeReaderOptions _xmlReadFlags) :
+        CHpccNativeResultsWriter(queryname, _client, false, MarkupFmt_XML, false, _isHTTP, _logctx, _xmlReadFlags)
+    {
+    }
+
+    virtual void addContent(TextMarkupFormat fmt, const char *content, const char *name)
+    {
+        StringBuffer xml;
+        if (!content || !*content)
+            return;
+        if (fmt==MarkupFmt_JSON)
+        {
+            Owned<IPropertyTree> convertPT = createPTreeFromXMLString(content);
+            if (name && *name)
+                appendXMLOpenTag(xml, name);
+            toXML(convertPT, xml, 0, 0);
+            if (name && *name)
+                appendXMLCloseTag(xml, name);
+        }
+    }
+
+    virtual void finalize(unsigned seqNo)
+    {
+        if (!isHTTP)
+        {
+            flush();
+            return;
+        }
+        CriticalBlock b(resultsCrit);
+        CriticalBlock b1(client->queryCrit());
+
+        StringBuffer responseHead, responseTail;
+        responseHead.append("<Results><Result>");
+        unsigned len = responseHead.length();
+        client->write(responseHead.detach(), len, true);
+
+        ForEachItemIn(seq, resultMap)
+        {
+            FlushingStringBuffer *result = resultMap.item(seq);
+            if (result)
+            {
+                result->flush(true);
+                for(;;)
+                {
+                    size32_t length;
+                    void *payload = result->getPayload(length);
+                    if (!length)
+                        break;
+                    client->write(payload, length, true);
+                }
+            }
+        }
+
+        responseTail.append("</Result></Results>");
+        len = responseTail.length();
+        client->write(responseTail.detach(), len, true);
+    }
+};
+
+class CHpccJsonResultsWriter : public CHpccNativeResultsWriter
+{
+public:
+    CHpccJsonResultsWriter(const char *queryname, SafeSocket *_client, const IContextLogger &_logctx, PTreeReaderOptions _xmlReadFlags) :
+        CHpccNativeResultsWriter(queryname, _client, false, MarkupFmt_JSON, false, true, _logctx, _xmlReadFlags)
+    {
+    }
+
+    virtual FlushingStringBuffer *createFlushingBuffer()
+    {
+        return new FlushingJsonBuffer(client, isBlocked, isHTTP, logctx);
+    }
+
+    virtual void finalize(unsigned seqNo)
+    {
+        CriticalBlock b(resultsCrit);
+        CriticalBlock b1(client->queryCrit());
+
+        StringBuffer responseHead, responseTail;
+        appendJSONName(responseHead, "Results").append(" {");
+        unsigned len = responseHead.length();
+        client->write(responseHead.detach(), len, true);
+
+        bool needDelimiter = false;
+        ForEachItemIn(seq, resultMap)
+        {
+            FlushingStringBuffer *result = resultMap.item(seq);
+            if (result)
+            {
+               result->flush(true);
+               for(;;)
+               {
+                   size32_t length;
+                   void *payload = result->getPayload(length);
+                   if (!length)
+                       break;
+                   if (needDelimiter)
+                   {
+                       StringAttr s(","); //write() will take ownership of buffer
+                       size32_t len = s.length();
+                       client->write((void *)s.detach(), len, true);
+                       needDelimiter=false;
+                   }
+                   client->write(payload, length, true);
+               }
+               needDelimiter=true;
+            }
+        }
+
+        responseTail.append("}");
+        len = responseTail.length();
+        client->write(responseTail.detach(), len, true);
+    }
+
+};
+
+class CHpccNativeProtocolResponse : public CInterface, implements IHpccNativeProtocolResponse
+{
+protected:
+    SafeSocket *client;
+    StringAttr queryName;
+    const IContextLogger &logctx;
+    TextMarkupFormat mlFmt;
+    PTreeReaderOptions xmlReadFlags;
+    Owned<CHpccNativeResultsWriter> results; //hpcc results section
+    IPointerArrayOf<FlushingStringBuffer> contentsMap; //other sections
+    CriticalSection contentsCrit;
+    unsigned protocolFlags;
+    bool isHTTP;
+    bool failed;
+
+public:
+    IMPLEMENT_IINTERFACE;
+    CHpccNativeProtocolResponse(const char *queryname, SafeSocket *_client, TextMarkupFormat _mlFmt, unsigned flags, bool _isHTTP, const IContextLogger &_logctx, PTreeReaderOptions _xmlReadFlags) :
+        client(_client), queryName(queryname), logctx(_logctx), mlFmt(_mlFmt), xmlReadFlags(_xmlReadFlags), protocolFlags(flags), isHTTP(_isHTTP)
+    {
+    }
+    ~CHpccNativeProtocolResponse()
+    {
+    }
+    virtual unsigned getFlags()
+    {
+        return protocolFlags;
+    }
+    inline bool getIsRaw()
+    {
+        return (protocolFlags & HPCC_PROTOCOL_NATIVE_RAW);
+    }
+    inline bool getIsBlocked()
+    {
+        return (protocolFlags & HPCC_PROTOCOL_BLOCKED);
+    }
+    inline bool getTrim()
+    {
+        return (protocolFlags & HPCC_PROTOCOL_TRIM);
+    }
+    virtual FlushingStringBuffer *queryAppendContentBuffer()
+    {
+        CriticalBlock procedure(contentsCrit);
+        FlushingStringBuffer *content;
+        if (mlFmt==MarkupFmt_JSON)
+            content = new FlushingJsonBuffer(client, getIsBlocked(), isHTTP, logctx);
+        else
+            content = new FlushingStringBuffer(client, getIsBlocked(), mlFmt, getIsRaw(), isHTTP, logctx);
+        content->isSoap = isHTTP;
+        content->trim = getTrim();
+        content->queryName.set(queryName);
+        if (!isHTTP)
+            content->startBlock();
+        contentsMap.append(content);
+        return content;
+    }
+
+    virtual IHpccProtocolResultsWriter *queryHpccResultsSection()
+    {
+        if (!results)
+            results.setown(new CHpccNativeResultsWriter(queryName, client, getIsBlocked(), mlFmt, getIsRaw(), isHTTP, logctx, xmlReadFlags));
+        return results;
+    }
+
+    virtual void appendContent(TextMarkupFormat mlFmt, const char *content, const char *name=NULL)
+    {
+        throwUnexpected();
+    }
+    virtual IXmlWriter *writeAppendContent(const char *name = NULL)
+    {
+        throwUnexpected();
+    }
+    virtual void finalize(unsigned seqNo)
+    {
+        flush();
+        if (!isHTTP)
+        {
+            unsigned replyLen = 0;
+            client->write(&replyLen, sizeof(replyLen));
+        }
+    }
+    virtual bool checkConnection()
+    {
+        return client->checkConnection();
+    }
+    virtual void sendHeartBeat()
+    {
+        client->sendHeartBeat(logctx);
+    }
+    virtual SafeSocket *querySafeSocket()
+    {
+        return client;
+    }
+    virtual void flush()
+    {
+        if (results)
+            results->flush();
+        ForEachItemIn(i, contentsMap)
+            contentsMap.item(i)->flush(true);
+    }
+    virtual void appendProbeGraph(const char *xml)
+    {
+        if (results)
+            results->appendProbeGraph(xml);
+    }
+};
+
+class CHpccJsonResponse : public CHpccNativeProtocolResponse
+{
+public:
+    CHpccJsonResponse(const char *queryname, SafeSocket *_client, unsigned flags, bool _isHttp, const IContextLogger &_logctx, PTreeReaderOptions _xmlReadFlags) :
+        CHpccNativeProtocolResponse(queryname, _client, MarkupFmt_JSON, flags, _isHttp, logctx, _xmlReadFlags)
+    {
+    }
+
+    virtual IHpccProtocolResultsWriter *getHpccResultsSection()
+    {
+        if (!results)
+            results.setown(new CHpccJsonResultsWriter(queryName, client, logctx, xmlReadFlags));
+        return results;
+    }
+
+
+    virtual void appendContent(TextMarkupFormat mlFmt, const char *content, const char *name=NULL)
+    {
+        if (mlFmt!=MarkupFmt_XML && mlFmt!=MarkupFmt_JSON)
+            return;
+        StringBuffer json;
+        if (mlFmt==MarkupFmt_XML)
+        {
+            Owned<IPropertyTree> convertPT = createPTreeFromXMLString(content);
+            toJSON(convertPT, json, 0, 0);
+            content = json.str();
+        }
+        FlushingStringBuffer *contentBuffer = queryAppendContentBuffer();
+        StringBuffer tag;
+        if (name && *name)
+            appendJSONName(tag, name);
+        contentBuffer->append(tag);
+        contentBuffer->append(content);
+    }
+    virtual IXmlWriter *writeAppendContent(const char *name = NULL)
+    {
+        FlushingStringBuffer *content = queryAppendContentBuffer();
+        if (name && *name)
+        {
+            StringBuffer tag;
+            appendJSONName(tag, name);
+            content->append(tag);
+        }
+        Owned<IXmlWriter> xmlwriter = createIXmlWriterExt(XWFnoindent, 1, content, WTJSON);
+        return xmlwriter.getClear();
+    }
+    virtual void outputContent()
+    {
+        CriticalBlock b1(client->queryCrit());
+
+        bool needDelimiter = false;
+        ForEachItemIn(seq, contentsMap)
+        {
+            FlushingStringBuffer *content = contentsMap.item(seq);
+            if (content)
+            {
+               content->flush(true);
+               for(;;)
+               {
+                   size32_t length;
+                   void *payload = content->getPayload(length);
+                   if (!length)
+                       break;
+                   if (needDelimiter)
+                   {
+                       StringAttr s(","); //write() will take ownership of buffer
+                       size32_t len = s.length();
+                       client->write((void *)s.detach(), len, true);
+                       needDelimiter=false;
+                   }
+                   client->write(payload, length, true);
+               }
+               needDelimiter=true;
+            }
+        }
+    }
+    virtual void finalize(unsigned seqNo)
+    {
+        if (!isHTTP)
+        {
+            CHpccNativeProtocolResponse::finalize(seqNo);
+            return;
+        }
+
+        CriticalBlock b(contentsCrit);
+
+        StringBuffer responseHead, responseTail;
+        StringBuffer name(queryName.get());
+        if (isHTTP)
+            name.append("Response");
+        appendJSONName(responseHead, name.str()).append(" {");
+        appendJSONValue(responseHead, "sequence", seqNo);
+        if (contentsMap.length() || results)
+            delimitJSON(responseHead);
+        unsigned len = responseHead.length();
+        client->write(responseHead.detach(), len, true);
+
+        outputContent();
+        if (results)
+            results->finalize(seqNo);
+
+        responseTail.append("}");
+        len = responseTail.length();
+        client->write(responseTail.detach(), len, true);
+    }
+};
+
+class CHpccXmlResponse : public CHpccNativeProtocolResponse
+{
+public:
+    CHpccXmlResponse(const char *queryname, SafeSocket *_client, unsigned flags, bool _isHTTP, const IContextLogger &_logctx, PTreeReaderOptions _xmlReadFlags) :
+        CHpccNativeProtocolResponse(queryname, _client, MarkupFmt_XML, flags, _isHTTP, _logctx, _xmlReadFlags)
+    {
+    }
+
+    virtual IHpccProtocolResultsWriter *getHpccResultsSection()
+    {
+        if (!results)
+            results.setown(new CHpccXmlResultsWriter(queryName, client, isHTTP, logctx, xmlReadFlags));
+        return results;
+    }
+
+    virtual void appendContent(TextMarkupFormat mlFmt, const char *content, const char *name=NULL)
+    {
+        if (mlFmt!=MarkupFmt_XML && mlFmt!=MarkupFmt_JSON)
+            return;
+        StringBuffer xml;
+        if (mlFmt==MarkupFmt_JSON)
+        {
+            Owned<IPropertyTree> convertPT = createPTreeFromJSONString(content);
+            toXML(convertPT, xml, 0, 0);
+            content = xml.str();
+        }
+        FlushingStringBuffer *contentBuffer = queryAppendContentBuffer();
+        if (name && *name)
+        {
+            StringBuffer tag;
+            appendXMLOpenTag(tag, name);
+            contentBuffer->append(tag.append('\n'));
+            appendXMLCloseTag(tag.clear(), name);
+            contentBuffer->setTail(tag.append('\n'));
+        }
+        contentBuffer->append(content);
+    }
+    virtual IXmlWriter *writeAppendContent(const char *name = NULL)
+    {
+        FlushingStringBuffer *content = queryAppendContentBuffer();
+        StringBuffer tag;
+        if (name && *name)
+        {
+            appendXMLOpenTag(tag, name);
+            content->append(tag);
+            appendXMLCloseTag(tag.clear(), name);
+            content->setTail(tag);
+        }
+        Owned<IXmlWriter> xmlwriter = createIXmlWriterExt(0, 1, content, WTStandard);
+        return xmlwriter.getClear();
+    }
+    virtual void outputContent()
+    {
+        CriticalBlock b1(client->queryCrit());
+
+        bool needDelimiter = false;
+        ForEachItemIn(seq, contentsMap)
+        {
+            FlushingStringBuffer *content = contentsMap.item(seq);
+            if (content)
+            {
+               content->flush(true);
+               if (!this->isHTTP)
+                   continue;
+               for(;;)
+               {
+                   size32_t length;
+                   void *payload = content->getPayload(length);
+                   if (!length)
+                       break;
+                   client->write(payload, length, true);
+               }
+            }
+        }
+    }
+    virtual void finalize(unsigned seqNo)
+    {
+        if (!isHTTP)
+        {
+            CHpccNativeProtocolResponse::finalize(seqNo);
+            return;
+        }
+        CriticalBlock b(contentsCrit);
+
+        StringBuffer responseHead, responseTail;
+        responseHead.append("<").append(queryName);
+        responseHead.append("Response").append(" xmlns=\"urn:hpccsystems:ecl:").appendLower(queryName.length(), queryName.str()).append('\"');
+        responseHead.append(" sequence=\"").append(seqNo).append("\">");
+        unsigned len = responseHead.length();
+        client->write(responseHead.detach(), len, true);
+
+        outputContent();
+        if (results)
+            results->finalize(seqNo);
+
+        responseTail.append("</").append(queryName);
+        if (isHTTP)
+            responseTail.append("Response");
+        responseTail.append('>');
+        len = responseTail.length();
+        client->write(responseTail.detach(), len, true);
+    }
+};
+
+IHpccProtocolResponse *createProtocolResponse(const char *queryname, SafeSocket *client, HttpHelper &httpHelper, const IContextLogger &logctx, unsigned protocolFlags, PTreeReaderOptions xmlReadFlags)
+{
+    if (protocolFlags & HPCC_PROTOCOL_NATIVE_RAW || protocolFlags & HPCC_PROTOCOL_NATIVE_ASCII)
+        return new CHpccNativeProtocolResponse(queryname, client, MarkupFmt_Unknown, protocolFlags, false, logctx, xmlReadFlags);
+    else if (httpHelper.queryContentFormat()==MarkupFmt_JSON)
+        return new CHpccJsonResponse(queryname, client, protocolFlags, httpHelper.isHttp(), logctx, xmlReadFlags);
+    return new CHpccXmlResponse(queryname, client, protocolFlags, httpHelper.isHttp(), logctx, xmlReadFlags);
+
+}
+
+class CHttpRequestAsyncFor : public CInterface, public CAsyncFor
+{
+private:
+    const char *queryName, *queryText, *querySetName;
+    const IContextLogger &logctx;
+    IArrayOf<IPropertyTree> &requestArray;
+    Linked<IHpccProtocolMsgSink> sink;
+    Linked<IHpccProtocolMsgContext> msgctx;
+    SafeSocket &client;
+    HttpHelper &httpHelper;
+    PTreeReaderOptions xmlReadFlags;
+    unsigned &memused;
+    unsigned &slaveReplyLen;
+    CriticalSection crit;
+    unsigned flags;
+
+public:
+    CHttpRequestAsyncFor(const char *_queryName, IHpccProtocolMsgSink *_sink, IHpccProtocolMsgContext *_msgctx, IArrayOf<IPropertyTree> &_requestArray,
+            SafeSocket &_client, HttpHelper &_httpHelper, unsigned _flags, unsigned &_memused, unsigned &_slaveReplyLen, const char *_queryText, const IContextLogger &_logctx, PTreeReaderOptions _xmlReadFlags, const char *_querySetName)
+    : sink(_sink), msgctx(_msgctx), requestArray(_requestArray), client(_client), httpHelper(_httpHelper), memused(_memused),
+      slaveReplyLen(_slaveReplyLen), logctx(_logctx), xmlReadFlags(_xmlReadFlags), querySetName(_querySetName), flags(_flags)
+    {
+        queryName = _queryName;
+        queryText = _queryText;
+    }
+
+    IMPLEMENT_IINTERFACE;
+
+    void onException(IException *E)
+    {
+        //if (!logctx.isBlind())
+        //    logctx.CTXLOG("FAILED: %s", queryText);
+        StringBuffer error("EXCEPTION: ");
+        E->errorMessage(error);
+        DBGLOG("%s", error.str());
+        client.checkSendHttpException(httpHelper, E, queryName);
+        E->Release();
+    }
+
+    void Do(unsigned idx)
+    {
+        try
+        {
+            IPropertyTree &request = requestArray.item(idx);
+            Owned<IHpccProtocolResponse> protocol = createProtocolResponse(request.queryName(), &client, httpHelper, logctx, flags, xmlReadFlags);
+            sink->onQueryMsg(msgctx, &request, protocol, flags, xmlReadFlags, querySetName, idx, memused, slaveReplyLen);
+        }
+        catch (IException * E)
+        {
+            onException(E);
+        }
+        catch (...)
+        {
+            onException(MakeStringException(ROXIE_INTERNAL_ERROR, "Unknown exception"));
+        }
+    }
+};
+
+//ADF - Haven't changed it yet, but this should eliminate the need to parse the query twice below
+//I can load the query and lookup the parse flags before doing a full parse
+//if it turns out I need more info I may delete this.
+class QueryNameExtractor : public CInterface, implements IPTreeNotifyEvent
+{
+public:
+    TextMarkupFormat mlFmt;
+    StringAttr prefix;
+    StringAttr name;
+    unsigned headerDepth;
+    bool isSoap;
+    bool isRequestArray;
+    bool stripWhitespace;
+    bool more;
+
+public:
+    IMPLEMENT_IINTERFACE;
+
+    QueryNameExtractor(TextMarkupFormat _mlFmt, bool _stripWhitespace) : mlFmt(_mlFmt), headerDepth(0), isSoap(false), isRequestArray(false), stripWhitespace(_stripWhitespace), more(true)
+    {
+    }
+    void extractName(const char *msg, const IContextLogger &logctx, const char *peer, unsigned port)
+    {
+        Owned<IPullPTreeReader> parser;
+        if (mlFmt==MarkupFmt_JSON)
+            parser.setown(createPullJSONStringReader(msg, *this));
+        else if (mlFmt==MarkupFmt_XML)
+            parser.setown(createPullXMLStringReader(msg, *this));
+        if (!parser)
+            return;
+        while (more && parser->next());
+        if (name.isEmpty())
+        {
+            const char *fmt = mlFmt==MarkupFmt_XML ? "XML" : "JSON";
+            IException *E = MakeStringException(-1, "ERROR: Invalid %s received from %s:%d - %s queryName not found", fmt, peer, port, msg);
+            logctx.logOperatorException(E, __FILE__, __LINE__, "Invalid query %s", fmt);
+            throw E;
+        }
+        String nameStr(name.get());
+        if (nameStr.endsWith("RequestArray"))
+        {
+            isRequestArray = true;
+            name.set(nameStr.str(), nameStr.length() - strlen("RequestArray"));
+        }
+        else if (nameStr.endsWith("Request"))
+        {
+            name.set(nameStr.str(), nameStr.length() - strlen("Request"));
+        }
+    }
+    virtual void beginNode(const char *tag, offset_t startOffset)
+    {
+        if (streq(tag, "__object__"))
+            return;
+        const char *local = strchr(tag, ':');
+        if (local)
+            local++;
+        else
+            local = tag;
+        if (mlFmt==MarkupFmt_XML)
+        {
+            if (!isSoap && streq(local, "Envelope"))
+            {
+                isSoap=true;
+                return;
+            }
+            if (isSoap && streq(local, "Header"))
+            {
+                headerDepth++;
+                return;
+            }
+            if (isSoap && !headerDepth && streq(local, "Body"))
+                return;
+        }
+        if (!headerDepth)
+        {
+            name.set(local);
+            if (tag!=local)
+                prefix.set(tag, local-tag-1);
+        }
+    }
+    virtual void newAttribute(const char *attr, const char *value)
+    {
+        if (!name.isEmpty() && streq(attr, "@_stripWhitespaceFromStoredDataset"))
+        {
+            stripWhitespace = strToBool(value);
+            more = false;
+        }
+    }
+    virtual void beginNodeContent(const char *tag)
+    {
+        if (!name.isEmpty())
+            more = false;
+    }
+    virtual void endNode(const char *tag, unsigned length, const void *value, bool binary, offset_t endOffset)
+    {
+        if (!name.isEmpty())
+            more = false;
+        else if (headerDepth && streq(tag, "Header"))
+            headerDepth--;
+    }
+
+};
+
+static Owned<IActiveQueryLimiterFactory> queryLimiterFactory;
+
+class RoxieSocketWorker : public ProtocolQueryWorker
+{
+    SocketEndpoint ep;
+    Owned<SafeSocket> client;
+    Owned<IHpccNativeProtocolMsgSink> sink;
+
+public:
+    IMPLEMENT_IINTERFACE;
+
+    RoxieSocketWorker(ProtocolSocketListener *_pool, SocketEndpoint &_ep)
+        : ProtocolQueryWorker(_pool), ep(_ep)
+    {
+        sink.set(dynamic_cast<IHpccNativeProtocolMsgSink*>(_pool->queryMsgSink()));
+    }
+
+    //  interface IPooledThread
+    virtual void init(void *_r)
+    {
+        client.setown(new CSafeSocket((ISocket *) _r));
+        ProtocolQueryWorker::init(_r);
+    }
+
+    virtual void main()
+    {
+        doMain("");
+    }
+
+    virtual void runOnce(const char *query)
+    {
+        doMain(query);
+    }
+
+private:
+    static void sendHttpServerTooBusy(SafeSocket &client, const IContextLogger &logctx)
+    {
+        StringBuffer message;
+
+        message.append("HTTP/1.0 503 Server Too Busy\r\n\r\n");
+        message.append("Server too busy, please try again later");
+
+        StringBuffer err("Too many active queries");  // write out Too many active queries - make searching for this error consistent
+        if (!global->trapTooManyActiveQueries)
+        {
+            err.appendf("  %s", message.str());
+            logctx.CTXLOG("%s", err.str());
+        }
+        else
+        {
+            IException *E = MakeStringException(ROXIE_TOO_MANY_QUERIES, "%s", err.str());
+            logctx.logOperatorException(E, __FILE__, __LINE__, "%s", message.str());
+            E->Release();
+        }
+
+        try
+        {
+            client.write(message.str(), message.length());
+        }
+        catch (IException *E)
+        {
+            logctx.logOperatorException(E, __FILE__, __LINE__, "Exception caught in sendHttpServerTooBusy");
+            E->Release();
+        }
+        catch (...)
+        {
+            logctx.logOperatorException(NULL, __FILE__, __LINE__, "sendHttpServerTooBusy write failed (Unknown exception)");
+        }
+    }
+
+    void skipProtocolRoot(Owned<IPropertyTree> &queryPT, HttpHelper &httpHelper, StringAttr &queryName, bool &isRequest, bool &isRequestArray)
+    {
+        if (queryPT)
+        {
+            queryName.set(queryPT->queryName());
+            isRequest = false;
+            isRequestArray = false;
+            if (httpHelper.isHttp())
+            {
+                if (httpHelper.queryContentFormat()==MarkupFmt_JSON)
+                {
+                    if (strieq(queryName, "__object__"))
+                    {
+                        queryPT.setown(queryPT->getPropTree("*[1]"));
+                        queryName.set(queryPT->queryName());
+                        isRequest = true;
+                        if (!queryPT)
+                            throw MakeStringException(ROXIE_DATA_ERROR, "Malformed JSON request (missing Body)");
+                    }
+                    else if (strieq(queryName, "__array__"))
+                        throw MakeStringException(ROXIE_DATA_ERROR, "JSON request array not implemented");
+                    else
+                        throw MakeStringException(ROXIE_DATA_ERROR, "Malformed JSON request");
+                }
+                else
+                {
+                    if (strieq(queryName, "envelope"))
+                        queryPT.setown(queryPT->getPropTree("Body/*"));
+                    else if (!strnicmp(httpHelper.queryContentType(), "application/soap", strlen("application/soap")))
+                        throw MakeStringException(ROXIE_DATA_ERROR, "Malformed SOAP request");
+                    else
+                        httpHelper.setUseEnvelope(false);
+                    if (!queryPT)
+                        throw MakeStringException(ROXIE_DATA_ERROR, "Malformed SOAP request (missing Body)");
+                    String reqName(queryPT->queryName());
+                    queryPT->removeProp("@xmlns:m");
+
+                    // following code is moved from main() - should be no performance hit
+                    String requestString("Request");
+                    String requestArrayString("RequestArray");
+
+                    if (reqName.endsWith(requestArrayString))
+                    {
+                        isRequestArray = true;
+                        queryName.set(reqName.str(), reqName.length() - requestArrayString.length());
+                    }
+                    else if (reqName.endsWith(requestString))
+                    {
+                        isRequest = true;
+                        queryName.set(reqName.str(), reqName.length() - requestString.length());
+                    }
+                    else
+                        queryName.set(reqName.str());
+
+                    queryPT->renameProp("/", queryName.get());  // reset the name of the tree
+                }
+            }
+        }
+    }
+
+    void sanitizeQuery(Owned<IPropertyTree> &queryPT, StringAttr &queryName, StringBuffer &saniText, HttpHelper &httpHelper, const char *&uid, bool &isRequest, bool &isRequestArray, bool &isBlind, bool &isDebug)
+    {
+        if (queryPT)
+        {
+            skipProtocolRoot(queryPT, httpHelper, queryName, isRequest, isRequestArray);
+
+            // convert to XML with attribute values in single quotes - makes replaying queries easier
+            uid = queryPT->queryProp("@uid");
+            if (!uid)
+                uid = queryPT->queryProp("_TransactionId");
+            isBlind = queryPT->getPropBool("@blind", false) || queryPT->getPropBool("_blind", false);
+            isDebug = queryPT->getPropBool("@debug") || queryPT->getPropBool("_Probe", false);
+            toXML(queryPT, saniText, 0, isBlind ? (XML_SingleQuoteAttributeValues | XML_Sanitize) : XML_SingleQuoteAttributeValues);
+        }
+        else
+            throw MakeStringException(ROXIE_DATA_ERROR, "Malformed request");
+    }
+    void parseQueryPTFromString(Owned<IPropertyTree> &queryPT, HttpHelper &httpHelper, const char *text, PTreeReaderOptions options)
+    {
+        if (strieq(httpHelper.queryContentType(), "application/json"))
+            queryPT.setown(createPTreeFromJSONString(text, ipt_caseInsensitive, options));
+        else
+            queryPT.setown(createPTreeFromXMLString(text, ipt_caseInsensitive, options));
+    }
+
+    void doMain(const char *runQuery)
+    {
+        StringBuffer rawText(runQuery);
+        unsigned memused = 0;
+        IpAddress peer;
+        bool continuationNeeded = false;
+        bool isStatus = false;
+
+        Owned<IHpccProtocolMsgContext> msgctx = sink->createMsgContext(startTime);
+        IContextLogger &logctx = *msgctx->queryLogContext();
+
+readAnother:
+        unsigned slavesReplyLen = 0;
+        StringArray allTargets;
+        sink->getTargetNames(allTargets);
+        HttpHelper httpHelper(&allTargets);
+        try
+        {
+            if (client)
+            {
+                client->querySocket()->getPeerAddress(peer);
+                if (!client->readBlock(rawText.clear(), WAIT_FOREVER, &httpHelper, continuationNeeded, isStatus, global->maxBlockSize))
+                {
+                    if (traceLevel > 8)
+                    {
+                        StringBuffer b;
+                        DBGLOG("No data reading query from socket");
+                    }
+                    client.clear();
+                    return;
+                }
+            }
+            if (continuationNeeded)
+            {
+                qstart = msTick();
+                time(&startTime);
+            }
+        }
+        catch (IException * E)
+        {
+            if (traceLevel > 0)
+            {
+                StringBuffer b;
+                DBGLOG("Error reading query from socket: %s", E->errorMessage(b).str());
+            }
+            E->Release();
+            client.clear();
+            return;
+        }
+
+        bool isHTTP = httpHelper.isHttp();
+        TextMarkupFormat mlFmt = isHTTP ? httpHelper.queryContentFormat() : MarkupFmt_XML;
+
+        bool failed = false;
+        bool isRequest = false;
+        bool isRequestArray = false;
+        bool isBlind = false;
+        bool isDebug = false;
+        unsigned protocolFlags = isHTTP ? 0 : HPCC_PROTOCOL_NATIVE;
+
+        Owned<IPropertyTree> queryPT;
+        StringBuffer sanitizedText;
+        StringBuffer peerStr;
+        peer.getIpText(peerStr);
+        const char *uid = "-";
+
+        StringAttr queryName;
+        StringAttr queryPrefix;
+        bool stripWhitespace = msgctx->getStripWhitespace();
+        if (mlFmt==MarkupFmt_XML || mlFmt==MarkupFmt_JSON)
+        {
+            QueryNameExtractor extractor(mlFmt, stripWhitespace);
+            extractor.extractName(rawText.str(), logctx, peerStr, ep.port);
+            queryName.set(extractor.name);
+            queryPrefix.set(extractor.prefix);
+            stripWhitespace = extractor.stripWhitespace;
+        }
+        try
+        {
+            if (streq(queryPrefix.str(), "control"))
+            {
+                if (httpHelper.isHttp())
+                    client->setHttpMode(queryName, false, httpHelper);
+
+                bool aclupdate = strieq(queryName, "aclupdate"); //ugly
+                byte iptFlags = aclupdate ? ipt_caseInsensitive : 0;
+
+                if (mlFmt==MarkupFmt_JSON)
+                    queryPT.setown(createPTreeFromJSONString(rawText.str(), iptFlags, (PTreeReaderOptions)(ptr_ignoreWhiteSpace|ptr_ignoreNameSpaces)));
+                else
+                    queryPT.setown(createPTreeFromXMLString(rawText.str(), iptFlags, (PTreeReaderOptions)(ptr_ignoreWhiteSpace|ptr_ignoreNameSpaces)));
+
+                IPropertyTree *root = queryPT;
+                skipProtocolRoot(queryPT, httpHelper, queryName, isRequest, isRequestArray);
+                if (!strchr(queryName, ':'))
+                {
+                    VStringBuffer fullname("control:%s", queryName.str()); //just easier to keep for debugging and internal checking
+                    queryPT->renameProp("/", fullname);
+                }
+                Owned<IHpccProtocolResponse> protocol = createProtocolResponse(queryPT->queryName(), client, httpHelper, logctx, protocolFlags, global->defaultXmlReadFlags);
+                sink->onControlMsg(msgctx, queryPT, protocol);
+                protocol->finalize(0);
+                if (streq(queryName, "lock") || streq(queryName, "childlock"))
+                    goto readAnother;
+            }
+            else if (isStatus)
+            {
+                client->write("OK", 2);
+            }
+            else
+            {
+                unsigned readFlags = (unsigned) global->defaultXmlReadFlags | ptr_ignoreNameSpaces;
+                readFlags &= ~ptr_ignoreWhiteSpace;
+                readFlags |= (stripWhitespace ? ptr_ignoreWhiteSpace : ptr_none);
+                try
+                {
+                    parseQueryPTFromString(queryPT, httpHelper, rawText.str(), (PTreeReaderOptions)readFlags);
+                }
+                catch (IException *E)
+                {
+                    logctx.logOperatorException(E, __FILE__, __LINE__, "Invalid XML received from %s:%d - %s", peerStr.str(), listener->queryPort(), rawText.str());
+                    logctx.CTXLOG("ERROR: Invalid XML received from %s:%d - %s", peerStr.str(), listener->queryPort(), rawText.str());
+                    throw;
+                }
+
+                uid = NULL;
+                sanitizeQuery(queryPT, queryName, sanitizedText, httpHelper, uid, isRequest, isRequestArray, isBlind, isDebug);
+                if (!uid)
+                    uid = "-";
+
+                sink->checkAccess(peer, queryName, sanitizedText, isBlind);
+
+                if (isDebug)
+                    msgctx->verifyAllowDebug();
+                isBlind = msgctx->checkSetBlind(isBlind);
+
+                if (msgctx->logFullQueries())
+                {
+                    StringBuffer soapStr;
+                    (isRequest) ? soapStr.append("SoapRequest") : (isRequestArray) ? soapStr.append("SoapRequest") : soapStr.clear();
+                    logctx.CTXLOG("%s %s:%d %s %s %s", isBlind ? "BLIND:" : "QUERY:", peerStr.str(), listener->queryPort(), uid, soapStr.str(), sanitizedText.str());
+                }
+                if (strieq(queryPrefix.str(), "debug"))
+                {
+                    FlushingStringBuffer response(client, false, MarkupFmt_XML, false, isHTTP, logctx);
+                    response.startDataset("Debug", NULL, (unsigned) -1);
+                    CommonXmlWriter out(0, 1);
+                    sink->onDebugMsg(msgctx, uid, queryPT, out);
+                    response.append(out.str());
+                }
+
+                Owned<IActiveQueryLimiter> l;
+                if (queryLimiterFactory)
+                    l.setown(queryLimiterFactory->create(listener));
+                if (!l->isAccepted())
+                {
+                    if (isHTTP)
+                    {
+                        sendHttpServerTooBusy(*client, logctx);
+                        logctx.CTXLOG("FAILED: %s", sanitizedText.str());
+                        logctx.CTXLOG("EXCEPTION: Too many active queries");
+                    }
+                    else
+                    {
+                        IException *e = MakeStringException(ROXIE_TOO_MANY_QUERIES, "Too many active queries");
+                        if (msgctx->trapTooManyActiveQueries())
+                            logctx.logOperatorException(e, __FILE__, __LINE__, NULL);
+                        throw e;
+                    }
+                }
+                else
+                {
+                    StringBuffer querySetName;
+                    if (isHTTP)
+                    {
+                        client->setHttpMode(queryName, isRequestArray, httpHelper);
+                        querySetName.set(httpHelper.queryTarget());
+                        if (querySetName.length())
+                        {
+                            const char *target = global->targetAliases->queryProp(querySetName.str());
+                            if (target)
+                                querySetName.set(target);
+                        }
+                    }
+                    if (msgctx->initQuery(querySetName, queryName))
+                    {
+                        int bindCores = queryPT->getPropInt("@bindCores", msgctx->getBindCores());
+                        if (bindCores > 0)
+                            listener->setThreadAffinity(bindCores);
+                        IArrayOf<IPropertyTree> requestArray;
+                        if (isHTTP)
+                        {
+                            mlFmt = httpHelper.queryContentFormat();
+                            if (isRequestArray)
+                            {
+                                StringBuffer reqIterString;
+                                reqIterString.append(queryName).append("Request");
+
+                                Owned<IPropertyTreeIterator> reqIter = queryPT->getElements(reqIterString.str());
+                                ForEach(*reqIter)
+                                {
+                                    IPropertyTree *fixedreq = createPTree(queryName, ipt_caseInsensitive);
+                                    Owned<IPropertyTreeIterator> iter = reqIter->query().getElements("*");
+                                    ForEach(*iter)
+                                    {
+                                        fixedreq->addPropTree(iter->query().queryName(), LINK(&iter->query()));
+                                    }
+                                    requestArray.append(*fixedreq);
+                                }
+                            }
+                            else
+                            {
+                                IPropertyTree *fixedreq = createPTree(queryName, ipt_caseInsensitive);
+                                Owned<IPropertyTreeIterator> iter = queryPT->getElements("*");
+                                ForEach(*iter)
+                                {
+                                    fixedreq->addPropTree(iter->query().queryName(), LINK(&iter->query()));
+                                }
+                                requestArray.append(*fixedreq);
+                            }
+                            if (httpHelper.getTrim())
+                                protocolFlags |= HPCC_PROTOCOL_TRIM;
+                        }
+                        else
+                        {
+                            const char *format = queryPT->queryProp("@format");
+                            if (format)
+                            {
+                                if (stricmp(format, "raw") == 0)
+                                {
+                                    protocolFlags |= HPCC_PROTOCOL_NATIVE_RAW;
+                                    mlFmt = MarkupFmt_Unknown;
+                                }
+                                else if (stricmp(format, "bxml") == 0)
+                                {
+                                    protocolFlags |= HPCC_PROTOCOL_BLOCKED;
+                                }
+                                else if (stricmp(format, "ascii") == 0)
+                                {
+                                    protocolFlags |= HPCC_PROTOCOL_NATIVE_ASCII;
+                                    mlFmt = MarkupFmt_Unknown;
+                                }
+                                else if (stricmp(format, "xml") != 0) // xml is the default
+                                    throw MakeStringException(ROXIE_INVALID_INPUT, "Unsupported format specified: %s", format);
+                            }
+                            if (queryPT->getPropBool("@trim", false))
+                                protocolFlags |= HPCC_PROTOCOL_TRIM;
+                            msgctx->setIntercept(queryPT->getPropBool("@log", false));
+                            msgctx->setTraceLevel(queryPT->getPropInt("@traceLevel", logctx.queryTraceLevel()));
+                        }
+
+                        msgctx->noteQueryActive();
+
+                        if (isHTTP)
+                        {
+                            CHttpRequestAsyncFor af(queryName, sink, msgctx, requestArray, *client, httpHelper, protocolFlags, memused, slavesReplyLen, sanitizedText, logctx, (PTreeReaderOptions)readFlags, querySetName);
+                            af.For(requestArray.length(), global->numRequestArrayThreads);
+                        }
+                        else
+                        {
+                            Owned<IHpccProtocolResponse> protocol = createProtocolResponse(queryPT->queryName(), client, httpHelper, logctx, protocolFlags, (PTreeReaderOptions)readFlags);
+                            sink->onQueryMsg(msgctx, queryPT, protocol, protocolFlags, (PTreeReaderOptions)readFlags, querySetName, 0, memused, slavesReplyLen);
+                        }
+                    }
+                }
+            }
+        }
+        catch (IException * E)
+        {
+            failed = true;
+            logctx.CTXLOG("FAILED: %s", sanitizedText.str());
+            StringBuffer error;
+            E->errorMessage(error);
+            logctx.CTXLOG("EXCEPTION: %s", error.str());
+            unsigned code = E->errorCode();
+            if (QUERYINTERFACE(E, ISEH_Exception))
+                code = ROXIE_INTERNAL_ERROR;
+            else if (QUERYINTERFACE(E, IOutOfMemException))
+                code = ROXIE_MEMORY_ERROR;
+            if (client)
+            {
+                if (isHTTP)
+                    client->checkSendHttpException(httpHelper, E, queryName);
+                else
+                    client->sendException("Roxie", code, error.str(), (protocolFlags & HPCC_PROTOCOL_NATIVE_RAW), logctx);
+            }
+            else
+            {
+                fprintf(stderr, "EXCEPTION: %s\n", error.str());
+            }
+            E->Release();
+        }
+#ifndef _DEBUG
+        catch(...)
+        {
+            failed = true;
+            logctx.CTXLOG("FAILED: %s", sanitizedText.str());
+            logctx.CTXLOG("EXCEPTION: Unknown exception");
+            {
+                if (isHTTP)
+                {
+                    Owned<IException> E = MakeStringException(ROXIE_INTERNAL_ERROR, "Unknown exception");
+                    client->checkSendHttpException(httpHelper, E, queryName);
+                }
+                else
+                    client->sendException("Roxie", ROXIE_INTERNAL_ERROR, "Unknown exception", isBlocked, logctx);
+            }
+        }
+#endif
+        if (isHTTP)
+        {
+            try
+            {
+                client->flush();
+            }
+            catch (IException * E)
+            {
+                StringBuffer error("RoxieSocketWorker failed to write to socket ");
+                E->errorMessage(error);
+                logctx.CTXLOG("%s", error.str());
+                E->Release();
+
+            }
+            catch(...)
+            {
+                logctx.CTXLOG("RoxieSocketWorker failed to write to socket (Unknown exception)");
+            }
+        }
+        unsigned bytesOut = client? client->bytesOut() : 0;
+        unsigned elapsed = msTick() - qstart;
+        if (continuationNeeded)
+        {
+            rawText.clear();
+            goto readAnother;
+        }
+        else
+        {
+            try
+            {
+                if (client && !isHTTP && !isStatus)
+                {
+                    if (msgctx->getIntercept())
+                    {
+                        FlushingStringBuffer response(client, (protocolFlags & HPCC_PROTOCOL_BLOCKED), mlFmt, (protocolFlags & HPCC_PROTOCOL_NATIVE_RAW), false, logctx);
+                        response.startDataset("Tracing", NULL, (unsigned) -1);
+                        msgctx->outputLogXML(response);
+                    }
+                    unsigned replyLen = 0;
+                    client->write(&replyLen, sizeof(replyLen));
+                }
+                client.clear();
+            }
+            catch (IException * E)
+            {
+                StringBuffer error("RoxieSocketWorker failed to close socket ");
+                E->errorMessage(error);
+                logctx.CTXLOG("%s", error.str()); // MORE - audience?
+                E->Release();
+
+            }
+            catch(...)
+            {
+                logctx.CTXLOG("RoxieSocketWorker failed to close socket (Unknown exception)"); // MORE - audience?
+            }
+        }
+    }
+};
+
+
+IPooledThread *ProtocolSocketListener::createNew()
+{
+    return new RoxieSocketWorker(this, ep);
+}
+
+void ProtocolSocketListener::runOnce(const char *query)
+{
+    Owned<RoxieSocketWorker> p = new RoxieSocketWorker(this, ep);
+    p->runOnce(query);
+}
+
+IHpccProtocolListener *createProtocolListener(const char *protocol, IHpccProtocolMsgSink *sink, unsigned port, unsigned listenQueue)
+{
+    if (traceLevel)
+        DBGLOG("Creating Roxie socket listener, protocol %s, pool size %d, listen queue %d%s", protocol, sink->getPoolSize(), listenQueue, sink->getIsSuspended() ? " SUSPENDED":"");
+    return new ProtocolSocketListener(sink, port, listenQueue);
+}
+
+extern IHpccProtocolPlugin *loadHpccProtocolPlugin(IHpccProtocolPluginContext *ctx, IActiveQueryLimiterFactory *_limiterFactory)
+{
+    if (!queryLimiterFactory)
+        queryLimiterFactory.set(_limiterFactory);
+    if (global)
+        return global;
+    if (!ctx)
+        return NULL;
+    global.setown(new CHpccProtocolPlugin(*ctx));
+    return global;
+}
+
+
+//================================================================================================================================

--- a/roxie/ccd/ccdprotocol.cpp
+++ b/roxie/ccd/ccdprotocol.cpp
@@ -1721,7 +1721,7 @@ readAnother:
                     client->checkSendHttpException(httpHelper, E, queryName);
                 }
                 else
-                    client->sendException("Roxie", ROXIE_INTERNAL_ERROR, "Unknown exception", isBlocked, logctx);
+                    client->sendException("Roxie", ROXIE_INTERNAL_ERROR, "Unknown exception", (protocolFlags & HPCC_PROTOCOL_BLOCKED), logctx);
             }
         }
 #endif

--- a/roxie/ccd/ccdprotocol.hpp
+++ b/roxie/ccd/ccdprotocol.hpp
@@ -1,0 +1,46 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2016 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef _CCDPROTOCOL_INCL
+#define _CCDPROTOCOL_INCL
+
+#include "hpccprotocol.hpp"
+
+#define HPCC_PROTOCOL_NATIVE           0x10000
+#define HPCC_PROTOCOL_NATIVE_RAW       0x20000
+#define HPCC_PROTOCOL_NATIVE_XML       0x40000
+#define HPCC_PROTOCOL_NATIVE_ASCII     0x80000
+
+interface IHpccNativeProtocolMsgSink : extends IHpccProtocolMsgSink
+{
+    virtual void onControlMsg(IHpccProtocolMsgContext *msgctx, IPropertyTree *msg, IHpccProtocolResponse *protocol) = 0;
+    virtual void onDebugMsg(IHpccProtocolMsgContext *msgctx, const char *uid, IPropertyTree *msg, IXmlWriter &out) = 0;
+};
+
+interface IHpccNativeProtocolResultsWriter : extends IHpccProtocolResultsWriter
+{
+    virtual void appendRawRow(unsigned sequence, unsigned len, const char *data) = 0;
+    virtual void appendSimpleRow(unsigned sequence, const char *str) = 0;
+    virtual void appendRaw(unsigned sequence, unsigned len, const char *data) = 0;
+};
+
+interface IHpccNativeProtocolResponse : extends IHpccProtocolResponse
+{
+    virtual SafeSocket *querySafeSocket() = 0; //still passed to debug context, and row streaming, for now.. tbd get rid of this
+};
+
+#endif

--- a/roxie/ccd/ccdquery.cpp
+++ b/roxie/ccd/ccdquery.cpp
@@ -1487,7 +1487,7 @@ public:
         throwUnexpected();   // only implemented in derived slave class
     }
 
-    virtual IRoxieServerContext *createContext(IPropertyTree *xml, SafeSocket &client, TextMarkupFormat mlFmt, bool isRaw, bool isBlocked, HttpHelper &httpHelper, bool trim, const ContextLogger &_logctx, PTreeReaderOptions xmlReadFlags, const char *querySetName) const
+    virtual IRoxieServerContext *createContext(IPropertyTree *xml, IHpccProtocolResponse *protocol, unsigned flags, const ContextLogger &_logctx, PTreeReaderOptions xmlReadFlags, const char *querySetName) const
     {
         throwUnexpected();   // only implemented in derived server class
     }
@@ -1611,10 +1611,10 @@ public:
         return activities;
     }
 
-    virtual IRoxieServerContext *createContext(IPropertyTree *context, SafeSocket &client, TextMarkupFormat mlFmt, bool isRaw, bool isBlocked, HttpHelper &httpHelper, bool trim, const ContextLogger &_logctx, PTreeReaderOptions _xmlReadFlags, const char *_querySetName) const
+    virtual IRoxieServerContext *createContext(IPropertyTree *context, IHpccProtocolResponse *protocol, unsigned flags, const ContextLogger &_logctx, PTreeReaderOptions _xmlReadFlags, const char *_querySetName) const
     {
         checkSuspended();
-        return createRoxieServerContext(context, this, client, mlFmt==MarkupFmt_XML, isRaw, isBlocked, httpHelper, trim, _logctx, _xmlReadFlags, _querySetName);
+        return createRoxieServerContext(context, protocol, this, flags, _logctx, _xmlReadFlags, _querySetName);
     }
 
     virtual IRoxieServerContext *createContext(IConstWorkUnit *wu, const ContextLogger &_logctx) const

--- a/roxie/ccd/ccdquery.hpp
+++ b/roxie/ccd/ccdquery.hpp
@@ -22,6 +22,7 @@
 #include "ccdserver.hpp"
 #include "ccdkey.hpp"
 #include "ccdfile.hpp"
+#include "ccdprotocol.hpp"
 #include "jhtree.hpp"
 #include "jisem.hpp"
 #include "dllserver.hpp"
@@ -165,7 +166,7 @@ interface IQueryFactory : extends IInterface
     virtual CRoxieWorkflowMachine *createWorkflowMachine(IConstWorkUnit *wu, bool isOnce, const IRoxieContextLogger &logctx) const = 0;
     virtual char *getEnv(const char *name, const char *defaultValue) const = 0;
 
-    virtual IRoxieServerContext *createContext(IPropertyTree *xml, SafeSocket &client, TextMarkupFormat mlFmt, bool isRaw, bool isBlocked, HttpHelper &httpHelper, bool trim, const ContextLogger &_logctx, PTreeReaderOptions xmlReadFlags, const char *querySetName) const = 0;
+    virtual IRoxieServerContext *createContext(IPropertyTree *xml, IHpccProtocolResponse *protocol, unsigned flags, const ContextLogger &_logctx, PTreeReaderOptions xmlReadFlags, const char *querySetName) const = 0;
     virtual IRoxieServerContext *createContext(IConstWorkUnit *wu, const ContextLogger &_logctx) const = 0;
     virtual void noteQuery(time_t startTime, bool failed, unsigned elapsed, unsigned memused, unsigned slavesReplyLen, unsigned bytesOut) = 0;
     virtual IPropertyTree *getQueryStats(time_t from, time_t to) = 0;

--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -20124,29 +20124,25 @@ public:
             storedName = "Dataset";
 
         MemoryBuffer result;
-        FlushingStringBuffer *response = NULL;
         bool saveInContext = (int) sequence < 0 || isReread;
         if (!meta.queryOriginal()) // this is a bit of a hack - don't know why no meta on an output....
             meta.set(input->queryOutputMeta());
         Owned<IOutputRowSerializer> rowSerializer;
-        Owned<IXmlWriter> writer;
+        Owned<IXmlWriter> xmlwriter;
+        bool appendRaw = false;
+
+        IHpccProtocolResultsWriter *results = NULL;
+        IHpccNativeProtocolResultsWriter *nativeResults = NULL;
+        IHpccProtocolResponse *protocol = serverContext->queryProtocol();
+        unsigned protocolFlags = (protocol) ? protocol->getFlags() : 0;
         if ((int) sequence >= 0)
         {
-            response = serverContext->queryResult(sequence);
-            if (response)
+            results = (protocol) ? protocol->queryHpccResultsSection() : NULL;
+            if (results)
             {
-                const IProperties *xmlns = serverContext->queryXmlns(sequence);
-                response->startDataset("Dataset", helper.queryName(), sequence, (helper.getFlags() & POFextend) != 0, xmlns);
-                if (response->mlFmt==MarkupFmt_XML || response->mlFmt==MarkupFmt_JSON)
-                {
-                    unsigned int writeFlags = serverContext->getXmlFlags();
-                    if (response->mlFmt==MarkupFmt_JSON)
-                        writeFlags |= XWFnoindent;
-                    writer.setown(createIXmlWriterExt(writeFlags, 1, response, (response->mlFmt==MarkupFmt_JSON) ? WTJSON : WTStandard));
-                    writer->outputBeginArray(DEFAULTXMLROWTAG);
-                }
+                nativeResults = dynamic_cast<IHpccNativeProtocolResultsWriter*>(results);
+                xmlwriter.setown(results->addDataset(helper.queryName(), sequence, "Dataset", appendRaw, serverContext->getXmlFlags(), (helper.getFlags() & POFextend) != 0, serverContext->queryXmlns(sequence)));  //xmlwriter only returned if needed
             }
-
         }
         size32_t outputLimitBytes = 0;
         IConstWorkUnit *workunit = serverContext->queryWorkUnit();
@@ -20165,7 +20161,7 @@ public:
             assertex(outputLimit<=0x1000); // 32bit limit because MemoryBuffer/CMessageBuffers involved etc.
             outputLimitBytes = outputLimit * 0x100000;
         }
-        if (workunit != NULL || (response && response->isRaw))
+        if (workunit != NULL || (results && protocol->getFlags() & HPCC_PROTOCOL_NATIVE_RAW))
         {
             createRowAllocator();
             rowSerializer.setown(rowAllocator->createDiskSerializer(ctx->queryCodeContext()));
@@ -20184,13 +20180,18 @@ public:
             {
                 if (workunit)
                     result.append(row == NULL);
-                if (response)
+                if (results)
                 {
-                    if (response->isRaw)
-                        response->append((char)(row == NULL));
-                    else
+                    if (protocolFlags & HPCC_PROTOCOL_NATIVE_RAW && nativeResults)
                     {
-                        response->append("<Row __GroupBreak__=\"1\"/>");        // sensible, but need to handle on input
+                        char val = (char)(row == NULL);
+                        nativeResults->appendRaw(sequence, 1, &val);
+                    }
+                    else if (xmlwriter)
+                    {
+                        xmlwriter->outputBeginNested("Row", false);
+                        xmlwriter->outputCString("1", "@__GroupBreak__");
+                        xmlwriter->outputEndNested("Row");
                     }
                 }
             }
@@ -20208,31 +20209,30 @@ public:
                 CThorDemoRowSerializer serializerTarget(result);
                 rowSerializer->serialize(serializerTarget, (const byte *) row);
             }
-            if (response)
+            if ((int) sequence >= 0)
             {
-                if (response->isRaw)
+                if (appendRaw && nativeResults)
                 {
                     // MORE - should be able to serialize straight to the response...
                     MemoryBuffer rowbuff;
                     CThorDemoRowSerializer serializerTarget(rowbuff);
                     rowSerializer->serialize(serializerTarget, (const byte *) row);
-                    response->append(rowbuff.length(), rowbuff.toByteArray());
+                    nativeResults->appendRawRow(sequence, rowbuff.length(), rowbuff.toByteArray());
                 }
-                else if (writer)
+                else if (xmlwriter)
                 {
-                    writer->outputBeginNested(DEFAULTXMLROWTAG, false);
-                    helper.serializeXml((byte *) row, *writer);
-                    writer->outputEndNested(DEFAULTXMLROWTAG);
+                    xmlwriter->outputBeginNested(DEFAULTXMLROWTAG, false);
+                    helper.serializeXml((byte *) row, *xmlwriter);
+                    xmlwriter->outputEndNested(DEFAULTXMLROWTAG);
+                    results->finalizeXmlRow(sequence);
                 }
-                else
+                else if (nativeResults)
                 {
                     SimpleOutputWriter x;
                     helper.serializeXml((byte *) row, x);
                     x.newline();
-                    response->append(x.str());
+                    nativeResults->appendSimpleRow(sequence, x.str());
                 }
-                response->incrementRowCount();
-                response->flush(false);
             }
             ReleaseRoxieRow(row);
             if (outputLimitBytes && result.length() > outputLimitBytes)
@@ -20248,8 +20248,8 @@ public:
                 throw MakeStringExceptionDirect(0, errMsg.str());
             }
         }
-        if (writer)
-            writer->outputEndArray(DEFAULTXMLROWTAG);
+        if (xmlwriter)
+            xmlwriter->outputEndArray(DEFAULTXMLROWTAG);
         if (saveInContext)
             serverContext->appendResultDeserialized(storedName, sequence, builder.getcount(), builder.linkrows(), (helper.getFlags() & POFextend) != 0, LINK(meta.queryOriginal()));
         if (workunit)

--- a/roxie/ccd/hpccprotocol.hpp
+++ b/roxie/ccd/hpccprotocol.hpp
@@ -1,0 +1,145 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2016 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef _HPCCPROTOCOL_INCL
+#define _HPCCPROTOCOL_INCL
+
+#include <jlib.hpp>
+#include "roxiehelper.hpp"
+
+#define HPCC_PROTOCOL_BLOCKED          0x0001
+#define HPCC_PROTOCOL_TRIM             0x0002
+
+interface IHpccProtocolMsgContext : extends IInterface
+{
+    virtual bool initQuery(StringBuffer &target, const char *queryname) = 0;
+    virtual void noteQueryActive() = 0;
+    virtual unsigned getQueryPriority() = 0;
+    virtual IContextLogger *queryLogContext() = 0;
+    virtual bool checkSetBlind(bool blind) = 0;
+    virtual void verifyAllowDebug() = 0;
+    virtual bool logFullQueries() = 0;
+    virtual bool trapTooManyActiveQueries() = 0;
+    virtual bool getStripWhitespace() = 0;
+    virtual int getBindCores() = 0;
+    virtual void setTraceLevel(unsigned val) = 0;
+    virtual void setIntercept(bool val) = 0;
+    virtual bool getIntercept() = 0;
+    virtual void outputLogXML(IXmlStreamFlusher &out) = 0;
+};
+
+interface IHpccProtocolResultsWriter : extends IInterface
+{
+    virtual IXmlWriter *addDataset(const char *name, unsigned sequence, const char *elementName, bool &appendRawData, unsigned xmlFlags, bool _extend, const IProperties *xmlns) = 0;
+    virtual void finalizeXmlRow(unsigned sequence) = 0;
+
+    virtual void setResultBool(const char *name, unsigned sequence, bool value) = 0;
+    virtual void setResultData(const char *name, unsigned sequence, int len, const void * data) = 0;
+    virtual void setResultDecimal(const char * stepname, unsigned sequence, int len, int precision, bool isSigned, const void *val) = 0;
+    virtual void setResultInt(const char *name, unsigned sequence, __int64 value, unsigned size) = 0;
+    virtual void setResultRaw(const char *name, unsigned sequence, int len, const void * data) = 0;
+    virtual void setResultReal(const char * stepname, unsigned sequence, double value) = 0;
+    virtual void setResultSet(const char *name, unsigned sequence, bool isAll, size32_t len, const void * data, ISetToXmlTransformer * transformer) = 0;
+    virtual void setResultString(const char *name, unsigned sequence, int len, const char * str) = 0;
+    virtual void setResultUInt(const char *name, unsigned sequence, unsigned __int64 value, unsigned size) = 0;
+    virtual void setResultUnicode(const char *name, unsigned sequence, int len, UChar const * str) = 0;
+    virtual void setResultVarString(const char * name, unsigned sequence, const char * value) = 0;
+    virtual void setResultVarUnicode(const char * name, unsigned sequence, UChar const * value) = 0;
+};
+
+interface IHpccProtocolResponse : extends IInterface
+{
+    virtual unsigned getFlags() = 0;
+    virtual IHpccProtocolResultsWriter *queryHpccResultsSection() = 0;
+
+    virtual void appendContent(TextMarkupFormat mlFmt, const char *content, const char *name=NULL) = 0; //will be transformed
+    virtual IXmlWriter *writeAppendContent(const char *name = NULL) = 0;
+    virtual void appendProbeGraph(const char *xml) = 0;
+
+    virtual void finalize(unsigned seqNo) = 0;
+
+    virtual bool checkConnection() = 0;
+    virtual void sendHeartBeat() = 0;
+    virtual void flush() = 0;
+};
+
+interface IHpccProtocolMsgSink : extends IInterface
+{
+    virtual CriticalSection &getActiveCrit() = 0;
+    virtual bool getIsSuspended() = 0;
+    virtual unsigned getActiveThreadCount() = 0;
+    virtual unsigned getPoolSize() = 0;
+    virtual unsigned getMaxActiveThreads() = 0;
+    virtual void setMaxActiveThreads(unsigned val) = 0;
+    virtual void incActiveThreadCount() = 0;
+    virtual void decActiveThreadCount() = 0;
+    virtual bool suspend(bool suspendIt) = 0;
+
+    virtual void addAccess(bool allow, bool allowBlind, const char *ip, const char *mask, const char *query, const char *errorMsg, int errorCode) = 0;
+    virtual void checkAccess(IpAddress &peer, const char *queryName, const char *queryText, bool isBlind) = 0;
+    virtual void queryAccessInfo(StringBuffer &info) = 0;
+
+    virtual IHpccProtocolMsgContext *createMsgContext(time_t startTime) = 0;
+    virtual StringArray &getTargetNames(StringArray &targets) = 0;
+
+    virtual void noteQuery(IHpccProtocolMsgContext *msgctx, const char *peer, bool failed, unsigned bytesOut, unsigned elapsed, unsigned priority, unsigned memused, unsigned slavesReplyLen, bool continuationNeeded) = 0;
+    virtual void onQueryMsg(IHpccProtocolMsgContext *msgctx, IPropertyTree *msg, IHpccProtocolResponse *protocol, unsigned flags, PTreeReaderOptions readFlags, const char *target, unsigned idx, unsigned &memused, unsigned &slaveReplyLen) = 0;
+};
+
+interface IHpccProtocolListener : extends IInterface
+{
+    virtual IHpccProtocolMsgSink *queryMsgSink() = 0;
+
+    virtual unsigned queryPort() const = 0;
+    virtual const SocketEndpoint &queryEndpoint() const = 0;
+
+    virtual void start() = 0;
+    virtual bool stop(unsigned timeout) = 0;
+    virtual void stopListening() = 0;
+    virtual void disconnectQueue() = 0;
+    virtual bool suspend(bool suspendIt) = 0;
+
+    virtual void runOnce(const char *query) = 0;
+};
+
+interface IHpccProtocolPluginContext : extends IInterface
+{
+    virtual int ctxGetPropInt(const char *propName, int defaultValue) const = 0;
+    virtual bool ctxGetPropBool(const char *propName, bool defaultValue) const = 0;
+    virtual const char *ctxQueryProp(const char *propName) const = 0;
+};
+
+interface IActiveQueryLimiter : extends IInterface
+{
+    virtual bool isAccepted() = 0;
+};
+
+interface IActiveQueryLimiterFactory : extends IInterface
+{
+    virtual IActiveQueryLimiter *create(IHpccProtocolListener *listener) = 0;
+};
+
+interface IHpccProtocolPlugin : extends IInterface
+{
+    virtual IHpccProtocolListener *createListener(const char *protocol, IHpccProtocolMsgSink *sink, unsigned port, unsigned listenQueue, const char *config)=0;
+};
+
+extern IHpccProtocolPlugin *loadHpccProtocolPlugin(IHpccProtocolPluginContext *ctx, IActiveQueryLimiterFactory *limiterFactory);
+typedef IHpccProtocolPlugin *(HpccProtocolInstallFunction)(IHpccProtocolPluginContext *ctx, IActiveQueryLimiterFactory *limiterFactory);
+
+
+#endif


### PR DESCRIPTION
Encapsulate roxie protocol handling behind generic interfaces.  Remove
all references to internal ccd code from roxie protocol component.

This is a major step toward allowing pluggable protocols, although more
work and testing will be needed to load additional protocol
implementations.

Signed-off-by: Anthony Fishbeck anthony.fishbeck@lexisnexis.com
