### PR TITLE
HPCC-15611 Do not percolate constants into a keyed distribute condition

### DIFF
--- a/ecl/hql/hqlfold.cpp
+++ b/ecl/hql/hqlfold.cpp
@@ -5500,6 +5500,7 @@ IHqlExpression * CExprFolderTransformer::percolateConstants(IHqlExpression * exp
         }
     case no_loop:
     case no_graphloop:
+    case no_keyeddistribute:
         //Safer to do nothing...
         break;
     case no_select:


### PR DESCRIPTION
Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
