### PR TITLE
HPCC-14462 Fix subfile removal when only one file

### DIFF
--- a/esp/src/eclwatch/SFDetailsWidget.js
+++ b/esp/src/eclwatch/SFDetailsWidget.js
@@ -76,6 +76,7 @@ define([
             this.inherited(arguments);
             this.summaryWidget = registry.byId(this.id + "_Summary");
             this.deleteBtn = registry.byId(this.id + "Delete");
+            this.removeBtn = registry.byId(this.id + "Remove");
         },
 
         startup: function (args) {
@@ -87,6 +88,13 @@ define([
         _onRefresh: function (event) {
             this.logicalFile.refresh();
         },
+
+        _onSubFileRefresh: function (event) {
+            this.subfilesGrid.set("query", {
+                Name: "*"
+            });
+        },
+
         _onSave: function (event) {
             var context = this;
             this.logicalFile.save(dom.byId(context.id + "Description").value);
@@ -97,7 +105,10 @@ define([
             }
         },
         _onRemove: function (event) {
-            this.logicalFile.removeSubfiles(this.subfilesGrid.getSelected());
+            if (confirm(this.i18n.RemoveSubfiles2)) {
+                this.logicalFile.removeSubfiles(this.subfilesGrid.getSelected());
+                this._onSubFileRefresh();
+            }
         },
         _onOpen: function (event) {
             var selections = this.subfilesGrid.getSelected();
@@ -232,11 +243,13 @@ define([
             });
             this.subfilesGrid.on("dgrid-select", function (evt) {
                 context.deleteBtn.set("disabled", true);
+                context.removeBtn.set("disabled", false);
             });
             this.subfilesGrid.on("dgrid-deselect", function (evt) {
                 var selections = context.subfilesGrid.getSelected();
                 if (selections.length === 0) {
                     context.deleteBtn.set("disabled", false);
+                    context.removeBtn.set("disabled", true);
                 }
             });
             this.subfilesGrid.on(".dgrid-row:dblclick", function (evt) {

--- a/esp/src/eclwatch/nls/hpcc.js
+++ b/esp/src/eclwatch/nls/hpcc.js
@@ -422,6 +422,7 @@ define({root:
     RemoteDaliIP: "Remote Dali IP Address",
     Remove: "Remove",
     RemoveSubfiles: "Remove Subfile(s)",
+    RemoveSubfiles2: "Remove Subfile(s)?",
     RemoveUser: "You are about to remove yourself from the group:",
     Rename: "Rename",
     RenderedSVG: "Rendered SVG",

--- a/esp/src/eclwatch/templates/SFDetailsWidget.html
+++ b/esp/src/eclwatch/templates/SFDetailsWidget.html
@@ -30,7 +30,7 @@
                 <div style="width: 100%; height: 66%" data-dojo-props="region: 'bottom', splitter: true, minSize: 120" data-dojo-type="dijit.layout.BorderContainer">
                     <div class="topPanel" data-dojo-props="region: 'top'" data-dojo-type="dijit.Toolbar">
                         <div id="${id}Open" data-dojo-attach-event="onClick:_onOpen" data-dojo-type="dijit.form.Button">${i18n.Open}</div>
-                        <div id="${id}Remove" data-dojo-attach-event="onClick:_onRemove" data-dojo-type="dijit.form.Button">${i18n.Remove}</div>
+                        <div id="${id}Remove" data-dojo-attach-event="onClick:_onRemove" data-dojo-type="dijit.form.Button">${i18n.RemoveSubfiles}</div>
                         <span data-dojo-type="dijit.ToolbarSeparator"></span>
                     </div>
                     <div id="${id}SubfilesGridCP" style="padding: 0px; border:0px; border-color:none" data-dojo-props="region: 'center'" data-dojo-type="dijit.layout.ContentPane">


### PR DESCRIPTION
If in ECL Watch you open a superfile which contains a single subfile, check the box and click on remove then though the file is removed and the file size in the Summary area is updated, the sub-file is still shown. It remains even if 'Refresh' is clicked, or the file tab is closed and re-opened.

Signed-off by: Miguel Vazquez miguel.vazquez@lexisnexis.com
