### PR TITLE
HPCC-15748 Don't special case getFileDescriptor super,1 subfile

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -5332,8 +5332,6 @@ public:
     IFileDescriptor *getFileDescriptor(const char *clustername)
     {
         CriticalBlock block (sect);
-        if (subfiles.ordinality()==1)
-            return subfiles.item(0).getFileDescriptor(clustername);
         // superfiles assume consistant replication & compression
         UnsignedArray subcounts;  
         bool mixedwidth = false;


### PR DESCRIPTION
IDistributedFile->getFileDescriptor() was special cased to return
the IFileDescriptor of the sole subfile if there was 1.
If there was >1, it would return a ISuperFileDescriptor.

Normally, nothing noticed, but code that knew it was dealing with
a IDistributedSuperFile and got it's descriptor expecting a
ISuperFileDescriptor got confused.
Namely this was hit in hthor when reading a superfile with 1
subfile in it.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
