### PR TITLE
HPCC-15466 Regression Test Engine doesn't handle properly the test execution retry count

### DIFF
--- a/testing/regress/hpcc/regression/regress.py
+++ b/testing/regress/hpcc/regression/regress.py
@@ -348,7 +348,7 @@ class Regression:
             sleepTime = defSleepTime
             if self.timeouts[threadId] >= 0:
                 self.loggermutex.acquire()
-                logging.debug("%3d. timeout counter:%d" % (cnt, self.timeouts[threadId]),  extra={'taskId':cnt})
+                logging.debug("%3d. timeout counter:%d (%d)" % (cnt, self.timeouts[threadId],  self.retryCount),  extra={'taskId':cnt})
                 self.loggermutex.release()
                 sleepTime = defSleepTime
             if self.timeouts[threadId] == 0:
@@ -496,12 +496,14 @@ class Regression:
                     res = eclCmd.runCmd("publish", cluster, query, report[0],
                                       server=self.config.espIp,
                                       username=self.config.username,
-                                      password=self.config.password)
+                                      password=self.config.password, 
+                                      retryCount=self.config.maxAttemptCount)
                 else:
                     res = eclCmd.runCmd("run", cluster, query, report[0],
                                       server=self.config.espIp,
                                       username=self.config.username,
-                                      password=self.config.password)
+                                      password=self.config.password, 
+                                      retryCount=self.config.maxAttemptCount)
             except Error as e:
                 logging.debug("Exception raised:'%s'"  % ( str(e)),  extra={'taskId':cnt})
                 res = False

--- a/testing/regress/hpcc/util/ecl/command.py
+++ b/testing/regress/hpcc/util/ecl/command.py
@@ -39,7 +39,9 @@ class ECLcmd(Shell):
         args.append('-fpickBestEngine=false')
         args.append('--target=' + cluster)
         args.append('--cluster=' + cluster)
-        args.append('--wait='+str(eclfile.getTimeout()*1000))
+        
+        retryCount = int(kwargs.pop('retryCount',  1))
+        args.append('--wait='+str(retryCount * eclfile.getTimeout() * 1000))  # ms
 
         server = kwargs.pop('server', False)
         if server:


### PR DESCRIPTION
Fix --wait parameter calculation
Add extra debug log

Signed-off-by: Attila Vamos attila.vamos@gmail.com
