### PR TITLE
HPCC-14585 Logical File Page Count Invalid

### DIFF
--- a/esp/src/eclwatch/ESPResult.js
+++ b/esp/src/eclwatch/ESPResult.js
@@ -77,6 +77,9 @@ define([
             }
         },
         preProcessResponse: function (response, request) {
+            if (response.Total == -1 || response.Total === 9223372036854776000 || response.Total === Number.MAX_VALUE) {
+                response.Total = response.Start + response.Count + 1000;
+            }
             if (lang.exists("Result.Row", response)) {
                 var context = this;
                 arrayUtil.forEach(response.Result.Row, function (item, index) {


### PR DESCRIPTION
When unknown it currently displays a very large number - changed to display a
few more than the current total (which also discourages users from paging to
end of file, which would be expensive).

Fixes HPCC-14585

Signed-off-by: Gordon Smith gordonjsmith@gmail.com
