### PR TITLE
HPCC-15438 On despray incorrect DZ selected when > 1 DZ per machine

### DIFF
--- a/esp/services/ws_fs/ws_fsService.cpp
+++ b/esp/services/ws_fs/ws_fsService.cpp
@@ -2234,16 +2234,23 @@ void CFileSprayEx::getDropZoneInfoByIP(const char* ip, const char* destFileIn, S
     if (!computer.length())
         return;
 
-    Owned<IConstDropZoneInfo> dropZone = env->getDropZoneByComputer(computer.str());
-    if (!dropZone)
-        return;
-    dropZone->getDirectory(directory);
+    Owned<IConstDropZoneInfo> dropZone;
 
     StringBuffer destFile;
     if (isAbsolutePath(destFileIn))
+    {
         destFile.set(destFileIn);
+        dropZone.setown(env->getDropZoneByAddressPath(ip, destFile.str()));
+        if (!dropZone)
+            return;
+        dropZone->getDirectory(directory);
+    }
     else
     {
+        dropZone.setown(env->getDropZoneByComputer(computer.str()));
+        if (!dropZone)
+            return;
+        dropZone->getDirectory(directory);
         destFile.set(directory.str());
         if (destFile.length())
             addPathSepChar(destFile);

--- a/esp/services/ws_fs/ws_fsService.cpp
+++ b/esp/services/ws_fs/ws_fsService.cpp
@@ -2218,22 +2218,7 @@ void CFileSprayEx::getDropZoneInfoByIP(const char* ip, const char* destFileIn, S
     if (!env)
         return;
 
-    Owned<IConstMachineInfo> machine = env->getMachineByAddress(ip);
-    if (!machine)
-    {
-        IpAddress ipAddr;
-        ipAddr.ipset(ip);
-        if (!ipAddr.isLocal())
-            return;
-        machine.setown(env->getMachineForLocalHost());
-        if (!machine)
-            return;
-    }
-    SCMStringBuffer computer, directory, maskBuf;
-    machine->getName(computer);
-    if (!computer.length())
-        return;
-
+    SCMStringBuffer directory;
     Owned<IConstDropZoneInfo> dropZone;
 
     StringBuffer destFile;
@@ -2247,6 +2232,21 @@ void CFileSprayEx::getDropZoneInfoByIP(const char* ip, const char* destFileIn, S
     }
     else
     {
+        SCMStringBuffer computer;
+        Owned<IConstMachineInfo> machine = env->getMachineByAddress(ip);
+        if (!machine)
+        {
+            IpAddress ipAddr;
+            ipAddr.ipset(ip);
+            if (!ipAddr.isLocal())
+                return;
+            machine.setown(env->getMachineForLocalHost());
+            if (!machine)
+                return;
+        }
+        machine->getName(computer);
+        if (!computer.length())
+            return;
         dropZone.setown(env->getDropZoneByComputer(computer.str()));
         if (!dropZone)
             return;
@@ -2259,6 +2259,7 @@ void CFileSprayEx::getDropZoneInfoByIP(const char* ip, const char* destFileIn, S
     destFileOut.set(destFile.str());
     if ((destFile.length() >= directory.length()) && !strnicmp(destFile.str(), directory.str(), directory.length()))
     {
+        SCMStringBuffer maskBuf;
         dropZone->getUMask(maskBuf);
         if (maskBuf.length())
             mask.set(maskBuf.str());


### PR DESCRIPTION
@AttilaVamos 
@wangkx 
@jakesmith 
Please review.

If a full path for a desprayed file is provided then use that together with the IP address to correctly locate DZ to get umask parameter.
Previously only the machine was used to locate the DZ and when there is more than one DZ per machine the wrong DZ could have been chosen.

Only question I had was if the call to getDropZoneByAddressPath(ip, destFile.str())); fails should we return an error or try to continue by searching by computer (as it was before this update).

Signed-off-by: Mark Kelly mark.kelly@lexisnexis.com
