### PR TITLE
HPCC-15660 Can't pass stored values to EMBED options in Thor

### DIFF
--- a/ecl/hql/hqlatoms.cpp
+++ b/ecl/hql/hqlatoms.cpp
@@ -55,6 +55,7 @@ IIdAtom * loadId;
 IIdAtom * macroId;
 IIdAtom * maxLengthId;
 IIdAtom * maxSizeId;
+IIdAtom * __optionsId;
 IIdAtom * outputId;
 IIdAtom * physicalLengthId;
 IIdAtom * selfId;
@@ -496,6 +497,7 @@ MODULE_INIT(INIT_PRIORITY_HQLATOM)
     MAKEID(macro);
     MAKEID(maxLength);
     MAKEID(maxSize);
+    MAKEID(__options);
     MAKEID(output);
     MAKEID(physicalLength);
     MAKEID(self);

--- a/ecl/hql/hqlatoms.hpp
+++ b/ecl/hql/hqlatoms.hpp
@@ -57,6 +57,7 @@ extern HQL_API IIdAtom * loadId;
 extern HQL_API IIdAtom * macroId;
 extern HQL_API IIdAtom * maxLengthId;
 extern HQL_API IIdAtom * maxSizeId;
+extern HQL_API IIdAtom * __optionsId;
 extern HQL_API IIdAtom * outputId;
 extern HQL_API IIdAtom * physicalLengthId;
 extern HQL_API IIdAtom * selfId;

--- a/ecl/hqlcpp/hqlcpp.hpp
+++ b/ecl/hqlcpp/hqlcpp.hpp
@@ -146,5 +146,6 @@ extern HQLCPP_API IHqlExpression * createTranslated(IHqlExpression * expr);
 extern HQLCPP_API IHqlExpression * createTranslatedOwned(IHqlExpression * expr);
 extern HQLCPP_API IHqlExpression * createTranslated(IHqlExpression * expr, IHqlExpression * length);
 extern HQLCPP_API IHqlExpression * getSimplifyCompareArg(IHqlExpression * expr);
+extern HQLCPP_API IHqlExpression * replaceInlineParameters(IHqlExpression * funcdef, IHqlExpression * expr);
 
 #endif

