### PR TITLE
HPCC-15428 CLocalEnvironment doesn't check properly the drop zone path in  getDropZoneByAddressPath() function.

### DIFF
--- a/common/environment/environment.cpp
+++ b/common/environment/environment.cpp
@@ -1579,9 +1579,7 @@ IConstDropZoneInfo * CLocalEnvironment::getDropZoneByAddressPath(const char * ne
         SCMStringBuffer dropZoneDir;
         zoneIt->query().getDirectory(dropZoneDir);
         StringBuffer fullDropZoneDir(dropZoneDir.str());
-        const char pathSeparator = fullDropZoneDir.charAt(0);
-        if (fullDropZoneDir.charAt(fullDropZoneDir.length()) != pathSeparator)
-            fullDropZoneDir.append(pathSeparator);
+        addPathSepChar(fullDropZoneDir);
         const char * pdropzoneDir = fullDropZoneDir.str();
 
         // Check target file path starts with this Drop zone path

--- a/common/environment/environment.cpp
+++ b/common/environment/environment.cpp
@@ -1576,12 +1576,13 @@ IConstDropZoneInfo * CLocalEnvironment::getDropZoneByAddressPath(const char * ne
 
     ForEach(*zoneIt)
     {
-        SCMStringBuffer dropZoneName;
-        zoneIt->query().getName(dropZoneName);
-
         SCMStringBuffer dropZoneDir;
         zoneIt->query().getDirectory(dropZoneDir);
-        const char * pdropzoneDir = dropZoneDir.str();
+        StringBuffer fullDropZoneDir(dropZoneDir.str());
+        const char pathSeparator = fullDropZoneDir.charAt(0);
+        if (fullDropZoneDir.charAt(fullDropZoneDir.length()) != pathSeparator)
+            fullDropZoneDir.append(pathSeparator);
+        const char * pdropzoneDir = fullDropZoneDir.str();
 
         // Check target file path starts with this Drop zone path
         // the drop zone paths can be nested (nothing forbids it) like


### PR DESCRIPTION
Add path separator character at the end of the drop zone path (if there
is not any) before compare it to the target file path.

Signed-off-by: Attila Vamos attila.vamos@gmail.com
