### PR TITLE
HPCC-14170 Pausing ECLCC, ECLServer throws error

### DIFF
--- a/esp/src/eclwatch/ActivityWidget.js
+++ b/esp/src/eclwatch/ActivityWidget.js
@@ -61,6 +61,11 @@ define([
                         context._refreshActionState();
                     });
                 }
+                if (item.ServerType === "ECLserver" || "ECLCCserver") {
+                    setTimeout(function() {
+                        context.refreshGrid();
+                    }, 100);
+                }
             }, this);
         },
 
@@ -71,6 +76,11 @@ define([
                     item.resume().then(function (response) {
                         context._refreshActionState();
                     });
+                }
+                if (item.ServerType === "ECLserver" || "ECLCCserver") {
+                    setTimeout(function() {
+                        context.refreshGrid();
+                    }, 100);
                 }
             }, this);
         },

--- a/esp/src/eclwatch/ESPQueue.js
+++ b/esp/src/eclwatch/ESPQueue.js
@@ -50,9 +50,11 @@ define([
             var context = this;
             return WsSMC.PauseQueue({
                 request: {
+                    ClusterType: this.ServerType,
                     QueueName: this.QueueName,
                     Cluster: this.ClusterName,
-                    ServerType: this.ServerType
+                    ServerType: this.ServerType,
+                    NetworkAddress: this.NetworkAddress
                 }
             }).then(function (response) {
                 context.refresh();
@@ -63,9 +65,11 @@ define([
             var context = this;
             return WsSMC.ResumeQueue({
                 request: {
+                    ClusterType: this.ServerType,
                     QueueName: this.QueueName,
                     Cluster: this.ClusterName,
-                    ServerType: this.ServerType
+                    ServerType: this.ServerType,
+                    NetworkAddress: this.NetworkAddress
                 }
             }).then(function (response) {
                 context.refresh();
@@ -207,7 +211,8 @@ define([
             return WsSMC.GetStatusServerInfo({
                 request: {
                     ServerName: this.ClusterName,
-                    ServerType: this.ServerType
+                    ServerType: this.ServerType,
+                    NetworkAddress: this.NetworkAddress
                 }
             }).then(function (response) {
                 if (lang.exists("GetStatusServerInfoResponse.StatusServerInfo.TargetClusterInfo", response)) {
@@ -282,7 +287,8 @@ define([
             return WsSMC.GetStatusServerInfo({
                 request: {
                     ServerName: this.ServerName,
-                    ServerType: this.ServerType
+                    ServerType: this.ServerType,
+                    NetworkAddress: this.NetworkAddress
                 }
             }).then(function (response) {
                 if (lang.exists("GetStatusServerInfoResponse.StatusServerInfo.ServerInfo", response)) {


### PR DESCRIPTION
Delayed data to grid whenever a user pauses a ECLServer queue or ECLCC. Also, fixes message of "Network Address not found" after the request does not have this passed in.

Signed-off by: Miguel Vazquez miguel.vazquez@lexisnexis.com
