### PR TITLE
HPCC-15516 Despray umask pull method support

### DIFF
--- a/dali/ft/filecopy.cpp
+++ b/dali/ft/filecopy.cpp
@@ -597,16 +597,15 @@ FileSprayer::FileSprayer(IPropertyTree * _options, IPropertyTree * _progress, IR
     decryptKey.set(options->queryProp(ANdecryptKey));
 
     fileUmask = -1;
-    if (options->hasProp(ANumask))
+    const char *umaskStr = options->queryProp(ANumask);
+    if (umaskStr)
     {
-        StringBuffer umaskStr;
-        options->getProp(ANumask, umaskStr);
-        char *eptr = '\0';
+        char *eptr = nullptr;
         errno = 0;
-        fileUmask = (int)strtol(umaskStr.str(), &eptr, 8);
+        fileUmask = (int)strtol(umaskStr, &eptr, 8);
         if (errno || *eptr != '\0')
         {
-            LOG(MCdebugInfo, job, "Invalid umask value <%s> ignored", umaskStr.str());
+            LOG(MCdebugInfo, job, "Invalid umask value <%s> ignored", umaskStr);
             fileUmask = -1;
         }
         else

--- a/dali/ft/filecopy.cpp
+++ b/dali/ft/filecopy.cpp
@@ -601,9 +601,10 @@ FileSprayer::FileSprayer(IPropertyTree * _options, IPropertyTree * _progress, IR
     {
         StringBuffer umaskStr;
         options->getProp(ANumask, umaskStr);
+        char *eptr = '\0';
         errno = 0;
-        fileUmask = (int)strtol(umaskStr.str(), NULL, 8);
-        if (errno)
+        fileUmask = (int)strtol(umaskStr.str(), &eptr, 8);
+        if (errno || *eptr != '\0')
         {
             LOG(MCdebugInfo, job, "Invalid umask value <%s> ignored", umaskStr.str());
             fileUmask = -1;

--- a/dali/ft/filecopy.cpp
+++ b/dali/ft/filecopy.cpp
@@ -78,6 +78,7 @@
 #define ANtransferBufferSize "@transferBufferSize"
 #define ANencryptKey        "@encryptKey"
 #define ANdecryptKey        "@decryptKey"
+#define ANumask             "@umask"
 
 #define PNpartition         "partition"
 #define PNprogress          "progress"
@@ -369,6 +370,9 @@ bool FileTransferThread::performTransfer()
             progress.item(i2).serializeExtra(msg, 1);
 
         //NB: Any extra data must be appended at the end...
+
+        msg.append(sprayer.fileUmask);
+
         if (!catchWriteBuffer(socket, msg))
             throwError1(RFSERR_TimeoutWaitConnect, url.str());
 
@@ -592,6 +596,24 @@ FileSprayer::FileSprayer(IPropertyTree * _options, IPropertyTree * _progress, IR
     encryptKey.set(options->queryProp(ANencryptKey));
     decryptKey.set(options->queryProp(ANdecryptKey));
 
+    fileUmask = -1;
+    if (options->hasProp(ANumask))
+    {
+        StringBuffer umaskStr;
+        options->getProp(ANumask, umaskStr);
+        errno = 0;
+        fileUmask = (int)strtol(umaskStr.str(), NULL, 8);
+        if (errno)
+        {
+            LOG(MCdebugInfo, job, "Invalid umask value <%s> ignored", umaskStr.str());
+            fileUmask = -1;
+        }
+        else
+        {
+            // never strip off owner
+            fileUmask &= 077;
+        }
+    }
 }
 
 
@@ -816,25 +838,6 @@ void FileSprayer::beforeTransfer()
         checker.For(targets.ordinality(), 25, true, true);
     }
 
-    int umask = -1;
-    if (options->hasProp("@umask"))
-    {
-        StringBuffer umaskStr;
-        options->getProp("@umask", umaskStr);
-        errno = 0;
-        umask = (int)strtol(umaskStr.str(), NULL, 8);
-        if (errno)
-        {
-            LOG(MCdebugInfo, job, "Invalid umask value <%s> ignored", umaskStr.str());
-            umask = -1;
-        }
-        else
-        {
-            // never strip off owner
-            umask &= 077;
-        }
-    }
-
     if (!isRecovering && !usePullOperation())
     {
         try {
@@ -852,8 +855,8 @@ void FileSprayer::beforeTransfer()
                     if (!dir->exists())
                     {
                         dir->createDirectory();
-                        if (umask != -1)
-                            dir->setFilePermissions(~umask&0777);
+                        if (fileUmask != -1)
+                            dir->setFilePermissions(~fileUmask&0777);
                     }
                 }
             }
@@ -892,8 +895,8 @@ void FileSprayer::beforeTransfer()
                     remote.getPath(name);
                     throwError1(DFTERR_CouldNotCreateOutput, name.str());
                 }
-                if (umask != -1)
-                    file->setFilePermissions(~umask&0666);
+                if (fileUmask != -1)
+                    file->setFilePermissions(~fileUmask&0666);
                 //Create the headers on the utf files.
                 unsigned headerSize = getHeaderSize(tgtFormat.type);
                 if (headerSize)

--- a/dali/ft/filecopy.cpp
+++ b/dali/ft/filecopy.cpp
@@ -600,7 +600,7 @@ FileSprayer::FileSprayer(IPropertyTree * _options, IPropertyTree * _progress, IR
     const char *umaskStr = options->queryProp(ANumask);
     if (umaskStr)
     {
-        char *eptr = nullptr;
+        char *eptr = NULL;
         errno = 0;
         fileUmask = (int)strtol(umaskStr, &eptr, 8);
         if (errno || *eptr != '\0')

--- a/dali/ft/filecopy.ipp
+++ b/dali/ft/filecopy.ipp
@@ -320,6 +320,7 @@ protected:
     bool                    preserveCompression;
     offset_t                headerSize;
     offset_t                footerSize;
+    int                     fileUmask;
 };
 
 

--- a/dali/ft/fttransform.cpp
+++ b/dali/ft/fttransform.cpp
@@ -648,7 +648,11 @@ void TransferServer::deserializeAction(MemoryBuffer & msg, unsigned action)
 
     LOG(MCdebugProgress, unknownJob, "throttle(%d), transferBufferSize(%d)", throttleNicSpeed, transferBufferSize);
     PROGLOG("compressedInput(%d), compressedOutput(%d), copyCompressed(%d)", compressedInput?1:0, compressOutput?1:0, copyCompressed?1:0);
-    PROGLOG("encrypt(%d), decrypt(%d), umask(%d)", encryptKey.isEmpty()?0:1, decryptKey.isEmpty()?0:1, fileUmask);
+    PROGLOG("encrypt(%d), decrypt(%d)", encryptKey.isEmpty()?0:1, decryptKey.isEmpty()?0:1);
+    if (fileUmask != -1)
+        PROGLOG("umask(0%o)", fileUmask);
+    else
+        PROGLOG("umask(default)");
 
     //---Finished deserializing ---
     displayProgress(progress);

--- a/dali/ft/fttransform.cpp
+++ b/dali/ft/fttransform.cpp
@@ -498,6 +498,7 @@ TransferServer::TransferServer(ISocket * _masterSocket)
     compressedInput = false;
     compressOutput = false;
     transferBufferSize = DEFAULT_STD_BUFFER_SIZE;
+    fileUmask = -1;
 }
 
 void TransferServer::sendProgress(OutputProgress & curProgress)
@@ -642,9 +643,12 @@ void TransferServer::deserializeAction(MemoryBuffer & msg, unsigned action)
     ForEachItemIn(i1, progress)
         progress.item(i1).deserializeExtra(msg, 1);
 
+    if (msg.remaining())
+        msg.read(fileUmask);
+
     LOG(MCdebugProgress, unknownJob, "throttle(%d), transferBufferSize(%d)", throttleNicSpeed, transferBufferSize);
     PROGLOG("compressedInput(%d), compressedOutput(%d), copyCompressed(%d)", compressedInput?1:0, compressOutput?1:0, copyCompressed?1:0);
-    PROGLOG("encrypt(%d), decrypt(%d)", encryptKey.isEmpty()?0:1, decryptKey.isEmpty()?0:1);
+    PROGLOG("encrypt(%d), decrypt(%d), umask(%d)", encryptKey.isEmpty()?0:1, decryptKey.isEmpty()?0:1, fileUmask);
 
     //---Finished deserializing ---
     displayProgress(progress);
@@ -890,6 +894,10 @@ processedProgress:
                     renameDfuTempToFinal(curPartition.outputName);
 
                     OwnedIFile output = createIFile(curPartition.outputName);
+
+                    if (fileUmask != -1)
+                        output->setFilePermissions(~fileUmask&0666);
+
                     if (mirror || replicate)
                     {
                         OwnedIFile input = createIFile(curPartition.inputName);

--- a/dali/ft/fttransform.ipp
+++ b/dali/ft/fttransform.ipp
@@ -243,6 +243,7 @@ protected:
     size32_t                transferBufferSize;
     StringAttr              encryptKey;
     StringAttr              decryptKey;
+    int                     fileUmask;
 };
 
 

--- a/esp/services/ws_fs/ws_fsService.cpp
+++ b/esp/services/ws_fs/ws_fsService.cpp
@@ -2314,7 +2314,13 @@ void CFileSprayEx::getDropZoneInfoByIP(const char* ip, const char* destFileIn, S
 
     StringBuffer destFile;
     if (isAbsolutePath(destFileIn))
+    {
         destFile.set(destFileIn);
+        // if multiple DZs per computer, use umask of single DZ returned
+        dropZone->getUMask(maskBuf);
+        if (maskBuf.length())
+            mask.set(maskBuf.str());
+    }
     else
     {
         destFile.set(directory.str());


### PR DESCRIPTION
Pull method of despray now supports umask DZ parameter.

I modified ws_fsService.cpp so that for 5.6 where multiple DZ are not really supported it will now at least use the umask parameter found in the env.xml for the first DZ so that if you have more than one DZ and you use the same umask for all it will be honored (this is not in 6.0.0 because multiple DZs are properly supported).

@AttilaVamos , @wangkx please review thoroughly

NOTE: very similar to: https://github.com/hpcc-systems/HPCC-Platform/pull/8626 for 6.0.0

Signed-off-by: Mark Kelly mark.kelly@lexisnexis.com
