### PR TITLE
HPCC-14999  Replace USE_XXX with _USE_XXX

### DIFF
--- a/common/remote/sockfile.cpp
+++ b/common/remote/sockfile.cpp
@@ -191,7 +191,7 @@ public:
 static CriticalSection              secureContextCrit;
 static Owned<ISecureSocketContext>  secureContext;
 
-#ifdef USE_OPENSSL
+#ifdef _USE_OPENSSL
 static ISecureSocket *createSecureSocket(ISocket *sock,SecureSocketType type)
 {
     {
@@ -894,7 +894,7 @@ class CRemoteBase: public CInterface
                     socket.setown(ISocket::connect(ep));
                 if (useSSL)
                 {
-#ifdef USE_OPENSSL
+#ifdef _USE_OPENSSL
                     Owned<ISecureSocket> ssock = createSecureSocket(socket.getClear(), ClientSocket);
                     int status = ssock->secure_connect();
                     if (status < 0)
@@ -5119,7 +5119,7 @@ public:
                     sock.setown(acceptsock->accept(true));
                     if (useSSL)
                     {
-#ifdef USE_OPENSSL
+#ifdef _USE_OPENSSL
                         Owned<ISecureSocket> ssock = createSecureSocket(sock.getClear(), ServerSocket);
                         int status = ssock->secure_accept();
                         if (status < 0)

--- a/common/thorhelper/thorsoapcall.cpp
+++ b/common/thorhelper/thorsoapcall.cpp
@@ -937,7 +937,7 @@ public:
         return error.getLink();
     }
     inline IEngineRowAllocator * queryOutputAllocator() const { return outputAllocator; }
-#ifdef USE_OPENSSL
+#ifdef _USE_OPENSSL
     ISecureSocket *createSecureSocket(ISocket *sock)
     {
         {
@@ -1778,7 +1778,7 @@ public:
                     socket.setown(blacklist->connect(connUrl.port, connUrl.host, master->logctx, (unsigned)master->maxRetries, master->timeoutMS, master->roxieAbortMonitor));
                     if (stricmp(url.method, "https") == 0)
                     {
-#ifdef USE_OPENSSL
+#ifdef _USE_OPENSSL
                         Owned<ISecureSocket> ssock = master->createSecureSocket(socket.getClear());
                         if (ssock) 
                         {

--- a/deployment/configgen/configengcallback.hpp
+++ b/deployment/configgen/configengcallback.hpp
@@ -138,7 +138,7 @@ class CConfigEngCallback: public CInterface, implements IDeploymentCallback
         StringBuffer errMsg(szMessage);
         String str(errMsg.trim());
 
-#ifdef USE_XALAN
+#ifdef _USE_XALAN
         if (str.lastIndexOf('[') > 0)
         {
           errMsg.clear();

--- a/deployment/deploy/DeploymentEngine.cpp
+++ b/deployment/deploy/DeploymentEngine.cpp
@@ -1813,7 +1813,7 @@ void CDeploymentEngine::setXsl(IXslProcessor* processor, IXslTransform* transfor
    m_externalFunction.setown(m_transform->createExternalFunction("addDeploymentFile", addDeploymentFile));
    m_transform->setExternalFunction(SEISINT_NAMESPACE, m_externalFunction.get(), true);
 
-#ifdef USE_OPENSSL
+#ifdef _USE_OPENSSL
    m_externalFunction2.setown(m_transform->createExternalFunction("siteCertificate", siteCertificateFunction));
    m_transform->setExternalFunction(SEISINT_NAMESPACE, m_externalFunction2.get(), true);
 #endif
@@ -2357,7 +2357,7 @@ void CDeploymentEngine::addDeploymentFile(StringBuffer &ret, const char *in, IXs
 //  siteCertificate
 //---------------------------------------------------------------------------
 /*static*/
-#ifdef USE_OPENSSL
+#ifdef _USE_OPENSSL
 void CDeploymentEngine::siteCertificateFunction(StringBuffer &ret, const char *in, IXslTransform*)
 {
     //input is of the format <processType>+<process name>+<instance name>+<output path>
@@ -2402,7 +2402,7 @@ void CDeploymentEngine::processCustomMethod(const char* method, const char *sour
         throw MakeStringException(0, "Process '%s': invalid method '%s' specified for file '%s'",
         m_name.get(), method, fileName);
 
-#ifdef USE_OPENSSL
+#ifdef _USE_OPENSSL
     siteCertificate(m_process, instanceName, outputFile);
 #else
     throw MakeStringException(0, "Process '%s' file '%s' method '%s': requires OpenSSL (disabled in build)",
@@ -2410,7 +2410,7 @@ void CDeploymentEngine::processCustomMethod(const char* method, const char *sour
 #endif
 }
 
-#ifdef USE_OPENSSL
+#ifdef _USE_OPENSSL
 //---------------------------------------------------------------------------
 //  processCustomMethod
 //---------------------------------------------------------------------------

--- a/deployment/deploy/DeploymentEngine.hpp
+++ b/deployment/deploy/DeploymentEngine.hpp
@@ -244,7 +244,7 @@ protected:
         EnvMachineOS os=MachineOsUnknown, const char* processName=NULL,bool isEspModuleOrPlugin=false);
    virtual void processCustomMethod(const char *method, const char *source, const char *outputFile, 
                                     const char *instanceName, EnvMachineOS os);
-#ifdef USE_OPENSSL
+#ifdef _USE_OPENSSL
    virtual void siteCertificate(IPropertyTree& process, const char *instanceName, const char *outputFile);
 #endif
 
@@ -289,7 +289,7 @@ protected:
                                    EnvMachineOS os, bool bCacheable, 
                                    const char* params=NULL);
    static void addDeploymentFile(StringBuffer &ret, const char *in, IXslTransform*);
-#ifdef USE_OPENSSL
+#ifdef _USE_OPENSSL
    static void siteCertificateFunction(StringBuffer &ret, const char *in, IXslTransform*);
 #endif
    virtual IEnvDeploymentEngine& getEnvDepEngine() const { return m_envDepEngine; }

--- a/ecl/hql/hqlexpr.ipp
+++ b/ecl/hql/hqlexpr.ipp
@@ -40,9 +40,6 @@
 #include "defvalue.hpp"
 #include "hqlexpr.hpp"
 
-#ifdef USE_TBB
-#include "tbb/scalable_allocator.h"
-#endif
 
 typedef byte transformdepth_t;
 #define TRANSFORM_DEPTH_MASK    0x7f
@@ -162,11 +159,6 @@ class HQL_API CHqlExpression : public LinkedBaseIHqlExpression
 public:
     friend class CHqlExprMeta;
     typedef LinkedBaseIHqlExpression Parent;
-
-#ifdef USE_TBB
-    void *operator new(size32_t size) { return scalable_malloc(size); }
-    void operator delete(void *ptr) { return scalable_free(ptr); }
-#endif
 
 protected:
     unsigned hashcode;          // CInterface is 4 byte aligned in 64bits, so use this to pad

--- a/ecl/hql/hqltrans.ipp
+++ b/ecl/hql/hqltrans.ipp
@@ -30,9 +30,6 @@
 
 #include "hqlexpr.hpp"
 #include "jset.hpp"
-#ifdef USE_TBB
-#include "tbb/scalable_allocator.h"
-#endif
 
 typedef MapOwnedToOwned<IHqlExpression, IHqlExpression> MapOwnedHqlToOwnedHql;
 
@@ -315,11 +312,6 @@ public:
     virtual void setTransformedSelector(IHqlExpression * expr) = 0;
 
     inline void setUnvisited() { lastPass = (byte)-1; }
-
-#ifdef USE_TBB
-    void *operator new(size32_t size) { return scalable_malloc(size); }
-    void operator delete(void *ptr) { return scalable_free(ptr); }
-#endif
 
 #ifdef OPTIMIZE_TRANSFORM_ALLOCATOR
     void *operator new(size32_t size, void * ptr) { return ptr; }                                                   

--- a/esp/test/httptest/httptest.cpp
+++ b/esp/test/httptest/httptest.cpp
@@ -151,7 +151,7 @@ HttpClient::HttpClient(int threads, int times, const char* host, int port, FILE*
     m_use_ssl = use_ssl;
     if(use_ssl)
     {
-#ifdef USE_OPENSSL
+#ifdef _USE_OPENSSL
         if(sslconfig != NULL)
             m_ssctx.setown(createSecureSocketContextEx2(sslconfig, ClientSocket));
         else
@@ -186,7 +186,7 @@ int HttpClient::getUrl(const char* url)
 
     if(m_use_ssl)
     {
-#if USE_OPENSSL
+#if _USE_OPENSSL
         if(m_ssctx.get() == NULL)
             m_ssctx.setown(createSecureSocketContext(ClientSocket));
 #else
@@ -283,7 +283,7 @@ int HttpClient::sendSoapRequest(const char* url, const char* soapaction, const c
 
     if(m_use_ssl)
     {
-#ifdef USE_OPENSSL
+#ifdef _USE_OPENSSL
         if(m_ssctx.get() == NULL)
             m_ssctx.setown(createSecureSocketContext(ClientSocket));
 #else
@@ -613,7 +613,7 @@ HttpServer::HttpServer(int port, const char* in, FILE* ofile, bool use_ssl, IPro
     m_recvDelay = m_sendDelay = m_closeDelay = 0;
     if(use_ssl)
     {
-#ifdef USE_OPENSSL
+#ifdef _USE_OPENSSL
         if(sslconfig != NULL)
             m_ssctx.setown(createSecureSocketContextEx2(sslconfig, ServerSocket));
         else
@@ -1183,7 +1183,7 @@ HttpProxy::HttpProxy(int localport, const char* host, int port, FILE* ofile, boo
     m_use_ssl = use_ssl;
     if(use_ssl)
     {
-#if USE_OPENSSL
+#if _USE_OPENSSL
         if(sslconfig != NULL)
             m_ssctx.setown(createSecureSocketContextEx2(sslconfig, ClientSocket));
         else

--- a/esp/tools/soapplus/http.cpp
+++ b/esp/tools/soapplus/http.cpp
@@ -461,7 +461,7 @@ HttpClient::HttpClient(IProperties* globals, const char* url, const char* inname
 
         if(stricmp(m_protocol.str(), "HTTPS") == 0)
         {
-#ifdef USE_OPENSSL
+#ifdef _USE_OPENSSL
             if(m_ssctx.get() == NULL)
                 m_ssctx.setown(createSecureSocketContext(ClientSocket));
 #else

--- a/esp/tools/soapplus/httpproxy.cpp
+++ b/esp/tools/soapplus/httpproxy.cpp
@@ -197,7 +197,7 @@ int COneServerHttpProxyThread::start()
         socket2.setown(ISocket::connect(ep));
         if(m_use_ssl && m_ssctx != NULL)
         {
-#ifdef USE_OPENSSL
+#ifdef _USE_OPENSSL
             Owned<ISecureSocket> securesocket = m_ssctx->createSecureSocket(socket2.getLink());
             int res = securesocket->secure_connect();
             if(res >= 0)
@@ -562,7 +562,7 @@ HttpProxy::HttpProxy(int localport, const char* url, FILE* ofile, const char* ur
 
         if(m_use_ssl)
         {
-#ifdef USE_OPENSSL
+#ifdef _USE_OPENSSL
             m_ssctx.setown(createSecureSocketContext(ClientSocket));
 #else
         throw MakeStringException(-1, "HttpProxy: failure to create SSL socket - OpenSSL not enabled in build");
@@ -582,7 +582,7 @@ HttpProxy::HttpProxy(int localport, const char* host, int port, FILE* ofile, boo
     m_use_ssl = use_ssl;
     if(use_ssl)
     {
-#ifdef USE_OPENSSL
+#ifdef _USE_OPENSSL
         if(sslconfig != NULL)
             m_ssctx.setown(createSecureSocketContextEx2(sslconfig, ClientSocket));
         else


### PR DESCRIPTION
change "USE_XALAN" and "USE_OPENSSL" to "_USE_XALAN" and "_USE_OPENSSL" in C++ code.
Also remove USE_TBB sections in ecl/hql/hqlexpr.ipp and ecl/hql/hqltrans.ipp
per discussion with Gevin.

Signed-off-by: Xiaoming Wang xiaoming.wang@lexisnexi.com

This should replace pull request #8291
