### PR TITLE
HPCC-14140 Potential thread and socket leak from cacheFileConnect

### DIFF
--- a/common/remote/rmtfile.cpp
+++ b/common/remote/rmtfile.cpp
@@ -568,17 +568,6 @@ void setDaliServixSocketCaching(bool set)
     clientSetDaliServixSocketCaching(set);
 }
 
-void cacheFileConnect(IFile *file,unsigned timeout)
-{
-    RemoteFilename rfn;
-    rfn.setRemotePath(file->queryFilename());
-    if (!rfn.isLocal()&&!rfn.isNull()) {
-        SocketEndpoint ep = rfn.queryEndpoint();
-        if (ep.port)
-            clientCacheFileConnect(ep,timeout);
-    }
-}
-
 void disconnectRemoteFile(IFile *file)
 {
     clientDisconnectRemoteFile(file);

--- a/common/remote/rmtfile.hpp
+++ b/common/remote/rmtfile.hpp
@@ -51,7 +51,6 @@ extern REMOTE_API IDaFileSrvHook *queryDaFileSrvHook();
 extern REMOTE_API unsigned short getDaliServixPort();  // assumed just the one for now
 extern REMOTE_API void setCanAccessDirectly(RemoteFilename & file,bool set);
 extern REMOTE_API void setDaliServixSocketCaching(bool set);
-extern REMOTE_API void cacheFileConnect(IFile *file,unsigned timeout);
 extern REMOTE_API bool canAccessDirectly(const RemoteFilename & file);
 extern REMOTE_API IFile *createDaliServixFile(const RemoteFilename & file);
 extern REMOTE_API bool testDaliServixPresent(const IpAddress &ip);

--- a/common/remote/sockfile.hpp
+++ b/common/remote/sockfile.hpp
@@ -79,7 +79,6 @@ extern void setDafsLocalMountRedirect(const IpAddress &ip,const char *dir,const 
 
 // client only
 extern void clientSetDaliServixSocketCaching(bool set);
-extern void clientCacheFileConnect(SocketEndpoint &ep,unsigned timeout);
 extern void clientDisconnectRemoteFile(IFile *file);
 extern void clientDisconnectRemoteIoOnExit(IFileIO *fileio,bool set);
 

--- a/initfiles/componentfiles/configxml/roxie.xsd.in
+++ b/initfiles/componentfiles/configxml/roxie.xsd.in
@@ -706,24 +706,10 @@
         </xs:appinfo>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="remoteConnectTimeout" type="xs:integer" use="optional" default="10000">
-      <xs:annotation>
-        <xs:appinfo>
-          <tooltip>Timeout (in ms) for remote file connections</tooltip>
-        </xs:appinfo>
-      </xs:annotation>
-    </xs:attribute>
     <xs:attribute name="remoteFilesExpire" type="xs:integer" use="optional" default="3600000">
       <xs:annotation>
         <xs:appinfo>
           <tooltip>Period (in ms) of inactivity before a remote datafile handle is closed</tooltip>
-        </xs:appinfo>
-      </xs:annotation>
-    </xs:attribute>
-    <xs:attribute name="remoteReadTimeout" type="xs:integer" use="optional" default="0">
-      <xs:annotation>
-        <xs:appinfo>
-          <tooltip>Timeout (in ms) for remote file reads</tooltip>
         </xs:appinfo>
       </xs:annotation>
     </xs:attribute>

--- a/initfiles/componentfiles/configxml/roxie.xsd.in
+++ b/initfiles/componentfiles/configxml/roxie.xsd.in
@@ -706,10 +706,24 @@
         </xs:appinfo>
       </xs:annotation>
     </xs:attribute>
+    <xs:attribute name="remoteConnectTimeout" type="xs:integer" use="optional" default="10000">
+      <xs:annotation>
+        <xs:appinfo>
+          <tooltip>Timeout (in ms) for remote file connections</tooltip>
+        </xs:appinfo>
+      </xs:annotation>
+    </xs:attribute>
     <xs:attribute name="remoteFilesExpire" type="xs:integer" use="optional" default="3600000">
       <xs:annotation>
         <xs:appinfo>
           <tooltip>Period (in ms) of inactivity before a remote datafile handle is closed</tooltip>
+        </xs:appinfo>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="remoteReadTimeout" type="xs:integer" use="optional" default="0">
+      <xs:annotation>
+        <xs:appinfo>
+          <tooltip>Timeout (in ms) for remote file reads</tooltip>
         </xs:appinfo>
       </xs:annotation>
     </xs:attribute>

--- a/roxie/ccd/ccdfile.cpp
+++ b/roxie/ccd/ccdfile.cpp
@@ -217,7 +217,7 @@ public:
         {
             StringBuffer filesTried;
             unsigned tries = 0;
-            bool firstTime = true; // first time try the "fast / cache" way - if that fails - try original away - if that still fails, error
+            bool firstTime = true;
             RoxieFileStatus fileStatus = FileNotFound;
 
             loop
@@ -226,7 +226,7 @@ public:
                     currentIdx = 0;
                 if (tries==sources.length())
                 {
-                    if (firstTime)  // if first time - reset and try again - non cache way
+                    if (firstTime)  // if first time - reset and try again
                     {
                         firstTime = false;
                         tries = 0;
@@ -245,14 +245,6 @@ public:
                         throw MakeStringException(ROXIE_FILE_OPEN_FAIL, "Pretending to fail on an open");
 #endif
                     IFile *f = &sources.item(currentIdx);
-                    if (firstTime)
-                        cacheFileConnect(f, dafilesrvLookupTimeout);  // set timeout to 10 seconds
-                    else
-                    {
-                        if (traceLevel > 10)
-                            DBGLOG("Looking for file using non-cached file open");
-                    }
-
                     fileStatus = queryFileCache().fileUpToDate(f, fileSize, fileDate, crc, isCompressed, false);
                     if (fileStatus == FileIsValid)
                     {
@@ -605,7 +597,6 @@ class CRoxieFileCache : public CInterface, implements ICopyFileProgress, impleme
             IFile *f;
         } autoDisconnector(f, autoDisconnect);
 
-        cacheFileConnect(f, dafilesrvLookupTimeout);  // set timeout to 10 seconds
         if (f->exists())
         {
             // only check size if specified

--- a/roxie/ccd/ccdmain.cpp
+++ b/roxie/ccd/ccdmain.cpp
@@ -678,6 +678,9 @@ int STARTQUERY_API start_query(int argc, const char *argv[])
         lowTimeout = topology->getPropInt("@lowTimeout", 10000);
         highTimeout = topology->getPropInt("@highTimeout", 2000);
         slaTimeout = topology->getPropInt("@slaTimeout", 2000);
+        unsigned remoteConnectTimeout = topology->getPropInt("@remoteConnectTimeout", 10000);
+        unsigned remoteReadTimeout = topology->getPropInt("@remoteReadTimeout", 0);
+        setRemoteFileTimeouts(remoteConnectTimeout, remoteReadTimeout);
         parallelLoopFlowLimit = topology->getPropInt("@parallelLoopFlowLimit", 100);
         perChannelFlowLimit = topology->getPropInt("@perChannelFlowLimit", 10);
         copyResources = topology->getPropBool("@copyResources", true);

--- a/roxie/ccd/ccdmain.cpp
+++ b/roxie/ccd/ccdmain.cpp
@@ -678,9 +678,6 @@ int STARTQUERY_API start_query(int argc, const char *argv[])
         lowTimeout = topology->getPropInt("@lowTimeout", 10000);
         highTimeout = topology->getPropInt("@highTimeout", 2000);
         slaTimeout = topology->getPropInt("@slaTimeout", 2000);
-        unsigned remoteConnectTimeout = topology->getPropInt("@remoteConnectTimeout", 10000);
-        unsigned remoteReadTimeout = topology->getPropInt("@remoteReadTimeout", 0);
-        setRemoteFileTimeouts(remoteConnectTimeout, remoteReadTimeout);
         parallelLoopFlowLimit = topology->getPropInt("@parallelLoopFlowLimit", 100);
         perChannelFlowLimit = topology->getPropInt("@perChannelFlowLimit", 10);
         copyResources = topology->getPropBool("@copyResources", true);
@@ -822,6 +819,7 @@ int STARTQUERY_API start_query(int argc, const char *argv[])
         maxFilesOpen[false] = topology->getPropInt("@maxLocalFilesOpen", 4000);
         maxFilesOpen[true] = topology->getPropInt("@maxRemoteFilesOpen", 1000);
         dafilesrvLookupTimeout = topology->getPropInt("@dafilesrvLookupTimeout", 10000);
+        setRemoteFileTimeouts(dafilesrvLookupTimeout, 0);
         topology->getProp("@daliServers", fileNameServiceDali);
         trapTooManyActiveQueries = topology->getPropBool("@trapTooManyActiveQueries", true);
         maxEmptyLoopIterations = topology->getPropInt("@maxEmptyLoopIterations", 1000);

--- a/roxie/ccd/ccdstate.cpp
+++ b/roxie/ccd/ccdstate.cpp
@@ -36,6 +36,7 @@
 #include "eclrtl.hpp"
 #include "dafdesc.hpp"
 #include "dautils.hpp"
+#include "rmtfile.hpp"
 
 #include "pkgimpl.hpp"
 #include "roxiehelper.hpp"
@@ -2107,6 +2108,7 @@ private:
             {
                 dafilesrvLookupTimeout = control->getPropInt("@val", 10000);
                 topology->setPropInt("@dafilesrvLookupTimeout", dafilesrvLookupTimeout);
+                setRemoteFileTimeouts(dafilesrvLookupTimeout, 0);
             }
             else if (stricmp(queryName, "control:defaultConcatPreload")==0)
             {


### PR DESCRIPTION
Remove weirdly-coded workaround for (since fixed) inability to set timeout
when connecting to remote files.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