--- a/ecl/hqlcpp/hqlttcpp.cpp
+++ b/ecl/hqlcpp/hqlttcpp.cpp
@@ -6224,18 +6224,81 @@ IHqlExpression * WorkflowTransformer::transformInternalFunction(IHqlExpression *
 
     HqlExprArray funcdefArgs;
     funcdefArgs.append(*LINK(newBody));
-    unwindChildren(funcdefArgs, newFuncDef, 1);
-    OwnedHqlExpr namedFuncDef = newFuncDef->clone(funcdefArgs);
-    inheritDependencies(namedFuncDef);
 
     if (ecl->getOperator() == no_embedbody)
-        return namedFuncDef.getClear();
+    {
+        IHqlExpression * outofline = newFuncDef->queryChild(0);
+        IHqlExpression * formals = newFuncDef->queryChild(1);
+        IHqlExpression * defaults = newFuncDef->queryChild(2);
+        assertex(outofline->getOperator() == no_outofline);
+        IHqlExpression * bodyCode = outofline->queryChild(0);
+        HqlExprArray attrArgs;
+        ForEachChild(idx, bodyCode)
+        {
+            IHqlExpression *child = bodyCode->queryChild(idx);
+            if (child->isAttribute() && child->queryName() != languageAtom && child->queryName() != importAtom)
+            {
+                StringBuffer attrParam;
+                if (attrArgs.ordinality())
+                    attrParam.append(",");
+                attrParam.append(child->queryName());
 
-    WorkflowItem * item = new WorkflowItem(namedFuncDef);
-    workflowOut->append(*item);
-    OwnedHqlExpr external = createExternalFuncdefFromInternal(namedFuncDef);
-    copyDependencies(queryBodyExtra(namedFuncDef), queryBodyExtra(external));
-    return external.getClear();
+                IHqlExpression * value = child->queryChild(0);
+                if (value)
+                    attrParam.append("=");
+                attrArgs.append(*createConstant(attrParam));
+                if (value)
+                    attrArgs.append(*ensureExprType(value, unknownStringType));
+            }
+        }
+        OwnedHqlExpr folded;
+        if (attrArgs.length())
+        {
+            OwnedHqlExpr concat = createUnbalanced(no_concat, unknownStringType, attrArgs);
+            OwnedHqlExpr cast = ensureExprType(concat, unknownVarStringType);
+
+            // It's not legal to use parameters in the options, since it becomes ambiguous whether they should be bound to embed variables or not.
+            // Check that they didn't and give a sensible error message
+            OwnedHqlExpr boundCast = replaceInlineParameters(newFuncDef, cast);
+            if (cast != boundCast)
+                throwError(HQLERR_EmbedParamNotSupportedInOptions);
+
+            folded.setown(foldHqlExpression(cast));
+        }
+        else
+            folded.setown(createConstant(""));
+        HqlExprArray newFormals;
+        HqlExprArray attrs;
+        unwindChildren(newFormals, formals, 0);
+        newFormals.append(*createParameter(createIdAtom("__options"), newFormals.length(), LINK(unknownVarStringType), attrs));
+
+        HqlExprArray newDefaults;
+        if (defaults)
+            unwindChildren(newDefaults, defaults, 0);
+        while (newDefaults.length() < formals->numChildren())
+            newDefaults.append(*createOmittedValue());
+        newDefaults.append(*folded.getClear());
+        formals = formals->clone(newFormals);
+        defaults = createValueSafe(no_sortlist, makeSortListType(NULL), newDefaults);
+        funcdefArgs.append(*LINK(formals));
+        funcdefArgs.append(*LINK(defaults));
+        unwindChildren(funcdefArgs, newFuncDef, 3);
+        OwnedHqlExpr namedFuncDef = newFuncDef->clone(funcdefArgs);
+        inheritDependencies(namedFuncDef);
+        return namedFuncDef.getClear();
+    }
+    else
+    {
+        unwindChildren(funcdefArgs, newFuncDef, 1);
+        OwnedHqlExpr namedFuncDef = newFuncDef->clone(funcdefArgs);
+        inheritDependencies(namedFuncDef);
+
+        WorkflowItem * item = new WorkflowItem(namedFuncDef);
+        workflowOut->append(*item);
+        OwnedHqlExpr external = createExternalFuncdefFromInternal(namedFuncDef);
+        copyDependencies(queryBodyExtra(namedFuncDef), queryBodyExtra(external));
+        return external.getClear();
+    }
 }
 
 IHqlExpression * WorkflowTransformer::transformInternalCall(IHqlExpression * transformed)
@@ -6245,6 +6308,18 @@ IHqlExpression * WorkflowTransformer::transformInternalCall(IHqlExpression * tra
 
     HqlExprArray parameters;
     unwindChildren(parameters, transformed);
+
+    IHqlExpression * body = newFuncDef->queryChild(0);
+    if (body->getOperator() == no_outofline)
+    {
+        IHqlExpression * ecl = body->queryChild(0);
+        if (ecl->getOperator() == no_embedbody)
+        {
+            // Copy the new default value into the end of the parameters array
+            parameters.append(*LINK(newFuncDef->queryChild(2)->queryChild(parameters.length())));
+        }
+    }
+
     OwnedHqlExpr rebound = createReboundFunction(newFuncDef, parameters);
     inheritDependencies(rebound);
     copyDependencies(queryBodyExtra(newFuncDef), queryBodyExtra(rebound));

--- a/ecl/hqlcpp/hqlttcpp.cpp
+++ b/ecl/hqlcpp/hqlttcpp.cpp
@@ -6269,8 +6269,8 @@ IHqlExpression * WorkflowTransformer::transformInternalFunction(IHqlExpression *
             folded.setown(createConstant(""));
         HqlExprArray newFormals;
         HqlExprArray attrs;
-        unwindChildren(newFormals, formals, 0);
-        newFormals.append(*createParameter(createIdAtom("__options"), newFormals.length(), LINK(unknownVarStringType), attrs));
+        unwindChildren(newFormals, formals);
+        newFormals.append(*createParameter(__optionsId, newFormals.length(), LINK(unknownVarStringType), attrs));
 
         HqlExprArray newDefaults;
         if (defaults)


### PR DESCRIPTION
Rework the code generated for EMBED options so that it is calculated outside
of the generated user function and passed in. This will mean that it can be
calculated just once (on the master, in Thor) and serialized to the slaves.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
