### PR TITLE
HPCC-15574 Use TBB allocator in Thor and Roxie only

### DIFF
--- a/roxie/ccd/CMakeLists.txt
+++ b/roxie/ccd/CMakeLists.txt
@@ -121,4 +121,8 @@ IF (USE_OPENSSL)
     )
 ENDIF()
 
+IF (USE_TBBMALLOC)
+   target_link_libraries ( ccd ${TBBMALLOC_LIBRARIES})
+ENDIF()
+
 

--- a/system/jlib/CMakeLists.txt
+++ b/system/jlib/CMakeLists.txt
@@ -198,10 +198,6 @@ target_link_libraries ( jlib
         lz4
        )
 
-if (USE_TBBMALLOC)
-   target_link_libraries ( jlib ${TBBMALLOC_LIBRARIES})
-endif()
-
 if ( ${HAVE_LIBDL} )
 target_link_libraries ( jlib dl)
 endif ( ${HAVE_LIBDL} )

--- a/thorlcr/graph/graph_lcr.cmake
+++ b/thorlcr/graph/graph_lcr.cmake
@@ -75,4 +75,8 @@ target_link_libraries ( graph_lcr
          roxiemem
     )
 
+if (USE_TBBMALLOC)
+   target_link_libraries ( graph_lcr ${TBBMALLOC_LIBRARIES})
+endif()
+
 


### PR DESCRIPTION
The TBB allocator shows significant speed gains in thread
contended queries in Thor and Roxie and little downside.
However, if used everywhere, TBB causes significant slowdown in
the code generator.
So switch TBB allocator on in Thor and Roxie only for now.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
