### PR TITLE
HPCC-14977 Show logical file protection

### DIFF
--- a/esp/src/eclwatch/DFUQueryWidget.js
+++ b/esp/src/eclwatch/DFUQueryWidget.js
@@ -460,6 +460,19 @@ define([
                         },
                         selectorType: 'checkbox'
                     }),
+                    IsProtected: {
+                        renderHeaderCell: function (node) {
+                            node.innerHTML = dojoConfig.getImageHTML("locked.png", context.i18n.Protected);
+                        },
+                        width: 25,
+                        sortable: false,
+                        formatter: function (_protected) {
+                            if (_protected == true) {
+                                return dojoConfig.getImageHTML("locked.png");
+                            }
+                            return "";
+                        }
+                    },
                     IsCompressed: {
                         width: 25, sortable: false,
                         renderHeaderCell: function (node) {

--- a/esp/src/eclwatch/ESPLogicalFile.js
+++ b/esp/src/eclwatch/ESPLogicalFile.js
@@ -387,6 +387,12 @@ define([
         getStateImageHTML: function () {
             return dojoConfig.getImageHTML(this.getStateImageName());
         },
+        getProtectedImage: function () {
+            if (this.IsProtected) {
+                return dojoConfig.getImageURL("locked.png");
+            }
+            return dojoConfig.getImageURL("unlocked.png");
+        },
         isDeleted: function () {
             return this.StateID === 999;
         }

--- a/esp/src/eclwatch/LFDetailsWidget.js
+++ b/esp/src/eclwatch/LFDetailsWidget.js
@@ -324,6 +324,8 @@ define([
                 this.updateInput("DespraySourceName", oldValue, newValue);
                 this.updateInput("CopySourceName", oldValue, newValue);
                 this.updateInput("CopyTargetName", oldValue, newValue);
+            } else if (name === "IsProtected") {
+                dom.byId(this.id + "ProtectedImage").src = this.logicalFile.getProtectedImage();
             } else if (name === "Ecl" && newValue) {
             } else if (name === "StateID") {
                 this.summaryWidget.set("iconClass", this.logicalFile.getStateIconClass());

--- a/esp/src/eclwatch/templates/LFDetailsWidget.html
+++ b/esp/src/eclwatch/templates/LFDetailsWidget.html
@@ -91,7 +91,7 @@
                 </div>
                 <div data-dojo-props="region: 'center'" data-dojo-type="dijit.layout.ContentPane">
                     <h2>
-                        <img id="${id}StateIdImage" class="iconLogicalFile" />&nbsp;<span id="${id}Name" class="bold"></span>
+                        <img id="${id}ProtectedImage" src="${dojoConfig.urlInfo.resourcePath}/img/locked.png" />&nbsp;<img id="${id}StateIdImage" class="iconLogicalFile" />&nbsp;<span id="${id}Name" class="bold"></span>
                     </h2>
                     <form id="${id}SummaryForm" class="leftAlignFields">
                         <ul>
@@ -114,6 +114,10 @@
                             <li>
                                 <label for="${id}JobName">${i18n.JobName}: </label>
                                 <div id="${id}JobName"></div>
+                            </li>
+                            <li>
+                                <label class="Prompt" for="${id}Protected">${i18n.Protected}:</label>
+                                <div><input id="${id}Protected" data-dojo-type="dijit.form.CheckBox"/></div>
                             </li>
                             <li>
                                 <label for="${id}Filesize">${i18n.ContentType}: </label>


### PR DESCRIPTION
Provide a visual way of determining if a logical file is locked or not.

Signed-off by: Miguel Vazquez miguel.vazquez@lexisnexis.com
