### PR TITLE
HPCC-13029 Clean up unit tests

### DIFF
--- a/common/thorhelper/roxiehelper.hpp
+++ b/common/thorhelper/roxiehelper.hpp
@@ -231,7 +231,7 @@ public:
 //Should be implemented in a subsequent pull request, which also uses ALGORITHM('x') instead of requiring STABLE/UNSTABLE
 typedef enum {
     heapSortAlgorithm,                  // heap sort
-    insertionSortAlgorithm,             // insertion sort - purely for comparison
+    insertionSortAlgorithm,             // insertion sort - purely for comparison (no longer supported)
     quickSortAlgorithm,                 // jlib implementation of quicksort
     stableQuickSortAlgorithm,           // jlib version of quick sort that uses an extra array indirect to ensure it is stable
     spillingQuickSortAlgorithm,         // quickSortAlgorithm with the ability to spill
@@ -260,7 +260,6 @@ extern THORHELPER_API ISortAlgorithm *createQuickSortAlgorithm(ICompare *_compar
 extern THORHELPER_API ISortAlgorithm *createStableQuickSortAlgorithm(ICompare *_compare);
 extern THORHELPER_API ISortAlgorithm *createParallelQuickSortAlgorithm(ICompare *_compare);
 extern THORHELPER_API ISortAlgorithm *createParallelStableQuickSortAlgorithm(ICompare *_compare);
-extern THORHELPER_API ISortAlgorithm *createInsertionSortAlgorithm(ICompare *_compare, roxiemem::IRowManager *_rowManager, unsigned _activityId);
 extern THORHELPER_API ISortAlgorithm *createHeapSortAlgorithm(ICompare *_compare);
 extern THORHELPER_API ISortAlgorithm *createSpillingQuickSortAlgorithm(ICompare *_compare, roxiemem::IRowManager &_rowManager, IOutputMetaData * _rowMeta, ICodeContext *_ctx, const char *_tempDirectory, unsigned _activityId, bool _stable);
 extern THORHELPER_API ISortAlgorithm *createMergeSortAlgorithm(ICompare *_compare);

--- a/roxie/ccd/ccdfile.cpp
+++ b/roxie/ccd/ccdfile.cpp
@@ -2695,6 +2695,9 @@ protected:
 
     void testCopy()
     {
+        remove("test.local");
+        remove("test.remote");
+        remove("test.buddy");
         CRoxieFileCache cache(true);
         StringArray remotes;
         DummyPartDescriptor pdesc;
@@ -2712,7 +2715,8 @@ protected:
 
         // Reading it should read 1
         val = 0;
-        io->read(0, sizeof(int), &val);
+        ssize_t bytesRead = io->read(0, sizeof(int), &val);
+        CPPUNIT_ASSERT(bytesRead==4);
         CPPUNIT_ASSERT(val==1);
 
         // Now create the buddy

--- a/roxie/ccd/ccdquery.cpp
+++ b/roxie/ccd/ccdquery.cpp
@@ -88,7 +88,7 @@ public:
     CQueryDll(const char *_dllName, ILoadedDllEntry *_dll) : dllName(_dllName), dll(_dll)
     {
         StringBuffer wuXML;
-        if (getEmbeddedWorkUnitXML(dll, wuXML))
+        if (!selfTestMode && getEmbeddedWorkUnitXML(dll, wuXML))
         {
             Owned<ILocalWorkUnit> localWU = createLocalWorkUnit(wuXML);
             wu.setown(localWU->unlock());

--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -8022,8 +8022,6 @@ public:
         }
         else if (stricmp(algorithmName, "heapsort")==0)
             sortAlgorithm = heapSortAlgorithm; // NOTE - we do allow UNSTABLE('heapsort') in order to facilitate runtime selection. Also explicit selection of heapsort overrides request to spill
-        else if (stricmp(algorithmName, "insertionsort")==0)
-            sortAlgorithm = insertionSortAlgorithm;
         else if (stricmp(algorithmName, "mergesort")==0)
             sortAlgorithm = (sortFlags & TAFspill) ? spillingMergeSortAlgorithm : mergeSortAlgorithm;
         else if (stricmp(algorithmName, "parmergesort")==0)
@@ -27537,7 +27535,6 @@ class CcdServerTest : public CppUnit::TestFixture
     CPPUNIT_TEST_SUITE(CcdServerTest);
         CPPUNIT_TEST(testSetup);
         CPPUNIT_TEST(testHeapSort);
-        CPPUNIT_TEST(testInsertionSort);
         CPPUNIT_TEST(testQuickSort);
         CPPUNIT_TEST(testMerge);
         CPPUNIT_TEST(testMergeDedup);
@@ -27555,6 +27552,7 @@ protected:
 
     void testSetup()
     {
+        selfTestMode = true;
         roxiemem::setTotalMemoryLimit(false, true, false, 100 * 1024 * 1024, 0, NULL, NULL);
     }
 
@@ -27731,8 +27729,6 @@ protected:
         sortAlgorithm = NULL;
         if (type==2)
             sortAlgorithm = "heapSort";
-        else if (type == 1)
-            sortAlgorithm = "insertionSort";
         else
             sortAlgorithm = "quickSort";
         DBGLOG("Testing %s activity", sortAlgorithm);
@@ -27841,10 +27837,6 @@ protected:
     {
         testSort(0);
     }
-    void testInsertionSort()
-    {
-        testSort(1);
-    }
     void testHeapSort()
     {
         testSort(2);
@@ -27928,7 +27920,7 @@ protected:
         unsigned start = msTick();
         testSplitActivity(factory, test, test, numOutputs, 0);
         testSplitActivity(factory, test12345, test12345, numOutputs, 0);
-        testSplitActivity(factory, test12345, test12345, numOutputs, 1000000);
+        testSplitActivity(factory, test12345, test12345, numOutputs, 100);
         unsigned elapsed = msTick() - start;
 
         DBGLOG("testSplit %d done in %dms", numOutputs, elapsed);

--- a/system/jlib/jfile.cpp
+++ b/system/jlib/jfile.cpp
@@ -37,6 +37,10 @@
 #include <sys/vfs.h>
 #include <sys/sendfile.h>
 #endif
+#if defined (__APPLE__)
+#include <sys/mount.h>
+#undef MIN
+#endif
 
 #include "time.h"
 
@@ -4215,7 +4219,7 @@ extern jlib_decl offset_t getFreeSpace(const char* name)
     }
 
 
-#elif defined (__linux__)
+#elif defined (__linux__) || defined (__APPLE__)
     struct statfs buf;
     int fResult = statfs(name, &buf);
 

--- a/testing/unittests/dalitests.cpp
+++ b/testing/unittests/dalitests.cpp
@@ -439,9 +439,10 @@ void dispFDesc(IFileDescriptor *fdesc)
 
 // ================================================================================== UNIT TESTS
 
-class CDaliTests : public CppUnit::TestFixture
+class CDaliTestsStress : public CppUnit::TestFixture
 {
-    CPPUNIT_TEST_SUITE( CDaliTests );
+    CPPUNIT_TEST_SUITE( CDaliTestsStress );
+        CPPUNIT_TEST(testInit);
         CPPUNIT_TEST(testDFS);
 //        CPPUNIT_TEST(testReadAllSDS); // Ignoring this test; See comments below
         CPPUNIT_TEST(testSDSRW);
@@ -691,14 +692,17 @@ class CDaliTests : public CppUnit::TestFixture
     const IContextLogger &logctx;
 
 public:
-    CDaliTests() : logctx(queryDummyContextLogger()) {
-        init();
+    CDaliTestsStress() : logctx(queryDummyContextLogger()) {
     }
 
-    ~CDaliTests() {
+    ~CDaliTestsStress() {
         destroy();
     }
 
+    void testInit()
+    {
+        init();
+    }
     void testSDSRW()
     {
         Owned<IPropertyTree> ref = createPTree("DAREGRESS");
@@ -2361,8 +2365,8 @@ public:
 
 };
 
-CPPUNIT_TEST_SUITE_REGISTRATION( CDaliTests );
-CPPUNIT_TEST_SUITE_NAMED_REGISTRATION( CDaliTests, "Dali" );
+CPPUNIT_TEST_SUITE_REGISTRATION( CDaliTestsStress );
+CPPUNIT_TEST_SUITE_NAMED_REGISTRATION( CDaliTestsStress, "Dali" );
 
 class CDaliUtils : public CppUnit::TestFixture
 {

--- a/testing/unittests/unittests.cpp
+++ b/testing/unittests/unittests.cpp
@@ -18,6 +18,8 @@
 #ifdef _USE_CPPUNIT
 #include "unittests.hpp"
 #include "jstats.h"
+#include "jregexp.hpp"
+#include "jfile.hpp"
 
 /*
  * This is the main unittest driver for HPCC. From here,
@@ -37,34 +39,213 @@
  * CPPUnit will automatically recognise and run them all.
  */
 
+void usage()
+{
+    printf("\n"
+    "Usage:\n"
+    "    unittests <options> <testnames>\n"
+    "\n"
+    "Options:\n"
+    "    -a  --all        Include all tests, including timing and stress tests\n"
+    "    -d  --load path  Dynamically load a library/all libraries in a directory.\n"
+    "                     By default, the HPCCSystems lib directory is loaded.\n"
+    "    -e  --exact      Match subsequent test names exactly\n"
+    "    -h  --help       Display this help text\n"
+    "    -l  --list       List matching tests but do not execute them\n"
+    "    -x  --exclude    Exclude subsequent test names\n"
+    "\n");
+}
+
+bool matchName(const char *name, const StringArray &patterns)
+{
+    ForEachItemIn(idx, patterns)
+    {
+        bool match;
+        const char *pattern = patterns.item(idx);
+        if (strchr(pattern, '*'))
+        {
+            match = WildMatch(name, pattern, true);
+        }
+        else
+            match = streq(name, pattern);
+        if (match)
+            return true;
+    }
+    return false;
+}
+
+LoadedObject *loadDll(const char *thisDll)
+{
+    try
+    {
+        DBGLOG("Loading %s", thisDll);
+        return new LoadedObject(thisDll);
+    }
+    catch (IException *E)
+    {
+        E->Release();
+    }
+    catch (...)
+    {
+    }
+    return NULL;
+}
+
+void loadDlls(IArray &objects, const char * libDirectory)
+{
+    const char * mask = "*" SharedObjectExtension;
+    Owned<IFile> libDir = createIFile(libDirectory);
+    Owned<IDirectoryIterator> libFiles = libDir->directoryFiles(mask,false,false);
+    ForEach(*libFiles)
+    {
+        const char *thisDll = libFiles->query().queryFilename();
+        if (!strstr(thisDll, "javaembed"))  // Bit of a hack, but loading this if java not present terminates...
+        {
+            LoadedObject *loaded = loadDll(thisDll);
+            if (loaded)
+                objects.append(*loaded);
+        }
+    }
+}
+
 int main(int argc, char* argv[])
 {
     InitModuleObjects();
-    // These are the internal unit tests covered by other modules and libraries
-    IArray objects;
-    objects.append(*(new LoadedObject ("jhtree")));
-    objects.append(*(new LoadedObject ("roxiemem")));
-    objects.append(*(new LoadedObject ("thorhelper")));
 
-    queryStderrLogMsgHandler()->setMessageFields(MSGFIELD_time);
-    CppUnit::TextUi::TestRunner runner;
-    if (argc==1)
+    StringArray includeNames;
+    StringArray excludeNames;
+    StringArray loadLocations;
+    bool wildMatch = true;
+    bool exclude = false;
+    bool includeAll = false;
+    bool verbose = false;
+    bool list = false;
+    bool useDefaultLocations = true;
+    for (int argNo = 1; argNo < argc; argNo++)
     {
-        CppUnit::TestFactoryRegistry &registry = CppUnit::TestFactoryRegistry::getRegistry();
-        runner.addTest( registry.makeTest() );
-    }
-    else 
-    {
-        for (int name = 1; name < argc; name++)
+        const char *arg = argv[argNo];
+        if (arg[0]=='-')
         {
-            CppUnit::TestFactoryRegistry &registry = CppUnit::TestFactoryRegistry::getRegistry(argv[name]);
-            runner.addTest( registry.makeTest() );
+            if (streq(arg, "-x") || streq(arg, "--exclude"))
+                exclude = true;
+            else if (streq(arg, "-v") || streq(arg, "--verbose"))
+                verbose = true;
+            else if (streq(arg, "-e") || streq(arg, "--exact"))
+                wildMatch = false;
+            else if (streq(arg, "-a") || streq(arg, "--all"))
+                includeAll = true;
+            else if (streq(arg, "-l") || streq(arg, "--list"))
+                list = true;
+            else if (streq(arg, "-d") || streq(arg, "--load"))
+            {
+                useDefaultLocations = false;
+                argNo++;
+                if (argNo<argc)
+                   loadLocations.append(argv[argNo]);
+            }
+            else
+            {
+                usage();
+                exit(streq(arg, "-h") || streq(arg, "--help")?0:4);
+            }
+        }
+        else
+        {
+            VStringBuffer pattern("*%s*", arg);
+            if (wildMatch && !strchr(arg, '*'))
+                arg = pattern.str();
+            if (exclude)
+                excludeNames.append(arg);
+            else
+                includeNames.append(arg);
         }
     }
-    bool wasSucessful = runner.run( "", false );
+    if (verbose)
+        queryStderrLogMsgHandler()->setMessageFields(MSGFIELD_time);
+    else
+        removeLog();
+
+    if (!includeNames.length())
+        includeNames.append("*");
+
+    if (!includeAll)
+    {
+        excludeNames.append("*stress*");
+        excludeNames.append("*timing*");
+    }
+
+    if (useDefaultLocations)
+    {
+        // Default library location depends on the executable location...
+        StringBuffer dir;
+        splitFilename(argv[0], &dir, &dir, NULL, NULL);
+        dir.replaceString(PATHSEPSTR "bin" PATHSEPSTR, PATHSEPSTR "lib" PATHSEPSTR);
+        if (verbose)
+            DBGLOG("Adding default library location %s", dir.str());
+        loadLocations.append(dir);
+#ifdef _DEBUG
+        dir.replaceString(PATHSEPSTR "lib" PATHSEPSTR, PATHSEPSTR "libs" PATHSEPSTR);
+        loadLocations.append(dir);
+        if (verbose)
+            DBGLOG("Adding default library location %s", dir.str());
+#endif
+    }
+    IArray objects;
+    ForEachItemIn(idx, loadLocations)
+    {
+        const char *location = loadLocations.item(idx);
+        Owned<IFile> file = createIFile(location);
+        switch (file->isDirectory())
+        {
+        case notFound:
+            if (verbose && !useDefaultLocations)
+                DBGLOG("Specified library location %s not found", location);
+            break;
+        case foundYes:
+            loadDlls(objects, location);
+            break;
+        case foundNo:
+            LoadedObject *loaded = loadDll(location);
+            if (loaded)
+                objects.append(*loaded);
+            break;
+        }
+    }
+
+    bool wasSuccessful = false;
+    {
+        // New scope as we need the TestRunner to be destroyed before unloading the dlls...
+        CppUnit::TestFactoryRegistry &registry = CppUnit::TestFactoryRegistry::getRegistry();
+        CppUnit::TextUi::TestRunner runner;
+        CppUnit::Test *all = registry.makeTest();
+        int numTests = all->getChildTestCount();
+        for (int i = 0; i < numTests; i++)
+        {
+            CppUnit::Test *sub = all->getChildTestAt(i);
+            std::string name = sub->getName();
+            if (matchName(name.c_str(), includeNames))
+            {
+                if (matchName(name.c_str(), excludeNames))
+                {
+                    if (verbose)
+                        DBGLOG("Excluding test %s", name.c_str());
+                }
+                else if (list)
+                    printf("%s\n", name.c_str());
+                else
+                {
+                    if (verbose)
+                        DBGLOG("Including test %s", name.c_str());
+                    runner.addTest(sub);
+                }
+            }
+        }
+        wasSuccessful = list || runner.run( "", false );
+    }
+    objects.kill();
     ExitModuleObjects();
     releaseAtoms();
-    return wasSucessful;
+    return wasSuccessful;
 }
 
 


### PR DESCRIPTION
Rework the unittest program to allow finer control over what tests are to be
run.

Delay initialization on Dali unit tests until it is proven they are included.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
