### PR TITLE
HPCC-15421 Invalid compiler warning in cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,21 +156,23 @@ endif(APPLE OR WIN32)
 ###
 ## CPack install and packaging setup.
 ###
-set ( CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP TRUE )
-include(InstallRequiredSystemLibraries)
-if (MSVC14)
-    find_file(MSVC14_REDIST "vcredist_x86.exe" HINTS ${MSVC14_REDIST_DIR}/1033 )
-    if (EXISTS "${MSVC14_REDIST}")
-        install ( PROGRAMS ${MSVC14_REDIST} DESTINATION tmp )
-        get_filename_component(MSVC14_REDIST_NAME ${MSVC14_REDIST} NAME)
-        list ( APPEND CPACK_NSIS_EXTRA_INSTALL_COMMANDS " 
-            ExecWait '$INSTDIR\\\\tmp\\\\${MSVC14_REDIST_NAME} /S'
-        ")
+if ( WIN32 )
+    set ( CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP TRUE )
+    include(InstallRequiredSystemLibraries)
+    if (MSVC14)
+        find_file(MSVC14_REDIST "vcredist_${CMAKE_MSVC_ARCH}.exe" HINTS ${MSVC14_REDIST_DIR}/1033 )
+        if (EXISTS "${MSVC14_REDIST}")
+            install ( PROGRAMS ${MSVC14_REDIST} DESTINATION tmp )
+            get_filename_component(MSVC14_REDIST_NAME ${MSVC14_REDIST} NAME)
+            list ( APPEND CPACK_NSIS_EXTRA_INSTALL_COMMANDS " 
+                ExecWait '$INSTDIR\\\\tmp\\\\${MSVC14_REDIST_NAME} /S'
+            ")
+        else ()
+            MESSAGE(WARNING "-- Unable to locate vcredist_x86.exe")
+        endif ()
     else ()
-        MESSAGE(WARNING "-- Unable to locate vcredist_x86.exe")
+        MESSAGE(WARNING "-- Unknown compiler version")
     endif ()
-else ()
-    MESSAGE(WARNING "-- Unknown compiler version")
 endif ()
 
 set(VER_SEPARATOR "-")


### PR DESCRIPTION
Moved into windows only conditional block.
Added support for 64bit build.

Fixes HPCC-15421
Fixes HPCC-15417

Signed-off-by: Gordon Smith gordonjsmith@gmail.com
