### PR TITLE
HPCC-15096 Build fails if mysql header not available.

### DIFF
--- a/esp/services/ws_loggingservice/CMakeLists.txt
+++ b/esp/services/ws_loggingservice/CMakeLists.txt
@@ -29,7 +29,6 @@ include_directories (
      ${HPCC_SOURCE_DIR}/system/security/shared
      ${HPCC_SOURCE_DIR}/system/security/securesocket
      ${HPCC_SOURCE_DIR}/common/environment
-     ${MYSQL_INCLUDE_DIR}
      ${HPCC_SOURCE_DIR}/dali/base
      ${HPCC_SOURCE_DIR}/esp/platform
      ${HPCC_SOURCE_DIR}/esp/bindings


### PR DESCRIPTION
Logging server tries to set include path for mysql, even though it doesn't use
it any more. This means cmake will fail if mysqlclient dev package is not
available.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
