### PR TITLE
HPCC-15227 Using wutool to move workunits to/from dali also moves files

### DIFF
--- a/cmake_modules/commonSetup.cmake
+++ b/cmake_modules/commonSetup.cmake
@@ -49,6 +49,7 @@ IF ("${COMMONSETUP_DONE}" STREQUAL "")
   option(DEVEL "Enable the building/inclusion of a Development component." OFF)
   option(CLIENTTOOLS_ONLY "Enable the building of Client Tools only." OFF)
   option(INCLUDE_PLUGINS "Enable the building of platform and all plugins for testing purposes" OFF)
+  option(INCLUDE_CASSANDRA "Include the Cassandra plugin in the base package" ON)
   option(PLUGIN "Enable building of a plugin" OFF)
   option(USE_SHLIBDEPS "Enable the use of dpkg-shlibdeps on ubuntu packaging" OFF)
 
@@ -238,6 +239,10 @@ IF ("${COMMONSETUP_DONE}" STREQUAL "")
         set(CASSANDRAEMBED ON)
         set(KAFKA ON)
     endif()
+
+  if (INCLUDE_CASSANDRA)
+    set(CASSANDRAEMBED ON)
+  endif()
 
   option(PORTALURL "Set url to hpccsystems portal download page")
 

--- a/common/workunit/workunit.hpp
+++ b/common/workunit/workunit.hpp
@@ -1258,7 +1258,7 @@ interface IWorkUnitFactory : extends IPluggableFactory
     virtual IConstWorkUnit * openWorkUnit(const char *wuid, ISecManager *secmgr = NULL, ISecUser *secuser = NULL) = 0;
     virtual IConstWorkUnitIterator * getWorkUnitsByOwner(const char * owner, ISecManager *secmgr = NULL, ISecUser *secuser = NULL) = 0;
     virtual IWorkUnit * updateWorkUnit(const char * wuid, ISecManager *secmgr = NULL, ISecUser *secuser = NULL) = 0;
-    virtual bool restoreWorkUnit(const char *base, const char *wuid) = 0;
+    virtual bool restoreWorkUnit(const char *base, const char *wuid, bool restoreAssociatedFiles) = 0;
     virtual int setTracingLevel(int newlevel) = 0;
     virtual IWorkUnit * createNamedWorkUnit(const char * wuid, const char * app, const char * scope, ISecManager *secmgr = NULL, ISecUser *secuser = NULL) = 0;
     virtual IWorkUnit * getGlobalWorkUnit(ISecManager *secmgr = NULL, ISecUser *secuser = NULL) = 0;
@@ -1300,7 +1300,7 @@ interface IExtendedWUInterface
 {
     virtual unsigned calculateHash(unsigned prevHash) = 0;
     virtual void copyWorkUnit(IConstWorkUnit *cached, bool all) = 0;
-    virtual bool archiveWorkUnit(const char *base,bool del,bool ignoredllerrors,bool deleteOwned) = 0;
+    virtual bool archiveWorkUnit(const char *base,bool del,bool ignoredllerrors,bool deleteOwned,bool exportAssociatedFiles) = 0;
     virtual IPropertyTree *getUnpackedTree(bool includeProgress) const = 0;
     virtual IPropertyTree *queryPTree() const = 0;
     

--- a/common/workunit/workunit.ipp
+++ b/common/workunit/workunit.ipp
@@ -313,7 +313,7 @@ public:
     virtual void getBuildVersion(IStringVal & buildVersion, IStringVal & eclVersion) const;
     virtual IPropertyTree * getDiskUsageStats();
     virtual IPropertyTreeIterator & getFileIterator() const;
-    virtual bool archiveWorkUnit(const char *base,bool del,bool ignoredllerrors,bool deleteOwned);
+    virtual bool archiveWorkUnit(const char *base,bool del,bool ignoredllerrors,bool deleteOwned,bool exportAssociatedFiles);
     virtual IJlibDateTime & getTimeScheduled(IJlibDateTime &val) const;
     virtual IPropertyTreeIterator & getFilesReadIterator() const;
     virtual void protect(bool protectMode);
@@ -595,7 +595,7 @@ public:
     virtual bool deleteWorkUnit(const char * wuid, ISecManager *secmgr, ISecUser *secuser);
     virtual IConstWorkUnit * openWorkUnit(const char * wuid, ISecManager *secmgr, ISecUser *secuser);
     virtual IWorkUnit * updateWorkUnit(const char * wuid, ISecManager *secmgr, ISecUser *secuser);
-    virtual bool restoreWorkUnit(const char *base, const char *wuid);
+    virtual bool restoreWorkUnit(const char *base, const char *wuid, bool restoreAssociated);
     virtual int setTracingLevel(int newlevel);
     virtual IWorkUnit * createNamedWorkUnit(const char * wuid, const char * app, const char *scope, ISecManager *secmgr, ISecUser *secuser);
     virtual IWorkUnit * getGlobalWorkUnit(ISecManager *secmgr, ISecUser *secuser) = 0;

--- a/dali/sasha/saarch.cpp
+++ b/dali/sasha/saarch.cpp
@@ -648,7 +648,7 @@ static bool doArchiveWorkUnit(IWorkUnitFactory *wufactory,const char *wuid, Stri
                         e->Release();
                     }
                 }
