### PR TITLE
HPCC-15299 Protect multi writer getWriter from race condition

### DIFF
--- a/thorlcr/thorutil/thbuf.cpp
+++ b/thorlcr/thorutil/thbuf.cpp
@@ -1766,6 +1766,7 @@ public:
 // ISharedWriteBuffer impl.
     virtual IRowWriter *getWriter()
     {
+        CThorArrayLockBlock block(rows);
         ++numWriters;
         return new CAWriter(*this);
     }


### PR DESCRIPTION
The IRowMultiWriterReader::getWriter() implementation incremented
a unprotected writer count, used to determine end of reading.
It's thread-unsafeness could cause premature termination of
the reader side.

NB: this is only used by the unsorted parallel join helper.
The race condition can cause the join to prematurely stop and
potentiall cause a timeout error when joining the remaining worker
threads [~CMulticoreUnorderedJoinHelper worker[xx] join timed out"

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
