### PR TITLE
HPCC-12499 MemberofWidget needs a refresh state

### DIFF
--- a/esp/src/eclwatch/MemberOfWidget.js
+++ b/esp/src/eclwatch/MemberOfWidget.js
@@ -62,7 +62,10 @@ define([
             this.grid.on("dgrid-datachange", function(event){
                 if (dojoConfig.isAdmin && params.username === context.currentUser && event.oldValue === true) {
                     var msg = confirm(context.i18n.RemoveUser + " " + event.rowId + ". " + context.i18n.ConfirmRemoval);
-                    if (!msg){
+                    if (msg) {
+                        location.hash = "";
+                        location.reload();
+                    } else {
                         event.preventDefault();
                     }
                 }


### PR DESCRIPTION
Whenever a user is removing himself/herself from a group with admin right we will perform a refresh state after they confirm their changes so they no longer have access to security options.

Signed-off by: Miguel Vazquez miguel.vazquez@lexisnexis.com
