### PR TITLE
HPCC-15599 Fix 5.4 regression with eclcc not flushing to file descriptors on exit

### DIFF
--- a/ecl/eclcc/eclcc.cpp
+++ b/ecl/eclcc/eclcc.cpp
@@ -477,6 +477,7 @@ int main(int argc, const char *argv[])
 #ifndef _DEBUG
     //In release mode exit without calling all the clean up code.
     //It is faster, and it helps avoids potential crashes if there are active objects which depend on objects in file hook dlls.
+    fflush(NULL);
     _exit(exitCode);
 #endif
 


### PR DESCRIPTION
Signed-off-by: Michael Gardner Michael.Gardner@lexisnexis.com
