### PR TITLE
HPCC-15199 Setting useTreeCopy may cause corrupt files on Roxie

### DIFF
--- a/common/remote/hooks/git/gitfile.cpp
+++ b/common/remote/hooks/git/gitfile.cpp
@@ -256,8 +256,6 @@ public:
     virtual void copySection(const RemoteFilename &dest, offset_t toOfs=(offset_t)-1, offset_t fromOfs=0, offset_t size=(offset_t)-1, ICopyFileProgress *progress=NULL, CFflags copyFlags=CFnone) { UNIMPLEMENTED; }
     virtual void copyTo(IFile *dest, size32_t buffersize=DEFAULT_COPY_BLKSIZE, ICopyFileProgress *progress=NULL, bool usetmp=false, CFflags copyFlags=CFnone) { UNIMPLEMENTED; }
     virtual IMemoryMappedFile *openMemoryMapped(offset_t ofs=0, memsize_t len=(memsize_t)-1, bool write=false)  { UNIMPLEMENTED; }
-    virtual void treeCopyTo(IFile *dest,IpSubNet &subnet,IpAddress &resfrom,bool usetmp=false,CFflags copyFlags=CFnone) { UNIMPLEMENTED; }
-
 
 protected:
     StringAttr gitDirectory;

--- a/common/remote/hooks/libarchive/archive.cpp
+++ b/common/remote/hooks/libarchive/archive.cpp
@@ -417,8 +417,6 @@ public:
     virtual void copySection(const RemoteFilename &dest, offset_t toOfs=(offset_t)-1, offset_t fromOfs=0, offset_t size=(offset_t)-1, ICopyFileProgress *progress=NULL, CFflags copyFlags=CFnone) { UNIMPLEMENTED; }
     virtual void copyTo(IFile *dest, size32_t buffersize=DEFAULT_COPY_BLKSIZE, ICopyFileProgress *progress=NULL, bool usetmp=false, CFflags copyFlags=CFnone) { UNIMPLEMENTED; }
     virtual IMemoryMappedFile *openMemoryMapped(offset_t ofs=0, memsize_t len=(memsize_t)-1, bool write=false)  { UNIMPLEMENTED; }
-    virtual void treeCopyTo(IFile *dest,IpSubNet &subnet,IpAddress &resfrom,bool usetmp=false,CFflags copyFlags=CFnone) { UNIMPLEMENTED; }
-
 
 protected:
     StringBuffer fullName;

--- a/common/remote/sockfile.cpp
+++ b/common/remote/sockfile.cpp
@@ -2008,51 +2008,6 @@ public:
     {
         return NULL;
     }
-
-    void treeCopyTo(IFile *dest,IpSubNet &subnet,IpAddress &resfrom,bool usetmp,CFflags copyFlags=CFnone)
-    {
-        resfrom.ipset(NULL);
-        MemoryBuffer sendBuffer;
-        initSendBuffer(sendBuffer);
-        MemoryBuffer replyBuffer;
-        sendBuffer.append((RemoteFileCommandType)(usetmp?RFCtreecopytmp:RFCtreecopy));
-        RemoteFilename rfn;
-        rfn.setPath(ep,filename);
-        rfn.serialize(sendBuffer);
-        const char *d = dest->queryFilename();
-        if (!isAbsolutePath(d)) 
-            throw MakeStringException(-1,"treeCopyFile destination '%s' is not an absolute path", d);
-        rfn.setRemotePath(d);
-        rfn.serialize(sendBuffer);
-        StringBuffer tmp;
-        subnet.getNetText(tmp);
-        sendBuffer.append(tmp);
-        subnet.getMaskText(tmp.clear());
-        sendBuffer.append(tmp);
-        unsigned status=1;
-        try {
-            sendRemoteCommand(sendBuffer, replyBuffer);
-            replyBuffer.read(status);
-        }
-        catch (IDAFS_Exception *e) {
-            if (e->errorCode()!=RFSERR_InvalidCommand) 
-                throw;
-            e->Release();
-            status = (unsigned)-1;
-        }
-        if (status==-1) {
-            resfrom.ipset(ep);
-            StringBuffer tmp;
-            WARNLOG("dafilesrv on %s does not support treeCopyTo - falling back to copyTo",resfrom.getIpText(tmp).str());
-            copyTo(dest,DEFAULT_COPY_BLKSIZE,NULL,usetmp,copyFlags);
-            status = 0;
-        }
-        else if (status==0)
-            resfrom.ipdeserialize(replyBuffer);
-    }
-
-
-
 };
 
 void clientCacheFileConnect(SocketEndpoint &_ep,unsigned timeout)

