### PR TITLE
HPCC-15180 Add eclcc option to save field usage

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -1931,10 +1931,10 @@ public:
     CLocalWUFileUsage(IPropertyTree& _p) { p.setown(&_p); }
 
     virtual IStringVal & getName(IStringVal & ret) const { ret.set(p->queryProp("@name")); return ret; }
-    virtual IStringVal & getType(IStringVal & ret) const { ret.set(p->queryName()); return ret; }
+    virtual IStringVal & getType(IStringVal & ret) const { ret.set(p->queryProp("@type")); return ret; }
     virtual unsigned getNumFields() const { return p->getPropInt("@numFields"); }
     virtual unsigned getNumFieldsUsed() const { return p->getPropInt("@numFieldsUsed"); }
-    virtual IConstWUFieldUsageIterator * getFields() const { return new CConstWUFieldUsageIterator(p->getElements("field")); }
+    virtual IConstWUFieldUsageIterator * getFields() const { return new CConstWUFieldUsageIterator(p->getElements("fields/field")); }
 };
 
 class CConstWUFileUsageIterator : public CInterface, implements IConstWUFileUsageIterator

--- a/common/workunit/workunit.hpp
+++ b/common/workunit/workunit.hpp
@@ -378,6 +378,29 @@ interface IConstWUAssociatedFileIterator : extends IScmIterator
 };
 
 
+interface IConstWUFieldUsage : extends IInterface // Defines a file (dataset or index) that contains used fields from queries
+{
+    virtual IStringVal & getName(IStringVal & ret) const = 0;
+};
+
+interface IConstWUFieldUsageIterator : extends IScmIterator // Iterates over files that contains used fields
+{
+    virtual IConstWUFieldUsage * get() const = 0;
+};
+
+interface IConstWUFileUsage : extends IInterface // Defines a file (dataset or index) that contains used fields from queries
+{
+    virtual IStringVal & getName(IStringVal & ret) const = 0;
+    virtual IStringVal & getType(IStringVal & ret) const = 0; // used file type: "dataset" or "index"
+    virtual unsigned getNumFields() const = 0;
+    virtual unsigned getNumFieldsUsed() const = 0;
+    virtual IConstWUFieldUsageIterator * getFields() const = 0;
+};
+
+interface IConstWUFileUsageIterator : extends IScmIterator // Iterates over files that contains used fields
+{
+    virtual IConstWUFileUsage * get() const = 0;
+};
 
 
 interface IConstWUQuery : extends IInterface
@@ -1035,6 +1058,8 @@ interface IConstWorkUnit : extends IConstWorkUnitInfo
     virtual void requestAbort() = 0;
     virtual void subscribe(WUSubscribeOptions options) = 0;
     virtual unsigned queryFileUsage(const char * filename) const = 0;
+    virtual IConstWUFileUsageIterator * getFieldUsage() const = 0;
+
     virtual unsigned getCodeVersion() const = 0;
     virtual unsigned getWuidVersion() const  = 0;
     virtual void getBuildVersion(IStringVal & buildVersion, IStringVal & eclVersion) const = 0;
@@ -1139,6 +1164,7 @@ interface IWorkUnit : extends IConstWorkUnit
     virtual void setIsClone(bool value) = 0;
     virtual void setTimeScheduled(const IJlibDateTime & val) = 0;
     virtual void noteFileRead(IDistributedFile * file) = 0;
+    virtual void noteFieldUsage(IPropertyTree * file) = 0;
     virtual void resetBeforeGeneration() = 0;
     virtual bool switchThorQueue(const char * newcluster, IQueueSwitcher * qs) = 0;
     virtual void setAllowedClusters(const char * value) = 0;

--- a/common/workunit/workunit.hpp
+++ b/common/workunit/workunit.hpp
@@ -380,7 +380,7 @@ interface IConstWUAssociatedFileIterator : extends IScmIterator
 
 interface IConstWUFieldUsage : extends IInterface // Defines a file (dataset or index) that contains used fields from queries
 {
-    virtual IStringVal & getName(IStringVal & ret) const = 0;
+    virtual const char * queryName() const = 0;
 };
 
 interface IConstWUFieldUsageIterator : extends IScmIterator // Iterates over files that contains used fields
