### PR TITLE
HPCC-15445 Errors building master on OSX

### DIFF
--- a/esp/services/ws_smc/ws_smcService.cpp
+++ b/esp/services/ws_smc/ws_smcService.cpp
@@ -1471,7 +1471,7 @@ bool CWsSMCEx::onRemoveJob(IEspContext &context, IEspSMCJobRequest &req, IEspSMC
     {
         checkAccess(context,THORQUEUE_FEATURE,SecAccess_Full);
 
-        secAbortWorkUnit(req.getWuid(), *context.querySecManager(), *context.queryUser());
+        abortWorkUnit(req.getWuid(), context.querySecManager(), context.queryUser());
 
         {
             Owned<IJobQueue> queue = createJobQueue(req.getQueueName());
@@ -1601,7 +1601,7 @@ bool CWsSMCEx::onClearQueue(IEspContext &context, IEspSMCQueueRequest &req, IEsp
             for(unsigned i=0;i<queue->ordinality();i++)
             {
                 Owned<IJobQueueItem> item = queue->getItem(i);
-                secAbortWorkUnit(item->queryWUID(), *context.querySecManager(), *context.queryUser());
+                abortWorkUnit(item->queryWUID(), context.querySecManager(), context.queryUser());
             }
             queue->clear();
         }

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -214,7 +214,7 @@ bool doAction(IEspContext& context, StringArray& wuids, CECLWUActions action, IP
                             wu->setState(WUStateAborted);
                         }
                         else
-                            secAbortWorkUnit(wuid, *context.querySecManager(), *context.queryUser());
+                            abortWorkUnit(wuid, context.querySecManager(), context.queryUser());
                         AuditSystemAccess(context.queryUserId(), true, "Aborted %s", wuid);
                     }
                     break;
@@ -1155,7 +1155,7 @@ bool CWsWorkunitsEx::onWUSyntaxCheckECL(IEspContext &context, IEspWUSyntaxCheckR
                 throw MakeStringException(ECLWATCH_CANNOT_DELETE_WORKUNIT, "Workunit %s cannot be deleted.", wuid.str());
             break;
         default:
-            secAbortWorkUnit(wuid.str(), *context.querySecManager(), *context.queryUser());
+            abortWorkUnit(wuid.str(), context.querySecManager(), context.queryUser());
             if (!factory->deleteWorkUnit(wuid.str()))
             {
                 throw MakeStringException(ECLWATCH_CANNOT_DELETE_WORKUNIT,


### PR DESCRIPTION
Checking a reference against NULL generates a fatal warning on Clang.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
