### PR TITLE
HPCC-15408 Graph edges duplication

### DIFF
--- a/esp/src/eclwatch/ESPGraph.js
+++ b/esp/src/eclwatch/ESPGraph.js
@@ -326,12 +326,20 @@ define([
 
         addSubgraph: function (subgraph) {
             subgraph.__hpcc_parent = this;
-            this.__hpcc_subgraphs.push(subgraph);
+            if (!arrayUtil.some(this.__hpcc_subgraphs, function (subgraph2) {
+                return subgraph === subgraph2;
+            })) {
+                this.__hpcc_subgraphs.push(subgraph);
+            }
         },
 
         addVertex: function (vertex) {
             vertex.__hpcc_parent = this;
-            this.__hpcc_vertices.push(vertex);
+            if (!arrayUtil.some(this.__hpcc_vertices, function (vertex2) {
+                return vertex === vertex2;
+            })) {
+                this.__hpcc_vertices.push(vertex);
+            }
         },
 
         removeVertex: function (vertex) {
@@ -342,7 +350,11 @@ define([
 
         addEdge: function (edge) {
             edge.__hpcc_parent = this;
-            this.__hpcc_edges.push(edge);
+            if (!arrayUtil.some(this.__hpcc_edges, function (edge2) {
+                return edge === edge2;
+            })) {
+                this.__hpcc_edges.push(edge);
+            }
         },
 
         removeEdge: function (edge) {

--- a/esp/src/eclwatch/JSGraphWidget.js
+++ b/esp/src/eclwatch/JSGraphWidget.js
@@ -467,14 +467,16 @@ define([
                                         source = inputs[0];
                                     }
                                 }
-                                item.__widget = new Edge()
-                                    .sourceVertex(source.__widget)
-                                    .targetVertex(target.__widget)
-                                    .targetMarker("arrowHead")
-                                    .weight(weight)
-                                    .strokeDasharray(strokeDasharray)
-                                ;
-                                item.__widget.__hpcc_globalID = item.__hpcc_id;
+                                if (!merge || !item.__widget) {
+                                    item.__widget = new Edge()
+                                        .sourceVertex(source.__widget)
+                                        .targetVertex(target.__widget)
+                                        .targetMarker("arrowHead")
+                                        .weight(weight)
+                                        .strokeDasharray(strokeDasharray)
+                                    ;
+                                    item.__widget.__hpcc_globalID = item.__hpcc_id;
+                                }
                                 item.__widget.text(label);
                                 item.__widget.tooltip(tooltip);
                                 item.__widget.classed({


### PR DESCRIPTION
Jobs with child queries could cause duplicate edges.

Fixes HPCC-15408

Signed-off-by: Gordon Smith gordonjsmith@gmail.com
