### PR TITLE
HPCC-14804 Clearing permissions cache causes dali to lose connection

### DIFF
--- a/dali/base/dasess.cpp
+++ b/dali/base/dasess.cpp
@@ -1503,7 +1503,7 @@ public:
         bool ok = true;
 #else
         bool ok = true;
-        if (ldapconn->getLDAPflags() & DLF_ENABLED)
+        if (ldapconn && ldapconn->getLDAPflags() & DLF_ENABLED)
             ok = ldapconn->clearPermissionsCache(udesc);
 #endif
         return ok;


### PR DESCRIPTION
When DALI is not LDAP enabled, calls from ESP to clear the permission cache
cause it to dereference a NULL pointer resulting in a DALI core. This PR
first checks to see if there is an LDAP security manager before calling it

Signed-off-by: Russ Whitehead william.whitehead@lexisnexis.com
