### PR TITLE
HPCC-15384 DFU server should distinguish between copy and replication

### DIFF
--- a/dali/ft/daft.cpp
+++ b/dali/ft/daft.cpp
@@ -78,6 +78,7 @@ void CDistributedFileSystem::exportFile(IDistributedFile * from, IFileDescriptor
     sprayer->setAbort(abort);
     sprayer->setPartFilter(filter);
     sprayer->setSource(from);
+    sprayer->checkTarget(to);
     sprayer->setTarget(to);
     sprayer->spray();
 }

--- a/dali/ft/filecopy.cpp
+++ b/dali/ft/filecopy.cpp
@@ -2661,6 +2661,17 @@ void FileSprayer::checkTargetPath(RemoteFilename & filename)
     }
 }
 
+void FileSprayer::checkTarget(IFileDescriptor * target)
+{
+    unsigned numParts = target->numParts();
+    RemoteFilename filename;
+    for (unsigned idx=0; idx < numParts; idx++)
+    {
+        target->getFilename(idx, 0, filename);
+        checkTargetPath(filename);
+    }
+}
+
 void FileSprayer::setTarget(IFileDescriptor * target, unsigned copy)
 {
     if (tgtFormat.restore(&target->queryProperties()))
@@ -2676,7 +2687,6 @@ void FileSprayer::setTarget(IFileDescriptor * target, unsigned copy)
     for (unsigned idx=0; idx < numParts; idx++)
     {
         target->getFilename(idx, copy, filename);
-        checkTargetPath(filename);
         targets.append(*new TargetLocation(filename));
     }
 }

--- a/dali/ft/filecopy.hpp
+++ b/dali/ft/filecopy.hpp
@@ -127,6 +127,7 @@ public:
     virtual void setTarget(IGroup * target) = 0;
     virtual void setTarget(INode * target) = 0;
     virtual void spray() = 0;
+    virtual void checkTarget(IFileDescriptor * target) = 0;
 };
 
 extern DALIFT_API IFileSprayer * createFileSprayer(IPropertyTree * _options, IPropertyTree * _progress, IRemoteConnection * recoveryConnection, const char *wuid);

--- a/dali/ft/filecopy.ipp
+++ b/dali/ft/filecopy.ipp
@@ -202,6 +202,7 @@ public:
     unsigned numParallelSlaves();
     void setError(const SocketEndpoint & ep, IException * e);
     bool canLocateSlaveForNode(const IpAddress &ip);
+    void checkTarget(IFileDescriptor * target);
 
 protected:
     void addEmptyFilesToPartition(unsigned from, unsigned to);

--- a/testing/regress/ecl/filecompcopy.ecl
+++ b/testing/regress/ecl/filecompcopy.ecl
@@ -13,7 +13,7 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
-############################################################################## */
+##############################################################################*/
 
 //noroxie 
 //skip nodfu       

--- a/testing/regress/ecl/persist_replicate.ecl
+++ b/testing/regress/ecl/persist_replicate.ecl
@@ -13,7 +13,7 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
-############################################################################## */
+##############################################################################*/
 
 import Std.File;
 


### PR DESCRIPTION
Add targetCheck() method to DFU server

Call targetCheck() from CDistributedFileSystem::exportFile()

Remove checkTargetPath() call from setTarget() which is commonly used in
despray and replicate operation

Change failed filecompcopy.ecl and persist_replica.ecl test cases header
to force their execution in smoketest.

Signed-off-by: Attila Vamos attila.vamos@gmail.com
