### PR TITLE
HPCC-15416 Calculate heap memory in use

### DIFF
--- a/system/jlib/jdebug.cpp
+++ b/system/jlib/jdebug.cpp
@@ -935,23 +935,47 @@ static unsigned evalAffinityCpus()
 
 memsize_t getMapInfo(const char *type)
 {
+    // NOTE: 'total' heap value includes Roxiemem allocation, if present
     memsize_t ret = 0;
     VStringBuffer procMaps("/proc/%d/maps", GetCurrentProcessId());
-    VStringBuffer typeStr("[%s]", type);
     FILE *diskfp = fopen(procMaps.str(), "r");
     if (!diskfp)
         return false;
     char ln[256];
     while (fgets(ln, sizeof(ln), diskfp))
     {
-        if (strstr(ln, typeStr.str()))
+        bool skipline = true;
+        if ( !strcmp(type, "heap") ) // 'general' heap includes anon mmapped + sbrk
+        {
+            if ( strstr(ln, "[heap") || (!strstr(ln, " /") && !strstr(ln, " [")) )
+            {
+                if ( strstr(ln, " rw-p") || strstr(ln, " ---p") )
+                    skipline = false;
+            }
+        }
+        else if ( !strcmp(type, "stack") )
+        {
+            if ( strstr(ln, "[stack") )
+                skipline = false;
+        }
+        else if ( !strcmp(type, "sbrk") )
+        {
+            if ( strstr(ln, "[heap") )
+                skipline = false;
+        }
+        else if ( !strcmp(type, "anon") )
+        {
+            if ( (!strstr(ln, " /") && !strstr(ln, " [")) )
+            {
+                if ( strstr(ln, " rw-p") || strstr(ln, " ---p") )
+                    skipline = false;
+            }
+        }
+        if ( !skipline )
         {
             unsigned __int64 addrLow, addrHigh;
             if (2 == sscanf(ln, "%16" I64F "x-%16" I64F "x", &addrLow, &addrHigh))
-            {
-                ret = (memsize_t)(addrHigh-addrLow);
-                break;
-            }
+                ret += (memsize_t)(addrHigh-addrLow);
         }
     }
     fclose(diskfp);

--- a/thorlcr/graph/thgraph.cpp
+++ b/thorlcr/graph/thgraph.cpp
@@ -2431,7 +2431,10 @@ CJobBase::~CJobBase()
     PROGLOG("Roxiemem stats: %s", memStatsStr.str());
     memsize_t heapUsage = getMapInfo("heap");
     if (heapUsage) // if 0, assumed to be unavailable
-        PROGLOG("Heap usage : %" I64F "d bytes", (unsigned __int64)heapUsage);
+    {
+        memsize_t rmtotal = roxiemem::getTotalMemoryLimit();
+        PROGLOG("Heap usage : %" I64F "d bytes", (unsigned __int64)(heapUsage-rmtotal));
+    }
 }
 
 CJobChannel &CJobBase::queryJobChannel(unsigned c) const

--- a/thorlcr/graph/thgraph.cpp
+++ b/thorlcr/graph/thgraph.cpp
@@ -2433,7 +2433,7 @@ CJobBase::~CJobBase()
     if (heapUsage) // if 0, assumed to be unavailable
     {
         memsize_t rmtotal = roxiemem::getTotalMemoryLimit();
-        PROGLOG("Heap usage : %" I64F "d bytes", (unsigned __int64)(heapUsage-rmtotal));
+        PROGLOG("Heap usage (excluding Roxiemem) : %" I64F "d bytes", (unsigned __int64)(heapUsage-rmtotal));
     }
 }
 


### PR DESCRIPTION
This funtction now accounts for the anon mmapped regions (in addition to sbrk) from a malloc() call.

@jakesmith please review

Signed-off-by: Mark Kelly mark.kelly@lexisnexis.com
