### PR TITLE
HPCC-15158 Complete-uninstall removes dependent packages

### DIFF
--- a/initfiles/sbin/complete-uninstall.sh.in
+++ b/initfiles/sbin/complete-uninstall.sh.in
@@ -101,26 +101,17 @@ fi
 
 if [ -e /etc/debian_version ]; then
     echo "Removing DEB"
-    if [ $force -eq 0 ]; then
-        dpkg --purge hpccsystems-platform
-        if [ $? -ne 0 ]; then
-           message dpkg
-           exit 1
-        fi
-    else
-        dpkg --purge --force-all hpccsystems-platform
+    apt-get remove -y hpccsystems-platform
+    if [ $? -ne 0 ]; then
+       echo "An error has occured during removal.  Try \`apt-get -f remove hpccsystems-platform\` to fix this issue."
+       exit 1
     fi
-
 elif [ -e /etc/redhat-release -o -e /etc/SuSE-release ]; then
     echo "Removing RPM"
-    if [ $force -eq 0 ]; then
-       rpm -e hpccsystems-platform
-       if [ $? -ne 0 ]; then
-           message rpm
-           exit 1
-       fi
-    else
-       rpm -e --nodeps hpccsystems-platform
+    yum remove -y hpccsystems-platform
+    if [ $? -ne 0 ]; then
+       echo "An error has occured during removal.  Try to fix any issues and then run \`yum-complete-transaction\`."
+       exit 1
     fi
 fi
 


### PR DESCRIPTION
Signed-off-by: Michael Gardner Michael.Gardner@lexisnexis.com

apt-get and yum remove use the database of installed packages to find all the packages that depend upon hpccsystems-platform and remove them in the process of removing the platform.  Since we have the dependency upon the hpccsystems-platform (= ${CPACK_PACKAGE_VERSION} for all our plugins, we can now use this feature in apt-get and yum to solve this problem for us.

I can mimic this behavior using dpkg and rpm but it will take a few more steps and won't be as clean.
