### PR TITLE
HPCC-15482 Implement read/write locks in permission cache

### DIFF
--- a/system/security/shared/caching.cpp
+++ b/system/security/shared/caching.cpp
@@ -74,7 +74,7 @@ int CResPermissionsCache::lookup( IArrayOf<ISecResource>& resources, bool* pFoun
             continue;
         }
 #ifdef _DEBUG
-        DBGLOG("CACHE: Looking up resource(%d) %s:%s", i, m_user.c_str(), resource);
+        DBGLOG("CACHE: CResPermissionsCache Looking up resource(%d of %d) %s:%s", i, nresources, m_user.c_str(), resource);
 #endif
         MapResAccess::iterator it = m_resAccessMap.find(SecCacheKeyEntry(resource, secResource.getResourceType()));
         if (it != m_resAccessMap.end())//exists in cache
@@ -95,7 +95,7 @@ int CResPermissionsCache::lookup( IArrayOf<ISecResource>& resources, bool* pFoun
                 {
                     secResource.copy(resParamCacheEntry.second);
 #ifdef _DEBUG
-                    DBGLOG("CACHE: FoundA %s:%s=>%d", m_user.c_str(), resource, ((ISecResource*)resParamCacheEntry.second)->getAccessFlags());
+                    DBGLOG("CACHE: CResPermissionsCache FoundA %s:%s=>%d", m_user.c_str(), resource, ((ISecResource*)resParamCacheEntry.second)->getAccessFlags());
 #endif
                     *pFound++ = true;
                     nFound++;
@@ -105,7 +105,7 @@ int CResPermissionsCache::lookup( IArrayOf<ISecResource>& resources, bool* pFoun
             {
                 secResource.copy(resParamCacheEntry.second);
 #ifdef _DEBUG
-                DBGLOG("CACHE: FoundB %s:%s=>%d", m_user.c_str(), resource, ((ISecResource*)resParamCacheEntry.second)->getAccessFlags());
+                DBGLOG("CACHE: CResPermissionsCache FoundB %s:%s=>%d", m_user.c_str(), resource, ((ISecResource*)resParamCacheEntry.second)->getAccessFlags());
 #endif
                 *pFound++ = true;
                 nFound++;
@@ -161,7 +161,7 @@ void CResPermissionsCache::add( IArrayOf<ISecResource>& resources )
             m_resAccessMap.erase(SecCacheKeyEntry(resource, resourcetype));
         }
 #ifdef _DEBUG
-        DBGLOG("CACHE: Adding %s:%s(%d)", m_user.c_str(), resource, permissions);
+        DBGLOG("CACHE: CResPermissionsCache Adding %s:%s(%d)", m_user.c_str(), resource, permissions);
 #endif
         m_resAccessMap.insert( pair<SecCacheKeyEntry, ResPermCacheEntry>(SecCacheKeyEntry(resource, resourcetype),  ResPermCacheEntry(tstamp, secResource->clone())));
         m_timestampMap.insert( pair<time_t, SecCacheKeyEntry>(tstamp, SecCacheKeyEntry(resource, resourcetype)));
@@ -216,11 +216,10 @@ CPermissionsCache::~CPermissionsCache()
 int CPermissionsCache::lookup( ISecUser& sec_user, IArrayOf<ISecResource>& resources, 
                             bool* pFound)
 {
-    synchronized block(m_cachemonitor);
     const char* userId = sec_user.getName();
     int nFound;
+    ReadLockBlock readLock(m_resPermCacheRWLock);
     MapResPermissionsCache::const_iterator i = m_resPermissionsMap.find( userId ); 
-
     if (i != m_resPermissionsMap.end())
     {
         CResPermissionsCache* pResPermissionsCache = (*i).second;
@@ -233,7 +232,7 @@ int CPermissionsCache::lookup( ISecUser& sec_user, IArrayOf<ISecResource>& resou
     }
 
 #ifdef _DEBUG
-    DBGLOG("CACHE: Looking up resources for %s:*, found %d matches", userId, nFound);
+    DBGLOG("CACHE: CPermissionsCache Looked up resources for %s:*, found %d of %d matches", userId, nFound, resources.ordinality());
 #endif
     return nFound;
 }
@@ -242,39 +241,46 @@ int CPermissionsCache::lookup( ISecUser& sec_user, IArrayOf<ISecResource>& resou
 
 void CPermissionsCache::add( ISecUser& sec_user, IArrayOf<ISecResource>& resources )
 {
-    synchronized block(m_cachemonitor);
     const char* user = sec_user.getName();
+    WriteLockBlock writeLock(m_resPermCacheRWLock);
     MapResPermissionsCache::const_iterator i = m_resPermissionsMap.find( user ); 
     CResPermissionsCache* pResPermissionsCache;
 
     if (i == m_resPermissionsMap.end())
     {
 #ifdef _DEBUG
-        DBGLOG("CACHE: Adding resources to cache for %s", user);
+        DBGLOG("CACHE: CPermissionsCache Adding resources to cache for new user %s", user);
 #endif
         pResPermissionsCache = new CResPermissionsCache(this, user);
         m_resPermissionsMap.insert(pair<string, CResPermissionsCache*>(user, pResPermissionsCache));
     }
     else
+    {
+#ifdef _DEBUG
+        DBGLOG("CACHE: CPermissionsCache Adding resources to cache for existing user %s", user);
+#endif
         pResPermissionsCache = (*i).second;
-
+    }
     pResPermissionsCache->add( resources );
 }
 
 void CPermissionsCache::removePermissions( ISecUser& sec_user)
 {
-    synchronized block(m_cachemonitor);
     const char* user = sec_user.getName();
     if(user != NULL && *user != '\0')
     {
+#ifdef _DEBUG
+        DBGLOG("CACHE: CPermissionsCache Removing permissions for user %s", user);
+#endif
+        WriteLockBlock writeLock(m_resPermCacheRWLock);
         m_resPermissionsMap.erase(user); 
     }
 }
 
 void CPermissionsCache::remove(SecResourceType rtype, const char* resourcename)
 {
-    synchronized block(m_cachemonitor);
     MapResPermissionsCache::const_iterator i;
+    WriteLockBlock writeLock(m_resPermCacheRWLock);
     MapResPermissionsCache::const_iterator iEnd = m_resPermissionsMap.end(); 
 
     for (i = m_resPermissionsMap.begin(); i != iEnd; i++)
@@ -293,9 +299,9 @@ bool CPermissionsCache::lookup(ISecUser& sec_user)
     if(!username || !*username)
         return false;
 
-    synchronized block(m_userCacheMonitor); 
-
     string key(username);
+    ReadLockBlock readLock(m_userCacheRWLock );
+
     MapUserCache::iterator it = m_userCache.find(key);
     if (it == m_userCache.end())
         return false;
@@ -319,6 +325,9 @@ bool CPermissionsCache::lookup(ISecUser& sec_user)
         md5_string(pw, md5pbuf);
         if(strcmp(cachedpw, md5pbuf.str()) == 0)
         {
+#ifdef _DEBUG
+            DBGLOG("CACHE: CPermissionsCache Found validated user %s", username);
+#endif
             // Copy cached user to the sec_user structure, but still keep the original clear text password.
             user->queryUser()->copyTo(sec_user);
             sec_user.credentials().setPassword(pw.str());
@@ -334,6 +343,7 @@ bool CPermissionsCache::lookup(ISecUser& sec_user)
 
     return false;
 }
+
 ISecUser* CPermissionsCache::getCachedUser( ISecUser& sec_user)
 {
     if(!isCacheEnabled())
@@ -343,15 +353,15 @@ ISecUser* CPermissionsCache::getCachedUser( ISecUser& sec_user)
     if(!username || !*username)
         return NULL;
 
-    synchronized block(m_userCacheMonitor); 
-
     string key(username);
+    ReadLockBlock readLock(m_userCacheRWLock );
     MapUserCache::iterator it = m_userCache.find(key);
     if (it == m_userCache.end())
         return NULL;
     CachedUser* user = (CachedUser*)(it->second);
     return LINK(user->queryUser());
 }
+
 void CPermissionsCache::add(ISecUser& sec_user)
 {
     if(!isCacheEnabled())
@@ -361,8 +371,8 @@ void CPermissionsCache::add(ISecUser& sec_user)
     if(!username || !*username)
         return;
     
-    synchronized block(m_userCacheMonitor);     
     string key(username);
+    WriteLockBlock writeLock(m_userCacheRWLock );
     MapUserCache::iterator it = m_userCache.find(key);
     CachedUser* user = NULL;
     if (it != m_userCache.end())
@@ -371,6 +381,9 @@ void CPermissionsCache::add(ISecUser& sec_user)
         m_userCache.erase(username);
         delete user;
     }
+#ifdef _DEBUG
+    DBGLOG("CACHE: CPermissionsCache Adding cached user %s", username);
+#endif
     m_userCache[username] = new CachedUser(sec_user.clone());
 }
 
@@ -379,21 +392,24 @@ void CPermissionsCache::removeFromUserCache(ISecUser& sec_user)
     const char* username = sec_user.getName();
     if(username && *username)
     {
-        synchronized block(m_userCacheMonitor);
         string key(username);
+        WriteLockBlock writeLock(m_userCacheRWLock );
         MapUserCache::iterator it = m_userCache.find(key);
         if (it != m_userCache.end())
         {
             CachedUser* user = (CachedUser*)(it->second);
             m_userCache.erase(username);
             delete user;
+#ifdef _DEBUG
+            DBGLOG("CACHE: CPermissionsCache Removing cached user %s", username);
+#endif
         }
     }
 }
 
 bool CPermissionsCache::addManagedFileScopes(IArrayOf<ISecResource>& scopes)
 {
-    synchronized block(m_managedFileScopesCacheMonitor);
+    WriteLockBlock writeLock(m_scopesRWLock);
     ForEachItemIn(x, scopes)
     {
         ISecResource* scope = &scopes.item(x);
@@ -419,7 +435,7 @@ bool CPermissionsCache::addManagedFileScopes(IArrayOf<ISecResource>& scopes)
 
 inline void CPermissionsCache::removeManagedFileScopes(IArrayOf<ISecResource>& scopes)
 {
-    synchronized block(m_managedFileScopesCacheMonitor);
+    WriteLockBlock writeLock(m_scopesRWLock);
     ForEachItemIn(x, scopes)
     {
         ISecResource* scope = &scopes.item(x);
@@ -440,7 +456,7 @@ inline void CPermissionsCache::removeManagedFileScopes(IArrayOf<ISecResource>& s
 
 inline void CPermissionsCache::removeAllManagedFileScopes()
 {
-    synchronized block(m_managedFileScopesCacheMonitor);
+    WriteLockBlock writeLock(m_scopesRWLock);
     map<string, ISecResource*>::const_iterator cit;
     map<string, ISecResource*>::const_iterator iEnd = m_managedFileScopesMap.end();
 
@@ -508,11 +524,11 @@ bool CPermissionsCache::queryPermsManagedFileScope(ISecUser& sec_user, const cha
         }
         scopes.append(scope.str());
     }
-    synchronized block(m_managedFileScopesCacheMonitor);
+
     ISecResource *matchedRes = NULL;
     ISecResource *res = NULL;
     bool isManaged = false;
-
+    ReadLockBlock readLock(m_scopesRWLock);
     for(unsigned i = 0; i < scopes.length(); i++)
     {
         const char* scope = scopes.item(i);
@@ -591,7 +607,7 @@ int CPermissionsCache::queryDefaultPermission(ISecUser& user)
 void CPermissionsCache::flush()
 {
     {
-        synchronized block(m_cachemonitor);
+        WriteLockBlock writeLock(m_resPermCacheRWLock);
         MapResPermissionsCache::const_iterator i;
         MapResPermissionsCache::const_iterator iEnd = m_resPermissionsMap.end();
         for (i = m_resPermissionsMap.begin(); i != iEnd; i++)
@@ -599,7 +615,7 @@ void CPermissionsCache::flush()
         m_resPermissionsMap.clear();
     }
     {
-        synchronized block(m_userCacheMonitor);
+        WriteLockBlock writeLock(m_userCacheRWLock );
         MapUserCache::const_iterator ui;
         MapUserCache::const_iterator uiEnd = m_userCache.end();
         for (ui = m_userCache.begin(); ui != uiEnd; ui++)

--- a/system/security/shared/caching.hpp
+++ b/system/security/shared/caching.hpp
@@ -136,6 +136,7 @@ public:
 //
 static CriticalSection PCCritSect;//guards instance factory
 static CPermissionsCache* instance = nullptr;//accessed via CPermissionsCache::queryInstance()
+
 class CPermissionsCache
 {
 public:
@@ -197,18 +198,18 @@ private:
     typedef std::map<string, CachedUser*> MapUserCache;
 
     MapResPermissionsCache m_resPermissionsMap;  //user specific resource permissions cache
-    Monitor m_cachemonitor;                               //for thread safety
+    mutable ReadWriteLock m_resPermCacheRWLock; //guards m_resPermissionsMap
+
     int m_cacheTimeout; //cleanup cycle period
     bool m_transactionalEnabled;
 
     MapUserCache m_userCache;
-    Monitor m_userCacheMonitor;
-
+    mutable ReadWriteLock m_userCacheRWLock;    //guards m_userCache
 
     //Managed File Scope support
     int                         m_defaultPermission;
     map<string, ISecResource*>  m_managedFileScopesMap;
-    Monitor                     m_managedFileScopesCacheMonitor;
+    mutable ReadWriteLock       m_scopesRWLock;//guards m_managedFileScopesMap
     ISecManager *               m_secMgr;
     time_t                      m_lastManagedFileScopesRefresh;
 };


### PR DESCRIPTION
Currently the permissions cache uses a critical section to guard access to
the permission cache, including all updates and lookups. This serializes
lookups, even when no updates are taking place. This PR implement read/write locks
as appropriate to lock the cache during updates, and allow multiple concurrent
lookups

Signed-off-by: Russ Whitehead william.whitehead@lexisnexis.com
