### PR TITLE
HPCC-15536 Regression in distribute stop could cause restart issue

### DIFF
--- a/thorlcr/activities/hashdistrib/thhashdistribslave.cpp
+++ b/thorlcr/activities/hashdistrib/thhashdistribslave.cpp
@@ -1990,7 +1990,7 @@ public:
         CriticalBlock block(stopsect);  // can be called async by distribute
         if (!inputstopped)
         {
-            PARENT::stop();
+            PARENT::stopInput(0);
             inputstopped = true;
         }
     }
@@ -2024,6 +2024,7 @@ public:
         }
         stopInput();
         instrm.clear();
+        dataLinkStop();
     }
     virtual void kill() override
     {


### PR DESCRIPTION
Distribute in a loop could hit an issue restarting.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
