### PR TITLE
Hpcc 15726 fix 6.0.2

### DIFF
--- a/plugins/fileservices/fileservices.cpp
+++ b/plugins/fileservices/fileservices.cpp
@@ -2174,11 +2174,30 @@ FILESERVICES_API void  FILESERVICES_CALL fsMoveExternalFile(ICodeContext * ctx,c
     if (ep.isNull())
         throw MakeStringException(-1,"fsMoveExternalFile: Cannot resolve location %s",location);
     CDfsLogicalFileName from;
-    from.setExternal(location,frompath);
+    try
+    {
+        from.setExternal(location,frompath);
+        checkExternalFileRights(ctx,from,true,true);
+    }
+    catch(IException* e)
+    {
+        StringBuffer s("MoveExternalFile Warning: source file name '");
+        s.append(frompath).append ("' is not a valid logical name.");
+        WUmessage(ctx,SeverityWarning, nullptr, s.str());
+    }
     CDfsLogicalFileName to;
-    to.setExternal(location,topath);
-    checkExternalFileRights(ctx,from,true,true);
-    checkExternalFileRights(ctx,to,false,true);
+    try
+    {
+        to.setExternal(location,topath);
+        checkExternalFileRights(ctx,to,false,true);
+    }
+    catch(IException* e)
+    {
+        StringBuffer s("MoveExternalFile Warning: target file name '");
+        s.append(topath).append("' is not a valid logical name. ");
+        WUmessage(ctx,SeverityWarning, nullptr, s.str());
+    }
+
     RemoteFilename fromrfn;
     fromrfn.setPath(ep,frompath);
     RemoteFilename torfn;

--- a/plugins/fileservices/fileservices.cpp
+++ b/plugins/fileservices/fileservices.cpp
@@ -2173,30 +2173,6 @@ FILESERVICES_API void  FILESERVICES_CALL fsMoveExternalFile(ICodeContext * ctx,c
     SocketEndpoint ep(location);
     if (ep.isNull())
         throw MakeStringException(-1,"fsMoveExternalFile: Cannot resolve location %s",location);
-    CDfsLogicalFileName from;
-    try
-    {
-        from.setExternal(location,frompath);
-        checkExternalFileRights(ctx,from,true,true);
-    }
-    catch(IException* e)
-    {
-        StringBuffer s("MoveExternalFile Warning: source file name '");
-        s.append(frompath).append ("' is not a valid logical name.");
-        WUmessage(ctx,SeverityWarning, nullptr, s.str());
-    }
-    CDfsLogicalFileName to;
-    try
-    {
-        to.setExternal(location,topath);
-        checkExternalFileRights(ctx,to,false,true);
-    }
-    catch(IException* e)
-    {
-        StringBuffer s("MoveExternalFile Warning: target file name '");
-        s.append(topath).append("' is not a valid logical name. ");
-        WUmessage(ctx,SeverityWarning, nullptr, s.str());
-    }
 
     RemoteFilename fromrfn;
     fromrfn.setPath(ep,frompath);


### PR DESCRIPTION
MoveExternalFile() unable to move file if the source or target name contains any character that's invalid to a logical file path
