### PR TITLE
HPCC-15683 Smart join deadlock if only some nodes fit in mem

### DIFF
--- a/thorlcr/activities/hashdistrib/thhashdistribslave.cpp
+++ b/thorlcr/activities/hashdistrib/thhashdistribslave.cpp
@@ -1813,7 +1813,7 @@ public:
         if (hasbuf[target]&&(waiting[target]!=TAG_NULL))
         {
 #ifdef TRACE_MP
-            ActPrintLog("HDIST MP dosend(%d,%d)",i,bufs[target].length());
+            ActPrintLog("HDIST MP dosend(%d,%d)",target,bufs[target].length());
 #endif
             size32_t sz = bufs[target].length();
             // TBD compress here?

--- a/thorlcr/activities/lookupjoin/thlookupjoinslave.cpp
+++ b/thorlcr/activities/lookupjoin/thlookupjoinslave.cpp
@@ -2232,12 +2232,8 @@ protected:
             if (getOptBool(THOROPT_LKJOIN_HASHJOINFAILOVER)) // for testing only (force to disk, as if spilt)
                 channelDistributor.spill(false);
 
-            Owned<IRowStream> distChannelStream;
-            if (!rhsCollated) // there may be some more undistributed rows
-            {
-                distChannelStream.setown(rhsDistributor->connect(queryRowInterfaces(rightITDL), right.getClear(), rightHash, NULL));
-                channelDistributor.processDistRight(distChannelStream);
-            }
+            Owned<IRowStream> distChannelStream = rhsDistributor->connect(queryRowInterfaces(rightITDL), right.getClear(), rightHash, NULL);
+            channelDistributor.processDistRight(distChannelStream);
             stream.setown(channelDistributor.getStream(&rhs));
         }
         catch (IException *e)


### PR DESCRIPTION
If some nodes manage to squeeze gathered RHS into memory, but
others do not (probably due to fragmentation), smart join
deadlocked. The deadlock was caused by the slaves that had
gathered, not starting the rhs distributor to gather rest, for
upcoming local lookupjoin attempt.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
