### PR TITLE
HPCC-15321 Moved from sudoers file to /etc/sudoers.d/hpcc

### DIFF
--- a/initfiles/sbin/add_conf_settings.sh.in
+++ b/initfiles/sbin/add_conf_settings.sh.in
@@ -26,12 +26,22 @@ PREFIX_PATH=`sed -n "/\[${SECTION}\]/,/\[/p" ${HPCC_CONFIG} | grep "^path *= *" 
 
 source $PREFIX_PATH/sbin/alter_confs.sh
 
-alter_file /etc/sudoers "^Cmnd_Alias HPCC_|^${USER_NAME} ALL =|^Defaults\:${USER_NAME} !requiretty" <<-%EOF
+if grep "\\#includedir /etc/sudoers.d" /etc/sudoers > /dev/null 2>&1; then
+  [[ ! -d /etc/sudoers.d ]] && mkdir -p /etc/sudoers.d
+  cat > /etc/sudoers.d/${USER_NAME}  <<- EOF
+Cmnd_Alias HPCC_DAFILESRV = /etc/init.d/dafilesrv
+Cmnd_Alias HPCC_HPCCINIT = /etc/init.d/hpcc-init
+${USER_NAME} ALL = NOPASSWD: HPCC_DAFILESRV, HPCC_HPCCINIT
+Defaults:${USER_NAME} !requiretty
+EOF
+else
+  alter_file /etc/sudoers "^Cmnd_Alias HPCC_|^${USER_NAME} ALL =|^Defaults\:${USER_NAME} !requiretty" <<-%EOF
 Cmnd_Alias HPCC_DAFILESRV = /etc/init.d/dafilesrv
 Cmnd_Alias HPCC_HPCCINIT = /etc/init.d/hpcc-init
 ${USER_NAME} ALL = NOPASSWD: HPCC_DAFILESRV, HPCC_HPCCINIT
 Defaults:${USER_NAME} !requiretty
 %EOF
+fi
 
 alter_file /etc/security/limits.conf "^${USER_NAME}" << %EOF
 ${USER_NAME} soft nofile 8192

--- a/initfiles/sbin/rm_conf_settings.sh.in
+++ b/initfiles/sbin/rm_conf_settings.sh.in
@@ -26,7 +26,11 @@ PREFIX_PATH=`cat ${HPCC_CONFIG} | sed -n "/\[${SECTION}\]/,/\[/p" | grep "^path=
 
 source $PREFIX_PATH/sbin/alter_confs.sh
 
-alter_file /etc/sudoers "^Cmnd_Alias HPCC_|^${USER_NAME} ALL =|Defaults:${USER_NAME}" < /dev/null
+if [[ -e "/etc/sudoers.d/${USER_NAME}" ]]; then
+  rm -f /etc/sudoers.d/${USER_NAME} > /dev/null 2>&1
+else
+  alter_file /etc/sudoers "^Cmnd_Alias HPCC_|^${USER_NAME} ALL =|Defaults:${USER_NAME}" < /dev/null
+fi
 
 alter_file /etc/security/limits.conf "^${USER_NAME}" < /dev/null
 


### PR DESCRIPTION
Behavior stays exactly the same if we don't have an /etc/sudoers.d/ directory (older distros don't support this behavior i.e. centos 5)

If /etc/sudoers.d/ is supported we then insert our sudoers rules into a file under that directory, instead of directly into the /etc/sudoers file.

Signed-off-by: Michael Gardner Michael.Gardner@lexisnexis.com
