### PR TITLE
HPCC-15108 Invalid gcc flag

### DIFF
--- a/system/jlib/jcomp.cpp
+++ b/system/jlib/jcomp.cpp
@@ -814,7 +814,7 @@ void CppCompiler::setTargetBitLength(unsigned bitlength)
     case GccCppCompiler:
         switch (bitlength)
         {
-        case 32: option = "-m32"; break;
+        case 32: option = ""; break;
         case 64: option = "-m64"; break;
         default:
             throwUnexpected();


### PR DESCRIPTION
Remove -m32 option as not needed by default.

Fixes HPCC-15108
