### PR TITLE
HPCC-15507 Rework shared permissions cache

### DIFF
--- a/system/security/LdapSecurity/ldapsecurity.cpp
+++ b/system/security/LdapSecurity/ldapsecurity.cpp
@@ -536,7 +536,7 @@ void CLdapSecManager::init(const char *serviceName, IPropertyTree* cfg)
     int cachetimeout = cfg->getPropInt("@cacheTimeout", 5);
 
     if (cfg->getPropBool("@sharedCache", true))
-        m_permissionsCache = CPermissionsCache::queryInstance();
+        m_permissionsCache = CPermissionsCache::queryInstance(cfg->queryProp("@name"));
     else
         m_permissionsCache = new CPermissionsCache();
 

--- a/system/security/LdapSecurity/ldapsecurity.cpp
+++ b/system/security/LdapSecurity/ldapsecurity.cpp
@@ -536,7 +536,7 @@ void CLdapSecManager::init(const char *serviceName, IPropertyTree* cfg)
     int cachetimeout = cfg->getPropInt("@cacheTimeout", 5);
 
     if (cfg->getPropBool("@sharedCache", true))
-        m_permissionsCache = CPermissionsCache::queryInstance(cfg->queryProp("@name"));
+        m_permissionsCache = CPermissionsCache::getInstance(cfg->queryProp("@name"));
     else
         m_permissionsCache = new CPermissionsCache();
 
@@ -554,8 +554,7 @@ CLdapSecManager::CLdapSecManager(const char *serviceName, IPropertyTree &config)
 
 CLdapSecManager::~CLdapSecManager()
 {
-    if (!m_cfg->getPropBool("@sharedCache", true))
-        delete m_permissionsCache;
+    m_permissionsCache->Release();
 }
 
 //interface ISecManager : extends IInterface

--- a/system/security/LdapSecurity/ldapsecurity.cpp
+++ b/system/security/LdapSecurity/ldapsecurity.cpp
@@ -536,9 +536,9 @@ void CLdapSecManager::init(const char *serviceName, IPropertyTree* cfg)
     int cachetimeout = cfg->getPropInt("@cacheTimeout", 5);
 
     if (cfg->getPropBool("@sharedCache", true))
-        m_permissionsCache = CPermissionsCache::getInstance(cfg->queryProp("@name"));
+        m_permissionsCache.setown(CPermissionsCache::getInstance(cfg->queryProp("@name")));
     else
-        m_permissionsCache = new CPermissionsCache();
+        m_permissionsCache.setown(new CPermissionsCache());
 
     m_permissionsCache->setCacheTimeout( 60 * cachetimeout);
     m_permissionsCache->setTransactionalEnabled(true);
@@ -554,7 +554,6 @@ CLdapSecManager::CLdapSecManager(const char *serviceName, IPropertyTree &config)
 
 CLdapSecManager::~CLdapSecManager()
 {
-    m_permissionsCache->Release();
 }
 
 //interface ISecManager : extends IInterface

--- a/system/security/LdapSecurity/ldapsecurity.ipp
+++ b/system/security/LdapSecurity/ldapsecurity.ipp
@@ -335,7 +335,7 @@ private:
     IUserArray m_user_array;
     Monitor m_monitor;
     Owned<IProperties> m_extraparams;
-    CPermissionsCache * m_permissionsCache;
+    Owned<CPermissionsCache> m_permissionsCache;
     bool m_cache_off[RT_SCOPE_MAX];
     bool m_usercache_off;
     bool authenticate(ISecUser* user);

