### PR TITLE
HPCC-14973 Remove ./ from despray path

### DIFF
--- a/esp/src/eclwatch/TargetSelectClass.js
+++ b/esp/src/eclwatch/TargetSelectClass.js
@@ -75,8 +75,9 @@ define([
             } else if (params.DropZones === true) {
                 this.loadDropZones();
             } else if (params.DropZoneFolders === true) {
-                this.defaultValue = ".";
-                this.set("value", ".");
+                this.defaultValue = "";
+                this.set("value", "");
+                this.set("placeholder", "/");
                 this.loadDropZoneFolders();
             } else if (params.WUState === true) {
                 this.loadWUState();
@@ -198,7 +199,7 @@ define([
         loadDropZoneFolders: function () {
             var context = this;
             this.getDropZoneFolder = function () {
-                var baseFolder = this._dropZoneTarget.machine.Directory + (this.endsWith(this._dropZoneTarget.machine.Directory, "/") ? "" : "/");
+                var baseFolder = this._dropZoneTarget.machine.Directory + (this.endsWith(this._dropZoneTarget.machine.Directory, "/") ? "" : "");
                 var selectedFolder = this.get("value");
                 return baseFolder + selectedFolder;
             }
@@ -209,7 +210,7 @@ define([
                         data: arrayUtil.map(results, function (_path) {
                             var path = _path.substring(context._dropZoneTarget.machine.Directory.length);
                             return {
-                                name: "." + path,
+                                name: path,
                                 id: _path
                             };
                         })

--- a/esp/src/eclwatch/templates/DFUQueryWidget.html
+++ b/esp/src/eclwatch/templates/DFUQueryWidget.html
@@ -130,7 +130,7 @@
                                     <div data-dojo-type="hpcc.TableContainer">
                                         <input id="${id}DesprayTargetSelect" title="${i18n.DropZone}:" name="destGroup" style="width: 100%;" data-dojo-type="TargetSelectWidget" />
                                         <input id="${id}DesprayTargetIPAddress" title="${i18n.IPAddress}:" name="destIP" style="width: 100%;" required="true" data-dojo-props="trim: true" data-dojo-type="dijit.form.ValidationTextBox" />
-                                        <input id="${id}DesprayTargetPath" title="${i18n.Path}:" name="destPath" required="true" style="width: 100%;" data-dojo-props="trim: true" data-dojo-type="TargetComboBoxWidget" />
+                                        <input id="${id}DesprayTargetPath" title="${i18n.Path}:" name="destPath" required="false" style="width: 100%;" data-dojo-props="trim: true, readonly: true" data-dojo-type="TargetComboBoxWidget" />
                                         <input id="${id}DesprayTargetSplitPrefix" title="${i18n.SplitPrefix}:" name="splitprefix" style="width: 100%;" data-dojo-props="trim: true" data-dojo-type="dijit.form.ValidationTextBox" />
                                     </div>
                                     <div id="${id}DesprayGrid" data-dojo-type="SelectionGridWidget">


### PR DESCRIPTION
Remove './' from TargetSelectClass.js. This prevents './' from being inserted as a prefix to each directory. Also, preventing user input to avoid creation of directories accidentally.

Signed-off by: Miguel Vazquez miguel.vazquez@lexisnexis.com
