### PR TITLE
HPCC-15434 System agnostic implementation of libmemcached generation

### DIFF
--- a/cmake_modules/FindLIBMEMCACHED.cmake
+++ b/cmake_modules/FindLIBMEMCACHED.cmake
@@ -21,47 +21,122 @@
 #  LIBMEMCACHED_INCLUDE_DIR - the libmemcached include directory(s)
 #  LIBMEMCACHED_LIBRARIES - The libraries needed to use libmemcached
 
+#  If the memcached libraries are found on the system, we assume they exist natively and dependencies
+#  can be handled through package management.  If the libraries are not found, and if
+#  MEMCACHED_USE_EXTERNAL_LIBRARY is ON, we will fetch, build, and include a copy of the neccessary
+#  Libraries.
+
+
 IF (NOT LIBMEMCACHED_FOUND)
-  IF (WIN32)
-    SET (libmemcached_lib "libmemcached")
-    SET (libmemcachedUtil_lib "libmemcachedutil")
-  ELSE()
-    SET (libmemcached_lib "memcached")
-    SET (libmemcachedUtil_lib "memcachedutil")
-  ENDIF()
+    option(MEMCACHED_USE_EXTERNAL_LIBRARY "Pull and build source from external location if local is not found" ON)
 
-  FIND_PATH(LIBMEMCACHED_INCLUDE_DIR libmemcached/memcached.hpp PATHS /usr/include /usr/share/include /usr/local/include PATH_SUFFIXES libmemcached)
-
-  FIND_LIBRARY (LIBMEMCACHEDCORE_LIBRARY NAMES ${libmemcached_lib} PATHS /usr/lib usr/lib/libmemcached /usr/share /usr/lib64 /usr/local/lib /usr/local/lib64)
-  FIND_LIBRARY (LIBMEMCACHEDUTIL_LIBRARY NAMES ${libmemcachedUtil_lib} PATHS /usr/lib /usr/share /usr/lib64 /usr/local/lib /usr/local/lib64)
-
-  #IF (LIBMEMCACHED_LIBRARY STREQUAL "LIBMEMCACHED_LIBRARY-NOTFOUND")
-  #  SET (LIBMEMCACHEDCORE_LIBRARY "")    # Newer versions of libmemcached are header-only, with no associated library.
-  #ENDIF()
-
-  SET (LIBMEMCACHED_LIBRARIES ${LIBMEMCACHEDCORE_LIBRARY} ${LIBMEMCACHEDUTIL_LIBRARY})
-
-  IF(LIBMEMCACHED_INCLUDE_DIR)
-    FILE (STRINGS "${LIBMEMCACHED_INCLUDE_DIR}/libmemcached-1.0/configure.h" version REGEX "#define LIBMEMCACHED_VERSION_STRING")
-    STRING(REGEX REPLACE "#define LIBMEMCACHED_VERSION_STRING " "" version "${version}")
-    STRING(REGEX REPLACE "\"" "" version "${version}")
-    SET (LIBMEMCACHED_VERSION_STRING ${version})
-    IF ("${LIBMEMCACHED_VERSION_STRING}" VERSION_EQUAL "${LIBMEMCACHED_FIND_VERSION}" OR "${LIBMEMCACHED_VERSION_STRING}" VERSION_GREATER "${LIBMEMCACHED_FIND_VERSION}")
-      SET (LIBMEMCACHED_VERSION_OK 1)
-      SET (MSG "${DEFAULT_MSG}")
+    # Search for native library to build against
+    IF (WIN32)
+        SET (libmemcached_lib "libmemcached")
+        SET (libmemcachedUtil_lib "libmemcachedutil")
     ELSE()
-      SET (LIBMEMCACHED_VERSION_OK 0)
-      SET(MSG "libmemcached version '${LIBMEMCACHED_VERSION_STRING}' incompatible with min version>=${LIBMEMCACHED_FIND_VERSION}")
+        SET (libmemcached_lib "memcached")
+        SET (libmemcachedUtil_lib "memcachedutil")
     ENDIF()
-  ENDIF()
-      
-  include(FindPackageHandleStandardArgs)
-  find_package_handle_standard_args(libmemcached ${MSG}
-    LIBMEMCACHED_LIBRARIES
-    LIBMEMCACHED_INCLUDE_DIR
-    LIBMEMCACHED_VERSION_OK
-  )
 
