### PR TITLE
HPCC-14899 Create new WU only if no wuid in WUUpdate request

### DIFF
--- a/esp/bindings/http/platform/httpbinding.cpp
+++ b/esp/bindings/http/platform/httpbinding.cpp
@@ -763,18 +763,23 @@ static void filterXmlBySchema(IPTree* in, IXmlType* type, const char* tag, Strin
     }
 }
 
-static void filterXmlBySchema(StringBuffer& in, StringBuffer& schema, StringBuffer& out)
+static void filterXmlBySchema(StringBuffer& in, StringBuffer& schema, const char* qName, StringBuffer& out)
 {
     Owned<IXmlSchema> sp = createXmlSchema(schema);
     Owned<IPTree> tree = createPTreeFromXMLString(in);
 
     //VStringBuffer name("tns:%s", tree->queryName());
-    const char* name = tree->queryName();
+    const char* name = qName;
     IXmlType* type = sp->queryElementType(name);
     if (!type)
     {
-        StringBuffer method(strlen(name)-7, name);
-        type = sp->queryElementType(method);
+        name = tree->queryName();
+        type = sp->queryElementType(name);
+        if (!type)
+        {
+            StringBuffer method(strlen(name)-7, name);
+            type = sp->queryElementType(method);
+        }
     }
 
     if (type)
@@ -784,6 +789,23 @@ static void filterXmlBySchema(StringBuffer& in, StringBuffer& schema, StringBuff
         const char* value = tree->queryProp(NULL);
         DBGLOG("Unknown xml tag ignored: <%s>%s</%s>", name, value?value:"", name);
     }
+}
+
+void EspHttpBinding::getXMLMessageTag(IEspContext& ctx, bool isRequest, const char *method, StringBuffer& tag)
+{
+    MethodInfoArray info;
+    getQualifiedNames(ctx, info);
+    for (unsigned i=0; i<info.length(); i++)
+    {
+        CMethodInfo& m = info.item(i);
+        if (!stricmp(m.m_label, method))
+        {
+            tag.set(isRequest ? m.m_requestLabel : m.m_responseLabel);
+            break;
+        }
+    }
+    if (!tag.length())
+        tag.append(method).append(isRequest ? "Request" : "Response");
 }
 
 // new way to generate soap message
@@ -797,11 +819,12 @@ void EspHttpBinding::getSoapMessage(StringBuffer& soapmsg, IEspContext& ctx, CHt
     Owned<IRpcRequestBinding> rpcreq = createReqBinding(ctx, request, serv, method);
     rpcreq->serialize(*msg);
 
-    StringBuffer req, schema, filtered;
+    StringBuffer req, tag, schema, filtered;
     msg->marshall(req, NULL);
 
     getSchema(schema,ctx,request,serv,method,false);
-    filterXmlBySchema(req,schema,filtered);
+    getXMLMessageTag(ctx, true, method, tag);
+    filterXmlBySchema(req,schema,tag.str(),filtered);
     
     StringBuffer ns;
     soapmsg.appendf(
@@ -1343,24 +1366,8 @@ void EspHttpBinding::generateSampleXml(bool isRequest, IEspContext &context, CHt
     if (!qualifyServiceName(context, serv, method, serviceQName, &methodQName))
         return;
 
-    MethodInfoArray info;
-    getQualifiedNames(context, info);
-    StringBuffer element;
-    for (unsigned i=0; i<info.length(); i++)
-    {
-        CMethodInfo& m = info.item(i);
-        if (stricmp(m.m_label, methodQName)==0)
-        {
-            element.set(isRequest ? m.m_requestLabel : m.m_responseLabel);
-            break;
-        }
-    }
-
-    if (!element.length())
-        element.append(methodQName.str()).append(isRequest ? "Request" : "Response");
-
-    StringBuffer schemaXml;
-
+    StringBuffer schemaXml, element;
+    getXMLMessageTag(context, isRequest, methodQName.str(), element);
     getSchema(schemaXml,context,request,serv,method,false);
     Owned<IXmlSchema> schema = createXmlSchema(schemaXml);
     if (schema.get())
@@ -1395,23 +1402,8 @@ void EspHttpBinding::generateSampleXmlFromSchema(bool isRequest, IEspContext &co
     if (!qualifyServiceName(context, serv, method, serviceQName, &methodQName))
         return;
 
-    MethodInfoArray info;
-    getQualifiedNames(context, info);
-    StringBuffer element;
-    for (unsigned i=0; i<info.length(); i++)
-    {
-        CMethodInfo& m = info.item(i);
-        if (stricmp(m.m_label, methodQName)==0)
-        {
-            element.set(isRequest ? m.m_requestLabel : m.m_responseLabel);
-            break;
-        }
-    }
-
-    if (!element.length())
-        element.append(methodQName.str()).append(isRequest ? "Request" : "Response");
-
-    StringBuffer schemaXmlbuff(schemaxml);
+    StringBuffer element, schemaXmlbuff(schemaxml);
+    getXMLMessageTag(context, isRequest, methodQName.str(), element);
 
     Owned<IXmlSchema> schema = createXmlSchema(schemaXmlbuff);
     if (schema.get())

--- a/esp/bindings/http/platform/httpbinding.hpp
+++ b/esp/bindings/http/platform/httpbinding.hpp
@@ -143,6 +143,7 @@ private:
     StringAttrMapping desc_map;
     StringAttrMapping help_map;
 
+    void getXMLMessageTag(IEspContext& ctx, bool isRequest, const char *method, StringBuffer& tag);
 protected:
     MethodInfoArray m_methods;
     bool                    m_includeSoapTest;

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -601,8 +601,13 @@ bool CWsWorkunitsEx::onWUCreateAndUpdate(IEspContext &context, IEspWUUpdateReque
         if (!context.validateFeatureAccess(OWN_WU_ACCESS, SecAccess_Write, false))
             throw MakeStringException(ECLWATCH_ECL_WU_ACCESS_DENIED, "Failed to create workunit. Permission denied.");
 
-        NewWsWorkunit wu(context);
-        req.setWuid(wu->queryWuid());
+        const char* wuid = req.getWuid();
+        if (!wuid || !*wuid)
+        {
+            NewWsWorkunit wu(context);
+            wuid = wu->queryWuid();
+        }
+        req.setWuid(wuid);
     }
     catch(IException* e)
     {


### PR DESCRIPTION
Since both WsWorkunits.WUUpdate and WsWorkunits.WUCreateAndUpdate
share the same request structure 'WUUpdateRequest', the correct
request for WsWorkunits.WUUpdate should be named as 'WUUpdate'.
If the request is named as 'WUUpdateRequest', WsWorkunits will
call WUCreateAndUpdate. This fix modifies the WUCreateAndUpdate
to check whether a wuid is in the 'WUUpdateRequest' or not. New
WU will be created only if no wuid in the 'WUUpdateRequest'.

A bug is fixed for adding soap request into ESP SOAP Test page.
The code similar to EspHttpBinding::generateSampleXml() is added
into EspHttpBinding::getSoapMessage() in order to find out
correct XML tag and filter SOAP request using the tag.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
