### PR TITLE
HPCC-15382 LDAPSecMgr sometimes creates conflicting LDAP entries

### DIFF
--- a/system/security/LdapSecurity/ldapconnection.cpp
+++ b/system/security/LdapSecurity/ldapconnection.cpp
@@ -1121,6 +1121,13 @@ public:
     virtual void init(IPermissionProcessor* pp)
     {
         m_pp = pp;
+        static CriticalSection  lcCrit;
+        static bool createdOU = false;
+        if (!createdOU)
+        {
+            CriticalBlock block(lcCrit);
+            if (!createdOU)
+            {
         if(m_ldapconfig->getServerType() == OPEN_LDAP)
         {
             try
@@ -1145,6 +1152,9 @@ public:
 
         createLdapBasedn(NULL, m_ldapconfig->getUserBasedn(), PT_ADMINISTRATORS_ONLY);
         createLdapBasedn(NULL, m_ldapconfig->getGroupBasedn(), PT_ADMINISTRATORS_ONLY);
+                createdOU = true;
+            }
+        }
     }
 
     virtual LdapServerType getServerType()

--- a/system/security/LdapSecurity/ldapconnection.cpp
+++ b/system/security/LdapSecurity/ldapconnection.cpp
@@ -1092,6 +1092,7 @@ static __int64 getMaxPwdAge(Owned<ILdapConnectionPool> _conns, const char * _bas
     return maxPwdAge;
 }
 
+static CriticalSection  lcCrit;
 class CLdapClient : public CInterface, implements ILdapClient
 {
 private:
@@ -1118,7 +1119,6 @@ public:
         //m_defaultWorkunitScopePermission = -2;
     }
 
-    static CriticalSection  lcCrit;
     virtual void init(IPermissionProcessor* pp)
     {
         m_pp = pp;

--- a/system/security/LdapSecurity/ldapconnection.cpp
+++ b/system/security/LdapSecurity/ldapconnection.cpp
@@ -1118,42 +1118,39 @@ public:
         //m_defaultWorkunitScopePermission = -2;
     }
 
+    static CriticalSection  lcCrit;
     virtual void init(IPermissionProcessor* pp)
     {
         m_pp = pp;
-        static CriticalSection  lcCrit;
         static bool createdOU = false;
+        CriticalBlock block(lcCrit);
         if (!createdOU)
         {
-            CriticalBlock block(lcCrit);
-            if (!createdOU)
+            if(m_ldapconfig->getServerType() == OPEN_LDAP)
             {
-                if(m_ldapconfig->getServerType() == OPEN_LDAP)
+                try
                 {
-                    try
-                    {
-                        addDC(m_ldapconfig->getBasedn());
-                    }
-                    catch(...)
-                    {
-                    }
-                    try
-                    {
-                        addGroup("Directory Administrators", m_ldapconfig->getBasedn());
-                    }
-                    catch(...)
-                    {
-                    }
+                    addDC(m_ldapconfig->getBasedn());
                 }
-                createLdapBasedn(NULL, m_ldapconfig->getResourceBasedn(RT_DEFAULT), PT_ADMINISTRATORS_ONLY);
-                createLdapBasedn(NULL, m_ldapconfig->getResourceBasedn(RT_FILE_SCOPE), PT_ADMINISTRATORS_ONLY);
-                createLdapBasedn(NULL, m_ldapconfig->getResourceBasedn(RT_WORKUNIT_SCOPE), PT_ADMINISTRATORS_ONLY);
-                createLdapBasedn(NULL, m_ldapconfig->getResourceBasedn(RT_SUDOERS), PT_ADMINISTRATORS_ONLY);
-
-                createLdapBasedn(NULL, m_ldapconfig->getUserBasedn(), PT_ADMINISTRATORS_ONLY);
-                createLdapBasedn(NULL, m_ldapconfig->getGroupBasedn(), PT_ADMINISTRATORS_ONLY);
-                createdOU = true;
+                catch(...)
+                {
+                }
+                try
+                {
+                    addGroup("Directory Administrators", m_ldapconfig->getBasedn());
+                }
+                catch(...)
+                {
+                }
             }
+            createLdapBasedn(NULL, m_ldapconfig->getResourceBasedn(RT_DEFAULT), PT_ADMINISTRATORS_ONLY);
+            createLdapBasedn(NULL, m_ldapconfig->getResourceBasedn(RT_FILE_SCOPE), PT_ADMINISTRATORS_ONLY);
+            createLdapBasedn(NULL, m_ldapconfig->getResourceBasedn(RT_WORKUNIT_SCOPE), PT_ADMINISTRATORS_ONLY);
+            createLdapBasedn(NULL, m_ldapconfig->getResourceBasedn(RT_SUDOERS), PT_ADMINISTRATORS_ONLY);
+
+            createLdapBasedn(NULL, m_ldapconfig->getUserBasedn(), PT_ADMINISTRATORS_ONLY);
+            createLdapBasedn(NULL, m_ldapconfig->getGroupBasedn(), PT_ADMINISTRATORS_ONLY);
+            createdOU = true;
         }
     }
 

--- a/system/security/LdapSecurity/ldapconnection.cpp
+++ b/system/security/LdapSecurity/ldapconnection.cpp
@@ -1128,30 +1128,30 @@ public:
             CriticalBlock block(lcCrit);
             if (!createdOU)
             {
-        if(m_ldapconfig->getServerType() == OPEN_LDAP)
-        {
-            try
-            {
-                addDC(m_ldapconfig->getBasedn());
-            }
-            catch(...)
-            {
-            }
-            try
-            {
-                addGroup("Directory Administrators", m_ldapconfig->getBasedn());
-            }
-            catch(...)
-            {
-            }
-        }
-        createLdapBasedn(NULL, m_ldapconfig->getResourceBasedn(RT_DEFAULT), PT_ADMINISTRATORS_ONLY);
-        createLdapBasedn(NULL, m_ldapconfig->getResourceBasedn(RT_FILE_SCOPE), PT_ADMINISTRATORS_ONLY);
-        createLdapBasedn(NULL, m_ldapconfig->getResourceBasedn(RT_WORKUNIT_SCOPE), PT_ADMINISTRATORS_ONLY);
-        createLdapBasedn(NULL, m_ldapconfig->getResourceBasedn(RT_SUDOERS), PT_ADMINISTRATORS_ONLY);
+                if(m_ldapconfig->getServerType() == OPEN_LDAP)
+                {
+                    try
+                    {
+                        addDC(m_ldapconfig->getBasedn());
+                    }
+                    catch(...)
+                    {
+                    }
+                    try
+                    {
+                        addGroup("Directory Administrators", m_ldapconfig->getBasedn());
+                    }
+                    catch(...)
+                    {
+                    }
+                }
+                createLdapBasedn(NULL, m_ldapconfig->getResourceBasedn(RT_DEFAULT), PT_ADMINISTRATORS_ONLY);
+                createLdapBasedn(NULL, m_ldapconfig->getResourceBasedn(RT_FILE_SCOPE), PT_ADMINISTRATORS_ONLY);
+                createLdapBasedn(NULL, m_ldapconfig->getResourceBasedn(RT_WORKUNIT_SCOPE), PT_ADMINISTRATORS_ONLY);
+                createLdapBasedn(NULL, m_ldapconfig->getResourceBasedn(RT_SUDOERS), PT_ADMINISTRATORS_ONLY);
 
-        createLdapBasedn(NULL, m_ldapconfig->getUserBasedn(), PT_ADMINISTRATORS_ONLY);
-        createLdapBasedn(NULL, m_ldapconfig->getGroupBasedn(), PT_ADMINISTRATORS_ONLY);
+                createLdapBasedn(NULL, m_ldapconfig->getUserBasedn(), PT_ADMINISTRATORS_ONLY);
+                createLdapBasedn(NULL, m_ldapconfig->getGroupBasedn(), PT_ADMINISTRATORS_ONLY);
                 createdOU = true;
             }
         }


### PR DESCRIPTION
Each instance of the LDAP security manager attempts to create the OU
structure found in the ESP configuration file.  There are collisions that
end up causing LDAP to create conflict entries by appending a GUID
to the end of the OU name
  U=eclwatch_mdm\0ACNF:4ec443c6-4041-4374-b085-c1111c99c0f8
This PR ensures that only one instance of the sec mgr creates these entries

Signed-off-by: Russ Whitehead william.whitehead@lexisnexis.com
