### PR TITLE
HPCC-15203 Preload option in a package copying all parts to all nodes

### DIFF
--- a/roxie/ccd/ccdstate.cpp
+++ b/roxie/ccd/ccdstate.cpp
@@ -620,7 +620,6 @@ protected:
                         if (resolved)
                         {
                             files.append(*const_cast<IResolvedFile *>(resolved));
-                            doPreload(0, resolved);
                             Owned<IPropertyTreeIterator> it = ccdChannels->getElements("RoxieSlaveProcess");
                             ForEach(*it)
                             {


### PR DESCRIPTION
Remove a line that was presumably intending to copy the TLK.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
