### PR TITLE
HPCC-15685 Allow server to be configured from ecl-test command line

### DIFF
--- a/testing/regress/ecl-test
+++ b/testing/regress/ecl-test
@@ -154,6 +154,8 @@ class RegressMain:
                                 type=checkPqParam,  default = 0,   metavar="threadNumber")
         commonParser.add_argument('--noversion', help="Avoid version expansion of queries. Execute them as a standard test.",
                                 action = 'store_true')
+        commonParser.add_argument('--server', help="ESP server address. Default value (espIp) defined in ecl-test.json config file.",
+                                nargs='?', default=None,  metavar="networkAddress")
 
         executionParser=argparse.ArgumentParser(add_help=False)
         executionParser.add_argument('--runclass', '-r', help="run subclass(es) of the suite. Default value is 'all'",
@@ -196,6 +198,9 @@ class RegressMain:
         # Process config parameter
         self.config = Config(self.args.config).configObj
         setConfig(self.config)
+        if 'server' in self.args:
+            self.config.set('espIp',  self.args.server)
+            pass
 
         # Process target parameter
         self.targetClusters = []

--- a/testing/regress/hpcc/common/dict.py
+++ b/testing/regress/hpcc/common/dict.py
@@ -27,3 +27,9 @@ class _dict(object):
             return self.__d[attr]
         except KeyError:
             raise AttributeError
+
+    def set(self, attr,  val):
+        try:
+            self.__d[attr] = val
+        except KeyError:
+             raise AttributeError


### PR DESCRIPTION
Add a new command line parameter --espip

Store the new ESP server address into the runtime config set. It doesn't
overwrite the config file.

Signed-off-by: Attila Vamos attila.vamos@gmail.com
