### PR TITLE
HPCC-15004 Pass in 0 for no preserve compression

### DIFF
--- a/esp/src/eclwatch/DFUQueryWidget.js
+++ b/esp/src/eclwatch/DFUQueryWidget.js
@@ -200,6 +200,9 @@ define([
         },
 
         _onCopyOk: function (event) {
+            var copyPreserveCompressionCheckbox = registry.byId(this.id + "CopyPreserveCompression");
+            var value = copyPreserveCompressionCheckbox.get("checked") ? 1 : 0;
+            
             if (this.copyForm.validate()) {
                 var context = this;
                 arrayUtil.forEach(this.copyGrid.store.data, function (item, idx) {
@@ -207,6 +210,7 @@ define([
                     var request = domForm.toObject(context.id + "CopyForm");
                     request.RenameSourceName = item.Name;
                     request.destLogicalName = item.targetCopyName;
+                    request.preserveCompression = value;
                     logicalFile.copy({
                         request: request
                     }).then(function (response) {


### PR DESCRIPTION
Previously, the preserve compress checkbox was enabled and returned "on" instead of 1. When unchecked the preserve compression checkbox would pass in no value into the request which it should pass in a 0.

Signed-off by: Miguel Vazquez miguel.vazquez@lexisnexis.com
