### PR TITLE
HPCC-15467 Allow leaf and block node cache configuration

### DIFF
--- a/system/jhtree/jhtree.cpp
+++ b/system/jhtree/jhtree.cpp
@@ -1253,7 +1253,10 @@ void CKeyStore::clearCache(bool killAll)
     synchronized block(mutex);
 
     if (killAll)
+    {
+        clearNodeCache(); // no point in keeping old nodes cached if key store cache has been cleared
         keyIndexCache.kill();
+    }
     else
     {
         StringArray goers;

--- a/thorlcr/graph/thgraph.hpp
+++ b/thorlcr/graph/thgraph.hpp
@@ -765,7 +765,6 @@ protected:
     unsigned forceLogGraphIdMin, forceLogGraphIdMax;
     Owned<IContextLogger> logctx;
     Owned<IPerfMonHook> perfmonhook;
-    size32_t oldNodeCacheMem;
     CIArrayOf<CJobChannel> jobChannels;
     OwnedMalloc<unsigned> jobChannelSlaveNumbers;
     OwnedMalloc<unsigned> jobSlaveChannelNum;

--- a/thorlcr/thorutil/thbufdef.hpp
+++ b/thorlcr/thorutil/thbufdef.hpp
@@ -55,6 +55,10 @@
 #define LOOP_SMART_BUFFER_SIZE                  (0x100000*12)           // 12MB
 #define LOCALRESULT_BUFFER_SIZE                 (0x100000*10)           // 10MB
 
+#define DEFAULT_KEYNODECACHEMB                  10
+#define DEFAULT_KEYLEAFCACHEMB                  50
+#define DEFAULT_KEYBLOBCACHEMB                  0
+
 #define DISTRIBUTE_RESMEM(N) ((DISTRIBUTE_DEFAULT_OUT_BUFFER_SIZE * (N)) + DISTRIBUTE_DEFAULT_IN_BUFFER_SIZE)
 
 


### PR DESCRIPTION
And base on # of channels by default.
Also clear node cache if keystore cache is being cleared.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
