### PR TITLE
HPCC-15165 Check for invalid date formats within Std.Date.ConvertDateFormatMultiple

### DIFF
--- a/ecllibrary/std/Date.ecl
+++ b/ecllibrary/std/Date.ecl
@@ -601,7 +601,7 @@ EXPORT Seconds_t SecondsFromDateTimeRec(DateTime_rec datetime, BOOLEAN is_local_
  * @param date_text     The string to be converted.
  * @param format        The format of the input string.
  *                      (See documentation for strftime)
- * @return              The date that was matched in the string.  Returns 0 if failed to match 
+ * @return              The date that was matched in the string.  Returns 0 if failed to match
  *                      or if the date components match but the result is an invalid date.
  *
  * Supported characters:
@@ -799,8 +799,13 @@ EXPORT STRING ConvertTimeFormat(STRING time_text, VARSTRING from_format='%H%M%S'
  * @return              The converted string, or blank if it failed to match the format.
  */
 
-EXPORT STRING ConvertDateFormatMultiple(STRING date_text, SET OF VARSTRING from_formats, VARSTRING to_format='%Y%m%d') :=
-    DateToString(MatchDateString(date_text, from_formats), to_format);
+EXPORT STRING ConvertDateFormatMultiple(STRING date_text, SET OF VARSTRING from_formats, VARSTRING to_format='%Y%m%d') := FUNCTION
+    matchResult := MatchDateString(date_text, from_formats);
+
+    reformatResult := IF(matchResult = (Date_t)0, '', DateToString(matchResult, to_format));
+
+    RETURN reformatResult;
+END;
 
 
 /**

--- a/ecllibrary/teststd/Date/TestFormat.ecl
+++ b/ecllibrary/teststd/Date/TestFormat.ecl
@@ -65,6 +65,8 @@ EXPORT TestFormat := MODULE
 
     ASSERT(Date.ConvertDateFormatMultiple('1/31/2011',DateFormats,'%Y-%m-%d') = '2011-01-31');
 
+    ASSERT(Date.ConvertDateFormatMultiple('',DateFormats,'%Y-%m-%d') = '');
+
     ASSERT(Date.ConvertTimeFormatMultiple('123456',TimeFormats,'%H:%M:%S') = '12:34:56');
 
     ASSERT(TRUE)


### PR DESCRIPTION
Add error check for internal call to Std.DateMatchDateString() and
set final result appropriately.  Add test for this condition.
