### PR TITLE
HPCC-15462  Fix compile warning due to auto_ptr

### DIFF
--- a/esp/bindings/SOAP/Platform/soapservice.cpp
+++ b/esp/bindings/SOAP/Platform/soapservice.cpp
@@ -158,7 +158,7 @@ int CSoapService::processRequest(ISoapMessage &req, ISoapMessage& resp)
     }
     
     //Parse the content
-    auto_ptr<XmlPullParser> xpp(new XmlPullParser());
+    std::unique_ptr<XmlPullParser> xpp(new XmlPullParser());
     int bufSize = requeststr.length();
     xpp->setSupportNamespaces(true);
     xpp->setInput(requeststr.str(), bufSize);


### PR DESCRIPTION
```
- replace auto_ptr with unique_ptr
```

Signed-off-by: Gleb Aronsky gleb.aronsky@lexisnexis.com
