### PR TITLE
HPCC-15298 Fix regression caused by rmtssh and environment changes

### DIFF
--- a/common/remote/rmtssh.cpp
+++ b/common/remote/rmtssh.cpp
@@ -565,6 +565,16 @@ public:
         workdir.set(workdirname);
         exec();
     }
+
+    const StringArray &getReplyText() const
+    {
+      return replytext;
+    }
+
+    const UnsignedArray &getReply() const
+    {
+      return reply;
+    }
 };
 
 IFRunSSH *createFRunSSH()

--- a/common/remote/rmtssh.hpp
+++ b/common/remote/rmtssh.hpp
@@ -44,6 +44,8 @@ interface IFRunSSH: extends IInterface
               const IpAddress &ip,
               const char *workdirname,
               bool _background) = 0;
+    virtual const StringArray &getReplyText() const = 0;
+    virtual const UnsignedArray &getReply() const= 0;
 };
 
 

--- a/esp/services/ws_machine/ws_machineService.cpp
+++ b/esp/services/ws_machine/ws_machineService.cpp
@@ -1187,7 +1187,18 @@ int Cws_machineEx::runCommand(IEspContext& context, const char* sAddress, const 
 
         IFRunSSH * connection = createFRunSSH();
         connection->init(command.str(),NULL,NULL,NULL,m_SSHConnectTimeoutSeconds,0);
+        // executed as single connection
         connection->exec(sAddress,NULL,true);
+        response.append(connection->getReplyText()[0]);
+        exitCode = connection->getReply()[0];
+        int len = response.length();
+        if (len > 0 && response.charAt(--len) == '\n') // strip newline
+          response.setLength(len);
+        if (response.length() && !exitCode)
+          response.insert(0, "Response: ");
+        else if (!exitCode)
+          response.insert(0, "No response recieved.\n");
+
     }
     // CFRunSSH uses a MakeStringExceptionDirect throw to pass code and result string
     catch(IException* e)

--- a/initfiles/etc/DIR_NAME/environment.xml.in
+++ b/initfiles/etc/DIR_NAME/environment.xml.in
@@ -761,7 +761,7 @@
   </EclSchedulerProcess>
  </Software>
  <EnvSettings>
-  <pid>${PID_DIR}</pid>
+  <pid>${PID_PATH}</pid>
   <sourcedir>${CONFIG_SOURCE_PATH}</sourcedir>
   <mpTraceLevel>0</mpTraceLevel>
   <mpStart>7101</mpStart>


### PR DESCRIPTION
- Added two getters to rmtssh. I did this so the original behavior of the class wouldn't be altered. Probably should move the code away from throwing exceptions as message passing tools and instead use these getters in the future.
- Fixed PID_PATH issue in the new environment.xml

Signed-off-by: Michael Gardner Michael.Gardner@lexisnexis.com
