### PR TITLE
HPCC-15544 FirstN/Enth lookahead issues in loop

### DIFF
--- a/thorlcr/activities/enth/thenthslave.cpp
+++ b/thorlcr/activities/enth/thenthslave.cpp
@@ -109,7 +109,9 @@ public:
 
         // restore original inputStream if lookAhead was installed, to avoid base start spuriously starting previously installed lookahead
         if (originalInputStream)
-            replaceInputStream(0, originalInputStream.getClear());
+        {
+            Owned<IEngineRowStream> lookAhead = replaceInputStream(0, originalInputStream.getClear());
+        }
     }
     virtual bool isGrouped() const override { return false; }
     void getMetaInfo(ThorDataLinkMetaInfo &info)

--- a/thorlcr/activities/firstn/thfirstnslave.cpp
+++ b/thorlcr/activities/firstn/thfirstnslave.cpp
@@ -213,7 +213,7 @@ class CFirstNSlaveGlobal : public CFirstNSlaveBase, implements ILookAheadStopNot
     rowcount_t maxres, skipped, totallimit;
     bool firstget;
     ThorDataLinkMetaInfo inputMeta;
-    IEngineRowStream *originalInputStream = nullptr;
+    Owned<IEngineRowStream> originalInputStream;
 
 protected:
     virtual void doStop()
@@ -232,11 +232,6 @@ public:
         PARENT::init(data, slaveData);
         mpTag = container.queryJobChannel().deserializeMPTag(data);
     }
-    virtual void setInputStream(unsigned index, CThorInput &_input, bool consumerOrdered) override
-    {
-        PARENT::setInputStream(index, _input, consumerOrdered);
-        originalInputStream = inputStream;
-    }
     virtual void start() override
     {
         ActivityTimer s(totalCycles, timeActivities);
@@ -249,10 +244,16 @@ public:
         totallimit = (rowcount_t)helper->getLimit();
         rowcount_t _skipCount = validRC(helper->numToSkip()); // max
         rowcount_t maxRead = (totallimit>(RCUNBOUND-_skipCount))?RCUNBOUND:totallimit+_skipCount;
-        IStartableEngineRowStream *lookAhead = createRowStreamLookAhead(this, originalInputStream, queryRowInterfaces(input), FIRSTN_SMART_BUFFER_SIZE, isSmartBufferSpillNeeded(this), false,
+        IStartableEngineRowStream *lookAhead = createRowStreamLookAhead(this, inputStream, queryRowInterfaces(input), FIRSTN_SMART_BUFFER_SIZE, isSmartBufferSpillNeeded(this), false,
                                                                               maxRead, this, &container.queryJob().queryIDiskUsage()); // if a very large limit don't bother truncating
-        setLookAhead(0, lookAhead);
+        originalInputStream.setown(replaceInputStream(0, lookAhead));
         lookAhead->start();
+    }
+    virtual void stop() override
+    {
+        PARENT::stop();
+        if (originalInputStream)
+            replaceInputStream(0, originalInputStream.getClear());
     }
     virtual void abort()
     {

--- a/thorlcr/activities/firstn/thfirstnslave.cpp
+++ b/thorlcr/activities/firstn/thfirstnslave.cpp
@@ -253,7 +253,9 @@ public:
     {
         PARENT::stop();
         if (originalInputStream)
-            replaceInputStream(0, originalInputStream.getClear());
+        {
+            Owned<IEngineRowStream> lookAhead = replaceInputStream(0, originalInputStream.getClear());
+        }
     }
     virtual void abort()
     {

--- a/thorlcr/graph/thgraphslave.cpp
+++ b/thorlcr/graph/thgraphslave.cpp
@@ -190,6 +190,16 @@ void CSlaveActivity::setInputStream(unsigned index, CThorInput &_input, bool con
     }
 }
 
+IEngineRowStream *CSlaveActivity::replaceInputStream(unsigned index, IEngineRowStream *_inputStream)
+{
+    CThorInput &_input = inputs.item(index);
+    IEngineRowStream *prevInputStream = _input.stream.getClear();
+    _input.stream.setown(_inputStream);
+    if (0 == index)
+        inputStream = _inputStream;
+    return prevInputStream;
+}
+
 void CSlaveActivity::setLookAhead(unsigned index, IStartableEngineRowStream *lookAhead)
 {
     CThorInput &_input = inputs.item(index);

--- a/thorlcr/graph/thgraphslave.hpp
+++ b/thorlcr/graph/thgraphslave.hpp
@@ -167,6 +167,7 @@ public:
     virtual void connectInputStreams(bool consumerOrdered);
 
     void setLookAhead(unsigned index, IStartableEngineRowStream *lookAhead);
+    IEngineRowStream *replaceInputStream(unsigned index, IEngineRowStream *_inputStream);
     IThorDataLink *queryOutput(unsigned index) const;
     IThorDataLink *queryInput(unsigned index) const;
     IEngineRowStream *queryInputStream(unsigned index) const;


### PR DESCRIPTION
Global FirstN and Enth's lookahead was not being correctly
restarted.
Avoid reconstruction if helper based settings haven't changed
and ensure lookahead object is restartable.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
