### PR TITLE
HPCC-15391 Fix Unexpected error:'<type 'exceptions.UnicodeDecodeError'>' in Regression Test Engine log processor

### DIFF
--- a/testing/regress/hpcc/util/ecl/command.py
+++ b/testing/regress/hpcc/util/ecl/command.py
@@ -157,7 +157,7 @@ class ECLcmd(Shell):
                     test = True
                 elif (res['state'] == 'failed') and (('error' in data) or ('exception' in data.lower())):
                     eclfile.diff = ("%3d. Test: %s\n") % (eclfile.taskId, eclfile.getBaseEclRealName())
-                    eclfile.diff += data
+                    eclfile.diff += repr(data)
                     test = False
                 else:
                     test = eclfile.testResults()

--- a/testing/regress/hpcc/util/ecl/file.py
+++ b/testing/regress/hpcc/util/ecl/file.py
@@ -230,6 +230,7 @@ class ECLFile:
             realName = self.basename + '.ecl ( version: ' + self.getVersion()  + ' )'
         else:
             realName = self.getBaseEcl()
+        logging.debug("%3d.return with:'%s'", self.taskId, realName)
         return realName
 
     def getWuid(self):


### PR DESCRIPTION
Fix Unicode character handling.

Add more debug log

Signed-off-by: Attila Vamos attila.vamos@gmail.com
