### PR TITLE
HPCC-15511 DOCS:Invalid XML error Programmer Guide

### DIFF
--- a/docs/ECLProgrammersGuide/PrGd-Includer.xml
+++ b/docs/ECLProgrammersGuide/PrGd-Includer.xml
@@ -185,6 +185,6 @@
                 xpointer="element(/1)"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />
 
-    <para />
+   
   </chapter>
 </book>


### PR DESCRIPTION
FIX HPCC-15511 DOCS:Invalid XML error Programmer Guide
Fix of XML Error in Programmer Guide.

Signed-off-by: G Panagiotatos greg.panagiotatos@lexisnexis.com
@JamesDeFabia please review
