### PR TITLE
HPCC-15249 FD_SET jsocket macros not correct for Power8

### DIFF
--- a/system/jlib/jsocket.cpp
+++ b/system/jlib/jsocket.cpp
@@ -329,7 +329,7 @@ struct MCASTREQ
 struct xfd_set { __fd_mask fds_bits[XFD_SETSIZE / __NFDBITS]; }; // define our own
 // linux 64 bit
 #ifdef __linux__
-#ifdef __x86_64__
+#ifdef __64BIT__
 #undef __FDMASK
 #define __FDMASK(d)     (1UL << ((d) % __NFDBITS))
 #undef __FDELT


### PR DESCRIPTION
Found this with JT on Power8 testing
Not sure if we even need to differentiate for 64bit.
Signed-off-by: Mark Kelly mark.kelly@lexisnexis.com
@ghalliday please review.
