### PR TITLE
HPCC-14871 - Missing include caused OSX build break

### DIFF
--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -40,6 +40,8 @@
 #include "rtlds_imp.hpp"
 #include "rtlread_imp.hpp"
 
+#include <algorithm>
+
 #include "dafdesc.hpp"
 #include "dautils.hpp"
 #include "ftbase.ipp"


### PR DESCRIPTION
Signed-off-by: Richard Chapman rchapman@hpccsystems.com
