### PR TITLE
HPCC-15072 Seg fault when MemoryBuffer grows beyond 32bit limit

### DIFF
--- a/system/jlib/jbuff.hpp
+++ b/system/jlib/jbuff.hpp
@@ -130,6 +130,8 @@ private:
     CLASS * ptr;
 };
 
+#define MEMBUFFER_MAXLEN UINT_MAX // size32_t
+
 class jlib_decl MemoryBuffer
 {
 public:
@@ -624,8 +626,8 @@ class CLargeMemorySequentialReader
 
 
 interface IOutOfMemException;
-jlib_decl IOutOfMemException *createOutOfMemException(int errcode, size_t wanted, size_t got=0,bool expected=false);
-jlib_decl void RaiseOutOfMemException(int errcode, size_t wanted, size_t got=0,bool expected=false);
+jlib_decl IOutOfMemException *createOutOfMemException(int errcode, size_t wanted, size_t got=0, bool expected=false, const char *errMsg=nullptr);
+jlib_decl void RaiseOutOfMemException(int errcode, size_t wanted, size_t got=0, bool expected=false, const char *errMsg=nullptr);
 
 interface ILargeMemLimitNotify: extends IInterface
 {


### PR DESCRIPTION
This update throws an exception when a MemoryBuffer is appended to or internally expanded beyond its 32bit maximum length, instead of ignoring the wrap and getting whatever comes with that.

Ultimately the MemoryBuffer should perhaps, when getting large, use Roxiemem, and could even spill to allow for arbitrarily large rows, etc.

@ghalliday or @jakesmith please review.

Signed-off-by: Mark Kelly mark.kelly@lexisnexis.com