-  MARK_AS_ADVANCED(LIBMEMCACHED_INCLUDE_DIRS LIBMEMCACHED_LIBRARIES)
+    FIND_PATH(LIBMEMCACHED_INCLUDE_DIR libmemcached/memcached.hpp PATHS /usr/include /usr/share/include /usr/local/include PATH_SUFFIXES libmemcached)
+
+    FIND_LIBRARY (LIBMEMCACHEDCORE_LIBRARY NAMES ${libmemcached_lib} PATHS /usr/lib usr/lib/libmemcached /usr/share /usr/lib64 /usr/local/lib /usr/local/lib64)
+    FIND_LIBRARY (LIBMEMCACHEDUTIL_LIBRARY NAMES ${libmemcachedUtil_lib} PATHS /usr/lib /usr/share /usr/lib64 /usr/local/lib /usr/local/lib64)
+
+    #IF (LIBMEMCACHED_LIBRARY STREQUAL "LIBMEMCACHED_LIBRARY-NOTFOUND")
+    #  SET (LIBMEMCACHEDCORE_LIBRARY "")    # Newer versions of libmemcached are header-only, with no associated library.
+    #ENDIF()
+
+    SET (LIBMEMCACHED_LIBRARIES ${LIBMEMCACHEDCORE_LIBRARY} ${LIBMEMCACHEDUTIL_LIBRARY})
+
+    IF(LIBMEMCACHED_INCLUDE_DIR)
+        FILE (STRINGS "${LIBMEMCACHED_INCLUDE_DIR}/libmemcached-1.0/configure.h" version REGEX "#define LIBMEMCACHED_VERSION_STRING")
+        STRING(REGEX REPLACE "#define LIBMEMCACHED_VERSION_STRING " "" version "${version}")
+        STRING(REGEX REPLACE "\"" "" version "${version}")
+        SET (LIBMEMCACHED_VERSION_STRING ${version})
+        IF ("${LIBMEMCACHED_VERSION_STRING}" VERSION_EQUAL "${LIBMEMCACHED_FIND_VERSION}" OR "${LIBMEMCACHED_VERSION_STRING}" VERSION_GREATER "${LIBMEMCACHED_FIND_VERSION}")
+            SET (LIBMEMCACHED_VERSION_OK 1)
+            SET (MSG "${DEFAULT_MSG}")
+        ELSE()
+            SET (LIBMEMCACHED_VERSION_OK 0)
+            SET(MSG "libmemcached version '${LIBMEMCACHED_VERSION_STRING}' incompatible with min version>=${LIBMEMCACHED_FIND_VERSION}")
+        ENDIF()
+    ENDIF()
+
+    include(FindPackageHandleStandardArgs)
+    find_package_handle_standard_args(libmemcached ${MSG}
+        LIBMEMCACHED_LIBRARIES
+        LIBMEMCACHED_INCLUDE_DIR
+        LIBMEMCACHED_VERSION_OK
+        )
+
+    if(NOT LIBMEMCACHED_FOUND AND MEMCACHED_USE_EXTERNAL_LIBRARY)
+        # Currently libmemcached versions are not sufficient on ubuntu 12.04 and 14.04 LTS
+        # until then, we build the required libraries from source
+        set(LIBMEMCACHED_URL https://launchpad.net/libmemcached/1.0/${LIBMEMCACHED_VERSION}/+download/libmemcached-${LIBMEMCACHED_FIND_VERSION}.tar.gz)
+        if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/libmemcached-${LIBMEMCACHED_FIND_VERSION}.tar.gz)
+            file(DOWNLOAD
+                ${LIBMEMCACHED_URL} ${CMAKE_CURRENT_SOURCE_DIR}/libmemcached-${LIBMEMCACHED_FIND_VERSION}.tar.gz
+                STATUS libmemcached_status
+                LOG libmemcached_log
+                TIMEOUT 30
+                TLS_VERIFY ON)
+            list(GET libmemcached_status 0 status_code)
+            list(GET libmemcached_status 1 status_msg)
+            if(NOT status_code EQUAL 0)
+                message(FATAL_ERROR "Fatal Error: download of ${LIBMEMCACHED_URL} failed
+                status_code: ${status_code}
+                status_msg: ${status_msg}
+                log: ${libmemcached_log}\n")
+            else()
+                message(STATUS "Download of external libmemcached ${LIBMEMCACHED_FIND_VERSION} library successful")
+            endif()
+        endif()
+        add_custom_command(
+            OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/libmemcached-${LIBMEMCACHED_FIND_VERSION}/libmemcached/.libs/libmemcached.so.11.0.0
+            COMMAND ${CMAKE_COMMAND} -E tar xzf ${CMAKE_CURRENT_SOURCE_DIR}/libmemcached-${LIBMEMCACHED_FIND_VERSION}.tar.gz -C ${CMAKE_CURRENT_BINARY_DIR}/libmemcached-${LIBMEMCACHED_FIND_VERSION}
+            COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_CURRENT_BINARY_DIR}/libmemcached-${LIBMEMCACHED_FIND_VERSION} ${CMAKE_CURRENT_BINARY_DIR}/libmemcached-${LIBMEMCACHED_FIND_VERSION}/configure --prefix=\"${INSTALL_DIR}\" LDFLAGS=\"-L${LIB_PATH}\" > /dev/null
+            COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_CURRENT_BINARY_DIR}/libmemcached-${LIBMEMCACHED_FIND_VERSION} ${CMAKE_MAKE_PROGRAM} LDFLAGS=\"-Wl,-rpath-link,${LIB_PATH}\" > /dev/null
+            DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/libmemcached-${LIBMEMCACHED_FIND_VERSION}.tar.gz
+            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+            COMMENT "building libmemcached-${LIBMEMCACHED_FIND_VERSION}")
+        add_custom_target(generate-libmemcached
+            DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/libmemcached-${LIBMEMCACHED_FIND_VERSION}/libmemcached/.libs/libmemcached.so.11.0.0)
+
+        add_library(libmemcached SHARED IMPORTED)
+        add_library(libmemcachedutil SHARED IMPORTED)
+        set_property(TARGET libmemcached
+            PROPERTY IMPORTED_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/libmemcached-${LIBMEMCACHED_FIND_VERSION}/libmemcached/.libs/libmemcached.so.11.0.0)
+        set_property(TARGET libmemcachedutil
+            PROPERTY IMPORTED_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/libmemcached-${LIBMEMCACHED_FIND_VERSION}/libmemcached/.libs/libmemcachedutil.so.2.0.0)
+        set_property(TARGET libmemcached
+            PROPERTY IMPORTED_LINK_DEPENDENT_LIBRARIES libmemcachedutil)
+        add_dependencies(libmemcached generate-libmemcached)
+        add_dependencies(libmemcachedutil generate-libmemcached)
+
+        install(PROGRAMS
+            ${CMAKE_CURRENT_BINARY_DIR}/libmemcached-${LIBMEMCACHED_FIND_VERSION}/libmemcached/.libs/libmemcached.so
+            ${CMAKE_CURRENT_BINARY_DIR}/libmemcached-${LIBMEMCACHED_FIND_VERSION}/libmemcached/.libs/libmemcached.so.11
+            ${CMAKE_CURRENT_BINARY_DIR}/libmemcached-${LIBMEMCACHED_FIND_VERSION}/libmemcached/.libs/libmemcached.so.11.0.0
+            ${CMAKE_CURRENT_BINARY_DIR}/libmemcached-${LIBMEMCACHED_FIND_VERSION}/libmemcached/.libs/libmemcachedutil.so
+            ${CMAKE_CURRENT_BINARY_DIR}/libmemcached-${LIBMEMCACHED_FIND_VERSION}/libmemcached/.libs/libmemcachedutil.so.2
+            ${CMAKE_CURRENT_BINARY_DIR}/libmemcached-${LIBMEMCACHED_FIND_VERSION}/libmemcached/.libs/libmemcachedutil.so.2.0.0
+            DESTINATION lib)
+
+        set(LIBMEMCACHED_LIBRARIES $<TARGET_FILE:libmemcached> $<TARGET_FILE:libmemcachedutil>)
+        set(LIBMEMCACHED_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/libmemcached-${LIBMEMCACHED_FIND_VERSION})
+        set(LIBMEMCACHED_VERSION_OK 1)
+
+        include(FindPackageHandleStandardArgs)
+        find_package_handle_standard_args(libmemcached ${MSG}
+            LIBMEMCACHED_LIBRARIES
+            LIBMEMCACHED_INCLUDE_DIR
+            LIBMEMCACHED_VERSION_OK
+            )
+
+    endif()
+
+    MARK_AS_ADVANCED(LIBMEMCACHED_INCLUDE_DIRS LIBMEMCACHED_LIBRARIES)
 ENDIF()
 

