### PR TITLE
HPCC-15392 Remove non-functional crcResources option in Roxie

### DIFF
--- a/roxie/ccd/ccdfile.cpp
+++ b/roxie/ccd/ccdfile.cpp
@@ -2696,7 +2696,7 @@ protected:
         CPPUNIT_ASSERT(wrote==sizeof(int));
         close(f);
 
-        Owned<ILazyFileIO> io = cache.openFile("test.local", 0, "test.local", NULL, remotes, sizeof(int), dummy, 0);
+        Owned<ILazyFileIO> io = cache.openFile("test.local", 0, "test.local", NULL, remotes, sizeof(int), dummy);
         CPPUNIT_ASSERT(io != NULL);
 
         // Reading it should read 1


### PR DESCRIPTION
Previous commit gave build errors if unit testing enabled.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
