### PR TITLE
HPCC-15341 add abortby and abortTime for workunit

### DIFF
--- a/common/workunit/workunit.hpp
+++ b/common/workunit/workunit.hpp
@@ -1074,6 +1074,8 @@ interface IConstWorkUnit : extends IConstWorkUnitInfo
     virtual void setNodeState(const char *graphName, WUGraphIDType nodeId, WUGraphState state) const = 0;
     virtual IWUGraphStats *updateStats(const char *graphName, StatisticCreatorType creatorType, const char * creator, unsigned subgraph) const = 0;
     virtual void clearGraphProgress() const = 0;
+    virtual IStringVal & getAbortBy(IStringVal & str) const = 0;
+    virtual unsigned __int64 getAbortTimeStamp() const = 0;
 };
 
 
@@ -1105,6 +1107,7 @@ interface IWorkUnit : extends IConstWorkUnit
     virtual void setStatistic(StatisticCreatorType creatorType, const char * creator, StatisticScopeType scopeType, const char * scope, StatisticKind kind, const char * optDescription, unsigned __int64 value, unsigned __int64 count, unsigned __int64 maxValue, StatsMergeAction mergeAction) = 0;
     virtual void setTracingValue(const char * propname, const char * value) = 0;
     virtual void setTracingValueInt(const char * propname, int value) = 0;
+    virtual void setTracingValueInt64(const char * propname, __int64 value) = 0;
     virtual void setUser(const char * value) = 0;
     virtual void setWuScope(const char * value) = 0;
     virtual void setSnapshot(const char * value) = 0;

--- a/common/workunit/workunit.ipp
+++ b/common/workunit/workunit.ipp
@@ -321,6 +321,8 @@ public:
     virtual unsigned getDebugAgentListenerPort() const;
     virtual IStringVal & getDebugAgentListenerIP(IStringVal &ip) const;
     virtual unsigned getTotalThorTime() const;
+    virtual IStringVal & getAbortBy(IStringVal & str) const;
+    virtual unsigned __int64 getAbortTimeStamp() const;
 
     void clearExceptions();
     void commit();
@@ -349,6 +351,7 @@ public:
     void setStatistic(StatisticCreatorType creatorType, const char * creator, StatisticScopeType scopeType, const char * scope, StatisticKind kind, const char * optDescription, unsigned __int64 value, unsigned __int64 count, unsigned __int64 maxValue, StatsMergeAction mergeAction);
     void setTracingValue(const char * propname, const char * value);
     void setTracingValueInt(const char * propname, int value);
+    void setTracingValueInt64(const char * propname, __int64 value);
     void setUser(const char * value);
     void setWarningSeverity(unsigned code, ErrorSeverity severity);
     void setWuScope(const char * value);

--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -237,6 +237,8 @@ ESPStruct [nil_remove] ECLWorkunit
     [min_ver("1.02")] bool HaveSubGraphTimings;
     [min_ver("1.28"), depr_ver("1.53")] string TotalThorTime;
     [min_ver("1.53")] string TotalClusterTime;
+    [min_ver("1.59")] string AbortBy;
+    [min_ver("1.59")] string AbortTime;
 
     ESPstruct ECLQuery Query;
     [min_ver("1.03")] ESParray<ESPstruct ECLHelpFile> Helpers;
@@ -1755,7 +1757,7 @@ ESPresponse [exceptions_inline, nil_remove] WUGetArchiveFileResponse
 };
 
 ESPservice [
-    version("1.58"), default_client_version("1.58"),
+    version("1.59"), default_client_version("1.59"),
     noforms,exceptions_inline("./smc_xslt/exceptions.xslt"),use_method_name] WsWorkunits
 {
     ESPmethod [resp_xsl_default("/esp/xslt/workunits.xslt")]     WUQuery(WUQueryRequest, WUQueryResponse);

--- a/esp/services/ws_workunits/ws_workunitsHelpers.hpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.hpp
@@ -200,6 +200,7 @@ public:
     IPropertyTree* getWorkunitArchive();
     void listArchiveFiles(IPropertyTree* archive, const char* path, IArrayOf<IEspWUArchiveModule>& modules, IArrayOf<IEspWUArchiveFile>& files);
     void getArchiveFile(IPropertyTree* archive, const char* moduleName, const char* attrName, const char* path, StringBuffer& file);
+    void setWUAbortTime(IEspECLWorkunit &info, unsigned __int64 abortTS);
 
 protected:
     void addTimerToList(SCMStringBuffer& name, const char * scope, IConstWUStatistic & stat, IArrayOf<IEspECLTimer>& timers);


### PR DESCRIPTION
When a workunit is aborted, store abortby and abortTime.
Also return the abortby and abortTime in WsWorkunits.WUInfo.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
