### PR TITLE
HPCC-15614 Spurious ticked in logical file

### DIFF
--- a/esp/src/eclwatch/DFUQueryWidget.js
+++ b/esp/src/eclwatch/DFUQueryWidget.js
@@ -157,6 +157,7 @@ define([
                 if (i == 0) {
                     firstTab = tab;
                 }
+                this.workunitsGrid.deselect(selections[i]);
             }
             if (firstTab) {
                 this.selectChild(firstTab, true);
@@ -276,6 +277,7 @@ define([
         _onRowDblClick: function (item) {
             var wuTab = this.ensureLFPane(item.__hpcc_id, item);
             this.selectChild(wuTab);
+            this.workunitsGrid.deselect(item);
         },
 
         _onRowContextMenu: function (item, colField, mystring) {

--- a/esp/src/eclwatch/EventScheduleWorkunitWidget.js
+++ b/esp/src/eclwatch/EventScheduleWorkunitWidget.js
@@ -216,6 +216,7 @@ define([
                 if (i == 0) {
                     firstTab = tab;
                 }
+                this.eventGrid.deselect(selections[i]);
             }
             if (firstTab) {
                 this.selectChild(firstTab, true);
@@ -238,6 +239,7 @@ define([
 
         _onRowDblClick: function (item) {
             var wuTab = this.ensurePane(item.Wuid, item);
+            this.eventGrid.deselect(item);
             this.selectChild(wuTab);
         },
 

--- a/esp/src/eclwatch/GetDFUWorkunitsWidget.js
+++ b/esp/src/eclwatch/GetDFUWorkunitsWidget.js
@@ -118,6 +118,7 @@ define([
                 if (i == 0) {
                     firstTab = tab;
                 }
+                this.workunitsGrid.deselect(selections[i]);
             }
             if (firstTab) {
                 this.selectChild(firstTab);
@@ -377,12 +378,14 @@ define([
                 if (context._onRowDblClick) {
                     var item = context.workunitsGrid.row(evt).data;
                     context._onRowDblClick(item.ID);
+                    context.workunitsGrid.deselect(item);
                 }
             });
             this.workunitsGrid.on(".dgrid-row:dblclick", function (evt) {
                 if (context._onRowDblClick) {
                     var item = context.workunitsGrid.row(evt).data;
                     context._onRowDblClick(item.ID);
+                    context.workunitsGrid.deselect(item);
                 }
             });
             this.workunitsGrid.on(".dgrid-row:contextmenu", function (evt) {

--- a/esp/src/eclwatch/GridDetailsWidget.js
+++ b/esp/src/eclwatch/GridDetailsWidget.js
@@ -86,6 +86,7 @@ define([
                 if (!firstTab && tab) {
                     firstTab = tab;
                 }
+                this.grid.deselect(selections[i]);
             }
             if (firstTab) {
                 this.selectChild(firstTab);
@@ -94,6 +95,7 @@ define([
 
         _onRowDblClick: function (row, params) {
             var tab = this.ensurePane(row, params);
+            this.grid.deselect(row);
             if (tab) {
                 this.selectChild(tab);
             }
@@ -136,12 +138,14 @@ define([
                 if (context._onRowDblClick) {
                     var row = context.grid.row(evt).data;
                     context._onRowDblClick(row);
+                    context.grid.deselect(row);
                 }
             });
             this.grid.on(".dgrid-row:dblclick", function (evt) {
                 if (context._onRowDblClick) {
                     var row = context.grid.row(evt).data;
                     context._onRowDblClick(row);
+                    context.grid.deselect(row);
                 }
             });
             this.grid.onSelectionChanged(function (event) {

--- a/esp/src/eclwatch/QuerySetQueryWidget.js
+++ b/esp/src/eclwatch/QuerySetQueryWidget.js
@@ -507,6 +507,7 @@ define([
                 if (i == 0) {
                     firstTab = tab;
                 }
+                this.querySetGrid.deselect(selections[i]);
             }
             if (firstTab) {
                 this.selectChild(firstTab);
@@ -528,6 +529,7 @@ define([
             } else {
                 tab = this.ensurePane(item.Id, item, false);
             }
+            this.querySetGrid.deselect(item);
             this.selectChild(tab);
         },
 

--- a/esp/src/eclwatch/SFDetailsWidget.js
+++ b/esp/src/eclwatch/SFDetailsWidget.js
@@ -118,6 +118,7 @@ define([
                 if (i == 0) {
                     firstTab = tab;
                 }
+                this.subfilesGrid.deselect(selections[i]);
             }
             if (firstTab) {
                 this.selectChild(firstTab, true);
@@ -239,6 +240,7 @@ define([
             this.subfilesGrid.on(".dgrid-row-url:click", function (evt) {
                 var item = context.subfilesGrid.row(evt).data;
                 var tab = context.ensureLFPane(item.Name, item);
+                context.subfilesGrid.deselect(item);
                 context.selectChild(tab, true);
             });
             this.subfilesGrid.on("dgrid-select", function (evt) {
@@ -255,6 +257,7 @@ define([
             this.subfilesGrid.on(".dgrid-row:dblclick", function (evt) {
                 var item = context.subfilesGrid.row(evt).data;
                 var tab = context.ensureLFPane(item.Name, item);
+                context.subfilesGrid.deselect(item);
                 context.selectChild(tab, true);
             });
             this.subfilesGrid.startup();

--- a/esp/src/eclwatch/UserQueryWidget.js
+++ b/esp/src/eclwatch/UserQueryWidget.js
@@ -508,12 +508,14 @@ define([
                 if (context._onGroupsRowDblClick) {
                     var item = context.groupsGrid.row(evt).data;
                     context._onGroupsRowDblClick(item.name);
+                    context.groupsGrid.deselect(item);
                 }
             });
             this.groupsGrid.on(".dgrid-row-url:click", function (evt) {
                 if (context._onGroupsRowDblClick) {
                     var item = context.groupsGrid.row(evt).data;
                     context._onGroupsRowDblClick(item.name);
+                    context.groupsGrid.deselect(item);
                 }
             });
             this.groupsGrid.onSelectionChanged(function (event) {
@@ -608,12 +610,14 @@ define([
                 if (context._onUsersRowDblClick) {
                     var item = context.usersGrid.row(evt).data;
                     context._onUsersRowDblClick(item.username,item.fullname,item.passwordexpiration);
+                    context.usersGrid.deselect(item);
                 }
             });
             this.usersGrid.on(".dgrid-row:dblclick", function (evt) {
                 if (context._onUsersRowDblClick) {
                     var item = context.usersGrid.row(evt).data;
                     context._onUsersRowDblClick(item.username,item.fullname,item.passwordexpiration);
+                    context.usersGrid.deselect(item);
                 }
             });
             this.usersGrid.onSelectionChanged(function (event) {
@@ -735,12 +739,14 @@ define([
                 if (context._onPermissionsRowDblClick) {
                     var item = context.permissionsGrid.row(evt).data;
                     context._onPermissionsRowDblClick(item.__hpcc_parent.basedn, item.__hpcc_parent.rtype, item.__hpcc_parent.rtitle, item.name, item.DisplayName);
+                    context.permissionsGrid.deselect(item);
                 }
             });
             this.permissionsGrid.on(".dgrid-row:dblclick", function (evt) {
                 if (context._onPermissionsRowDblClick) {
                     var item = context.permissionsGrid.row(evt).data;
                     context._onPermissionsRowDblClick(item.__hpcc_parent.basedn, item.__hpcc_parent.rtype, item.__hpcc_parent.rtitle, item.name, item.DisplayName);
+                    context.permissionsGrid.deselect(item);
                 }
             });
             this.permissionsGrid.onSelectionChanged(function (event) {

--- a/esp/src/eclwatch/WUQueryWidget.js
+++ b/esp/src/eclwatch/WUQueryWidget.js
@@ -120,6 +120,7 @@ define([
                 if (i == 0) {
                     firstTab = tab;
                 }
+                 this.workunitsGrid.deselect(selections[i]);
             }
             if (firstTab) {
                 this.selectChild(firstTab);
@@ -437,12 +438,14 @@ define([
                 if (context._onRowDblClick) {
                     var item = context.workunitsGrid.row(evt).data;
                     context._onRowDblClick(item.Wuid);
+                    context.workunitsGrid.deselect(item);
                 }
             });
             this.workunitsGrid.on(".dgrid-row:dblclick", function (evt) {
                 if (context._onRowDblClick) {
                     var item = context.workunitsGrid.row(evt).data;
                     context._onRowDblClick(item.Wuid);
+                    context.workunitsGrid.deselect(item);
                 }
             });
             this.workunitsGrid.on(".dgrid-row:contextmenu", function (evt) {


### PR DESCRIPTION
Whenever a user clicks from a grid into a detailed view the previous item remains checked and can cause issues whenever modifying another file such as deleting or modifying.

Signed-off by: Miguel Vazquez miguel.vazquez@lexisnexis.com
