### PR TITLE
HPCC-15622 MySQLEMBED build (candidate-6.0.0) fails on CentOS 5

### DIFF
--- a/plugins/mysql/mysqlembed.cpp
+++ b/plugins/mysql/mysqlembed.cpp
@@ -1200,19 +1200,19 @@ public:
                             case ParamTypeUInt:
                                 {
                                     unsigned int oval = strtoul(val, nullptr, 10);
-                                    rc = mysql_options(*conn, optDef.option, &oval);
+                                    rc = mysql_options(*conn, optDef.option, (const char *) &oval);
                                     break;
                                 }
                             case ParamTypeULong:
                                 {
                                     unsigned long oval = strtoul(val, nullptr, 10);
-                                    rc = mysql_options(*conn, optDef.option, &oval);
+                                    rc = mysql_options(*conn, optDef.option, (const char *) &oval);
                                     break;
                                 }
                             case ParamTypeBool:
                                 {
                                     my_bool oval = clipStrToBool(val);
-                                    rc = mysql_options(*conn, optDef.option, &oval);
+                                    rc = mysql_options(*conn, optDef.option, (const char *) &oval);
                                     break;
                                 }
                             }


### PR DESCRIPTION
The mysql_options API prototype has changed betewen MySQL 5.0 and MySQL 5.5.
Inserting a cast should ensure it compiles on both.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
