### PR TITLE
HPCC-14607 Some orphaned temp files not deleted

### DIFF
--- a/thorlcr/activities/thdiskbaseslave.cpp
+++ b/thorlcr/activities/thdiskbaseslave.cpp
@@ -229,6 +229,10 @@ void CDiskReadSlaveActivityBase::init(MemoryBuffer &data, MemoryBuffer &slaveDat
     data.read(parts);
     if (parts)
         deserializePartFileDescriptors(data, partDescs);
+
+    // put temp files in individual slave temp dirs (incl port)
+    if ((helper->getFlags() & TDXtemporary) && (!container.queryJob().queryUseCheckpoints()))
+        partDescs.item(0).queryOwner().setDefaultDir(queryTempDir());
 }
 
 const char *CDiskReadSlaveActivityBase::queryLogicalFilename(unsigned index)
@@ -475,6 +479,11 @@ void CDiskWriteSlaveActivityBase::init(MemoryBuffer &data, MemoryBuffer &slaveDa
             fileCRC.reset(~crc);
     }
     partDesc.setown(deserializePartFileDescriptor(data));
+
+    // put temp files in individual slave temp dirs (incl port)
+    if ((diskHelperBase->getFlags() & TDXtemporary) && (!container.queryJob().queryUseCheckpoints()))
+        partDesc->queryOwner().setDefaultDir(queryTempDir());
+
     if (dlfn.isExternal())
     {
         mpTag = container.queryJobChannel().deserializeMPTag(data);


### PR DESCRIPTION
This PR moves thor slave temp files from temp dir to temp/<slave-port> dir.
In the event there is an error and thor restarts, the slave clean-up of all files in temp/<slave-port> will now remove these files.
(It is also possible to have slave-port dirs point to separate disks/file-systems for capacity/performance)

@jakesmith please review

Signed-off-by: Mark Kelly mark.kelly@lexisnexis.com
