### PR TITLE
HPCC-15482 Implement read/write locks in permission cache

### DIFF
--- a/initfiles/componentfiles/configxml/ldapserver.xsd
+++ b/initfiles/componentfiles/configxml/ldapserver.xsd
@@ -169,6 +169,13 @@
                     </xs:appinfo>
                 </xs:annotation>
             </xs:attribute>
+            <xs:attribute name="sharedCache" type="xs:boolean" use="optional" default="true">
+                <xs:annotation>
+                    <xs:appinfo>
+                        <tooltip>Use a single, shared LDAP cache.</tooltip>
+                    </xs:appinfo>
+                </xs:annotation>
+            </xs:attribute>
             <xs:attribute name="systemUser" type="xs:string" use="optional">
                 <xs:annotation>
                     <xs:appinfo>

--- a/initfiles/componentfiles/configxml/ldapserver.xsl
+++ b/initfiles/componentfiles/configxml/ldapserver.xsl
@@ -37,5 +37,6 @@
  systemBasedn="<xsl:value-of select="@systemBasedn"/>"
  usersBasedn="<xsl:value-of select="@usersBasedn"/>"
  workunitsBasedn="<xsl:value-of select="@workunitsBasedn"/>"
+ sharedCache="<xsl:value-of select="@sharedCache"/>"
    </xsl:template>
 </xsl:stylesheet>

--- a/system/security/LdapSecurity/ldapsecurity.cpp
+++ b/system/security/LdapSecurity/ldapsecurity.cpp
@@ -534,9 +534,15 @@ void CLdapSecManager::init(const char *serviceName, IPropertyTree* cfg)
     m_ldap_client.setown(ldap_client);
     m_pp.setown(pp);
     int cachetimeout = cfg->getPropInt("@cacheTimeout", 5);
-    m_permissionsCache.setCacheTimeout( 60 * cachetimeout);
-    m_permissionsCache.setTransactionalEnabled(true);
-    m_permissionsCache.setSecManager(this);
+
+    if (cfg->getPropBool("@sharedCache", true))
+        m_permissionsCache = CPermissionsCache::queryInstance();
+    else
+        m_permissionsCache = new CPermissionsCache();
+
+    m_permissionsCache->setCacheTimeout( 60 * cachetimeout);
+    m_permissionsCache->setTransactionalEnabled(true);
+    m_permissionsCache->setSecManager(this);
     m_passwordExpirationWarningDays = cfg->getPropInt(".//@passwordExpirationWarningDays", 10); //Default to 10 days
 };
 
@@ -548,6 +554,8 @@ CLdapSecManager::CLdapSecManager(const char *serviceName, IPropertyTree &config)
 
 CLdapSecManager::~CLdapSecManager()
 {
+    if (!m_cfg->getPropBool("@sharedCache", true))
+        delete m_permissionsCache;
 }
 
 //interface ISecManager : extends IInterface
@@ -584,7 +592,7 @@ bool CLdapSecManager::authenticate(ISecUser* user)
     if(user->getAuthenticateStatus() == AS_AUTHENTICATED)
         return true;
 
