### PR TITLE
HPCC-15712 Spurious warnings from generated code when using Clang

### DIFF
--- a/ecl/hqlcpp/hqlcpp.cpp
+++ b/ecl/hqlcpp/hqlcpp.cpp
@@ -11735,6 +11735,7 @@ void HqlCppTranslator::buildCppFunctionDefinition(BuildCtx &funcctx, IHqlExpress
                 "#pragma GCC diagnostic ignored \"-Wall\"\n"
                 "#pragma GCC diagnostic ignored \"-Wextra\"\n"
                 "#pragma GCC diagnostic ignored \"-Wunused-variable\"\n"  // Some variants of gcc seem to be buggy - this SHOULD be covered by -Wall above but gcc4.8.4 needs it explicit
+                "#pragma GCC diagnostic ignored \"-Wparentheses\"\n"      // Some variants of gcc seem to be buggy - this SHOULD be covered by -Wall above but gcc4.8.4 needs it explicit
                 "#endif\n");
     }
     if (location)

--- a/ecl/hqlcpp/hqlhtcpp.cpp
+++ b/ecl/hqlcpp/hqlhtcpp.cpp
@@ -17961,9 +17961,11 @@ void HqlCppTranslator::buildWorkflow(WorkflowArray & workflow)
     {
         switch (options.targetCompiler)
         {
+#ifndef __APPLE__
         case GccCppCompiler:
             optimizectx.addQuoted("#define OPTIMIZE __attribute__((optimize(3)))");
             break;
+#endif
         default:
             optimizectx.addQuoted("#define OPTIMIZE");
             break;


### PR DESCRIPTION
This is a bit of a hack, but there is another Jira open for a proper fix
(introducing a new CLang compiler type). And it makes my life a lot easier in
the meantime.

Also has a workaround for a gcc compiler bug that makes the warnings
referenced in HPCC-15713 fatal errors on some platforms. HPCC-15713 should
remain open (and we should move towards warning-free generated code).

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
