### PR TITLE
HPCC-14229 Nested superfiles not displaying

### DIFF
--- a/esp/src/eclwatch/SFDetailsWidget.js
+++ b/esp/src/eclwatch/SFDetailsWidget.js
@@ -314,7 +314,7 @@ define([
                     id: id,
                     title: params.Name,
                     closable: true,
-                    delayWidget: "LFDetailsWidget",
+                    delayWidget: params.isSuperfile ? "SFDetailsWidget" : "LFDetailsWidget",
                     _hpccParams: {
                         NodeGroup: params.NodeGroup,
                         Name: params.Name


### PR DESCRIPTION
Whenever a sub file is a super file it opens up the details of a logical file. We need to display it in a super file type details page which is appropriate.

Signed-off by: Miguel Vazquez miguel.vazquez@lexisnexis.com
