### PR TITLE
HPCC-15489 Fix crash with child datasets and multiple channels

### DIFF
--- a/common/thorhelper/roxierow.cpp
+++ b/common/thorhelper/roxierow.cpp
@@ -386,9 +386,9 @@ IEngineRowAllocator * createCrcRoxieRowAllocator(IRowAllocatorMetaActIdCache * c
 struct AllocatorKey
 {
     IOutputMetaData *meta;
-    unsigned activityId;
+    unsigned __int64 activityId;
     roxiemem::RoxieHeapFlags flags;
-    AllocatorKey(IOutputMetaData *_meta, unsigned &_activityId, roxiemem::RoxieHeapFlags _flags)
+    AllocatorKey(IOutputMetaData *_meta, unsigned __int64 &_activityId, roxiemem::RoxieHeapFlags _flags)
         : meta(_meta), activityId(_activityId), flags(_flags)
     {
     }
@@ -420,7 +420,7 @@ class CAllocatorCache : public CSimpleInterfaceOf<IRowAllocatorMetaActIdCache>
     Owned<roxiemem::IRowManager> rowManager;
     IRowAllocatorMetaActIdCacheCallback *callback;
 
-    inline CAllocatorCacheItem *lookup(IOutputMetaData *meta, unsigned activityId, roxiemem::RoxieHeapFlags flags) const
+    inline CAllocatorCacheItem *lookup(IOutputMetaData *meta, unsigned __int64 activityId, roxiemem::RoxieHeapFlags flags) const
     {
         AllocatorKey key(meta, activityId, flags);
         return cache.find(key);
@@ -430,7 +430,7 @@ public:
     {
     }
 // IRowAllocatorMetaActIdCache
-    virtual IEngineRowAllocator *ensure(IOutputMetaData * meta, unsigned activityId, roxiemem::RoxieHeapFlags flags) override
+    virtual IEngineRowAllocator *ensure(IOutputMetaData * meta, unsigned __int64 activityId, roxiemem::RoxieHeapFlags flags) override
     {
         SpinBlock b(allAllocatorsLock);
         loop
@@ -442,7 +442,7 @@ public:
                     return LINK(&container->queryElement());
                 // if in cache but unique, reuse allocatorId
                 SpinUnblock b(allAllocatorsLock);
-                return callback->createAllocator(this, meta, activityId & ACTIVITY_MASK, container->queryAllocatorId(), flags);
+                return callback->createAllocator(this, meta, (unsigned)(activityId & ACTIVITY_MASK), container->queryAllocatorId(), flags);
             }
             // NB: a RHFunique allocator, will cause 1st to be added to 'allAllocators'
             // subsequent requests for the same type of unique allocator, will share same allocatorId
@@ -453,7 +453,7 @@ public:
             IEngineRowAllocator *ret;
             {
                 SpinUnblock b(allAllocatorsLock);
-                ret = callback->createAllocator(this, meta, activityId & ACTIVITY_MASK, allocatorId, flags);
+                ret = callback->createAllocator(this, meta, (unsigned)(activityId & ACTIVITY_MASK), allocatorId, flags);
                 assertex(ret);
             }
             if (allocatorId == allAllocators.ordinality())

--- a/common/thorhelper/roxierow.cpp
+++ b/common/thorhelper/roxierow.cpp
@@ -412,7 +412,7 @@ public:
     unsigned queryAllocatorId() const { return allocatorId; }
 };
 
-class CAllocatorCache : public CSimpleInterface, implements IRowAllocatorMetaActIdCache
+class CAllocatorCache : public CSimpleInterfaceOf<IRowAllocatorMetaActIdCache>
 {
     OwningSimpleHashTableOf<CAllocatorCacheItem, AllocatorKey> cache;
     IArrayOf<IEngineRowAllocator> allAllocators;
@@ -420,39 +420,29 @@ class CAllocatorCache : public CSimpleInterface, implements IRowAllocatorMetaAct
     Owned<roxiemem::IRowManager> rowManager;
     IRowAllocatorMetaActIdCacheCallback *callback;
 
-    inline CAllocatorCacheItem *_lookup(IOutputMetaData *meta, unsigned activityId, roxiemem::RoxieHeapFlags flags) const
+    inline CAllocatorCacheItem *lookup(IOutputMetaData *meta, unsigned activityId, roxiemem::RoxieHeapFlags flags) const
     {
         AllocatorKey key(meta, activityId, flags);
         return cache.find(key);
     }
 public:
-    IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
-
     CAllocatorCache(IRowAllocatorMetaActIdCacheCallback *_callback) : callback(_callback)
     {
     }
 // IRowAllocatorMetaActIdCache
-    inline IEngineRowAllocator *lookup(IOutputMetaData *meta, unsigned activityId, roxiemem::RoxieHeapFlags flags) const
-    {
-        SpinBlock b(allAllocatorsLock);
-        CAllocatorCacheItem *container = _lookup(meta, activityId, flags);
-        if (!container)
-            return NULL;
-        return &container->queryElement();
-    }
-    virtual IEngineRowAllocator *ensure(IOutputMetaData * meta, unsigned activityId, roxiemem::RoxieHeapFlags flags)
+    virtual IEngineRowAllocator *ensure(IOutputMetaData * meta, unsigned activityId, roxiemem::RoxieHeapFlags flags) override
     {
         SpinBlock b(allAllocatorsLock);
         loop
         {
-            CAllocatorCacheItem *container = _lookup(meta, activityId, flags);
+            CAllocatorCacheItem *container = lookup(meta, activityId, flags);
             if (container)
             {
                 if (0 == (roxiemem::RHFunique & flags))
                     return LINK(&container->queryElement());
                 // if in cache but unique, reuse allocatorId
                 SpinUnblock b(allAllocatorsLock);
-                return callback->createAllocator(this, meta, activityId, container->queryAllocatorId(), flags);
+                return callback->createAllocator(this, meta, activityId & ACTIVITY_MASK, container->queryAllocatorId(), flags);
             }
             // NB: a RHFunique allocator, will cause 1st to be added to 'allAllocators'
             // subsequent requests for the same type of unique allocator, will share same allocatorId
@@ -463,7 +453,7 @@ public:
             IEngineRowAllocator *ret;
             {
                 SpinUnblock b(allAllocatorsLock);
-                ret = callback->createAllocator(this, meta, activityId, allocatorId, flags);
+                ret = callback->createAllocator(this, meta, activityId & ACTIVITY_MASK, allocatorId, flags);
                 assertex(ret);
             }
             if (allocatorId == allAllocators.ordinality())

--- a/common/thorhelper/roxierow.hpp
+++ b/common/thorhelper/roxierow.hpp
@@ -25,7 +25,7 @@
 
 interface IRowAllocatorMetaActIdCache : extends roxiemem::IRowAllocatorCache
 {
-    virtual IEngineRowAllocator *ensure(IOutputMetaData * meta, unsigned activityId, roxiemem::RoxieHeapFlags flags) = 0;
+    virtual IEngineRowAllocator *ensure(IOutputMetaData * meta, unsigned __int64 activityId, roxiemem::RoxieHeapFlags flags) = 0;
     virtual unsigned items() const = 0;
 };
 

--- a/thorlcr/thorutil/thmem.cpp
+++ b/thorlcr/thorutil/thmem.cpp
@@ -2289,7 +2289,7 @@ protected:
     roxiemem::RoxieHeapFlags defaultFlags;
     IContextLogger *logctx;
     unsigned numChannels;
-    unsigned channelBits = 0;
+    unsigned __int64 channelBits = 0;
 
 public:
     IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
@@ -2323,8 +2323,7 @@ public:
         defaultFlags = sharedAllocator.queryFlags();
         logctx = sharedAllocator.queryLoggingContext();
         numChannels = 0;
-        dbgassertex(channel <= 0xffff);
-        channelBits = (channel+1) << (8*3); // channel bits occupt top byte;
+        channelBits = ((unsigned __int64)(channel+1)) << 32; // channel bits occupy top 4 bytes;
     }
     ~CThorAllocator()
     {
@@ -2340,11 +2339,11 @@ public:
 // IThorAllocator
     virtual IEngineRowAllocator *getRowAllocator(IOutputMetaData * meta, activity_id activityId, roxiemem::RoxieHeapFlags flags) const
     {
-        return allocatorMetaCache->ensure(meta, activityId | channelBits, flags);
+        return allocatorMetaCache->ensure(meta, ((unsigned __int64)activityId) | channelBits, flags);
     }
     virtual IEngineRowAllocator *getRowAllocator(IOutputMetaData * meta, activity_id activityId) const
     {
-        return allocatorMetaCache->ensure(meta, activityId | channelBits, defaultFlags);
+        return allocatorMetaCache->ensure(meta, ((unsigned __int64)activityId) | channelBits, defaultFlags);
     }
     virtual roxiemem::IRowManager *queryRowManager() const
     {


### PR DESCRIPTION
With multiple thor slave channels configured, an assert in
roximeme allocator caching would be hit (in debug) because the
channels allocators had their own cache, but the slave row
managers were not using them.

Fix by unifying to single cache and augmenting activity id with
channel id in the cache key.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
