### PR TITLE
HPCC-15208 time_t is not always 32-bit

### DIFF
--- a/system/security/shared/caching.cpp
+++ b/system/security/shared/caching.cpp
@@ -30,7 +30,7 @@ time_t getThreadCreateTime()
     if(tslval == NULL)
         return 0;
 
-    memcpy(&t, tslval, 4);
+    memcpy(&t, tslval, sizeof(t));
     return t;
 }
 


### PR DESCRIPTION
memcpy is assuming incorrect size for time_t. This PR corrects it to use
sizeof()

Signed-off-by: Russ Whitehead william.whitehead@lexisnexis.com
