### PR TITLE
HPCC-14300 File upload dialog columns do not align

### DIFF
--- a/esp/src/eclwatch/css/hpcc.css
+++ b/esp/src/eclwatch/css/hpcc.css
@@ -1148,3 +1148,9 @@ margin-left:-20px;
     overflow: hidden;
     width: 80px;
 }
+
+.dojoxUploaderFileListHeader th {
+    background-color:#eee;
+    padding:3px;
+    text-align: left;
+}


### PR DESCRIPTION
Whenever a user uploads a file via LZBrowseWidget the column headers and the column content does not line up.

Signed-off by: Miguel Vazquez miguel.vazquez@lexisnexis.com
