### PR TITLE
HPCC-15285 Improve information when Compiling from a git repository

### DIFF
--- a/ecl/eclccserver/vchooks/git.sh
+++ b/ecl/eclccserver/vchooks/git.sh
@@ -134,7 +134,7 @@ function fetch_repo {
         echo "Failed to run git rev-parse $git_branch" 1>&2
         exit 2
     fi
-    export GIT_INCLUDE_PATH="${GIT_INCLUDE_PATH} -I${git_directory}/{$last_commit}/ -a${repo}_commit=${last_commit}"
+    export GIT_INCLUDE_PATH="${GIT_INCLUDE_PATH} -I${git_directory}/{$last_commit}/ -a${repo}_commit=${last_commit} -a${repo}_branch=${git_branch}"
 }
 
 repositories=(${GIT_REPOSITORIES//:/ })


### PR DESCRIPTION
Add the name of the branch used into the workuning as an application option.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
