### PR TITLE
HPCC-15590 Unable to rename group in summary tab

### DIFF
--- a/esp/src/eclwatch/nls/hpcc.js
+++ b/esp/src/eclwatch/nls/hpcc.js
@@ -72,6 +72,7 @@ define({root:
     Configuration: "Configuration",
     ConfirmPassword: "Confirm Password",
     ConfirmRemoval: "Are you sure you want to do this?",
+    ContactAdmin: "If you wish to rename this group, please contact your LDAP admin.",
     Content: "Content",
     Contents: "Contents",
     ContentType: "Content Type",

--- a/esp/src/eclwatch/templates/GroupDetailsWidget.html
+++ b/esp/src/eclwatch/templates/GroupDetailsWidget.html
@@ -11,6 +11,9 @@
                     <h2>
                         <span id="${id}Group" class="bold">${i18n.GroupName}</span>
                     </h2>
+                    <h3>
+                        <span class="bold">${i18n.ContactAdmin}</span>
+                    </h3>
                     <form>
                         <ul>
                             <li>


### PR DESCRIPTION
In the summary tab there was simply a group name and a read-only text field which would eventually allow a group rename. We have removed the ability to rename a group name should not be supported via ECL Watch.

Signed-off by: Miguel Vazquez miguel.vazquez@lexisnexis.com
