### PR TITLE
HPCC-14459 Job queues should not ignore queued items from closed clients

### DIFF
--- a/common/workunit/wujobq.cpp
+++ b/common/workunit/wujobq.cpp
@@ -1105,11 +1105,15 @@ public:
         if (connected)
             disconnect();
         dosubscribe();
-        ForEachQueue(qd) {
-            unsigned connected;
-            unsigned waiting;
-            unsigned count;
-            getStats(*qd,connected,waiting,count); // clear any duff clients
+        ForEachQueue(qd)
+        {
+            if (validateitemsessions)
+            {
+                unsigned connected;
+                unsigned waiting;
+                unsigned count;
+                getStats(*qd,connected,waiting,count); // clear any duff clients
+            }
             IPropertyTree *croot = queryClientRootSession(*qd);
             croot->setPropInt64("@connected",croot->getPropInt64("@connected",0)+1);
         }
@@ -1640,7 +1644,7 @@ public:
             IPropertyTree *croot = queryClientRootIndex(qd,i);
             if (!croot)
                 break;
-            if (!validSession(croot)) {
+            if (validateitemsessions && !validSession(croot)) {
                 Cconnlockblock block(this,true);
                 qd.root->removeTree(croot);
             }

--- a/common/workunit/wujobq.hpp
+++ b/common/workunit/wujobq.hpp
@@ -90,7 +90,7 @@ interface IJobQueue: extends IJobQueueConst
     virtual void enqueueAfter(IJobQueueItem *qitem,const char *prevwuid)=0;
 
 // dequeueing
-    virtual void connect(bool validateitemsessions=true)=0;     // must be called before dequeueing
+    virtual void connect(bool validateitemsessions)=0;     // must be called before dequeueing
                                                                 // validateitemsessions ensures that all queue items have running session
     virtual IJobQueueItem *dequeue(unsigned timeout=INFINITE)=0;
     virtual IJobQueueItem *prioDequeue(int minprio,unsigned timeout=INFINITE)=0;

--- a/dali/dfu/dfurun.cpp
+++ b/dali/dfu/dfurun.cpp
@@ -216,7 +216,7 @@ class CDFUengine: public CInterface, implements IDFUengine
         int run()
         {
             try {
-                queue->connect();
+                queue->connect(false);
             }
             catch (IException *e) {
                 EXCLOG(e, "DFURUN Server Connect queue: ");

--- a/ecl/agentexec/agentexec.cpp
+++ b/ecl/agentexec/agentexec.cpp
@@ -119,7 +119,7 @@ int CEclAgentExecutionServer::run()
         initClientProcess(serverGroup, DCR_AgentExec);
         getAgentQueueNames(queueNames, agentName);
         queue.setown(createJobQueue(queueNames.str()));
-        queue->connect();
+        queue->connect(false);
     }
     catch (IException *e) 
     {

--- a/ecl/eclccserver/eclccserver.cpp
+++ b/ecl/eclccserver/eclccserver.cpp
@@ -632,7 +632,7 @@ public:
     {
         DBGLOG("eclccServer (%d threads) waiting for requests on queue(s) %s", poolSize, queueName.get());
         queue.setown(createJobQueue(queueName.get()));
-        queue->connect();
+        queue->connect(false);
         running = true;
         LocalIAbortHandler abortHandler(*this);
         while (running)

--- a/roxie/ccd/ccdlistener.cpp
+++ b/roxie/ccd/ccdlistener.cpp
@@ -1017,7 +1017,7 @@ public:
                     try
                     {
                         queue.setown(createJobQueue(queueNames.str()));
-                        queue->connect();
+                        queue->connect(false);
                         daliHelper->noteQueuesRunning(queueNames.str());
                         while (running && daliHelper->connected())
                         {

--- a/thorlcr/master/thgraphmanager.cpp
+++ b/thorlcr/master/thgraphmanager.cpp
@@ -567,7 +567,7 @@ void CJobManager::run()
                         {
                             if (!jobQConnected)
                             {
-                                jobq->connect();
+                                jobq->connect(true);
                                 jobQConnected = true;
                             }
                             // NB: this is expecting to get an item without delay, timeout JIC.
@@ -613,7 +613,7 @@ void CJobManager::run()
             {
                 if (!jobQConnected)
                 {
-                    jobq->connect();
+                    jobq->connect(true);
                     jobQConnected = true;
                 }
                 IJobQueueItem *_item;


### PR DESCRIPTION
Makes some sense for Thor, since if eclagent has closed the job will fail. But
not otherwise.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
