### PR TITLE
HPCC-15356 Possible race condition in ASyncFor can cause core in sem_post

### DIFF
--- a/system/jlib/jthread.cpp
+++ b/system/jlib/jthread.cpp
@@ -706,6 +706,7 @@ void CAsyncFor::For(unsigned num,unsigned maxatonce,bool abortFollowingException
         for (i=0;(i<num)&&(i<maxatonce);i++)
             ready.signal();
         IArrayOf<Thread> started;
+        started.ensure(num);
         for (i=0;i<num;i++) {
             ready.wait();
             if (abortFollowingException && e) break;


### PR DESCRIPTION
Under very heavy load, there is a possibility that the semaphore that is
signalled to indicate a thread is complete may be unloaded part way through
the execution of sem_post, leading to a core.

Requires that the parent calling ASyncFor is in a thread which terminates during the time that the caller of sem_post is unscheduled. Doesn't happen often as thread stacks are normally
cached and reused, but has been observed on batch roxie.

Thread::join has some (rather convoluted) code in that prevents a similar
race, so use that.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
