### PR TITLE
HPCC-15499 Redis Plugin: add redis command INCRBY

### DIFF
--- a/plugins/redis/lib_redis.ecllib
+++ b/plugins/redis/lib_redis.ecllib
@@ -35,6 +35,8 @@ EXPORT redis := SERVICE : plugin('redis'), namespace('RedisPlugin')
   REAL          GetReal(CONST VARSTRING key, CONST VARSTRING options, INTEGER4 database = 0, CONST VARSTRING password = '', UNSIGNED4 timeout = 1000) : cpp,once,context,entrypoint='SyncRGetDouble';
   DATA          GetData(CONST VARSTRING key, CONST VARSTRING options, INTEGER4 database = 0, CONST VARSTRING password = '', UNSIGNED4 timeout = 1000) : cpp,once,context,entrypoint='SyncRGetData';
 
+  INTEGER8 INCRBY(CONST VARSTRING key, INTEGER value = 1, CONST VARSTRING options, INTEGER4 database = 0, CONST VARSTRING password = '', UNSIGNED4 timeout = 1000) : cpp,once,context,entrypoint='SyncRINCRBY';
+
   BOOLEAN Exists(CONST VARSTRING key, CONST VARSTRING options, INTEGER4 database = 0, CONST VARSTRING password = '', UNSIGNED4 timeout = 1000) : cpp,once,context,entrypoint='RExist';
   FlushDB(CONST VARSTRING options, INTEGER4 database = 0, CONST VARSTRING password = '', UNSIGNED4 timeout = 1000) : cpp,action,context,entrypoint='RClear';
   Delete(CONST VARSTRING key, CONST VARSTRING options, INTEGER4 database = 0, CONST VARSTRING password = '', UNSIGNED4 timeout = 1000) : cpp,action,context,entrypoint='RDel';
@@ -76,6 +78,8 @@ EXPORT RedisServer(VARSTRING options, VARSTRING password = '', UNSIGNED4 timeout
   EXPORT GetUnsigned(VARSTRING key, INTEGER4 database = 0) := redis.GetUnsigned(key, options, database, password, timeout);
   EXPORT     GetData(VARSTRING key, INTEGER4 database = 0) :=     redis.GetData(key, options, database, password, timeout);
 
+  EXPORT  INCRBY(VARSTRING key, INTEGER value, INTEGER4 database = 0) := redis.INCRBY (key, value, options, database, password, timeout);
+
   EXPORT Exists(VARSTRING key, INTEGER4 database = 0) := redis.Exists(key, options, database, password, timeout);
   EXPORT FlushDB(INTEGER4 database = 0) := redis.FlushDB(options, database, password, timeout);
   EXPORT Delete(VARSTRING key, INTEGER4 database = 0) := redis.Delete(key, options, database, password, timeout);
@@ -116,6 +120,8 @@ EXPORT RedisServerWithoutTimeout(VARSTRING options, VARSTRING password = '') := 
   EXPORT  GetInteger(VARSTRING key, INTEGER4 database = 0, UNSIGNED4 timeout = 1000) :=  redis.GetInteger(key, options, database, password, timeout);
   EXPORT GetUnsigned(VARSTRING key, INTEGER4 database = 0, UNSIGNED4 timeout = 1000) := redis.GetUnsigned(key, options, database, password, timeout);
   EXPORT     GetData(VARSTRING key, INTEGER4 database = 0, UNSIGNED4 timeout = 1000) :=     redis.GetData(key, options, database, password, timeout);
+
+  EXPORT  INCRBY(VARSTRING key, INTEGER value, INTEGER4 database = 0, UNSIGNED4 timeout = 1000) := redis.INCRBY (key, value, options, database, password, timeout);
 
   EXPORT Exists(VARSTRING key, INTEGER4 database = 0, UNSIGNED4 timeout = 1000) := redis.Exists(key, options, database, password, timeout);
   EXPORT FlushDB(INTEGER4 database = 0, UNSIGNED4 timeout = 1000) := redis.FlushDB(options, database, password, timeout);

--- a/plugins/redis/redis.hpp
+++ b/plugins/redis/redis.hpp
@@ -70,6 +70,8 @@ namespace RedisPlugin {
     ECL_REDIS_API unsigned __int64 ECL_REDIS_CALL SyncRPub(ICodeContext * _ctx, const char * keyOrChannel, size32_t messageLength, const char * message, const char * options, int database, const char * pswd, unsigned timeout, bool lockedKey);
     ECL_REDIS_API void ECL_REDIS_CALL SyncRSub(ICodeContext * _ctx, size32_t & messageLength, char * & message, const char * keyOrChannel, const char * options, int database, const char * pswd, unsigned timeout, bool lockedKey);
 
+    ECL_REDIS_API signed __int64 ECL_REDIS_CALL SyncRINCRBY(ICodeContext * _ctx, const char * key, signed __int64 value, const char * options, int database, const char * pswd, unsigned timeout);
+
     //--------------------------------AUXILLARIES---------------------------
     ECL_REDIS_API bool             ECL_REDIS_CALL RExist  (ICodeContext * _ctx, const char * key, const char * options, int database, const char * pswd, unsigned timeout);
     ECL_REDIS_API void             ECL_REDIS_CALL RClear  (ICodeContext * _ctx, const char * options, int database, const char * pswd, unsigned timeout);

--- a/testing/regress/ecl/key/rediserrortests.xml
+++ b/testing/regress/ecl/key/rediserrortests.xml
@@ -31,3 +31,9 @@
 <Dataset name='Result 11'>
  <Row><value>Timed Out</value></Row>
 </Dataset>
+<Dataset name='Result 12'>
+ <Row><value>1</value></Row>
+</Dataset>
+<Dataset name='Result 13'>
+ <Row><value>1</value></Row>
+</Dataset>

--- a/testing/regress/ecl/key/redissynctest.xml
+++ b/testing/regress/ecl/key/redissynctest.xml
@@ -5,7 +5,7 @@
  <Row><Result_2>3.14159265359</Result_2></Row>
 </Dataset>
 <Dataset name='Result 3'>
- <Row><Result_3>4614256656552046314</Result_3></Row>
+ <Row><Result_3>3</Result_3></Row>
 </Dataset>
 <Dataset name='Result 4'>
  <Row><Result_4>9.869604401090658</Result_4></Row>
@@ -47,7 +47,7 @@
  <Row><Result_16>D790D791D792D793D794D795D796D798D799D79AD79BD79CD79DD79DD79ED79FD7A0D7A1D7A2D7A3D7A4D7A5D7A6D7A7D7A8D7A9D7AA</Result_16></Row>
 </Dataset>
 <Dataset name='Result 17'>
- <Row><Result_17>7523094288207667809</Result_17></Row>
+ <Row><Result_17>0</Result_17></Row>
 </Dataset>
 <Dataset name='Result 18'>
  <Row><Result_18>false</Result_18></Row>
@@ -93,4 +93,22 @@
 </Dataset>
 <Dataset name='Result 32'>
  <Row><Result_32>OK</Result_32></Row>
+</Dataset>
+<Dataset name='Result 33'>
+ <Row><Result_33>21</Result_33></Row>
+</Dataset>
+<Dataset name='Result 34'>
+ <Row><Result_34>21</Result_34></Row>
+</Dataset>
+<Dataset name='Result 35'>
+ <Row><Result_35>489</Result_35></Row>
+</Dataset>
+<Dataset name='Result 36'>
+ <Row><Result_36>489</Result_36></Row>
+</Dataset>
+<Dataset name='Result 37'>
+ <Row><Result_37>611</Result_37></Row>
+</Dataset>
+<Dataset name='Result 38'>
+ <Row><Result_38>611</Result_38></Row>
 </Dataset>

--- a/testing/regress/ecl/rediserrortests.ecl
+++ b/testing/regress/ecl/rediserrortests.ecl
@@ -126,4 +126,20 @@ SEQUENTIAL(
                                                                          'Timed Out', 'Unexpected Error - ' + FAILMESSAGE)))));
     );
 
