### PR TITLE
HPCC-15531 Switch queue needs to use cluster name, not thor name

### DIFF
--- a/dali/sasha/saqmon.cpp
+++ b/dali/sasha/saqmon.cpp
@@ -97,7 +97,7 @@ public:
                     }
                     if (ok) {
                         qnames.append(qname);
-                        cnames.append(cna.item(i1));
+                        cnames.append(tna.item(i1));
                     }
                 }
             }


### PR DESCRIPTION
Signed-off-by: Jake Smith jake.smith@lexisnexis.com
