### PR TITLE
HPCC-15787 Write a log entry and continue instead of throw an exception when the de-spray target is not in any drop zone.

### DIFF
--- a/dali/ft/filecopy.cpp
+++ b/dali/ft/filecopy.cpp
@@ -2661,7 +2661,7 @@ void FileSprayer::checkTargetPath(RemoteFilename & filename)
 
             Owned<IConstDropZoneInfo> targetDropZone = env->getDropZoneByAddressPath(netaddress.str(), ptargetFilePath);
             if (!targetDropZone)
-                    throwError1(DFTERR_NoMatchingDropzonePath, ptargetFilePath);
+                LOG(MCdebugInfo, unknownJob, "No matching drop zone path to target file path: '%s'", targetFilePath.str());
         }
     }
 }


### PR DESCRIPTION
Replace throw with LOG if no matching target zone path find

Signed-off-by: Attila Vamos attila.vamos@gmail.com
