### PR TITLE
HPCC-15114 Add file name to exception when iterateFilteredFiles

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -8789,9 +8789,20 @@ public:
         ForEachItemIn(i,filters)
         {
             CDFUSFFilter &filter = filters.item(i);
-            bool match = filter.checkFilter(file);
-            if (!match)
-                return match;
+            const char* attrPath = filter.getAttrPath();
+            try
+            {
+                if (!filter.checkFilter(file))
+                    return false;
+            }
+            catch (IException *e)
+            {
+                VStringBuffer msg("Failed to check filter %s for %s: ", attrPath, name);
+                int code = e->errorCode();
+                e->errorMessage(msg);
+                e->Release();
+                throw MakeStringException(code, "%s", msg.str());
+            }
         }
         return true;
     }


### PR DESCRIPTION
Dali returns 'IPropertyTree: Ambiguous xpath' exception when bad data
is in dali and the iterateFilteredFiles is called. It will be easy
for Operations/QA to check and fix the bad date if the exception
indicates which file has the problem.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
