### PR TITLE
HPCC-14332 LogicalFile State Cache Error

### DIFF
--- a/esp/src/eclwatch/ESPLogicalFile.js
+++ b/esp/src/eclwatch/ESPLogicalFile.js
@@ -87,7 +87,9 @@ define([
             lang.mixin(item, {
                 __hpcc_id: createID(item.NodeGroup, item.Name),
                 __hpcc_isDir: false,
-                __hpcc_displayName: item.Name
+                __hpcc_displayName: item.Name,
+                StateID: 0,
+                State: ""
             });
         },
         mayHaveChildren: function (object) {
@@ -257,7 +259,13 @@ define([
         doDelete: function (params) {
             var context = this;
             WsDfu.DFUArrayAction([this], "Delete").then(function (response) {
-                context.refresh();
+                if (lang.exists("DFUArrayActionResponse.ActionResults.DFUActionInfo", response) && 
+                        response.DFUArrayActionResponse.ActionResults.DFUActionInfo.length &&
+                        !response.DFUArrayActionResponse.ActionResults.DFUActionInfo[0].Failed) {
+                    context.updateData({ StateID: 999, State: "deleted" })
+                } else {
+                    context.refresh();
+                }
             });
         },
         despray: function (params) {

--- a/esp/src/eclwatch/WsDfu.js
+++ b/esp/src/eclwatch/WsDfu.js
@@ -187,6 +187,9 @@ define([
                             });
                         }
                     });
+                } else if (lang.exists("DFUInfoResponse.FileDetail", response)) {
+                    response.DFUInfoResponse.FileDetail.StateID = 0;
+                    response.DFUInfoResponse.FileDetail.State = "";
                 }
                 return response;
             });


### PR DESCRIPTION
Deleting a logical file will "stick" at the deleted state until the entire web
page is refreshed.

Fixes HPCC-14332

Signed-off-by: Gordon Smith gordonjsmith@gmail.com
