### PR TITLE
HPCC-15201 Improve error message on corrupt indexes

### DIFF
--- a/system/jhtree/jhtree.cpp
+++ b/system/jhtree/jhtree.cpp
@@ -594,8 +594,16 @@ public:
             {
                 keySize = ki->keySize();
                 keyedSize = ki->keyedSize();
-                assertex(keySize);
+                if (!keySize)
+                {
+                    StringBuffer err;
+                    err.appendf("Key appears corrupt - key file (%s) indicates record size is zero", keyName.get());
+                    IException *e = MakeStringExceptionDirect(1000, err.str());
+                    EXCLOG(e, err.str());
+                    throw e;
+                }
                 keyBuffer = (char *) malloc(keySize);
+
             }
             else
             {


### PR DESCRIPTION
Indexes that have the most commonly observed corruption (zero bytes
written in place of data) currently report

ERROR: 3000: assert(keySize) failed

This change will mean that a more helpful error message (including the key
name) will be reported.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
