### PR TITLE
HPCC-15017 Roxie cumulative counts not working

### DIFF
--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -481,7 +481,7 @@ public:
         if (_processed)
         {
             CriticalBlock b(statsCrit);
-            processed += processed;
+            processed += _processed;
         }
     }
 


### PR DESCRIPTION
Cumultative edge counts were only working on splitters.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
