### PR TITLE
HPCC-15722 Compiler regression suite doesn't run on OSX

### DIFF
--- a/ecl/regress/regress.sh
+++ b/ecl/regress/regress.sh
@@ -38,7 +38,7 @@ eclcc=
 diff=
 query=
 valgrind=
-np=`grep -c processor /proc/cpuinfo`
+np=`getconf _NPROCESSORS_ONLN`
 export ECLCC_ECLINCLUDE_PATH=
 
 ## Get cmd line options (overrite default args)


### PR DESCRIPTION
getconf is posix compliant and seems to be portable.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
