### PR TITLE
HPCC-15194 Log and check connection to dali

### DIFF
--- a/dali/base/dacsds.cpp
+++ b/dali/base/dacsds.cpp
@@ -1730,6 +1730,8 @@ IRemoteConnections *CClientSDSManager::connect(IMultipleConnector *mConnect, Ses
                 mConnect->getConnectionDetails(c, xpath, mode);
                 Owned<CRemoteConnection> conn = new CRemoteConnection(*this, connId, xpath, id, mode & ~RTM_CREATE_MASK, timeout);
                 assertex(conn.get());
+                if (queryProperties().getPropBool("Client/@LogConnection"))
+                    DBGLOG("SDSManager::connect() - IMultipleConnector: RemoteConnection ID<%" I64F "x>, timeout<%d>", connId, timeout);
 
                 CClientRemoteTree *tree;
                 { CDisableFetchChangeBlock block(*conn);
@@ -1776,6 +1778,8 @@ IRemoteConnection *CClientSDSManager::connect(const char *xpath, SessionId id, u
             mb.read(connId);
             conn = new CRemoteConnection(*this, connId, xpath, id, mode & ~RTM_CREATE_MASK, timeout);
             assertex(conn);
+            if (queryProperties().getPropBool("Client/@LogConnection"))
+                DBGLOG("SDSManager::connect(): xpath<%s>, RemoteConnection ID<%" I64F "x>, mode<%x>, timeout<%d>", xpath, connId, mode, timeout);
 
             CClientRemoteTree *tree;
             { CDisableFetchChangeBlock block(*conn);

--- a/dali/base/dautils.cpp
+++ b/dali/base/dautils.cpp
@@ -3188,8 +3188,8 @@ public:
                     }
                     case 1: // daliadmin
                     {
-                        out.appendf("Server IP           |Session         |Mode    |Time                |Duration    |Lock").newline();
-                        out.appendf("====================|================|========|====================|============|======").newline();
+                        out.appendf("Server IP           |Session         |Connection    |Mode    |Time                |Duration    |Lock").newline();
+                        out.appendf("====================|================|==============|========|====================|============|======").newline();
                         break;
                     }
                     default:
@@ -3214,7 +3214,7 @@ public:
                         out.appendf("%-20s|%-16" I64F "x|%-16" I64F "x|%-8x|%s(%d ms)", lD.queryEp(), lD.sessId, lD.connectionId, lD.mode, timeStr.str(), lockedFor);
                         break;
                     case 1: // daliadmin
-                        out.appendf("%-20s|%-16" I64F "x|%-8x|%-20s|%-12d|%s", lD.queryEp(), lD.sessId, lD.mode, timeStr.str(), lockedFor, altText ? altText : xpath.get());
+                        out.appendf("%-20s|%-16" I64F "x|%-16" I64F "x|%-8x|%-20s|%-12d|%s", lD.queryEp(), lD.sessId, lD.connectionId, lD.mode, timeStr.str(), lockedFor, altText ? altText : xpath.get());
                         break;
                     default:
                         throwUnexpected();

--- a/esp/services/ws_smc/ws_smcService.cpp
+++ b/esp/services/ws_smc/ws_smcService.cpp
@@ -141,6 +141,9 @@ void CWsSMCEx::init(IPropertyTree *cfg, const char *process, const char *service
 
     xpath.setf("Software/EspProcess[@name=\"%s\"]/EspService[@name=\"%s\"]/ActivityInfoCacheSeconds", process, service);
     activityInfoCacheSeconds = cfg->getPropInt(xpath.str(), DEFAULTACTIVITYINFOCACHETIMEOUTSECOND);
+    xpath.setf("Software/EspProcess[@name=\"%s\"]/EspService[@name=\"%s\"]/LogDaliConnection", process, service);
+    if (cfg->getPropBool(xpath.str()))
+        querySDS().setConfigOpt("Client/@LogConnection", "true");
 }
 
 struct CActiveWorkunitWrapper: public CActiveWorkunit

--- a/initfiles/componentfiles/configxml/@temp/esp_service_WsSMC.xsl
+++ b/initfiles/componentfiles/configxml/@temp/esp_service_WsSMC.xsl
@@ -145,6 +145,9 @@ This is required by its binding with ESP service '<xsl:value-of select="$espServ
             <xsl:if test="string(@ActivityInfoCacheSeconds) != ''">
                 <ActivityInfoCacheSeconds><xsl:value-of select="@ActivityInfoCacheSeconds"/></ActivityInfoCacheSeconds>
             </xsl:if>
+            <xsl:if test="string(@enableLogDaliConnection) != ''">
+                <LogDaliConnection><xsl:value-of select="@enableLogDaliConnection"/></LogDaliConnection>
+            </xsl:if>
         </EspService>
         <EspBinding name="{$bindName}" service="{$serviceName}" protocol="{$bindingNode/@protocol}" type="{$bindType}" 
              plugin="{$servicePlugin}" netAddress="0.0.0.0" port="{$bindingNode/@port}" defaultBinding="true">

--- a/initfiles/componentfiles/configxml/espsmcservice.xsd.in
+++ b/initfiles/componentfiles/configxml/espsmcservice.xsd.in
@@ -132,6 +132,13 @@
                     </xs:appinfo>
                 </xs:annotation>
             </xs:attribute>
+            <xs:attribute name="enableLogDaliConnection" type="xs:boolean" use="optional" default="false">
+                <xs:annotation>
+                    <xs:appinfo>
+                        <tooltip>Enable ESP/Dali Connection ID to be logged into esp.xml.</tooltip>
+                    </xs:appinfo>
+                </xs:annotation>
+            </xs:attribute>
                         <xs:attribute name="allowNewRoxieOnDemandQuery" type="xs:boolean" use="optional" default="false">
                                 <xs:annotation>
                                         <xs:appinfo>


### PR DESCRIPTION
We got several reports about files being locked by ESP. Without
logging (and checking) connection ID for each lock, it may be
difficult to find out which ESP call creates a file lock and
whether the lock is a leak or not.

In this fix, an option 'LogConnection' is added to the CClient-
SDSManager. If the option is set, the SDSManager will log the
Connection ID when a connection is created to dali. I also add
the Connection ID back to daliadmin dalilocks report.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