+STRING pluginIntExpected := 'Redis Plugin: ERROR - INCRBY \'testINCRBY1\' on database 0 for 127.0.0.1:6379 failed : ERR value is not an integer or out of range';
+dsINCRBY := DATASET(NOFOLD(1), TRANSFORM({INTEGER value}, SELF.value := myRedis.INCRBY('testINCRBY' + (string)COUNTER, 11)));
+SEQUENTIAL(
+    myRedis.FlushDB();
+    myRedis.setString('testINCRBY1', 'this is a string and not an integer'),
+    OUTPUT(CATCH(dsINCRBY, ONFAIL(TRANSFORM({ INTEGER value }, SELF.value := IF(FAILMESSAGE = pluginIntExpected, 1, 0) ))));
+    );
+
+STRING erange := 'Redis Plugin: ERROR - INCRBY \'testINCRBY11\' on database 0 for 127.0.0.1:6379 failed : ERR value is not an integer or out of range';
+dsINCRBY2 := DATASET(NOFOLD(1), TRANSFORM({INTEGER value}, SELF.value := myRedis.INCRBY('testINCRBY1' + (string)COUNTER, -11)));
+SEQUENTIAL(
+    myRedis.FlushDB();
+    myRedis.setUnsigned('testINCRBY11', -1),
+    OUTPUT(CATCH(dsINCRBY2, ONFAIL(TRANSFORM({ INTEGER value }, SELF.value := IF(FAILMESSAGE = erange, 1, 0) ))));
+    );
+
 myRedis.FlushDB();

--- a/testing/regress/ecl/redissynctest.ecl
+++ b/testing/regress/ecl/redissynctest.ecl
@@ -189,5 +189,26 @@ SEQUENTIAL(
     );
     // N*3 > result < N*4 => all subs received a pub, however, there were result-N*3 subs still open for the second pub. result > N*4 => gremlins.
 
+SEQUENTIAL(
+    myRedis.FlushDB(),
+    myRedis.SetInteger('testINCRBY', 10),
+    myRedis.INCRBY('testINCRBY', 11),
+    myRedis.GetInteger('testINCRBY')
+);
+
+SEQUENTIAL(
+    myRedis.FlushDB(),
+    myRedis.SetString('testINCRBY2', '500'),
+    myRedis.INCRBY('testINCRBY2', -11),
+    myRedis.GetInteger('testINCRBY2')
+);
+
+SEQUENTIAL(
+    myRedis.FlushDB(),
+    myRedis.SetUnsigned('testINCRBY3', 600),
+    myRedis.INCRBY('testINCRBY3', 11),
+    myRedis.GetUnsigned('testINCRBY3')
+);
+
 myRedis.FlushDB();
 myRedis2.FlushDB();


### PR DESCRIPTION
This also removes redisContext \* context as the initial parameter to Connection::redisCommand so as to use the member version instead. Original, I exposed this method to make the code less layered when adding this new function and then thought better of it and now can't be bothered to add it back simply to remove it in another PR.
Signed-off-by: James Noss james.noss@lexisnexis.com