@@ -390,8 +390,8 @@ interface IConstWUFieldUsageIterator : extends IScmIterator // Iterates over fil
 
 interface IConstWUFileUsage : extends IInterface // Defines a file (dataset or index) that contains used fields from queries
 {
-    virtual IStringVal & getName(IStringVal & ret) const = 0;
-    virtual IStringVal & getType(IStringVal & ret) const = 0; // used file type: "dataset" or "index"
+    virtual const char * queryName() const = 0;
+    virtual const char * queryType() const = 0; // used file type: "dataset" or "index"
     virtual unsigned getNumFields() const = 0;
     virtual unsigned getNumFieldsUsed() const = 0;
     virtual IConstWUFieldUsageIterator * getFields() const = 0;

--- a/common/workunit/workunit.hpp
+++ b/common/workunit/workunit.hpp
@@ -1059,6 +1059,7 @@ interface IConstWorkUnit : extends IConstWorkUnitInfo
     virtual void subscribe(WUSubscribeOptions options) = 0;
     virtual unsigned queryFileUsage(const char * filename) const = 0;
     virtual IConstWUFileUsageIterator * getFieldUsage() const = 0;
+    virtual bool getFieldUsageArray(StringArray & filenames, StringArray & columnnames, const char * clusterName) const = 0;
 
     virtual unsigned getCodeVersion() const = 0;
     virtual unsigned getWuidVersion() const  = 0;

--- a/common/workunit/workunit.ipp
+++ b/common/workunit/workunit.ipp
@@ -38,7 +38,6 @@ public:
     virtual const char *queryValue() const;
 };
 
