### PR TITLE
HPCC-15156 - Roxie crashes unloading workunit after running once.ecl

### DIFF
--- a/roxie/ccd/ccdcontext.cpp
+++ b/roxie/ccd/ccdcontext.cpp
@@ -1971,16 +1971,18 @@ protected:
                     persists = createPTree();
                 return *persists;
             }
+        case ResultSequenceOnce:
+            {
+                if (!workUnit)
+                	return factory->queryOnceContext(logctx);
+                // fall into...
+            }
         case ResultSequenceInternal:
             {
                 CriticalBlock b(contextCrit);
                 if (!temporaries)
                     temporaries = createPTree();
                 return *temporaries;
-            }
-        case ResultSequenceOnce:
-            {
-                return factory->queryOnceContext(logctx);
             }
         default:
             {
@@ -1998,7 +2000,9 @@ protected:
         switch ((int) sequence)
         {
         case ResultSequenceOnce:
-            return factory->queryOnceResultStore();
+        	if (!workUnit)
+        		return factory->queryOnceResultStore();
+        	// fall into...
         default:
             // No need to have separate stores for other temporaries...
             CriticalBlock b(contextCrit);


### PR DESCRIPTION
In workunit mode the ONCE workflow item is not special. If you store
stuff into the once context you end up executing the ONCE part twice, and
releasing the memory before you release the manager that stored it.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
