### PR TITLE
HPCC-15490 MADV_HUGEPAGE define missing from CentOS build

### DIFF
--- a/roxie/roxiemem/roxiemem.cpp
+++ b/roxie/roxiemem/roxiemem.cpp
@@ -30,6 +30,10 @@
 
 #ifndef _WIN32
 #include <sys/mman.h>
+# if defined(__linux__)
+   // MADV_HUGEPAGE on CentOS
+#  include <linux/mman.h>
+# endif
 #endif
 
 #if defined(_USE_TBB)


### PR DESCRIPTION
@ghalliday, @xwang2713 please review

Signed-off-by: Mark Kelly mark.kelly@lexisnexis.com
