### PR TITLE
HPCC-14629 EclWatch Results + Tab Chars

### DIFF
--- a/esp/src/eclwatch/ESPResult.js
+++ b/esp/src/eclwatch/ESPResult.js
@@ -335,7 +335,10 @@ define([
                             column = {
                                 label: name,
                                 field: prefix + name,
-                                width: this.extractWidth(type, name) * 9
+                                width: this.extractWidth(type, name) * 9,
+                                formatter: function (cell, row) {
+                                    return cell.replace("\t", "&nbsp;&nbsp;&nbsp;&nbsp;");
+                                }
                             };
                         }
                     } else if (children) {


### PR DESCRIPTION
ECLWatch (HTML in general) does not display \t chars correctly.

Fixes HPCC-14629

Signed-off-by: Gordon Smith gordonjsmith@gmail.com
