### PR TITLE
HPCC-15395 Thormaster crash when running job and asked to stop

### DIFF
--- a/thorlcr/master/thgraphmanager.cpp
+++ b/thorlcr/master/thgraphmanager.cpp
@@ -966,7 +966,14 @@ void abortThor(IException *e, unsigned errCode, bool abortCurrentJob)
         aborting = 2;
         LOG(MCdebugProgress, thorJob, "aborting any current active job");
         if (jM)
+        {
+            if (!e)
+            {
+                _e.setown(MakeThorException(TE_AbortException, "THOR ABORT"));
+                e = _e;
+            }
             jM->fireException(e);
+        }
         if (errCode == TEC_Clean)
         {
             LOG(MCdebugProgress, thorJob, "Removing sentinel upon normal shutdown");


### PR DESCRIPTION
@jakesmith @AttilaVamos please review.

If a job was running and we stop thor (service hpcc-init stop) thormaster would crash because Exception e was NULL.

Signed-off-by: Mark Kelly mark.kelly@lexisnexis.com
