### PR TITLE
HPCC-14042 Water mark warning writing workunits to Cassandra

### DIFF
--- a/plugins/cassandra/cassandraembed.cpp
+++ b/plugins/cassandra/cassandraembed.cpp
@@ -177,6 +177,16 @@ void CassandraClusterSession::setOptions(const StringArray &options)
                 unsigned max_concurrent_creation = getUnsignedOption(val, "max_concurrent_creation");
                 checkSetOption(cass_cluster_set_max_concurrent_creation(cluster, max_concurrent_creation), "max_concurrent_creation");
             }
+            else if (stricmp(optName, "write_bytes_high_water_mark")==0)
+            {
+                unsigned write_bytes_high_water_mark = getUnsignedOption(val, "write_bytes_high_water_mark");
+                checkSetOption(cass_cluster_set_write_bytes_high_water_mark(cluster, write_bytes_high_water_mark), "write_bytes_high_water_mark");
+            }
+            else if (stricmp(optName, "write_bytes_low_water_mark")==0)
+            {
+                unsigned write_bytes_low_water_mark = getUnsignedOption(val, "write_bytes_low_water_mark");
+                checkSetOption(cass_cluster_set_write_bytes_low_water_mark(cluster, write_bytes_low_water_mark), "write_bytes_low_water_mark");
+            }
             else if (stricmp(optName, "pending_requests_high_water_mark")==0)
             {
                 unsigned pending_requests_high_water_mark = getUnsignedOption(val, "pending_requests_high_water_mark");

--- a/plugins/cassandra/cassandrawu.cpp
+++ b/plugins/cassandra/cassandrawu.cpp
@@ -2976,6 +2976,7 @@ public:
     CCasssandraWorkUnitFactory(const SharedObject *_dll, const IPropertyTree *props) : cluster(cass_cluster_new()), randomizeSuffix(0), randState((unsigned) get_cycles_now()), cacheRetirer(*this)
     {
         StringArray options;
+        options.append("write_bytes_high_water_mark=1000000");  // Set the default HWM - workunits get big. This can be overridden by supplied options
         Owned<IPTreeIterator> it = props->getElements("Option");
         ForEach(*it)
         {


### PR DESCRIPTION
Default the threshold higher for workunits. It can be overridden if needed.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
