### PR TITLE
HPCC-15513 Fix missing Build Version in ZAP report

### DIFF
--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -4320,10 +4320,17 @@ void CWsWorkunitsEx::createZAPWUInfoFile(IEspWUCreateZAPInfoRequest &req, Owned<
     StringBuffer sb;
     sb.append("Workunit:     ").append(cwu->queryWuid()).append("\r\n");
     sb.append("User:         ").append(cwu->queryUser()).append("\r\n");
-    sb.append("Build Version:").append(req.getBuildVersion()).append("\r\n");
+    sb.append("Build Version:").append(getBuildVersion()).append("\r\n");
     sb.append("Cluster:      ").append(cwu->queryClusterName()).append("\r\n");
     if (req.getESPIPAddress())
         sb.append("ESP:          ").append(req.getESPIPAddress()).append("\r\n");
+    else
+    {
+        StringBuffer EspIP;
+        IpAddress ipaddr = queryHostIP();
+        ipaddr.getIpText(EspIP);
+        sb.append("ESP:          ").append(EspIP.str()).append("\r\n");
+    }
     if (req.getThorIPAddress())
         sb.append("Thor:         ").append(req.getThorIPAddress()).append("\r\n");
     //Exceptions/Warnings/Info


### PR DESCRIPTION
In the existing WsWorkunits.WUCreateZAPInfo, both ESP Build Version
and ESP Network Address are added to ZAP report based on the values
inside the WUCreateZAPInfo request (which are forwarded by Create
ZAP Report form). When an ECLWU ZAP report is not created using the
form, both ESP Build Version and ESP Network Address are empty in
the report. In this fix, the code is added to read those values
into the report.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
