### PR TITLE
HPCC-15679 An attempt to replace a logical file belongs to a superfile with re-spray generates wrong error message.

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -8228,13 +8228,13 @@ void CDistributedFileDirectory::addEntry(CDfsLogicalFileName &dlfn,IPropertyTree
     IPropertyTree *prev = getNamedPropTree(sroot,superfile?queryDfsXmlBranchName(DXB_SuperFile):queryDfsXmlBranchName(DXB_File),"@name",tail.str(),false);
     if (!prev) // check super/file doesn't exist
         prev = getNamedPropTree(sroot,superfile?queryDfsXmlBranchName(DXB_File):queryDfsXmlBranchName(DXB_SuperFile),"@name",tail.str(),false);
-    if (prev!=NULL) {
+    if (prev!=nullptr)
+    {
         prev->Release();
         root->Release();
         if (ignoreexists)
             return;
-        IDFS_Exception *e = new CDFS_Exception(DFSERR_LogicalNameAlreadyExists,dlfn.get());
-        throw e;
+        throw new CDFS_Exception(DFSERR_LogicalNameAlreadyExists,dlfn.get());
     }
     root->setProp("@name",tail.str());
     root->setProp("OrigName",dlfn.get());

--- a/dali/dfu/dfurun.cpp
+++ b/dali/dfu/dfurun.cpp
@@ -1250,10 +1250,15 @@ public:
                             else {
                                 Owned<IDistributedFile> oldfile = fdir.lookup(tmp.str(),userdesc,true);
                                 if (oldfile) {
+                                    StringBuffer reason;
+                                    bool canRemove = oldfile->canRemove(reason);
                                     oldfile.clear();
+                                    if (!canRemove)
+                                        throw MakeStringException(-1,"%s",reason.str());
                                     if (!options->getOverwrite())
                                         throw MakeStringException(-1,"Destination file %s already exists and overwrite not specified",tmp.str());
-                                    fdir.removeEntry(tmp.str(),userdesc);
+                                    if (!fdir.removeEntry(tmp.str(),userdesc))
+                                        throw MakeStringException(-1,"Internal error in attempt to remove file %s",tmp.str());
                                 }
                             }
                             StringBuffer jobname;


### PR DESCRIPTION
Add code to handle this situation
Add correct error message

Signed-off-by: Attila Vamos attila.vamos@gmail.com
