### PR TITLE
HPCC-15339 Setup.ecl and setup_fetch.ecl fails on thor in Regression Suite setup.

### DIFF
--- a/testing/regress/ecl/platform.ecl
+++ b/testing/regress/ecl/platform.ecl
@@ -13,7 +13,7 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
-############################################################################## */
+##############################################################################*/
 
 import std.system.thorlib;
 

--- a/testing/regress/hpcc/regression/suite.py
+++ b/testing/regress/hpcc/regression/suite.py
@@ -28,10 +28,11 @@ from ..util.util import checkClusters, getConfig
 
 class Suite:
     def __init__(self, clusterName, dir_ec, dir_a, dir_ex, dir_r, logDir, args, isSetup=False,  fileList = None):
+        self.clusterName = clusterName
+        self.targetName = clusterName
         if isSetup:
-            self.clusterName = 'setup_'+clusterName
-        else:
-            self.clusterName = clusterName
+            self.targetName = 'setup_'+clusterName
+
         self.args=args
         self.suite = []
         self.dir_ec = dir_ec
@@ -48,7 +49,7 @@ class Suite:
 
         if len(self.exclude):
             curTime = time.strftime("%y-%m-%d-%H-%M-%S")
-            logName = self.clusterName + "-exclusion." + curTime + ".log"
+            logName = self.targetName + "-exclusion." + curTime + ".log"
             self.logName = os.path.join(self.logDir, logName)
             args.exclusionFile=self.logName
             self.log = open(self.logName, "w");
@@ -83,11 +84,11 @@ class Suite:
             if file.endswith(".ecl"):
                 ecl = os.path.join(self.dir_ec, file)
                 eclfile = ECLFile(ecl, self.dir_a, self.dir_ex,
-                                  self.dir_r,  self.clusterName,  args)
+                                  self.dir_r,  self.clusterName,   args)
                 if isSetup:
                     skipResult = eclfile.testSkip('setup')
                 else:
-                    skipResult = eclfile.testSkip(self.clusterName)
+                    skipResult = eclfile.testSkip(self.targetName)
 
                 if not skipResult['skip']:
                     exclude=False
@@ -105,7 +106,7 @@ class Suite:
                         exclude = (not included )  or excluded
                         exclusionReason=' class member excluded'
                     if not exclude:
-                        exclude = eclfile.testExclusion(self.clusterName)
+                        exclude = eclfile.testExclusion(self.targetName)
                         exclusionReason=' ECL excluded'
 
                     if not exclude:
@@ -126,7 +127,7 @@ class Suite:
             versions = eclfile.getVersions()
             versionId = 1
             for version in versions:
-                if 'no'+self.clusterName in version:
+                if 'no'+self.targetName in version:
                     # Exclude it from this target
                     pass
                 else:
@@ -176,7 +177,7 @@ class Suite:
         return self.endTime-self.startTime
 
     def getSuiteName(self):
-        return self.clusterName
+        return self.targetName
 
     def cleanUp(self):
         # If there are some temporary files left, then remove them


### PR DESCRIPTION
Fix setup key file name generation bug

Change confusing variable name.

Manual test with setup and platform.ecl

Modify platform.ecl to force smoketest to execute.

Signed-off-by: Attila Vamos attila.vamos@gmail.com
