### PR TITLE
HPCC-15412 Use vcredist.exe to install vc runtimes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,7 +156,22 @@ endif(APPLE OR WIN32)
 ###
 ## CPack install and packaging setup.
 ###
+set ( CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP TRUE )
 include(InstallRequiredSystemLibraries)
+if (MSVC14)
+    find_file(MSVC14_REDIST "vcredist_x86.exe" HINTS ${MSVC14_REDIST_DIR}/1033 )
+    if (EXISTS "${MSVC14_REDIST}")
+        install ( PROGRAMS ${MSVC14_REDIST} DESTINATION tmp )
+        get_filename_component(MSVC14_REDIST_NAME ${MSVC14_REDIST} NAME)
+        list ( APPEND CPACK_NSIS_EXTRA_INSTALL_COMMANDS " 
+            ExecWait '$INSTDIR\\\\tmp\\\\${MSVC14_REDIST_NAME} /S'
+        ")
+    else ()
+        MESSAGE(WARNING "-- Unable to locate vcredist_x86.exe")
+    endif ()
+else ()
+    MESSAGE(WARNING "-- Unknown compiler version")
+endif ()
 
 set(VER_SEPARATOR "-")
 if("${stagever}" MATCHES "^rc[0-9]+$")


### PR DESCRIPTION
Removed inline runtime DLLs

Fixes HPCC-15412

Signed-off-by: Gordon Smith gordonjsmith@gmail.com
