### PR TITLE
HPCC-14936 EclWatch logical file copy to other clusters, loses blockCompression flag and adds other spurious meta flags.

### DIFF
--- a/dali/ft/filecopy.cpp
+++ b/dali/ft/filecopy.cpp
@@ -3136,7 +3136,6 @@ void FileSprayer::updateTargetProperties()
                      ((stricmp(aname,"@blockCompressed")==0)&&copyCompressed) ||
                      ((stricmp(aname,"@rowCompressed")==0)&&copyCompressed)||
                      (stricmp(aname,"@local")==0)||
-                     (stricmp(aname,"@checkSum")==0)||
                      (stricmp(aname,"@recordCount")==0)
                      )
                     )

--- a/dali/ft/filecopy.cpp
+++ b/dali/ft/filecopy.cpp
@@ -2990,10 +2990,10 @@ void FileSprayer::updateTargetProperties()
 
             partCRC.addChildCRC(curProgress.outputLength, curProgress.outputCRC, false);
             totalCRC.addChildCRC(curProgress.outputLength, curProgress.outputCRC, false);
-            offset_t physPartLength = curProgress.outputLength;
+
             if (copyCompressed) {
                 FilePartInfo & curSource = sources.item(cur.whichInput);
-                partLength = physPartLength;
+                partLength = curSource.size;
                 totalLength += partLength;
             }
             else {
@@ -3047,10 +3047,14 @@ void FileSprayer::updateTargetProperties()
 
                 curProps.setPropInt64(FAsize, partLength);
 
-                if (compressOutput || copyCompressed)
+                if (compressOutput)
                 {
                     curProps.setPropInt64(FAcompressedSize, curProgress.compressedPartSize);
                     totalCompressedSize += curProgress.compressedPartSize;
+                } else if (copyCompressed)
+                {
+                    curProps.setPropInt64(FAcompressedSize, curProgress.outputLength);
+                    totalCompressedSize += curProgress.outputLength;
                 }
 
                 TargetLocation & curTarget = targets.item(cur.whichOutput);


### PR DESCRIPTION
Fix compressed file copy issues
Fix/restict header/footerlength attributes insertion.

Signed-off-by: Attila Vamos attila.vamos@gmail.com