--- a/plugins/memcached/CMakeLists.txt
+++ b/plugins/memcached/CMakeLists.txt
@@ -25,27 +25,11 @@
 project( memcached )
 
 if (MEMCACHED)
-    ADD_PLUGIN(memcached)
-    if(MAKE_MEMCACHED)
-        # Currently libmemcached versions are not sufficient on ubuntu 12.04 and 14.04 LTS
-        # until then, we build the required libraries from source
-
+    if(NOT DEFINED LIBMEMCACHED_VERSION)
         set(LIBMEMCACHED_VERSION "1.0.10")
-        add_custom_command(
-            OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/libmemcached/.libs/libmemcached.so
-            COMMAND wget -q https://launchpad.net/libmemcached/1.0/${LIBMEMCACHED_VERSION}/+download/libmemcached-${LIBMEMCACHED_VERSION}.tar.gz
-            COMMAND tar -xzf ${CMAKE_CURRENT_BINARY_DIR}/libmemcached-${LIBMEMCACHED_VERSION}.tar.gz
-            COMMAND cd ${CMAKE_CURRENT_BINARY_DIR}/libmemcached-${LIBMEMCACHED_VERSION}
-            COMMAND ${CMAKE_CURRENT_BINARY_DIR}/libmemcached-${LIBMEMCACHED_VERSION}/configure > /dev/null
-            COMMAND make -j > /dev/null
-            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-            COMMENT "fetching and building libmemcached-${LIBMEMCACHED_VERSION}")
-        add_custom_target(generate-libmemcached
-            DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/libmemcached/.libs/libmemcached.so)
-        add_library(libmemcached SHARED IMPORTED)
-        set_target_properties(libmemcached
-            PROPERTIES IMPORTED_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/libmemcached/.libs/libmemcached.so.11.0.0)
-        set(LIBMEMCACHED_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/libmemcached-${LIBMEMCACHED_VERSION})
+    endif()
+    ADD_PLUGIN(memcached PACKAGES LIBMEMCACHED MINVERSION ${LIBMEMCACHED_VERSION})
+    if(MAKE_MEMCACHED)
 
         set(
             SRCS
@@ -73,23 +57,19 @@ if (MEMCACHED)
             set_target_properties(memcached PROPERTIES NO_SONAME 1)
         endif()
 
-        add_dependencies(memcached generate-libmemcached)
+        #if we are using generated libmemcached, target appropriate dependencies
+        if(MEMCACHED_USE_EXTERNAL_LIBRARY)
+            add_dependencies(memcached libmemcached libmemcachedutil)
+        endif()
         target_link_libraries(
             memcached
             eclrtl
             jlib
-            libmemcached)
+            ${LIBMEMCACHED_LIBRARIES})
 
-        install(CODE "set(ENV{LD_LIBRARY_PATH} \"\$ENV{LD_LIBRARY_PATH}:${PROJECT_BINARY_DIR}:${PROJECT_BINARY_DIR}/libmemcached/.libs\")")
         install(
             TARGETS memcached
             DESTINATION plugins)
-        install(FILES
-            ${CMAKE_CURRENT_BINARY_DIR}/libmemcached/.libs/libmemcached.so
-            ${CMAKE_CURRENT_BINARY_DIR}/libmemcached/.libs/libmemcached.so.11
-            ${CMAKE_CURRENT_BINARY_DIR}/libmemcached/.libs/libmemcached.so.11.0.0
-            DESTINATION lib
-            PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
     endif()
 endif()
 


### PR DESCRIPTION
Modified the libmemcached fetch and generate commands to be entirely system agnostic.  It requires that you have a cmake version built against the systems curl that is capable of handling ssl connections.  This is the default on most pre-built cmake packages for systems like osx or windows, but not always the case on linux systems that had to build updated cmake versions from source.

Signed-off-by: Michael Gardner Michael.Gardner@lexisnexis.com
