### PR TITLE
HPCC-14990 Make merge on table the default

### DIFF
--- a/ecl/hql/hqlgram.y
+++ b/ecl/hql/hqlgram.y
@@ -11558,6 +11558,12 @@ sortItem
     | FEW               {   $$.setExpr(createAttribute(fewAtom));   }
     | MANY              {   $$.setExpr(createAttribute(manyAtom));  }
     | MERGE             {   $$.setExpr(createAttribute(mergeAtom)); }
+    | MERGE '(' expression ')'
+                        {
+                            parser->normalizeExpression($3, type_boolean, true);
+                            $$.setExpr(createExprAttribute(mergeAtom, $3.getExpr()));
+                            $$.setPosition($1);
+                        }
     | SORTED            {   $$.setExpr(createAttribute(sortedAtom));    }
     | UNSORTED          {   $$.setExpr(createAttribute(unsortedAtom)); }
     | skewAttribute

--- a/ecl/hqlcpp/hqlcpp.cpp
+++ b/ecl/hqlcpp/hqlcpp.cpp
@@ -1734,6 +1734,7 @@ void HqlCppTranslator::cacheOptions()
         DebugOption(options.implicitGroupSubSort,"implicitGroupSubSort",true),
         DebugOption(options.implicitGroupHashAggregate,"implicitGroupHashAggregate",false),
         DebugOption(options.implicitGroupHashDedup,"implicitGroupHashDedup",false),
+        DebugOption(options.implicitMergeTable,"implicitMergeTable",true),
         DebugOption(options.reportFieldUsage,"reportFieldUsage",false),
         DebugOption(options.reportFileUsage,"reportFileUsage",false),
         DebugOption(options.subsortLocalJoinConditions,"subsortLocalJoinConditions",false),

--- a/ecl/hqlcpp/hqlcpp.ipp
+++ b/ecl/hqlcpp/hqlcpp.ipp
@@ -716,6 +716,7 @@ struct HqlCppOptions
     bool                implicitGroupSubSort;  // use subsort if some sort conditions match when grouping
     bool                implicitGroupHashAggregate;  // convert aggregate(sort(x,a),{..},a,d) to aggregate(group(sort(x,a),a_,{},d))
     bool                implicitGroupHashDedup;
+    bool                implicitMergeTable;  // assume ,MERGE on TABLE unless explicitly indicated otherwise
     bool                reportFieldUsage;
     bool                reportFileUsage;
     bool                subsortLocalJoinConditions;

--- a/ecl/hqlcpp/hqlttcpp.ipp
+++ b/ecl/hqlcpp/hqlttcpp.ipp
@@ -1230,6 +1230,7 @@ protected:
         bool constantFoldNormalize;
         bool allowActivityForKeyedJoin;
         bool implicitSubSort;
+        bool implicitMergeTable;
     } options;
     unsigned nextSequenceValue;
     bool seenForceLocal;


### PR DESCRIPTION
If ,FEW is not specified, we assume ,MERGE

,MERGE(FALSE) can be specified to force the prior behaviour. Option
"implicitMergeTable" can also set the preferred behaviour globally - this
defaults to true.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
