### PR TITLE
HPCC-14037 ECL Watch Resource URL always equals 1

### DIFF
--- a/esp/src/eclwatch/QuerySetDetailsWidget.js
+++ b/esp/src/eclwatch/QuerySetDetailsWidget.js
@@ -232,8 +232,8 @@ define([
                         tooltip += " " + newValue[i].Time;
                 }
                 this.graphsTab.set("tooltip", tooltip);
-            } else if (name === "ResourceURLCount" && newValue) {
-                this.widget._Resources.set("title", this.i18n.Resources + " (" + newValue + ")");
+            } else if (name === "ResourceURLCount" && newValue - 1) {
+                this.widget._Resources.set("title", this.i18n.Resources + " (" + (newValue - 1) + ")");
             } else if (name === "SuperFiles") {
                 if (lang.exists("SuperFile.length", newValue)) {
                     this.superFilesTab.set("title", this.i18n.SuperFiles + " (" + newValue.SuperFile.length + ")");


### PR DESCRIPTION
All work units have one resource URL therefore, always reporting 1 in the tab which was misleading users. We have similar functionality for the grid setter in ESPWorkunit.js #153

Signed-off by: Miguel Vazquez miguel.vazquez@lexisnexis.com
