### PR TITLE
HPCC-15416 Calculate heap memory in use

### DIFF
--- a/thorlcr/graph/thgraph.cpp
+++ b/thorlcr/graph/thgraph.cpp
@@ -2431,7 +2431,10 @@ CJobBase::~CJobBase()
     PROGLOG("Roxiemem stats: %s", memStatsStr.str());
     memsize_t heapUsage = getMapInfo("heap");
     if (heapUsage) // if 0, assumed to be unavailable
-        PROGLOG("Heap usage : %" I64F "d bytes", (unsigned __int64)heapUsage);
+    {
+        memsize_t rmtotal = roxiemem::getTotalMemoryLimit();
+        PROGLOG("Heap usage : %" I64F "d bytes", (unsigned __int64)(heapUsage-rmtotal));
+    }
 }
 
 CJobChannel &CJobBase::queryJobChannel(unsigned c) const


### PR DESCRIPTION
The function now accounts for anonymous mmapped regions (and the heap) that would be from malloc() callls.

@jakesmith please review.

Signed-off-by: Mark Kelly mark.kelly@lexisnexis.com
