### PR TITLE
HPCC-15440 Conditional could cause grouping to be wrong

### DIFF
--- a/thorlcr/activities/loop/thloopslave.cpp
+++ b/thorlcr/activities/loop/thloopslave.cpp
@@ -839,7 +839,7 @@ public:
             dataLinkIncrement();
         return ret.getClear();
     }
-    virtual bool isGrouped() const override { return selectedItdl ? selectedItdl->isGrouped() : false; }
+    virtual bool isGrouped() const override { return container.queryGrouped(); }
     virtual void getMetaInfo(ThorDataLinkMetaInfo &info) override
     {
         initMetaInfo(info);


### PR DESCRIPTION
Signed-off-by: Jake Smith jake.smith@lexisnexis.com
