### PR TITLE
HPCC-15713 Spurious compiler warnings in generated code

### DIFF
--- a/ecl/hqlcpp/hqlwcpp.cpp
+++ b/ecl/hqlcpp/hqlwcpp.cpp
@@ -312,13 +312,13 @@ unsigned getPrecedence(IHqlExpression * expr)
         case no_eq: case no_ne:
             return 9;
         case no_band:
-            return 8;
+            return 6;  // Really 8, but generating extra parens for expressions with mixed & and | helps reduce compiler warnings
         case no_bxor:
-            return 7;
+            return 6;  // Really 7, but generating extra parens for expressions with mixed & and | helps reduce compiler warnings
         case no_bor:
             return 6;
         case no_and:
-            return 5;
+            return 4;  // Really 5, but generating extra parens for expressions with mixed && and || helps reduce compiler warnings
         case no_or:
             return 4;
         case no_if:

--- a/ecl/regress/precedence.ecl
+++ b/ecl/regress/precedence.ecl
@@ -1,0 +1,15 @@
+boolean b1 := false : stored('b1');
+boolean b2 := false : stored('b2');
+boolean b3 := false : stored('b3');
+
+unsigned u1 := 0 : stored('u1');
+unsigned u2 := 0 : stored('u2');
+unsigned u3 := 0 : stored('u3');
+
+b1 and b2 or b3;
+(b1 and b2) or b3;
+b1 and (b2 or b3);
+
+u1 & u2 | u3;
+(u1 & u2) | u3;
+u1 & (u2 | u3);


### PR DESCRIPTION
Generated code was correct but extra parens make intent clearer to c++
compiler and potentially to human readers.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
