### PR TITLE
HPCC-15565 Fix problems with inconsistent expression folding

### DIFF
--- a/ecl/hql/hqlerror.cpp
+++ b/ecl/hql/hqlerror.cpp
@@ -240,11 +240,6 @@ IErrorReceiver * createThrowingErrorReceiver()
 
 //---------------------------------------------------------------------------------------------------------------------
 
-class HQL_API NullErrorReceiver : public ErrorReceiverSink
-{
-public:
-};
-
 IErrorReceiver * createNullErrorReceiver()
 {
     return new NullErrorReceiver;

--- a/ecl/hql/hqlerror.hpp
+++ b/ecl/hql/hqlerror.hpp
@@ -60,6 +60,12 @@ private:
 
 //---------------------------------------------------------------------------------------------------------------------
 
+class HQL_API NullErrorReceiver : public ErrorReceiverSink
+{
+};
+
+//---------------------------------------------------------------------------------------------------------------------
+
 class IndirectErrorReceiver : public CInterfaceOf<IErrorReceiver>
 {
 public:

--- a/ecl/hql/hqlfold.hpp
+++ b/ecl/hql/hqlfold.hpp
@@ -57,6 +57,9 @@ extern HQLFOLD_API IHqlExpression * foldScopedHqlExpression(IErrorReceiver & err
 extern HQLFOLD_API void foldHqlExpression(IErrorReceiver & errorProcessor, HqlExprArray & tgt, HqlExprArray & src, unsigned options=0);
 extern HQLFOLD_API IHqlExpression * lowerCaseHqlExpr(IHqlExpression * expr);
 extern HQLFOLD_API IHqlExpression * foldExprIfConstant(IHqlExpression * expr);
+extern HQLFOLD_API bool queryCompareConstantValues(int & result, IHqlExpression * left, IHqlExpression * right);
+extern HQLFOLD_API IHqlExpression * foldConstantCaseExpr(IHqlExpression * expr);
+extern HQLFOLD_API IHqlExpression * foldConstantMapExpr(IHqlExpression * expr);
 
 extern HQLFOLD_API bool areExclusiveConditions(IHqlExpression * left, IHqlExpression * right);
 

--- a/ecl/hql/hqlgram.y
+++ b/ecl/hql/hqlgram.y
@@ -2508,14 +2508,16 @@ actionStmt
                             HqlExprArray args;
                             $3.unwindCommaList(args);
                             args.append(*$5.getExpr());
-                            $$.setExpr(createValue(no_map, makeVoidType(), args), $1);
+                            OwnedHqlExpr expr = createValue(no_map, makeVoidType(), args);
+                            $$.setExpr(foldConstantMapExpr(expr), $1);
                         }
     | MAP '(' mapActionSpec ')'
                         {
                             HqlExprArray args;
                             $3.unwindCommaList(args);
                             args.append(*createValue(no_null, makeVoidType()));
-                            $$.setExpr(createValue(no_map, makeVoidType(), args), $1);
+                            OwnedHqlExpr expr = createValue(no_map, makeVoidType(), args);
+                            $$.setExpr(foldConstantMapExpr(expr), $1);
                         }
     | CASE '(' expression ',' beginList caseActionSpec ',' action ')'
                         {
@@ -2525,7 +2527,8 @@ actionStmt
                             parser->checkCaseForDuplicates(args, $6);
                             args.add(*$3.getExpr(),0);
                             args.append(*$8.getExpr());
-                            $$.setExpr(createValue(no_case, makeVoidType(), args), $1);
+                            OwnedHqlExpr expr = createValue(no_case, makeVoidType(), args);
+                            $$.setExpr(foldConstantCaseExpr(expr), $1);
                         }
     | CASE '(' expression ',' beginList caseActionSpec ')'
                         {
@@ -2535,7 +2538,8 @@ actionStmt
                             parser->checkCaseForDuplicates(args, $6);
                             args.add(*$3.getExpr(),0);
                             args.append(*createValue(no_null, makeVoidType()));
-                            $$.setExpr(createValue(no_case, makeVoidType(), args), $1);
+                            OwnedHqlExpr expr = createValue(no_case, makeVoidType(), args);
+                            $$.setExpr(foldConstantCaseExpr(expr), $1);
                         }
     | CASE '(' expression ',' beginList action ')'
                         {
@@ -5773,7 +5777,8 @@ primexpr1
                             $3.unwindCommaList(args);
                             ITypeInfo * retType = parser->promoteMapToSameType(args, $5);
                             args.append(*$5.getExpr());
-                            $$.setExpr(createValue(no_map, retType, args));
+                            OwnedHqlExpr expr = createValue(no_map, retType, args);
+                            $$.setExpr(foldConstantMapExpr(expr), $1);
                         }
     | CASE '(' expression ',' beginList caseSpec ',' expression ')'
                         {
@@ -5785,7 +5790,8 @@ primexpr1
                             ITypeInfo * retType = parser->promoteCaseToSameType($3, args, $8);
                             args.add(*$3.getExpr(),0);
                             args.append(*$8.getExpr());
-                            $$.setExpr(createValue(no_case, retType, args));
+                            OwnedHqlExpr expr = createValue(no_case, retType, args);
+                            $$.setExpr(foldConstantCaseExpr(expr), $1);
                         }
     | CASE '(' expression ',' beginList expression ')'
                         {
@@ -7611,8 +7617,8 @@ simpleDictionary
                                 parser->checkRecordTypesMatch(cur, elseDict, $5);
                             }
                             args.append(*elseDict);
-                            $$.setExpr(::createDictionary(no_map, args));
-                            $$.setPosition($1);
+                            OwnedHqlExpr expr = createDictionary(no_map, args);
+                            $$.setExpr(foldConstantMapExpr(expr), $1);
                         }
     | MAP '(' mapDictionarySpec ')'
                         {
@@ -7629,8 +7635,8 @@ simpleDictionary
                                 parser->checkRecordTypesMatch(cur, elseDict, $1);
                             }
                             args.append(*elseDict);
-                            $$.setExpr(::createDictionary(no_map, args));
-                            $$.setPosition($1);
+                            OwnedHqlExpr expr = createDictionary(no_map, args);
+                            $$.setExpr(foldConstantMapExpr(expr), $1);
                         }
     | CASE '(' expression ',' beginList caseDictionarySpec ',' dictionary ')'
                         {
@@ -7646,8 +7652,8 @@ simpleDictionary
                             }
                             args.add(*$3.getExpr(),0);
                             args.append(*elseDict);
