### PR TITLE
HPCC-15600 Use a consistent include directory for the regression tests

### DIFF
--- a/testing/regress/hpcc/regression/regress.py
+++ b/testing/regress/hpcc/regression/regress.py
@@ -79,6 +79,7 @@ class Regression:
         self.dir_a = os.path.join(self.regressionDir, self.config.archiveDir)
         self.dir_r = os.path.join(self.regressionDir, self.config.resultDir)
         self.dir_zap =  os.path.join(self.regressionDir,self.config.zapDir)
+        self.dir_inc =  self.dir_ec
         logging.debug("Suite Dir      : %s", self.suiteDir)
         logging.debug("Regression Dir : %s", self.regressionDir)
         logging.debug("Result Dir     : %s", self.dir_r)
@@ -87,7 +88,7 @@ class Regression:
         logging.debug("Key Dir        : %s", self.dir_ex)
         logging.debug("Archive Dir    : %s", self.dir_a)
         logging.debug("ZAP Dir        : %s", self.dir_zap )
-
+        logging.debug("INC Dir        : %s", self.dir_inc )
 
         numOfThreads=1
         if 'pq' in args:
@@ -130,7 +131,7 @@ class Regression:
         self.createDirectory(self.logDir)
         self.createDirectory(self.dir_zap)
 
-        self.suites[cluster] = Suite(cluster, self.dir_ec, self.dir_a, self.dir_ex, self.dir_r, self.logDir, args, False, fileList)
+        self.suites[cluster] = Suite(cluster, self.dir_ec, self.dir_a, self.dir_ex, self.dir_r, self.logDir, self.dir_inc, args, False, fileList)
         self.maxtasks = len(self.suites[cluster].getSuite())
 
     def createDirectory(self, dir_n):
@@ -142,9 +143,10 @@ class Regression:
         self.createDirectory(self.dir_a)
         self.createDirectory(self.dir_r)
         self.createDirectory(self.logDir)
+        self.createDirectory(self.dir_zap)
         self.setupDir = ExpandCheck.dir_exists(os.path.join(self.suiteDir, self.config.setupDir), True)
         logging.debug("Setup Dir      : %s", self.setupDir)
-        self.setupSuite = Suite(args.target, self.setupDir, self.dir_a, self.dir_ex, self.dir_r, self.logDir, args, True)
+        self.setupSuite = Suite(args.target, self.setupDir, self.dir_a, self.dir_ex, self.dir_r, self.logDir, self.dir_inc, args, True)
         self.maxtasks = len(self.setupSuite.getSuite())
         return self.setupSuite
 

--- a/testing/regress/hpcc/regression/suite.py
+++ b/testing/regress/hpcc/regression/suite.py
@@ -27,7 +27,7 @@ from ..common.error import Error
 from ..util.util import checkClusters, getConfig
 
 class Suite:
-    def __init__(self, clusterName, dir_ec, dir_a, dir_ex, dir_r, logDir, args, isSetup=False,  fileList = None):
+    def __init__(self, clusterName, dir_ec, dir_a, dir_ex, dir_r, logDir, dir_inc, args, isSetup=False,  fileList = None):
         self.clusterName = clusterName
         self.targetName = clusterName
         if isSetup:
@@ -40,6 +40,7 @@ class Suite:
         self.dir_ex = dir_ex
         self.dir_r = dir_r
         self.logDir = logDir
+        self.dir_inc = dir_inc
         self.exclude = []
         self.publish = []
 
@@ -84,7 +85,7 @@ class Suite:
             if file.endswith(".ecl"):
                 ecl = os.path.join(self.dir_ec, file)
                 eclfile = ECLFile(ecl, self.dir_a, self.dir_ex,
-                                  self.dir_r,  self.clusterName,   args)
+                                  self.dir_r, self.dir_inc, self.clusterName,   args)
                 if isSetup:
                     skipResult = eclfile.testSkip('setup')
                 else:
@@ -145,7 +146,7 @@ class Suite:
             # generate ECLs to suite
             for file in files:
                 generatedEclFile = ECLFile(basename, self.dir_a, self.dir_ex,
-                                 self.dir_r,  self.clusterName, self.args)
+                                 self.dir_r,  self.dir_inc, self.clusterName, self.args)
 
                 generatedEclFile.setDParameters(file['version'])
                 generatedEclFile.setVersionId(file['id'])

--- a/testing/regress/hpcc/util/ecl/cc.py
+++ b/testing/regress/hpcc/util/ecl/cc.py
@@ -44,7 +44,7 @@ class ECLCC(Shell):
             return repr(err)
 
     def makeArchive(self, ecl):
-        self.addIncludePath(ecl.dir_ec)
+        self.addIncludePath(ecl.dir_inc)
         dirname = ecl.dir_a
         filename = ecl.getArchive()
 

--- a/testing/regress/hpcc/util/ecl/file.py
+++ b/testing/regress/hpcc/util/ecl/file.py
@@ -54,11 +54,12 @@ class ECLFile:
             self.tempFile.close()
             pass
 
-    def __init__(self, ecl, dir_a, dir_ex, dir_r,  cluster, args):
+    def __init__(self, ecl, dir_a, dir_ex, dir_r, dir_inc, cluster, args):
         self.dir_ec = os.path.dirname(ecl)
         self.dir_ex = dir_ex
         self.dir_r = dir_r
         self.dir_a = dir_a
+        self.dir_inc = dir_inc
         self.cluster = cluster;
         self.baseEcl = os.path.basename(ecl)
         self.basename = os.path.splitext(self.baseEcl)[0]


### PR DESCRIPTION
Add dedicated variable to the include directory and set it to the ECL dir.

Signed-off-by: Attila Vamos attila.vamos@gmail.com
