### PR TITLE
HPCC-13758 Test Page page cannot be found message

### DIFF
--- a/esp/src/eclwatch/WsTopology.js
+++ b/esp/src/eclwatch/WsTopology.js
@@ -125,7 +125,7 @@ define([
                     arrayUtil.forEach(response.TpServiceQueryResponse.ServiceList.TpEspServers.TpEspServer, function (item, idx) {
                         if (lang.exists("TpBindings.TpBinding", item)) {
                             arrayUtil.forEach(item.TpBindings.TpBinding, function (binding, idx) {
-                                if (binding.Service === type) {
+                                if (binding.ServiceType === type && binding.Protocol + ":" === location.protocol) {
                                     retVal = ESPRequest.getURL({
                                         port: binding.Port,
                                         pathname: ""


### PR DESCRIPTION
The wsecl pages within the test pages tabs were not displaying and were giving a "Page Cannot Be Found" due to the port number not matching to the protocol being used. I added some logic to make it match the existing location.protocol.

Signed-off by: Miguel Vazquez miguel.vazquez@lexisnexis.com
