### PR TITLE
HPCC-15109 LDAP Resources listed twice in ECLWatch

### DIFF
--- a/system/security/LdapSecurity/ldapconnection.cpp
+++ b/system/security/LdapSecurity/ldapconnection.cpp
@@ -3225,25 +3225,24 @@ public:
             {
                 StringBuffer descbuf;
                 StringBuffer curname;
-                CLDAPGetAttributesWrapper   atts(ld, message);
+
+                CLDAPGetValuesLenWrapper vals(ld, message, attribute);
+                if (vals.hasValues())
                 {
-                    CLDAPGetValuesLenWrapper vals(ld, message, attribute);
-                    if (vals.hasValues())
+                    const char* val = vals.queryCharValue(0);
+                    if(val != NULL)
                     {
-                        const char* val = vals.queryCharValue(0);
-                        if(val != NULL)
+                        if(stricmp(attribute, fldname) == 0)
                         {
-                            if(stricmp(attribute, fldname) == 0)
-                            {
-                                curname.append(val);
-                            }
-                            else if(stricmp(attribute, "description") == 0)
-                            {
-                                descbuf.append(val);
-                            }
+                            curname.append(val);
+                        }
+                        else if(stricmp(attribute, "description") == 0)
+                        {
+                            descbuf.append(val);
                         }
                     }
                 }
+
                 if(curname.length() == 0)
                     continue;
                 StringBuffer resourcename;

--- a/system/security/LdapSecurity/ldapconnection.cpp
+++ b/system/security/LdapSecurity/ldapconnection.cpp
@@ -3226,9 +3226,6 @@ public:
                 StringBuffer descbuf;
                 StringBuffer curname;
                 CLDAPGetAttributesWrapper   atts(ld, message);
-                for ( attribute = atts.getFirst();
-                      attribute != NULL;
-                      attribute = atts.getNext())
                 {
                     CLDAPGetValuesLenWrapper vals(ld, message, attribute);
                     if (vals.hasValues())


### PR DESCRIPTION
The LDAP paged result feature introduced an extra loop in the getResources()
method that results in each resource being returned twice or more. This PR
removes the extra loop

Signed-off-by: Russ Whitehead william.whitehead@lexisnexis.com
