### PR TITLE
HPCC-15487 Fileservices functions not threadsafe if ESP URL not supplied

### DIFF
--- a/plugins/fileservices/fileservices.cpp
+++ b/plugins/fileservices/fileservices.cpp
@@ -263,7 +263,7 @@ StringBuffer & constructLogicalName(IConstWorkUnit * wu, const char * partialLog
 
     if (*partialLogicalName == '~')
         ++partialLogicalName;
-    else
+    else if (wu)
     {
         StringBuffer prefix;
         wu->getScope(StringBufferAdaptor(prefix));
@@ -887,7 +887,8 @@ FILESERVICES_API char * FILESERVICES_CALL fsfDespray(ICodeContext *ctx, const ch
     CClientFileSpray server;
     Owned<IConstWorkUnit> wu = getWorkunit(ctx);
     server.addServiceUrl(getEspServerURL(espServerIpPort));
-    setServerAccess(server, wu);
+    if (wu)
+        setServerAccess(server, wu);
 
     Owned<IClientDespray> req = server.createDesprayRequest();
     StringBuffer logicalName;

--- a/plugins/fileservices/fileservices.cpp
+++ b/plugins/fileservices/fileservices.cpp
@@ -198,14 +198,17 @@ static IPropertyTree *getEnvironmentTree(IConstEnvironment * daliEnv)
     return getHPCCEnvironment();
 }
 
+static StringAttr espurl;           // Default ESP url if none specified
+static CriticalSection espURLcrit;
+
 static const char *getEspServerURL(const char *param)
 {
     if (param&&*param)
         return param;
 
-    //MORE: Not thread safe, although not very likely to cause problems.
-    static StringAttr espurl;
-    if (espurl.isEmpty()) {
+    CriticalBlock b(espURLcrit);
+    if (espurl.isEmpty())
+    {
         Owned<IConstEnvironment> daliEnv = openDaliEnvironment();
         Owned<IPropertyTree> env = getEnvironmentTree(daliEnv);
         StringBuffer tmp;


### PR DESCRIPTION
This can affect Roxie in particular where sinks are executed in parallel.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