-
 class CLocalWUStatistic : public CInterface, implements IConstWUStatistic
 {
     Owned<IPropertyTree> p;
@@ -306,6 +305,8 @@ public:
     virtual void copyWorkUnit(IConstWorkUnit *cached, bool all);
     virtual IPropertyTree *queryPTree() const;
     virtual unsigned queryFileUsage(const char *filename) const;
+    virtual IConstWUFileUsageIterator * getFieldUsage() const;
+
     virtual bool getCloneable() const;
     virtual IUserDescriptor * queryUserDescriptor() const;
     virtual unsigned getCodeVersion() const;
@@ -382,6 +383,7 @@ public:
     virtual IWUResult * updateVariableByName(const char * name);
     void addFile(const char *fileName, StringArray *clusters, unsigned usageCount, WUFileKind fileKind, const char *graphOwner);
     void noteFileRead(IDistributedFile *file);
+    void noteFieldUsage(IPropertyTree * usage);
     void releaseFile(const char *fileName);
     void resetBeforeGeneration();
     void deleteTempFiles(const char *graph, bool deleteOwned, bool deleteJobOwned);

--- a/common/workunit/workunit.ipp
+++ b/common/workunit/workunit.ipp
@@ -306,6 +306,7 @@ public:
     virtual IPropertyTree *queryPTree() const;
     virtual unsigned queryFileUsage(const char *filename) const;
     virtual IConstWUFileUsageIterator * getFieldUsage() const;
+    virtual bool getFieldUsageArray(StringArray & filenames, StringArray & columnnames, const char * clusterName) const;
 
     virtual bool getCloneable() const;
     virtual IUserDescriptor * queryUserDescriptor() const;

--- a/common/workunit/wuerror.hpp
+++ b/common/workunit/wuerror.hpp
@@ -51,4 +51,5 @@
 #define WUERR_GraphProgressWriteUnsupported     5026
 #define WUERR_WorkunitPluginError               5027
 #define WUERR_WorkunitVersionMismatch           5028
+#define WUERR_InvalidFieldUsage                 5029
 #endif

--- a/ecl/hql/hqlusage.cpp
+++ b/ecl/hql/hqlusage.cpp
@@ -344,6 +344,7 @@ static IPropertyTree * addSelect(IPropertyTree * xml, IHqlExpression * expr, boo
     Owned<IPropertyTree> field = createPTree(isUsed ? "field" : "unused");
     field->setProp("@name", text.str());
     const char * tag = field->queryName();
+    xml = ensurePTree(xml, "fields");
     return xml->addPropTree(tag, field.getClear());
 }
 
@@ -416,8 +417,9 @@ IPropertyTree * SourceFieldUsage::createReport(bool includeFieldDetail, const IP
             return NULL;
     }
 
-    Owned<IPropertyTree> entry = createPTree(type);
+    Owned<IPropertyTree> entry = createPTree("datasource");
     entry->setProp("@name", nameText);
+    entry->setProp("@type", type);
 
     unsigned numFields = 0;
     unsigned numFieldsUsed = 0;

--- a/ecl/hqlcpp/hqlcpp.cpp
+++ b/ecl/hqlcpp/hqlcpp.cpp
@@ -1758,6 +1758,7 @@ void HqlCppTranslator::cacheOptions()
         DebugOption(options.implicitGroupHashDedup,"implicitGroupHashDedup",false),
         DebugOption(options.reportFieldUsage,"reportFieldUsage",false),
         DebugOption(options.reportFileUsage,"reportFileUsage",false),
+        DebugOption(options.recordFieldUsage,"recordFieldUsage",false),
         DebugOption(options.subsortLocalJoinConditions,"subsortLocalJoinConditions",false),
         DebugOption(options.projectNestedTables,"projectNestedTables",true),
         DebugOption(options.showSeqInGraph,"showSeqInGraph",false),  // For tracking down why projects are not commoned up

--- a/ecl/hqlcpp/hqlcpp.ipp
+++ b/ecl/hqlcpp/hqlcpp.ipp
@@ -733,6 +733,7 @@ struct HqlCppOptions
     bool                implicitGroupHashDedup;
     bool                reportFieldUsage;
     bool                reportFileUsage;
+    bool                recordFieldUsage;
     bool                subsortLocalJoinConditions;
     bool                projectNestedTables;
     bool                showSeqInGraph;

--- a/ecl/hqlcpp/hqlhtcpp.cpp
+++ b/ecl/hqlcpp/hqlhtcpp.cpp
@@ -6141,12 +6141,13 @@ void HqlCppTranslator::writeFieldUsage(const char * targetDir, IPropertyTree * s
 
 void HqlCppTranslator::generateStatistics(const char * targetDir, const char * variant)
 {
-    if ((options.reportFieldUsage || options.reportFileUsage) && trackedSources.ordinality())
+    if (options.reportFieldUsage || options.reportFileUsage)
     {
         Owned<IPropertyTree> sources = gatherFieldUsage(variant, NULL);
         writeFieldUsage(targetDir, sources, NULL);
     }
-    else if (options.recordFieldUsage && trackedSources.ordinality()) // to enable column-level security
+    
+    if (options.recordFieldUsage)
     {
         Owned<IPropertyTree> sources = gatherFieldUsage(variant, NULL);
         wu()->noteFieldUsage(LINK(sources));

--- a/ecl/hqlcpp/hqlhtcpp.cpp
+++ b/ecl/hqlcpp/hqlhtcpp.cpp
@@ -6078,7 +6078,7 @@ IPropertyTree * HqlCppTranslator::gatherFieldUsage(const char * variant, const I
     trackedSources.sort(compareTrackedSourceByName);
     ForEachItemIn(i, trackedSources)
     {
-        IPropertyTree * next = trackedSources.item(i).createReport(options.reportFieldUsage, exclude);
+        IPropertyTree * next = trackedSources.item(i).createReport(options.reportFieldUsage || options.recordFieldUsage, exclude);
         if (next)
             sources->addPropTree(next->queryName(), next);
     }
@@ -6088,7 +6088,7 @@ IPropertyTree * HqlCppTranslator::gatherFieldUsage(const char * variant, const I
 
 SourceFieldUsage * HqlCppTranslator::querySourceFieldUsage(IHqlExpression * expr)
 {
-    if (!(options.reportFieldUsage || options.reportFileUsage) || !expr)
+    if (!(options.reportFieldUsage || options.recordFieldUsage || options.reportFileUsage) || !expr)
         return NULL;
 
     if (expr->hasAttribute(_spill_Atom) || expr->hasAttribute(jobTempAtom))
@@ -6145,6 +6145,11 @@ void HqlCppTranslator::generateStatistics(const char * targetDir, const char * v
     {
         Owned<IPropertyTree> sources = gatherFieldUsage(variant, NULL);
         writeFieldUsage(targetDir, sources, NULL);
+    }
+    else if (options.recordFieldUsage && trackedSources.ordinality()) // to enable column-level security
+    {
+        Owned<IPropertyTree> sources = gatherFieldUsage(variant, NULL);
+        wu()->noteFieldUsage(LINK(sources));
     }
 }
 

--- a/plugins/cassandra/cassandrawu.cpp
+++ b/plugins/cassandra/cassandrawu.cpp
@@ -711,7 +711,7 @@ public:
 private:
     const char *elemName;
     const char *nameAttr;
-} graphMapColumnMapper("Graph", "@name"), workflowMapColumnMapper("Item", "@wfid"), associationsMapColumnMapper("File", "@filename");;
+} graphMapColumnMapper("Graph", "@name"), workflowMapColumnMapper("Item", "@wfid"), associationsMapColumnMapper("File", "@filename"), usedFieldsMapColumnMapper("field", "@name");
 
 
 static class WarningsMapColumnMapper : implements CassandraColumnMapper
@@ -968,7 +968,7 @@ static const CassandraXmlMapping versionMappings [] =
 
 // The following describe child tables - all keyed by wuid
 
-enum ChildTablesEnum { WuQueryChild, WuExceptionsChild, WuStatisticsChild, WuGraphsChild, WuResultsChild, WuVariablesChild, WuTemporariesChild, WuFilesReadChild, WuFilesWrittenChild, ChildTablesSize };
+enum ChildTablesEnum { WuQueryChild, WuExceptionsChild, WuStatisticsChild, WuGraphsChild, WuResultsChild, WuVariablesChild, WuTemporariesChild, WuFilesReadChild, WuFilesWrittenChild, WuFieldUsage, ChildTablesSize };
 
 struct ChildTableInfo
 {
@@ -1160,8 +1160,27 @@ static const ChildTableInfo wuFilesWrittenTable =
     wuFilesWrittenMappings
 };
 
+static const CassandraXmlMapping wuFieldUsageMappings [] =
+{
+    {"partition", "int", NULL, hashRootNameColumnMapper},
+    {"wuid", "text", NULL, rootNameColumnMapper},
+    {"name", "text", "@name", stringColumnMapper},
+    {"type", "text", "@type", stringColumnMapper},
+    {"numFields", "int", "@numFields", intColumnMapper},
+    {"numFieldsUsed", "int", "@numFieldsUsed", intColumnMapper},
+    {"fields", "map<text, text>", "fields", usedFieldsMapColumnMapper},
+    { NULL, "wuFieldUsage", "((partition, wuid), name)", stringColumnMapper}
+};
+
+static const ChildTableInfo wuFieldUsageTable =
+{
+    "usedsources", "datasource",
+    WuFieldUsage,
+    wuFieldUsageMappings
+};
+
 // Order should match the enum above
-static const ChildTableInfo * const childTables [] = { &wuQueriesTable, &wuExceptionsTable, &wuStatisticsTable, &wuGraphsTable, &wuResultsTable, &wuVariablesTable, &wuTemporariesTable, &wuFilesReadTable, &wuFilesWrittenTable, NULL };
+static const ChildTableInfo * const childTables [] = { &wuQueriesTable, &wuExceptionsTable, &wuStatisticsTable, &wuGraphsTable, &wuResultsTable, &wuVariablesTable, &wuTemporariesTable, &wuFilesReadTable, &wuFilesWrittenTable, &wuFieldUsageTable, NULL };
 
 // Graph progress tables are read directly, XML mappers not used
 
@@ -2182,6 +2201,8 @@ public:
                 childXMLtoCassandra(sessionCache, *batch, wuStatisticsMappings, p, "Statistics/Statistic", 0);
                 childXMLtoCassandra(sessionCache, *batch, wuFilesReadMappings, p, "FilesRead/File", 0);
                 childXMLtoCassandra(sessionCache, *batch, wuFilesWrittenMappings, p, "Files/File", 0);
+                childXMLtoCassandra(sessionCache, *batch, wuFieldUsageMappings, p, "usedsources/datasource", 0);
+
                 IPTree *query = p->queryPropTree("Query");
                 if (query)
                     childXMLRowtoCassandra(sessionCache, *batch, wuQueryMappings, wuid, *query, 0);
@@ -2384,6 +2405,11 @@ public:
     {
         checkChildLoaded(wuQueriesTable);
         return CPersistedWorkUnit::getQuery();
+    }
+    virtual IConstWUFileUsageIterator * getFieldUsage() const
+    {
+        checkChildLoaded(wuFieldUsageTable);
+        return CPersistedWorkUnit::getFieldUsage();
     }
     virtual IWUException *createException()
     {
@@ -2784,7 +2810,26 @@ protected:
         // NOTE - should be called inside critsec
         if (!childLoaded[childTable.index])
         {
-            CassandraResult result(sessionCache->fetchDataForWuid(childTable.mappings, queryWuid(), false));
+            const CassResult* cassResult;
+            try
+            {
+                cassResult = sessionCache->fetchDataForWuid(childTable.mappings, queryWuid(), false);
+            }
+            catch (IException* e)
+            {
+                int errorCode = e->errorCode();
+                StringBuffer origErrorMsg;
+                e->errorMessage(origErrorMsg);
+                e->Release();
+
+                const char* tableName = queryTableName(childTable.mappings);
+
+                VStringBuffer newErrorMsg("Failed to read from cassandra table '%s' (Have you run wutool to initialize cassandra repository?), [%s]", tableName, origErrorMsg.str());
+
+                rtlFail(errorCode, newErrorMsg);
+            }
+
+            CassandraResult result(cassResult);
             IPTree *results = p->queryPropTree(childTable.parentElement);
             CassandraIterator rows(cass_iterator_from_result(result));
             while (cass_iterator_next(rows))


### PR DESCRIPTION
1. Added "recordFieldUsage" option to save field usage info into WU and Dali
2. Added an iterator for iterating through field usages:
   - can query file source type ("dataset" or "index")
   - can query file name
   - can query number of fields and used fields
   - can query field name

Signed-off-by: Suk Hwan Hong suk.hong@gatech.edu