--- a/system/security/shared/caching.cpp
+++ b/system/security/shared/caching.cpp
@@ -210,7 +210,10 @@ void CResPermissionsCache::remove(SecResourceType rtype, const char* resourcenam
 
 CPermissionsCache::~CPermissionsCache()
 {
-    g_mapCache.clear();
+    {
+        CriticalBlock block(PCCritSect);
+        g_mapCache.erase(m_secMgrClass.str());
+    }
     flush();
 }
 

--- a/system/security/shared/caching.cpp
+++ b/system/security/shared/caching.cpp
@@ -210,6 +210,7 @@ void CResPermissionsCache::remove(SecResourceType rtype, const char* resourcenam
 
 CPermissionsCache::~CPermissionsCache()
 {
+    if (!m_secMgrClass.isEmpty())
     {
         CriticalBlock block(PCCritSect);
         g_mapCache.erase(m_secMgrClass.str());

--- a/system/security/shared/caching.cpp
+++ b/system/security/shared/caching.cpp
@@ -210,6 +210,7 @@ void CResPermissionsCache::remove(SecResourceType rtype, const char* resourcenam
 
 CPermissionsCache::~CPermissionsCache()
 {
+    g_mapCache.clear();
     flush();
 }
 

--- a/system/security/shared/caching.hpp
+++ b/system/security/shared/caching.hpp
@@ -151,12 +151,12 @@ public:
 
     virtual ~CPermissionsCache();
 
-    //Returns a shared cache of a given type
+    //Returns a shared cache of a given class type.
     //Call this method with a unique class string ("LDAP", "MyOtherSecMgr")
     //to create a cache shared amongst security managers of the same class
     static CPermissionsCache* queryInstance(const char * _secMgrClass)
     {
-        const char * secMgrClass = (_secMgrClass && *_secMgrClass) : _secMgrClass ? "genericSecMgrClass";
+        const char * secMgrClass = (_secMgrClass != nullptr  &&  *_secMgrClass) ? _secMgrClass : "genericSecMgrClass";
         typedef map<string, CPermissionsCache*> MapCache;
         static MapCache m_mapCache;
 

--- a/system/security/shared/caching.hpp
+++ b/system/security/shared/caching.hpp
@@ -134,10 +134,6 @@ public:
 
 // main cache that stores all user-specific caches (defined by CResPermissionsCache above)
 //
-static CriticalSection PCCritSect;//guards instance factory
-typedef map<string, CPermissionsCache*> MapCache;
-static MapCache g_mapCache;
-
 class CPermissionsCache : public CInterface, implements IInterface
 {
 public:
@@ -155,27 +151,10 @@ public:
 
     virtual ~CPermissionsCache();
 
-    //Returns an owned reference to a shared cache of a given class type.
+    //Returns an owned reference to a shared cache of a given Sec Mgr class type.
     //Call this method with a unique class string ("LDAP", "MyOtherSecMgr")
     //to create a cache shared amongst security managers of the same class
-    static CPermissionsCache* getInstance(const char * _secMgrClass)
-    {
-        const char * secMgrClass = (_secMgrClass != nullptr  &&  *_secMgrClass) ? _secMgrClass : "genericSecMgrClass";
-
-        CriticalBlock block(PCCritSect);
-        MapCache::iterator it = g_mapCache.find(secMgrClass);
-        if (it != g_mapCache.end())//exists in cache
-        {
-            LINK((*it).second);
-            return (*it).second;
-        }
-        else
-        {
-            CPermissionsCache * instance = new CPermissionsCache(_secMgrClass);
-            g_mapCache.insert(pair<string, CPermissionsCache*>(secMgrClass, instance));
-            return instance;
-        }
-    }
+    static CPermissionsCache* getInstance(const char * _secMgrClass);
 
     //finds cached permissions for a number of resources and sets them in
     //and also returns status in the boolean array passed in
@@ -231,6 +210,5 @@ private:
 };
 
 time_t getThreadCreateTime();
-
 
 #endif

--- a/system/security/shared/caching.hpp
+++ b/system/security/shared/caching.hpp
@@ -143,13 +143,14 @@ class CPermissionsCache : public CInterface, implements IInterface
 public:
     IMPLEMENT_IINTERFACE
 
-    CPermissionsCache()
+    CPermissionsCache(const char * _secMgrClass = nullptr)
     {
         m_cacheTimeout = 300;
         m_transactionalEnabled = false;
         m_secMgr = NULL;
         m_lastManagedFileScopesRefresh = 0;
         m_defaultPermission = SecAccess_Unknown;
+        m_secMgrClass.set(_secMgrClass);
     }
 
     virtual ~CPermissionsCache();
@@ -170,7 +171,7 @@ public:
         }
         else
         {
-            CPermissionsCache * instance = new CPermissionsCache();
+            CPermissionsCache * instance = new CPermissionsCache(_secMgrClass);
             g_mapCache.insert(pair<string, CPermissionsCache*>(secMgrClass, instance));
             return instance;
         }
@@ -218,6 +219,8 @@ private:
 
     MapUserCache m_userCache;
     mutable ReadWriteLock m_userCacheRWLock;    //guards m_userCache
+
+    StringAttr                  m_secMgrClass;
 
     //Managed File Scope support
     int                         m_defaultPermission;

--- a/system/security/shared/caching.hpp
+++ b/system/security/shared/caching.hpp
@@ -151,27 +151,12 @@ public:
 
     virtual ~CPermissionsCache();
 
-    //Returns a shared cache
-    static CPermissionsCache* queryInstance()
-    {
-        {
-            CriticalBlock block(PCCritSect);
-            if (instance == nullptr)
-            {
-                instance = new CPermissionsCache();
-            }
-        }
-        return instance;
-    }
-
     //Returns a shared cache of a given type
     //Call this method with a unique class string ("LDAP", "MyOtherSecMgr")
     //to create a cache shared amongst security managers of the same class
-    static CPermissionsCache* queryInstance(const char * secMgrClass)
+    static CPermissionsCache* queryInstance(const char * _secMgrClass)
     {
-        if (secMgrClass == nullptr)
-            return queryInstance();
-
+        const char * secMgrClass = (_secMgrClass && *_secMgrClass) : _secMgrClass ? "genericSecMgrClass";
         typedef map<string, CPermissionsCache*> MapCache;
         static MapCache m_mapCache;
 


### PR DESCRIPTION
Add the capability to create a permissions cache that is shared by a class
of security managers. This will allow various security managers classes
to coexist without sharing a single cache.

Signed-off-by: Russ Whitehead william.whitehead@lexisnexis.com
