### PR TITLE
HPCC-15445 Errors building master on OSX

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -8815,12 +8815,9 @@ extern WORKUNIT_API void secAbortWorkUnit(const char *wuid, ISecManager &secmgr,
         return;
 
     WorkunitUpdate wu(&cw->lock());
-    if (&secuser)
-    {
-        const char *abortBy = secuser.getName();
-        if (abortBy && *abortBy)
-            wu->setTracingValue("AbortBy", abortBy);
-    }
+    const char *abortBy = secuser.getName();
+    if (abortBy && *abortBy)
+        wu->setTracingValue("AbortBy", abortBy);
     wu->setTracingValueInt64("AbortTimeStamp", getTimeStampNowValue());
 }
 

--- a/system/security/zcrypt/CMakeLists.txt
+++ b/system/security/zcrypt/CMakeLists.txt
@@ -51,6 +51,7 @@ ADD_DEFINITIONS ( -D_USRDLL -DZCRYPT_EXPORTS )
 HPCC_ADD_LIBRARY( zcrypt SHARED ${SRCS} )
 install ( TARGETS zcrypt RUNTIME DESTINATION ${EXEC_DIR} LIBRARY DESTINATION ${LIB_DIR} )
 target_link_libraries ( zcrypt
+         jlib
          ${ZLIB_LIBRARIES} 
          ${OPENSSL_LIBRARIES} 
     )


### PR DESCRIPTION
Checking a reference against NULL generates a fatal warning on Clang.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
