### PR TITLE
HPCC-15451 - Add c++11 move semantics

### DIFF
--- a/system/jlib/jstring.cpp
+++ b/system/jlib/jstring.cpp
@@ -93,6 +93,12 @@ StringBuffer::StringBuffer(const StringBuffer & value)
     append(value);
 }
 
+StringBuffer::StringBuffer(StringBuffer && value)
+{
+    init();
+    swapWith(value);
+}
+
 StringBuffer::StringBuffer(bool useInternal)
 {
     if (useInternal)
@@ -1279,6 +1285,20 @@ StringAttr::StringAttr(const StringAttr & src)
 {
     text = NULL;
     set(src.get());
+}
+
+StringAttr::StringAttr(StringAttr && src)
+{
+    text = src.text;
+    src.text = nullptr;
+}
+
+StringAttr& StringAttr::operator = (StringAttr && from)
+{
+    char *temp = text;
+    text = from.text;
+    from.text = temp;
+    return *this;
 }
 
 void StringAttr::set(const char * _text)
@@ -2481,4 +2501,10 @@ const char * nullText(const char * text)
 {
     if (text) return text;
     return "(null)";
+}
+
+StringBuffer& StringBuffer::operator=(StringBuffer&& value)
+{
+    swapWith(value);
+    return *this;
 }

--- a/system/jlib/jstring.hpp
+++ b/system/jlib/jstring.hpp
@@ -38,6 +38,7 @@ public:
     StringBuffer();
     StringBuffer(String & value);
     StringBuffer(const char *value);
+    StringBuffer(StringBuffer && value);
     StringBuffer(unsigned len, const char *value);
     StringBuffer(const StringBuffer & value);
     StringBuffer(bool useInternal);
@@ -131,6 +132,7 @@ public:
     {
         return clear().append(value.str());
     }
+    StringBuffer& operator=(StringBuffer&& value);
 
     StringBuffer &  appendlong(long value);
     StringBuffer &  appendulong(unsigned long value);
@@ -180,6 +182,7 @@ public:
 
     virtual const char * str() const { return s.str(); };
     virtual void set(const char *val) { s.clear().append(val); };
+    virtual void set(StringBuffer &&str) { s.swapWith(str); }
     virtual void clear() { s.clear(); };
     virtual void setLen(const char *val, unsigned length) { s.clear().append(length, val); };
     virtual unsigned length() const { return s.length(); };
@@ -249,6 +252,8 @@ public:
     StringAttr(const char * _text, unsigned _len);
     StringAttr(const char * _text);
     StringAttr(const StringAttr & src);
+    StringAttr(StringAttr && src);
+    StringAttr& operator = (StringAttr && from);
     inline ~StringAttr(void) { free(text); }
     
     inline operator const char * () const       { return text; }


### PR DESCRIPTION
Add move semantics to StringBuffer, StringAttr, and CDfsLogicalFileName.
Add operator+ and operator+= to StringBuffer using move semantics.

Signed-off-by: Gleb Aronsky gleb.aronsky@lexisnexis.com
