### PR TITLE
HPCC-h14879 Support gzip option in soapcall

### DIFF
--- a/common/thorhelper/CMakeLists.txt
+++ b/common/thorhelper/CMakeLists.txt
@@ -83,7 +83,8 @@ include_directories (
          ./../../rtl/nbcd 
          ./../../system/include 
          ./../../system/mp
-         ./../../system/jlib 
+         ./../../system/jlib
+         ./../../system/security/zcrypt
          ./../../dali/base
          ./../deftype 
          ./../workunit
@@ -118,5 +119,12 @@ endif()
 IF (USE_OPENSSL)
     target_link_libraries ( thorhelper 
     	securesocket
+    )
+ENDIF()
+
+IF (USE_ZLIB)
+    target_link_libraries ( thorhelper
+        ${ZLIB_LIBRARIES}
+        zcrypt
     )
 ENDIF()

--- a/system/security/zcrypt/CMakeLists.txt
+++ b/system/security/zcrypt/CMakeLists.txt
@@ -43,6 +43,7 @@ include_directories (
          ${ZLIB_INCLUDE_DIR}
          ${OPENSSL_INCLUDE_DIR}
          ./../../include 
+         ./../../jlib
     )
 
 ADD_DEFINITIONS ( -D_USRDLL -DZCRYPT_EXPORTS )

--- a/system/security/zcrypt/zcrypt.hpp
+++ b/system/security/zcrypt/zcrypt.hpp
@@ -31,6 +31,8 @@
 #endif 
 
 #include <string>
+#include "platform.h"
+#include "jlib.hpp"
 
 using namespace std;
 
@@ -87,5 +89,15 @@ ZCRYPT_API IZEncryptor* createZEncryptor(const char* publickey);
 ZCRYPT_API IZDecryptor* createZDecryptor(const char* privatekey, const char* passphrase);
 ZCRYPT_API void releaseIZ(IZInterface* iz);
 }
+
+// the following GZ_* values map to corresponding Z_* values defined in zlib.h
+#define GZ_BEST_SPEED             1
+#define GZ_BEST_COMPRESSION       9
+#define GZ_DEFAULT_COMPRESSION  (-1)
+
+// Compress a character buffer using zlib in gzip format with given compression level
+char* gzip( const char* inputBuffer, unsigned int inputSize,
+    unsigned int* outlen, int compressionLevel=GZ_DEFAULT_COMPRESSION);
+void gunzip(const byte* compressed, unsigned int comprLen, StringBuffer& sOutput);
 
 #endif


### PR DESCRIPTION
This fix enables gzip compress in soapcall request
and response. Also allows gzip in httpcall response.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
