### PR TITLE
HPCC-15702 Misspelled property name in ws_ecl_service.cpp

### DIFF
--- a/esp/services/ws_ecl/ws_ecl_service.cpp
+++ b/esp/services/ws_ecl/ws_ecl_service.cpp
@@ -204,7 +204,7 @@ bool CWsEclService::init(const char * name, const char * type, IPropertyTree * c
         throw MakeStringException(-1, "ESP Process %s not configured", process);
 
     auth_method.set(prc->queryProp("Authentication/@method"));
-    portal_URL.set(prc->queryProp("@protalurl"));
+    portal_URL.set(prc->queryProp("@portalurl"));
 
     StringBuffer daliAddress;
     const char *daliServers = prc->queryProp("@daliServers");


### PR DESCRIPTION
Fixed a misspelled attribute (@protalurl -> @portalurl)

Signed-off-by: Suk Hwan Hong suk.hong@gatech.edu