-    if(m_permissionsCache.isCacheEnabled() && !m_usercache_off && m_permissionsCache.lookup(*user))
+    if(m_permissionsCache->isCacheEnabled() && !m_usercache_off && m_permissionsCache->lookup(*user))
     {
         user->setAuthenticateStatus(AS_AUTHENTICATED);
         return true;
@@ -593,8 +601,8 @@ bool CLdapSecManager::authenticate(ISecUser* user)
     bool ok = m_ldap_client->authenticate(*user);
     if(ok)
     {
-        if(m_permissionsCache.isCacheEnabled() && !m_usercache_off)
-            m_permissionsCache.add(*user);
+        if(m_permissionsCache->isCacheEnabled() && !m_usercache_off)
+            m_permissionsCache->add(*user);
 
         user->setAuthenticateStatus(AS_AUTHENTICATED);
     }
@@ -628,10 +636,10 @@ bool CLdapSecManager::authorizeEx(SecResourceType rtype, ISecUser& sec_user, ISe
     bool rc;
 
     time_t tctime = getThreadCreateTime();
-    if ((m_permissionsCache.isCacheEnabled() || (m_permissionsCache.isTransactionalEnabled() && tctime > 0)) && (!m_cache_off[rtype]))
+    if ((m_permissionsCache->isCacheEnabled() || (m_permissionsCache->isTransactionalEnabled() && tctime > 0)) && (!m_cache_off[rtype]))
     {
         bool* cached_found = (bool*)alloca(nResources*sizeof(bool));
-        int nFound = m_permissionsCache.lookup(sec_user, rlist, cached_found);
+        int nFound = m_permissionsCache->lookup(sec_user, rlist, cached_found);
         if (nFound < nResources)
         {
             IArrayOf<ISecResource> rlist2;
@@ -649,7 +657,7 @@ bool CLdapSecManager::authorizeEx(SecResourceType rtype, ISecUser& sec_user, ISe
 
             rc = m_ldap_client->authorize(rtype, sec_user, rlist2);
             if (rc)
-                m_permissionsCache.add(sec_user, rlist2);
+                m_permissionsCache->add(sec_user, rlist2);
         }
         else
             rc = true;  
@@ -703,10 +711,10 @@ bool CLdapSecManager::authorizeEx(SecResourceType rtype, ISecUser& sec_user, ISe
     bool rc;
 
     time_t tctime = getThreadCreateTime();
-    if ((m_permissionsCache.isCacheEnabled() || (m_permissionsCache.isTransactionalEnabled() && tctime > 0)) && (!m_cache_off[rtype]))
+    if ((m_permissionsCache->isCacheEnabled() || (m_permissionsCache->isTransactionalEnabled() && tctime > 0)) && (!m_cache_off[rtype]))
     {
         bool* cached_found = (bool*)alloca(nResources*sizeof(bool));
-        int nFound = m_permissionsCache.lookup(sec_user, rlist, cached_found);
+        int nFound = m_permissionsCache->lookup(sec_user, rlist, cached_found);
         if (nFound < nResources)
         {
             IArrayOf<ISecResource> rlist2;
@@ -724,7 +732,7 @@ bool CLdapSecManager::authorizeEx(SecResourceType rtype, ISecUser& sec_user, ISe
 
             rc = m_ldap_client->authorize(rtype, sec_user, rlist2);
             if (rc)
-                m_permissionsCache.add(sec_user, rlist2);
+                m_permissionsCache->add(sec_user, rlist2);
         }
         else
             rc = true;  
@@ -780,10 +788,10 @@ int CLdapSecManager::getAccessFlagsEx(SecResourceType rtype, ISecUser & user, co
     bool ok = false;
 
     time_t tctime = getThreadCreateTime();
-    if ((m_permissionsCache.isCacheEnabled() || (m_permissionsCache.isTransactionalEnabled() && tctime > 0)) && (!m_cache_off[rtype]))
+    if ((m_permissionsCache->isCacheEnabled() || (m_permissionsCache->isTransactionalEnabled() && tctime > 0)) && (!m_cache_off[rtype]))
     {
         bool* cached_found = (bool*)alloca(nResources*sizeof(bool));
-        int nFound = m_permissionsCache.lookup(user, rlist, cached_found);
+        int nFound = m_permissionsCache->lookup(user, rlist, cached_found);
         if (nFound < nResources)
         {
             IArrayOf<ISecResource> rlist2;
@@ -801,7 +809,7 @@ int CLdapSecManager::getAccessFlagsEx(SecResourceType rtype, ISecUser & user, co
 
             ok = m_ldap_client->authorize(rtype, user, rlist2);
             if (ok)
-                m_permissionsCache.add(user, rlist2);
+                m_permissionsCache->add(user, rlist2);
         }
         else
             ok = true;  
@@ -830,14 +838,14 @@ int CLdapSecManager::authorizeFileScope(ISecUser & user, const char * filescope)
         return SecAccess_Full;
 
     StringBuffer managedFilescope;
-    if(m_permissionsCache.isCacheEnabled() && !m_usercache_off)
+    if(m_permissionsCache->isCacheEnabled() && !m_usercache_off)
     {
         int accessFlags;
         //See if file scope in question is managed by LDAP permissions.
         //  If not, return default file permission (dont call out to LDAP)
         //  If is, look in cache for permission of longest matching managed scope strings. If found return that permission (no call to LDAP),
         //  otherwise a call to LDAP "authorizeFileScope" is necessary, specifying the longest matching managed scope string
-        bool gotPerms = m_permissionsCache.queryPermsManagedFileScope(user, filescope, managedFilescope, &accessFlags);
+        bool gotPerms = m_permissionsCache->queryPermsManagedFileScope(user, filescope, managedFilescope, &accessFlags);
         if (gotPerms)
             return accessFlags;
     }
@@ -1114,9 +1122,9 @@ bool CLdapSecManager::updateUserPassword(ISecUser& user, const char* newPassword
 
     //Update password if authenticated
     bool ok = m_ldap_client->updateUserPassword(user, newPassword, currPassword);
-    if(ok && m_permissionsCache.isCacheEnabled() && !m_usercache_off)
+    if(ok && m_permissionsCache->isCacheEnabled() && !m_usercache_off)
     {
-        m_permissionsCache.removeFromUserCache(user);
+        m_permissionsCache->removeFromUserCache(user);
     }
     return ok;
 }
@@ -1124,8 +1132,8 @@ bool CLdapSecManager::updateUserPassword(ISecUser& user, const char* newPassword
 bool CLdapSecManager::updateUser(const char* type, ISecUser& user)
 {
     bool ok = m_ldap_client->updateUser(type, user);
-    if(ok && m_permissionsCache.isCacheEnabled() && !m_usercache_off)
-        m_permissionsCache.removeFromUserCache(user);
+    if(ok && m_permissionsCache->isCacheEnabled() && !m_usercache_off)
+        m_permissionsCache->removeFromUserCache(user);
 
     return ok;
 }
@@ -1197,8 +1205,8 @@ void CLdapSecManager::deleteResource(SecResourceType rtype, const char * name, c
     m_ldap_client->deleteResource(rtype, name, basedn);
 
     time_t tctime = getThreadCreateTime();
-    if ((m_permissionsCache.isCacheEnabled() || (m_permissionsCache.isTransactionalEnabled() && tctime > 0)) && (!m_cache_off[rtype]))
-        m_permissionsCache.remove(rtype, name);
+    if ((m_permissionsCache->isCacheEnabled() || (m_permissionsCache->isTransactionalEnabled() && tctime > 0)) && (!m_cache_off[rtype]))
+        m_permissionsCache->remove(rtype, name);
 }
 
 void CLdapSecManager::renameResource(SecResourceType rtype, const char * oldname, const char * newname, const char * basedn)
@@ -1206,8 +1214,8 @@ void CLdapSecManager::renameResource(SecResourceType rtype, const char * oldname
     m_ldap_client->renameResource(rtype, oldname, newname, basedn);
 
     time_t tctime = getThreadCreateTime();
-    if ((m_permissionsCache.isCacheEnabled() || (m_permissionsCache.isTransactionalEnabled() && tctime > 0)) && (!m_cache_off[rtype]))
-        m_permissionsCache.remove(rtype, oldname);
+    if ((m_permissionsCache->isCacheEnabled() || (m_permissionsCache->isTransactionalEnabled() && tctime > 0)) && (!m_cache_off[rtype]))
+        m_permissionsCache->remove(rtype, oldname);
 }
 
 void CLdapSecManager::copyResource(SecResourceType rtype, const char * oldname, const char * newname, const char * basedn)
@@ -1285,7 +1293,7 @@ int CLdapSecManager::queryDefaultPermission(ISecUser& user)
 
 bool CLdapSecManager::clearPermissionsCache(ISecUser& user)
 {
-    if(m_permissionsCache.isCacheEnabled())
+    if(m_permissionsCache->isCacheEnabled())
     {
         if (!authenticate(&user))
         {
@@ -1297,7 +1305,7 @@ bool CLdapSecManager::clearPermissionsCache(ISecUser& user)
             PROGLOG("User %s denied, only a superuser can clear permissions cache", user.getName());
             return false;
         }
-        m_permissionsCache.flush();
+        m_permissionsCache->flush();
     }
     return true;
 }

--- a/system/security/LdapSecurity/ldapsecurity.ipp
+++ b/system/security/LdapSecurity/ldapsecurity.ipp
@@ -335,7 +335,7 @@ private:
     IUserArray m_user_array;
     Monitor m_monitor;
     Owned<IProperties> m_extraparams;
-    CPermissionsCache m_permissionsCache;
+    CPermissionsCache * m_permissionsCache;
     bool m_cache_off[RT_SCOPE_MAX];
     bool m_usercache_off;
     bool authenticate(ISecUser* user);

--- a/system/security/shared/caching.cpp
+++ b/system/security/shared/caching.cpp
@@ -74,7 +74,7 @@ int CResPermissionsCache::lookup( IArrayOf<ISecResource>& resources, bool* pFoun
             continue;
         }
 #ifdef _DEBUG
-        DBGLOG("CACHE: Looking up resource(%d) %s:%s", i, m_user.c_str(), resource);
+        DBGLOG("CACHE: CResPermissionsCache Looking up resource(%d of %d) %s:%s", i, nresources, m_user.c_str(), resource);
 #endif
         MapResAccess::iterator it = m_resAccessMap.find(SecCacheKeyEntry(resource, secResource.getResourceType()));
         if (it != m_resAccessMap.end())//exists in cache
@@ -95,7 +95,7 @@ int CResPermissionsCache::lookup( IArrayOf<ISecResource>& resources, bool* pFoun
                 {
                     secResource.copy(resParamCacheEntry.second);
 #ifdef _DEBUG
-                    DBGLOG("CACHE: FoundA %s:%s=>%d", m_user.c_str(), resource, ((ISecResource*)resParamCacheEntry.second)->getAccessFlags());
+                    DBGLOG("CACHE: CResPermissionsCache FoundA %s:%s=>%d", m_user.c_str(), resource, ((ISecResource*)resParamCacheEntry.second)->getAccessFlags());
 #endif
                     *pFound++ = true;
                     nFound++;
@@ -105,7 +105,7 @@ int CResPermissionsCache::lookup( IArrayOf<ISecResource>& resources, bool* pFoun
             {
                 secResource.copy(resParamCacheEntry.second);
 #ifdef _DEBUG
-                DBGLOG("CACHE: FoundB %s:%s=>%d", m_user.c_str(), resource, ((ISecResource*)resParamCacheEntry.second)->getAccessFlags());
+                DBGLOG("CACHE: CResPermissionsCache FoundB %s:%s=>%d", m_user.c_str(), resource, ((ISecResource*)resParamCacheEntry.second)->getAccessFlags());
 #endif
                 *pFound++ = true;
                 nFound++;
@@ -161,7 +161,7 @@ void CResPermissionsCache::add( IArrayOf<ISecResource>& resources )
             m_resAccessMap.erase(SecCacheKeyEntry(resource, resourcetype));
         }
 #ifdef _DEBUG
-        DBGLOG("CACHE: Adding %s:%s(%d)", m_user.c_str(), resource, permissions);
+        DBGLOG("CACHE: CResPermissionsCache Adding %s:%s(%d)", m_user.c_str(), resource, permissions);
 #endif
         m_resAccessMap.insert( pair<SecCacheKeyEntry, ResPermCacheEntry>(SecCacheKeyEntry(resource, resourcetype),  ResPermCacheEntry(tstamp, secResource->clone())));
         m_timestampMap.insert( pair<time_t, SecCacheKeyEntry>(tstamp, SecCacheKeyEntry(resource, resourcetype)));
@@ -216,11 +216,10 @@ CPermissionsCache::~CPermissionsCache()
 int CPermissionsCache::lookup( ISecUser& sec_user, IArrayOf<ISecResource>& resources, 
                             bool* pFound)
 {
-    synchronized block(m_cachemonitor);
     const char* userId = sec_user.getName();
     int nFound;
+    ReadLockBlock b(m_resPermCacheRWLock);
     MapResPermissionsCache::const_iterator i = m_resPermissionsMap.find( userId ); 
-
     if (i != m_resPermissionsMap.end())
     {
         CResPermissionsCache* pResPermissionsCache = (*i).second;
@@ -233,7 +232,7 @@ int CPermissionsCache::lookup( ISecUser& sec_user, IArrayOf<ISecResource>& resou
     }
 
 #ifdef _DEBUG
-    DBGLOG("CACHE: Looking up resources for %s:*, found %d matches", userId, nFound);
+    DBGLOG("CACHE: CPermissionsCache Looked up resources for %s:*, found %d of %d matches", userId, nFound, resources.ordinality());
 #endif
     return nFound;
 }
@@ -242,39 +241,46 @@ int CPermissionsCache::lookup( ISecUser& sec_user, IArrayOf<ISecResource>& resou
 
 void CPermissionsCache::add( ISecUser& sec_user, IArrayOf<ISecResource>& resources )
 {
-    synchronized block(m_cachemonitor);
     const char* user = sec_user.getName();
+    WriteLockBlock b(m_resPermCacheRWLock);
     MapResPermissionsCache::const_iterator i = m_resPermissionsMap.find( user ); 
     CResPermissionsCache* pResPermissionsCache;
 
     if (i == m_resPermissionsMap.end())
     {
 #ifdef _DEBUG
-        DBGLOG("CACHE: Adding resources to cache for %s", user);
+        DBGLOG("CACHE: CPermissionsCache Adding resources to cache for new user %s", user);
 #endif
         pResPermissionsCache = new CResPermissionsCache(this, user);
         m_resPermissionsMap.insert(pair<string, CResPermissionsCache*>(user, pResPermissionsCache));
     }
     else
+    {
+#ifdef _DEBUG
+        DBGLOG("CACHE: CPermissionsCache Adding resources to cache for existing user %s", user);
+#endif
         pResPermissionsCache = (*i).second;
-
+    }
     pResPermissionsCache->add( resources );
 }
 
 void CPermissionsCache::removePermissions( ISecUser& sec_user)
 {
-    synchronized block(m_cachemonitor);
     const char* user = sec_user.getName();
     if(user != NULL && *user != '\0')
     {
+#ifdef _DEBUG
+        DBGLOG("CACHE: CPermissionsCache Removing permissions for user %s", user);
+#endif
+        WriteLockBlock b(m_resPermCacheRWLock);
         m_resPermissionsMap.erase(user); 
     }
 }
 
 void CPermissionsCache::remove(SecResourceType rtype, const char* resourcename)
 {
-    synchronized block(m_cachemonitor);
     MapResPermissionsCache::const_iterator i;
+    WriteLockBlock b(m_resPermCacheRWLock);
     MapResPermissionsCache::const_iterator iEnd = m_resPermissionsMap.end(); 
 
     for (i = m_resPermissionsMap.begin(); i != iEnd; i++)
@@ -293,9 +299,9 @@ bool CPermissionsCache::lookup(ISecUser& sec_user)
     if(!username || !*username)
         return false;
 
-    synchronized block(m_userCacheMonitor); 
-
     string key(username);
+    ReadLockBlock b(m_userCacheRWLock );
+
     MapUserCache::iterator it = m_userCache.find(key);
     if (it == m_userCache.end())
         return false;
@@ -319,6 +325,9 @@ bool CPermissionsCache::lookup(ISecUser& sec_user)
         md5_string(pw, md5pbuf);
         if(strcmp(cachedpw, md5pbuf.str()) == 0)
         {
+#ifdef _DEBUG
+            DBGLOG("CACHE: CPermissionsCache Found validated user %s", username);
+#endif
             // Copy cached user to the sec_user structure, but still keep the original clear text password.
             user->queryUser()->copyTo(sec_user);
             sec_user.credentials().setPassword(pw.str());
@@ -334,6 +343,7 @@ bool CPermissionsCache::lookup(ISecUser& sec_user)
 
     return false;
 }
+
 ISecUser* CPermissionsCache::getCachedUser( ISecUser& sec_user)
 {
     if(!isCacheEnabled())
@@ -343,15 +353,15 @@ ISecUser* CPermissionsCache::getCachedUser( ISecUser& sec_user)
     if(!username || !*username)
         return NULL;
 
-    synchronized block(m_userCacheMonitor); 
-
     string key(username);
+    ReadLockBlock b(m_userCacheRWLock );
     MapUserCache::iterator it = m_userCache.find(key);
     if (it == m_userCache.end())
         return NULL;
     CachedUser* user = (CachedUser*)(it->second);
     return LINK(user->queryUser());
 }
+
 void CPermissionsCache::add(ISecUser& sec_user)
 {
     if(!isCacheEnabled())
@@ -361,8 +371,8 @@ void CPermissionsCache::add(ISecUser& sec_user)
     if(!username || !*username)
         return;
     
-    synchronized block(m_userCacheMonitor);     
     string key(username);
+    WriteLockBlock b(m_userCacheRWLock );
     MapUserCache::iterator it = m_userCache.find(key);
     CachedUser* user = NULL;
     if (it != m_userCache.end())
@@ -371,6 +381,9 @@ void CPermissionsCache::add(ISecUser& sec_user)
         m_userCache.erase(username);
         delete user;
     }
+#ifdef _DEBUG
+    DBGLOG("CACHE: CPermissionsCache Adding cached user %s", username);
+#endif
     m_userCache[username] = new CachedUser(sec_user.clone());
 }
 
@@ -379,21 +392,24 @@ void CPermissionsCache::removeFromUserCache(ISecUser& sec_user)
     const char* username = sec_user.getName();
     if(username && *username)
     {
-        synchronized block(m_userCacheMonitor);
         string key(username);
+        WriteLockBlock b(m_userCacheRWLock );
         MapUserCache::iterator it = m_userCache.find(key);
         if (it != m_userCache.end())
         {
             CachedUser* user = (CachedUser*)(it->second);
             m_userCache.erase(username);
             delete user;
+#ifdef _DEBUG
+            DBGLOG("CACHE: CPermissionsCache Removing cached user %s", username);
+#endif
         }
     }
 }
 
 bool CPermissionsCache::addManagedFileScopes(IArrayOf<ISecResource>& scopes)
 {
-    synchronized block(m_managedFileScopesCacheMonitor);
+    WriteLockBlock readBlock(m_scopesRWLock);
     ForEachItemIn(x, scopes)
     {
         ISecResource* scope = &scopes.item(x);
@@ -419,7 +435,7 @@ bool CPermissionsCache::addManagedFileScopes(IArrayOf<ISecResource>& scopes)
 
 inline void CPermissionsCache::removeManagedFileScopes(IArrayOf<ISecResource>& scopes)
 {
-    synchronized block(m_managedFileScopesCacheMonitor);
+    WriteLockBlock readBlock(m_scopesRWLock);
     ForEachItemIn(x, scopes)
     {
         ISecResource* scope = &scopes.item(x);
@@ -440,7 +456,7 @@ inline void CPermissionsCache::removeManagedFileScopes(IArrayOf<ISecResource>& s
 
 inline void CPermissionsCache::removeAllManagedFileScopes()
 {
-    synchronized block(m_managedFileScopesCacheMonitor);
+    WriteLockBlock readBlock(m_scopesRWLock);
     map<string, ISecResource*>::const_iterator cit;
     map<string, ISecResource*>::const_iterator iEnd = m_managedFileScopesMap.end();
 
@@ -508,7 +524,7 @@ bool CPermissionsCache::queryPermsManagedFileScope(ISecUser& sec_user, const cha
         }
         scopes.append(scope.str());
     }
-    synchronized block(m_managedFileScopesCacheMonitor);
+    ReadLockBlock readBlock(m_scopesRWLock);
     ISecResource *matchedRes = NULL;
     ISecResource *res = NULL;
     bool isManaged = false;
@@ -591,7 +607,7 @@ int CPermissionsCache::queryDefaultPermission(ISecUser& user)
 void CPermissionsCache::flush()
 {
     {
-        synchronized block(m_cachemonitor);
+        WriteLockBlock b(m_resPermCacheRWLock);
         MapResPermissionsCache::const_iterator i;
         MapResPermissionsCache::const_iterator iEnd = m_resPermissionsMap.end();
         for (i = m_resPermissionsMap.begin(); i != iEnd; i++)
@@ -599,7 +615,7 @@ void CPermissionsCache::flush()
         m_resPermissionsMap.clear();
     }
     {
-        synchronized block(m_userCacheMonitor);
+        WriteLockBlock b(m_userCacheRWLock );
         MapUserCache::const_iterator ui;
         MapUserCache::const_iterator uiEnd = m_userCache.end();
         for (ui = m_userCache.begin(); ui != uiEnd; ui++)

--- a/system/security/shared/caching.cpp
+++ b/system/security/shared/caching.cpp
@@ -218,7 +218,7 @@ int CPermissionsCache::lookup( ISecUser& sec_user, IArrayOf<ISecResource>& resou
 {
     const char* userId = sec_user.getName();
     int nFound;
-    ReadLockBlock b(m_resPermCacheRWLock);
+    ReadLockBlock readLock(m_resPermCacheRWLock);
     MapResPermissionsCache::const_iterator i = m_resPermissionsMap.find( userId ); 
     if (i != m_resPermissionsMap.end())
     {
@@ -242,7 +242,7 @@ int CPermissionsCache::lookup( ISecUser& sec_user, IArrayOf<ISecResource>& resou
 void CPermissionsCache::add( ISecUser& sec_user, IArrayOf<ISecResource>& resources )
 {
     const char* user = sec_user.getName();
-    WriteLockBlock b(m_resPermCacheRWLock);
+    WriteLockBlock writeLock(m_resPermCacheRWLock);
     MapResPermissionsCache::const_iterator i = m_resPermissionsMap.find( user ); 
     CResPermissionsCache* pResPermissionsCache;
 
@@ -272,7 +272,7 @@ void CPermissionsCache::removePermissions( ISecUser& sec_user)
 #ifdef _DEBUG
         DBGLOG("CACHE: CPermissionsCache Removing permissions for user %s", user);
 #endif
-        WriteLockBlock b(m_resPermCacheRWLock);
+        WriteLockBlock writeLock(m_resPermCacheRWLock);
         m_resPermissionsMap.erase(user); 
     }
 }
@@ -280,7 +280,7 @@ void CPermissionsCache::removePermissions( ISecUser& sec_user)
 void CPermissionsCache::remove(SecResourceType rtype, const char* resourcename)
 {
     MapResPermissionsCache::const_iterator i;
-    WriteLockBlock b(m_resPermCacheRWLock);
+    WriteLockBlock writeLock(m_resPermCacheRWLock);
     MapResPermissionsCache::const_iterator iEnd = m_resPermissionsMap.end(); 
 
     for (i = m_resPermissionsMap.begin(); i != iEnd; i++)
@@ -300,7 +300,7 @@ bool CPermissionsCache::lookup(ISecUser& sec_user)
         return false;
 
     string key(username);
-    ReadLockBlock b(m_userCacheRWLock );
+    ReadLockBlock readLock(m_userCacheRWLock );
 
     MapUserCache::iterator it = m_userCache.find(key);
     if (it == m_userCache.end())
@@ -354,7 +354,7 @@ ISecUser* CPermissionsCache::getCachedUser( ISecUser& sec_user)
         return NULL;
 
     string key(username);
-    ReadLockBlock b(m_userCacheRWLock );
+    ReadLockBlock readLock(m_userCacheRWLock );
     MapUserCache::iterator it = m_userCache.find(key);
     if (it == m_userCache.end())
         return NULL;
@@ -372,7 +372,7 @@ void CPermissionsCache::add(ISecUser& sec_user)
         return;
     
     string key(username);
-    WriteLockBlock b(m_userCacheRWLock );
+    WriteLockBlock writeLock(m_userCacheRWLock );
     MapUserCache::iterator it = m_userCache.find(key);
     CachedUser* user = NULL;
     if (it != m_userCache.end())
@@ -393,7 +393,7 @@ void CPermissionsCache::removeFromUserCache(ISecUser& sec_user)
     if(username && *username)
     {
         string key(username);
-        WriteLockBlock b(m_userCacheRWLock );
+        WriteLockBlock writeLock(m_userCacheRWLock );
         MapUserCache::iterator it = m_userCache.find(key);
         if (it != m_userCache.end())
         {
@@ -409,7 +409,7 @@ void CPermissionsCache::removeFromUserCache(ISecUser& sec_user)
 
 bool CPermissionsCache::addManagedFileScopes(IArrayOf<ISecResource>& scopes)
 {
-    WriteLockBlock readBlock(m_scopesRWLock);
+    WriteLockBlock writeLock(m_scopesRWLock);
     ForEachItemIn(x, scopes)
     {
         ISecResource* scope = &scopes.item(x);
@@ -435,7 +435,7 @@ bool CPermissionsCache::addManagedFileScopes(IArrayOf<ISecResource>& scopes)
 
 inline void CPermissionsCache::removeManagedFileScopes(IArrayOf<ISecResource>& scopes)
 {
-    WriteLockBlock readBlock(m_scopesRWLock);
+    WriteLockBlock writeLock(m_scopesRWLock);
     ForEachItemIn(x, scopes)
     {
         ISecResource* scope = &scopes.item(x);
@@ -456,7 +456,7 @@ inline void CPermissionsCache::removeManagedFileScopes(IArrayOf<ISecResource>& s
 
 inline void CPermissionsCache::removeAllManagedFileScopes()
 {
-    WriteLockBlock readBlock(m_scopesRWLock);
+    WriteLockBlock writeLock(m_scopesRWLock);
     map<string, ISecResource*>::const_iterator cit;
     map<string, ISecResource*>::const_iterator iEnd = m_managedFileScopesMap.end();
 
@@ -524,11 +524,11 @@ bool CPermissionsCache::queryPermsManagedFileScope(ISecUser& sec_user, const cha
         }
         scopes.append(scope.str());
     }
-    ReadLockBlock readBlock(m_scopesRWLock);
+
     ISecResource *matchedRes = NULL;
     ISecResource *res = NULL;
     bool isManaged = false;
-
+    ReadLockBlock readLock(m_scopesRWLock);
     for(unsigned i = 0; i < scopes.length(); i++)
     {
         const char* scope = scopes.item(i);
@@ -607,7 +607,7 @@ int CPermissionsCache::queryDefaultPermission(ISecUser& user)
 void CPermissionsCache::flush()
 {
     {
-        WriteLockBlock b(m_resPermCacheRWLock);
+        WriteLockBlock writeLock(m_resPermCacheRWLock);
         MapResPermissionsCache::const_iterator i;
         MapResPermissionsCache::const_iterator iEnd = m_resPermissionsMap.end();
         for (i = m_resPermissionsMap.begin(); i != iEnd; i++)
@@ -615,7 +615,7 @@ void CPermissionsCache::flush()
         m_resPermissionsMap.clear();
     }
     {
-        WriteLockBlock b(m_userCacheRWLock );
+        WriteLockBlock writeLock(m_userCacheRWLock );
         MapUserCache::const_iterator ui;
         MapUserCache::const_iterator uiEnd = m_userCache.end();
         for (ui = m_userCache.begin(); ui != uiEnd; ui++)

--- a/system/security/shared/caching.cpp
+++ b/system/security/shared/caching.cpp
@@ -73,8 +73,9 @@ int CResPermissionsCache::lookup( IArrayOf<ISecResource>& resources, bool* pFoun
             *pFound++ = false;
             continue;
         }
-        //DBGLOG("CACHE: Looking up %s:%s", m_user.c_str(), resource);
-
+#ifdef _DEBUG
+        DBGLOG("CACHE: Looking up resource(%d) %s:%s", i, m_user.c_str(), resource);
+#endif
         MapResAccess::iterator it = m_resAccessMap.find(SecCacheKeyEntry(resource, secResource.getResourceType()));
         if (it != m_resAccessMap.end())//exists in cache
         {
@@ -93,6 +94,9 @@ int CResPermissionsCache::lookup( IArrayOf<ISecResource>& resources, bool* pFoun
                 else
                 {
                     secResource.copy(resParamCacheEntry.second);
+#ifdef _DEBUG
+                    DBGLOG("CACHE: FoundA %s:%s=>%d", m_user.c_str(), resource, ((ISecResource*)resParamCacheEntry.second)->getAccessFlags());
+#endif
                     *pFound++ = true;
                     nFound++;
                 }
@@ -100,7 +104,9 @@ int CResPermissionsCache::lookup( IArrayOf<ISecResource>& resources, bool* pFoun
             else
             {
                 secResource.copy(resParamCacheEntry.second);
-                //DBGLOG("CACHE: Found %s:%s=>%d", m_user.c_str(), resource, resParamCacheEntry.second);
+#ifdef _DEBUG
+                DBGLOG("CACHE: FoundB %s:%s=>%d", m_user.c_str(), resource, ((ISecResource*)resParamCacheEntry.second)->getAccessFlags());
+#endif
                 *pFound++ = true;
                 nFound++;
             }
@@ -154,7 +160,9 @@ void CResPermissionsCache::add( IArrayOf<ISecResource>& resources )
             }
             m_resAccessMap.erase(SecCacheKeyEntry(resource, resourcetype));
         }
-        //DBGLOG("CACHE: Adding %s:%s(%d)", m_user.c_str(), resource, permissions);
+#ifdef _DEBUG
+        DBGLOG("CACHE: Adding %s:%s(%d)", m_user.c_str(), resource, permissions);
+#endif
         m_resAccessMap.insert( pair<SecCacheKeyEntry, ResPermCacheEntry>(SecCacheKeyEntry(resource, resourcetype),  ResPermCacheEntry(tstamp, secResource->clone())));
         m_timestampMap.insert( pair<time_t, SecCacheKeyEntry>(tstamp, SecCacheKeyEntry(resource, resourcetype)));
     }
@@ -222,9 +230,11 @@ int CPermissionsCache::lookup( ISecUser& sec_user, IArrayOf<ISecResource>& resou
     {
         nFound = 0;
         memset(pFound, 0, sizeof(bool)*resources.ordinality());
-        //DBGLOG("CACHE: Looking up %s:*", userId);
     }
 
+#ifdef _DEBUG
+    DBGLOG("CACHE: Looking up resources for %s:*, found %d matches", userId, nFound);
+#endif
     return nFound;
 }
 
@@ -239,7 +249,9 @@ void CPermissionsCache::add( ISecUser& sec_user, IArrayOf<ISecResource>& resourc
 
     if (i == m_resPermissionsMap.end())
     {
-        //DBGLOG("CACHE: Adding cache for %s", user);
+#ifdef _DEBUG
+        DBGLOG("CACHE: Adding resources to cache for %s", user);
+#endif
         pResPermissionsCache = new CResPermissionsCache(this, user);
         m_resPermissionsMap.insert(pair<string, CResPermissionsCache*>(user, pResPermissionsCache));
     }

--- a/system/security/shared/caching.hpp
+++ b/system/security/shared/caching.hpp
@@ -135,7 +135,7 @@ public:
 // main cache that stores all user-specific caches (defined by CResPermissionsCache above)
 //
 static CriticalSection PCCritSect;//guards instance factory
-
+static CPermissionsCache* instance = nullptr;//accessed via CPermissionsCache::queryInstance()
 class CPermissionsCache
 {
 public:
@@ -152,8 +152,6 @@ public:
 
     static CPermissionsCache* queryInstance()
     {
-        static CPermissionsCache* instance = nullptr;
-
         {
             CriticalBlock block(PCCritSect);
             if (instance == nullptr)

--- a/system/security/shared/caching.hpp
+++ b/system/security/shared/caching.hpp
@@ -136,6 +136,7 @@ public:
 //
 static CriticalSection PCCritSect;//guards instance factory
 static CPermissionsCache* instance = nullptr;//accessed via CPermissionsCache::queryInstance()
+
 class CPermissionsCache
 {
 public:
@@ -197,18 +198,18 @@ private:
     typedef std::map<string, CachedUser*> MapUserCache;
 
     MapResPermissionsCache m_resPermissionsMap;  //user specific resource permissions cache
-    Monitor m_cachemonitor;                               //for thread safety
+    mutable ReadWriteLock m_resPermCacheRWLock; //guards m_resPermissionsMap
+
     int m_cacheTimeout; //cleanup cycle period
     bool m_transactionalEnabled;
 
     MapUserCache m_userCache;
-    Monitor m_userCacheMonitor;
-
+    mutable ReadWriteLock m_userCacheRWLock;    //guards m_userCache
 
     //Managed File Scope support
     int                         m_defaultPermission;
     map<string, ISecResource*>  m_managedFileScopesMap;
-    Monitor                     m_managedFileScopesCacheMonitor;
+    mutable ReadWriteLock       m_scopesRWLock;//guards m_managedFileScopesMap
     ISecManager *               m_secMgr;
     time_t                      m_lastManagedFileScopesRefresh;
 };

--- a/system/security/shared/caching.hpp
+++ b/system/security/shared/caching.hpp
@@ -134,18 +134,35 @@ public:
 
 // main cache that stores all user-specific caches (defined by CResPermissionsCache above)
 //
+static CriticalSection PCCritSect;//guards instance factory
+
 class CPermissionsCache
 {
 public:
     CPermissionsCache()
-    { 
+    {
         m_cacheTimeout = 300;
         m_transactionalEnabled = false;
         m_secMgr = NULL;
         m_lastManagedFileScopesRefresh = 0;
         m_defaultPermission = SecAccess_Unknown;
     }
+
     virtual ~CPermissionsCache();
+
+    static CPermissionsCache* queryInstance()
+    {
+        static CPermissionsCache* instance = nullptr;
+
+        {
+            CriticalBlock block(PCCritSect);
+            if (instance == nullptr)
+            {
+                instance = new CPermissionsCache();
+            }
+        }
+        return instance;
+    }
 
     //finds cached permissions for a number of resources and sets them in
     //and also returns status in the boolean array passed in
@@ -181,8 +198,6 @@ private:
     typedef std::map<string, CResPermissionsCache*> MapResPermissionsCache;
     typedef std::map<string, CachedUser*> MapUserCache;
 
-    CPermissionsCache(const CPermissionsCache&);
-
     MapResPermissionsCache m_resPermissionsMap;  //user specific resource permissions cache
     Monitor m_cachemonitor;                               //for thread safety
     int m_cacheTimeout; //cleanup cycle period
@@ -201,5 +216,6 @@ private:
 };
 
 time_t getThreadCreateTime();
+
 
 #endif


### PR DESCRIPTION
Currently the permissions cache uses a critical section to guard access to
the permission cache, including all updates and lookups. This serializes
lookups, even when no updates are taking place. This PR implement read/write locks
as appropriate to lock the cache during updates, and allow multiple concurrent
lookups

Signed-off-by: Russ Whitehead william.whitehead@lexisnexis.com
