### PR TITLE
HPCC-14764 Roxie protocol encapsulation

### DIFF
--- a/roxie/ccd/ccdcontext.cpp
+++ b/roxie/ccd/ccdcontext.cpp
@@ -2543,10 +2543,10 @@ public:
 
 class CRoxieServerContext : public CRoxieContextBase, implements IRoxieServerContext, implements IGlobalCodeContext
 {
-    const IQueryFactory *serverQueryFactory;
-    IHpccProtocolResponse *protocol;
-    IHpccProtocolResultsWriter *results;
-    IHpccNativeProtocolResponse *nativeProtocol;
+    const IQueryFactory *serverQueryFactory = nullptr;
+    IHpccProtocolResponse *protocol = nullptr;
+    IHpccProtocolResultsWriter *results = nullptr;
+    IHpccNativeProtocolResponse *nativeProtocol = nullptr;
     CriticalSection daliUpdateCrit;
     StringAttr querySetName;
 


### PR DESCRIPTION
Fix some uninitialized member variables that caused some Roxie chaos.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