--- a/initfiles/componentfiles/configxml/roxie.xsd.in
+++ b/initfiles/componentfiles/configxml/roxie.xsd.in
@@ -799,13 +799,6 @@
         </xs:appinfo>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="useTreeCopy" type="xs:boolean" use="optional" default="false">
-      <xs:annotation>
-        <xs:appinfo>
-          <tooltip>Should data file copies use new tree copy mechanism or old individual style copy</tooltip>
-        </xs:appinfo>
-      </xs:annotation>
-    </xs:attribute>
     <xs:attribute name="useMemoryMappedIndexes" type="xs:boolean" use="optional" default="false">
       <xs:annotation>
         <xs:appinfo>

--- a/roxie/ccd/ccdfile.cpp
+++ b/roxie/ccd/ccdfile.cpp
@@ -754,7 +754,6 @@ class CRoxieFileCache : public CInterface, implements ICopyFileProgress, impleme
             StringBuffer prevTempFile;
             splitFilename(targetFilename, &destPath, &destPath, &prevTempFile, &prevTempFile);
             prevTempFile.append("*.$$$");
-
             Owned<IFile> dirf = createIFile(destPath.str());
             Owned<IDirectoryIterator> iter = dirf->directoryFiles(prevTempFile.str(),false,false);
             ForEach(*iter)

--- a/system/jlib/jfile.cpp
+++ b/system/jlib/jfile.cpp
@@ -1530,21 +1530,11 @@ public:
         ifile->copySection(dest,toOfs,fromOfs,size,progress,copyFlags);
     }
 
-
     IMemoryMappedFile *openMemoryMapped(offset_t ofs, memsize_t len, bool write)
     {
         throw MakeStringException(-1,"Remote file cannot be memory mapped");
         return NULL;
     }
-
-    void treeCopyTo(IFile *dest,IpSubNet &subnet,IpAddress &resfrom, bool usetmp, CFflags copyFlags)
-    {
-        // no special action for windows
-        GetHostIp(resfrom);
-        copyTo(dest,DEFAULT_COPY_BLKSIZE,NULL,usetmp,copyFlags);
-    }
-
-
 };
 #endif
 

--- a/system/jlib/jfile.hpp
+++ b/system/jlib/jfile.hpp
@@ -123,10 +123,6 @@ interface IFile :extends IInterface
     virtual void copyTo(IFile *dest, size32_t buffersize=DEFAULT_COPY_BLKSIZE, ICopyFileProgress *progress=NULL, bool usetmp=false, CFflags copyFlags=CFnone)=0;
 
     virtual IMemoryMappedFile *openMemoryMapped(offset_t ofs=0, memsize_t len=(memsize_t)-1, bool write=false)=0;
-
-    virtual void treeCopyTo(IFile *dest,IpSubNet &subnet,IpAddress &resfrom,bool usetmp=false,CFflags copyFlags=CFnone) = 0;
-
-
 };
 
 struct CDirectoryEntry: public CInterface

--- a/system/jlib/jfile.ipp
+++ b/system/jlib/jfile.ipp
@@ -81,14 +81,7 @@ public:
     virtual void copyTo(IFile *dest, size32_t buffersize, ICopyFileProgress *progress, bool usetmp, CFflags copyFlags=CFnone);
 
     virtual IMemoryMappedFile *openMemoryMapped(offset_t ofs=0, memsize_t len=(memsize_t)-1, bool write=false);
-    
-    virtual void treeCopyTo(IFile *dest,IpSubNet &subnet,IpAddress &resfrom,bool usetmp,CFflags copyFlags=CFnone)
-    {
-        // not really for local but simulate
-        GetHostIp(resfrom);
-        copyTo(dest,DEFAULT_COPY_BLKSIZE,NULL,usetmp,copyFlags);
-    }
-    
+
 protected:
     StringAttr filename;
     unsigned flags;


### PR DESCRIPTION
The useTreeCopy option has never been tested in anger as far as I know (it's
been in the system for years, but no-one knows how the code works or what it
is supposed to do).

Give that the one time someone DID try it it seems to have not handled error
cases well and ended up with corrupted indexes on Roxie. the commit removes
the option and associated code altogether.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
