### PR TITLE
HPCC-15461 FTSlave incorrectly reports/logs chunk parameters at start of the transfer.

### DIFF
--- a/dali/ft/ftbase.cpp
+++ b/dali/ft/ftbase.cpp
@@ -573,7 +573,7 @@ MemoryBuffer & OutputProgress::deserializeExtra(MemoryBuffer & in, unsigned vers
 static const char * const statusText[] = {"Init","Active","Copied","Renamed"};
 void OutputProgress::trace()
 {
-    LOG(MCdebugInfoDetail, unknownJob, "[%d] %s  %" I64F "d[%x]->%" I64F "d[%x]", whichPartition, statusText[status], inputLength, inputCRC, outputLength, outputCRC);
+    LOG(MCdebugInfoDetail, unknownJob, "Chunk %d status: %s  input length: %" I64F "d[CRC:%x] -> output length:%" I64F "d[CRC:%x]", whichPartition, statusText[status], inputLength, inputCRC, outputLength, outputCRC);
 }
 
 MemoryBuffer & OutputProgress::serializeCore(MemoryBuffer & out)        

--- a/dali/ft/fttransform.cpp
+++ b/dali/ft/fttransform.cpp
@@ -669,7 +669,10 @@ void TransferServer::transferChunk(unsigned chunkIndex)
     PartitionPoint & curPartition = partition.item(chunkIndex);
     OutputProgress & curProgress = progress.item(chunkIndex);
 
-    LOG(MCdebugProgress, unknownJob, "Begin to transfer chunk %d: Start at length %" I64F "d", chunkIndex, curProgress.inputLength);
+    StringBuffer targetPath;
+    curPartition.outputName.getPath(targetPath);
+    LOG(MCdebugProgress, unknownJob, "Begin to transfer chunk %d (offset: %" I64F "d, size: %" I64F "d) to target:'%s' (offset: %" I64F "d, size: %" I64F "d) ",
+                        chunkIndex, curPartition.inputOffset, curPartition.inputLength, targetPath.str(), curPartition.outputOffset, curPartition.outputLength);
     const unsigned __int64 startOutOffset = out->tell();
     if (startOutOffset != curPartition.outputOffset+curProgress.outputLength)
         throwError4(DFTERR_OutputOffsetMismatch, out->tell(), curPartition.outputOffset+curProgress.outputLength, "start", chunkIndex);


### PR DESCRIPTION
Fix and improve progress report/log info

Signed-off-by: Attila Vamos attila.vamos@gmail.com
