### PR TITLE
HPCC-15319 Allow spaces before #option inside embedc++

### DIFF
--- a/ecl/hql/hqlutil.cpp
+++ b/ecl/hql/hqlutil.cpp
@@ -5650,7 +5650,9 @@ IHqlExpression * extractCppBodyAttrs(unsigned lenBuffer, const char * buffer)
     unsigned prev = '\n';
     for (unsigned i=0; i < lenBuffer; i++)
     {
-        switch (buffer[i])
+        unsigned next = buffer[i];
+        bool ignore = false;
+        switch (next)
         {
         case '*':
             if ('/' == prev) // Ignore directives in multi-line comments
@@ -5669,7 +5671,7 @@ IHqlExpression * extractCppBodyAttrs(unsigned lenBuffer, const char * buffer)
             }
             break;
         case ' ': case '\t':
-            // allow whitespace in front of #option
+            ignore = true; // allow whitespace in front of #option
             break;
         case '#':
             if (prev == '\n')
@@ -5709,7 +5711,8 @@ IHqlExpression * extractCppBodyAttrs(unsigned lenBuffer, const char * buffer)
                 }
             }
         }
-        prev = buffer[i];
+        if (!ignore)
+            prev = next;
     }
     return attrs.getClear();
 }

--- a/ecl/hql/hqlutil.cpp
+++ b/ecl/hql/hqlutil.cpp
@@ -5661,6 +5661,7 @@ IHqlExpression * extractCppBodyAttrs(unsigned lenBuffer, const char * buffer)
                 while (i < lenBuffer && ('*' != buffer[i-1] || '/' != buffer[i])) 
                     ++i;
             }
+            next = ' '; // treat as whitespace
             break;
         case '/':
             if ('/' == prev) // Ignore directives in single line comments
@@ -5669,6 +5670,7 @@ IHqlExpression * extractCppBodyAttrs(unsigned lenBuffer, const char * buffer)
                 while (i < lenBuffer && !iseol(buffer[i]))
                     ++i;
             }
+            next = '\n';
             break;
         case ' ': case '\t':
             ignore = true; // allow whitespace in front of #option

--- a/ecl/regress/cppbody7.ecl
+++ b/ecl/regress/cppbody7.ecl
@@ -30,7 +30,7 @@ ENDC++;
 
 integer4 mkRandom3 :=
 BEGINC++
-#option action
+    #option action
 return rtlRandom();
 ENDC++;
 

--- a/ecl/regress/issue15319.ecl
+++ b/ecl/regress/issue15319.ecl
@@ -1,0 +1,52 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2016 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+integer4 mkRandom1() :=
+BEGINC++
+return rtlRandom();
+ENDC++;
+
+integer4 mkRandom2() :=
+BEGINC++
+    #option action
+return rtlRandom();
+ENDC++;
+
+integer4 mkRandom3() :=
+BEGINC++
+    return 1
+    //comment
+*rtlRandom();
+    #option action
+/* ignore me
+*/
+ENDC++;
+
+integer4 mkRandom4() :=
+BEGINC++
+    return 1
+    /*comment
+*/*rtlRandom();
+    #option action
+/* ignore me
+*/
+ENDC++;
+
+output(mkRandom1() * mkRandom1());
+output(mkRandom2() * mkRandom2());
+output(mkRandom3() * mkRandom3());
+output(mkRandom4() * mkRandom4());


### PR DESCRIPTION
Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
