### PR TITLE
HPCC-15061 Same ID registered error

### DIFF
--- a/esp/src/eclwatch/LZBrowseWidget.js
+++ b/esp/src/eclwatch/LZBrowseWidget.js
@@ -393,8 +393,6 @@ define([
 
         _onSprayXml: function(event) {
             var context = this;
-            this.sprayXmlTargetRowTag = registry.byId(this.id + "sprayXmlTargetRowTag");
-            if (this.sprayXmlTargetRowTag.getValue()) {
                 this._spraySelectedOneAtATime("SprayXmlDropDown", "SprayXmlForm", function (request, item) {
                     lang.mixin(request, {
                         sourceRowTag: item.targetRowTag
@@ -405,13 +403,6 @@ define([
                         context._handleResponse("SprayResponse.wuid", response);
                     });
                 });
-            } else {
-                topic.publish("hpcc/brToaster", {
-                    Severity: "Error",
-                    Source: "FileSpray.SprayVariable",
-                    Exceptions: [{ Message: this.i18n.TargetRowTagRequired }]
-                });
-            }
         },
 
         _onSprayJson: function(event) {
@@ -655,7 +646,6 @@ define([
                         editor: dijit.form.ValidationTextBox,
                         editorArgs: {
                             required: true,
-                            id: this.id + "sprayXmlTargetRowTag",
                             placeholder: this.i18n.RequiredForXML,
                             promptMessage: this.i18n.RequiredForXML
                         }


### PR DESCRIPTION
Whenever choosing multiple files in ECLWatch within the landing zone I encountered a console message that states "already registered ID." This causes the spray xml grid to not render for the second file.

Signed-off by: Miguel Vazquez miguel.vazquez@lexisnexis.com