-                            $$.setExpr(::createDataset(no_case, args));
-                            $$.setPosition($1);
+                            OwnedHqlExpr expr = createDictionary(no_case, args);
+                            $$.setExpr(foldConstantCaseExpr(expr), $1);
                         }
     | CASE '(' expression ',' beginList caseDictionarySpec ')'
                         {
@@ -7667,8 +7673,8 @@ simpleDictionary
                             }
                             args.add(*$3.getExpr(),0);
                             args.append(*elseDict);
-                            $$.setExpr(::createDictionary(no_case, args));
-                            $$.setPosition($1);
+                            OwnedHqlExpr expr = createDictionary(no_case, args);
+                            $$.setExpr(foldConstantCaseExpr(expr), $1);
                         }
     | CASE '(' expression ',' beginList dictionary ')'
                         {
@@ -9091,8 +9097,8 @@ simpleDataSet
                             $3.unwindCommaList(args);
                             parser->ensureMapToRecordsMatch(elseExpr, args, $5, false);
                             args.append(*elseExpr.getClear());
-                            $$.setExpr(::createDataset(no_map, args));
-                            $$.setPosition($1);
+                            OwnedHqlExpr expr = createDataset(no_map, args);
+                            $$.setExpr(foldConstantMapExpr(expr), $1);
                         }
     | MAP '(' mapDatasetSpec ')'
                         {
@@ -9106,8 +9112,8 @@ simpleDataSet
 
                             parser->ensureMapToRecordsMatch(elseExpr, args, $3, false);
                             args.append(*elseExpr.getClear());
-                            $$.setExpr(::createDataset(no_map, args));
-                            $$.setPosition($1);
+                            OwnedHqlExpr expr = createDataset(no_map, args);
+                            $$.setExpr(foldConstantMapExpr(expr), $1);
                         }
     | CASE '(' expression ',' beginList caseDatasetSpec ',' dataSet ')'
                         {
@@ -9121,8 +9127,8 @@ simpleDataSet
 
                             args.add(*$3.getExpr(),0);
                             args.append(*elseExpr.getClear());
-                            $$.setExpr(::createDataset(no_case, args));
-                            $$.setPosition($1);
+                            OwnedHqlExpr expr = createDataset(no_case, args);
+                            $$.setExpr(foldConstantCaseExpr(expr), $1);
                         }
     | CASE '(' expression ',' beginList caseDatasetSpec ')'
                         {
@@ -9433,8 +9439,8 @@ simpleDataSet
                             parser->ensureMapToRecordsMatch(elseExpr, args, $5, true);
 
                             args.append(*elseExpr.getClear());
-                            $$.setExpr(::createRow(no_map, args));
-                            $$.setPosition($1);
+                            OwnedHqlExpr expr = createRow(no_map, args);
+                            $$.setExpr(foldConstantMapExpr(expr), $1);
                         }
     | CASE '(' expression ',' beginList caseDatarowSpec ',' dataRow ')'
                         {
@@ -9448,7 +9454,8 @@ simpleDataSet
 
                             args.add(*$3.getExpr(),0);
                             args.append(*elseExpr.getClear());
-                            $$.setExpr(::createRow(no_case, args), $1);
+                            OwnedHqlExpr expr = createRow(no_case, args);
+                            $$.setExpr(foldConstantCaseExpr(expr), $1);
                         }
     | WHEN '(' dataSet ',' action sideEffectOptions ')'
                         {

--- a/ecl/hql/hqlutil.cpp
+++ b/ecl/hql/hqlutil.cpp
@@ -1293,8 +1293,8 @@ IHqlExpression * createImpureOwn(IHqlExpression * expr)
 
 IHqlExpression * getNormalizedFilename(IHqlExpression * filename)
 {
-    Owned<IErrorReceiver> errorProcessor = createNullErrorReceiver();
-    OwnedHqlExpr folded = foldHqlExpression(*errorProcessor, filename, NULL, HFOloseannotations);
+    NullErrorReceiver errorProcessor;
+    OwnedHqlExpr folded = foldHqlExpression(errorProcessor, filename, NULL, HFOloseannotations);
     return lowerCaseHqlExpr(folded);
 }
 


### PR DESCRIPTION
If something is folded when binding a parameter it should be folded
when a the ECL is parsed, otherwise it can lead to inconsistencies.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