-                QUERYINTERFACE(wu.get(), IExtendedWUInterface)->archiveWorkUnit(path.str(),del,true,deleteOwned);
+                QUERYINTERFACE(wu.get(), IExtendedWUInterface)->archiveWorkUnit(path.str(),del,true,deleteOwned,true);
                 res.append("OK");
                 return true;
             }
@@ -674,7 +674,7 @@ static bool doRestoreWorkUnit(IWorkUnitFactory *wufactory,const char *wuid, Stri
         StringBuffer base;
         getLdsPath(ldspath.str(), base);
         try {
-            if (wufactory->restoreWorkUnit(base, wuid)) {
+            if (wufactory->restoreWorkUnit(base, wuid, true)) {
                 res.append("OK");
                 return true;
             }

--- a/tools/wutool/wutool.cpp
+++ b/tools/wutool/wutool.cpp
@@ -49,8 +49,8 @@ void usage()
            "   delete <workunits>  - Delete workunits\n"
            "   results <workunits> - Dump results from specified workunits\n"
            "\n"
-           "   archive <workunits> - Archive to xml files [TO=<directory>] [DEL=1] [KEEPFILERESULTS=1]\n"
-           "   restore <filenames> - Restore from xml files\n"
+           "   archive <workunits> - Archive to xml files [TO=<directory>] [DEL=1] [KEEPFILERESULTS=1] [INCLUDEFILES=1]\n"
+           "   restore <filenames> - Restore from xml files [INCLUDEFILES=1]\n"
             "\n"
            "   orphans             - Delete orphaned information from store\n"
            "   cleanup [days=NN]   - Delete workunits older than NN days\n"
@@ -107,7 +107,7 @@ void process(IConstWorkUnit &w, IProperties *globals)
         if (to.length()==0)
             to.append('.');
         StringAttr wuid(w.queryWuid());
-        if (QUERYINTERFACE(&w, IExtendedWUInterface)->archiveWorkUnit(to.str(), globals->getPropBool("DEL", false), true, !globals->getPropBool("KEEPFILERESULTS", false)))
+        if (QUERYINTERFACE(&w, IExtendedWUInterface)->archiveWorkUnit(to.str(), globals->getPropBool("DEL", false), true, !globals->getPropBool("KEEPFILERESULTS", true), globals->getPropBool("INCLUDEFILES", false)))
             printf("archived %s\n", wuid.str());
         else
             printf("archive of %s failed\n", wuid.str());
@@ -374,7 +374,7 @@ int main(int argc, const char *argv[])
                 {
                     if (base.length()==0)
                         base.append('.');
-                    if (factory->restoreWorkUnit(base.str(), wuid))
+                    if (factory->restoreWorkUnit(base.str(), wuid, globals->getPropBool("INCLUDEFILES", false)))
                         printf("restored %s\n", wuid.str());
                     else
                         printf("failed to restore %s\n", wuid.str());

--- a/tools/wutool/wutool.cpp
+++ b/tools/wutool/wutool.cpp
@@ -49,7 +49,7 @@ void usage()
            "   delete <workunits>  - Delete workunits\n"
            "   results <workunits> - Dump results from specified workunits\n"
            "\n"
-           "   archive <workunits> - Archive to xml files [TO=<directory>] [DEL=1] [KEEPFILERESULTS=1] [INCLUDEFILES=1]\n"
+           "   archive <workunits> - Archive to xml files [TO=<directory>] [DEL=1] [DELETERESULTS=1] [INCLUDEFILES=1]\n"
            "   restore <filenames> - Restore from xml files [INCLUDEFILES=1]\n"
             "\n"
            "   orphans             - Delete orphaned information from store\n"
@@ -107,7 +107,7 @@ void process(IConstWorkUnit &w, IProperties *globals)
         if (to.length()==0)
             to.append('.');
         StringAttr wuid(w.queryWuid());
-        if (QUERYINTERFACE(&w, IExtendedWUInterface)->archiveWorkUnit(to.str(), globals->getPropBool("DEL", false), true, !globals->getPropBool("KEEPFILERESULTS", true), globals->getPropBool("INCLUDEFILES", false)))
+        if (QUERYINTERFACE(&w, IExtendedWUInterface)->archiveWorkUnit(to.str(), globals->getPropBool("DEL", false), true, globals->getPropBool("DELETERESULTS", false), globals->getPropBool("INCLUDEFILES", false)))
             printf("archived %s\n", wuid.str());
         else
             printf("archive of %s failed\n", wuid.str());


### PR DESCRIPTION
We don't want to archive off the generated dlls just because we are moving
from Dali to Cassandra.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
