### PR TITLE
HPCC-15793 Cassandra plugin not being built

### DIFF
--- a/esp/logging/loggingagent/cassandraloggingagent/CMakeLists.txt
+++ b/esp/logging/loggingagent/cassandraloggingagent/CMakeLists.txt
@@ -33,7 +33,6 @@ include_directories (
      ${HPCC_SOURCE_DIR}/roxie/roxiemem
      ${HPCC_SOURCE_DIR}/common/deftype
      ${HPCC_SOURCE_DIR}/common/environment
-     ${HPCC_SOURCE_DIR}/plugins/cassandra/libuv/include
      ${HPCC_SOURCE_DIR}/plugins/cassandra/cpp-driver/include
      ${HPCC_SOURCE_DIR}/plugins/cassandra
      ${HPCC_SOURCE_DIR}/esp/platform
@@ -45,7 +44,6 @@ include_directories (
 ADD_DEFINITIONS( -D_USRDLL  -DMYSQLLOGGINGLISTENER_EXPORTS -DMYSQLLOGAGENT_EXPORTS )
 
 set ( SRCS
-    ${HPCC_SOURCE_DIR}/plugins/cassandra/cassandraembed.cpp
     cassandralogagent.cpp
 )
 
@@ -54,6 +52,7 @@ HPCC_ADD_LIBRARY( cassandralogagent SHARED ${SRCS} )
 install ( TARGETS cassandralogagent RUNTIME DESTINATION bin LIBRARY DESTINATION lib )
 add_dependencies (cassandralogagent espscm)
 target_link_libraries ( cassandralogagent
+    cassandraembed
     cassandra
     eclrtl
     esphttp

--- a/plugins/cassandra/CMakeLists.txt
+++ b/plugins/cassandra/CMakeLists.txt
@@ -28,7 +28,7 @@ project(cassandraembed)
 # When there is (and the distros catch up) we may want to add them as dependencies here
 # until then, we build the required libraries from source
 # Build libuv, required by the cassandra driver but not available on all distros
-if(USE_CASSANDRA OR CASSANDRAEMBED)
+if(USE_CASSANDRA)
   if(APPLE)
     add_custom_command(
       OUTPUT ${PROJECT_BINARY_DIR}/libuv.dylib
@@ -83,62 +83,57 @@ if(USE_CASSANDRA OR CASSANDRAEMBED)
       DESTINATION ${LIB_DIR}
       COMPONENT Runtime)
   endif()
-endif()
 
-  if(CASSANDRAEMBED)
-    ADD_PLUGIN(cassandraembed)
-    if(MAKE_CASSANDRAEMBED)
+  ADD_PLUGIN(cassandraembed)
 
-      set(
-        SRCS
-        cassandraembed.cpp
-        cassandrawu.cpp)
+  set(
+    SRCS
+    cassandraembed.cpp
+    cassandrawu.cpp)
 
-      include_directories(
-        ./../../system/include
-        ./../../rtl/eclrtl
-        ./../../roxie/roxiemem
-        ./../../rtl/include
-        ./../../rtl/nbcd
-        ./../../common/deftype
-        ./../../common/workunit
-        ./../../system/jlib
-        ./../../system/security/shared 
-        ./../../system/mp
-        ./../../dali/base 
-        ./cpp-driver/include)
+  include_directories(
+    ./../../system/include
+    ./../../rtl/eclrtl
+    ./../../roxie/roxiemem
+    ./../../rtl/include
+    ./../../rtl/nbcd
+    ./../../common/deftype
+    ./../../common/workunit
+    ./../../system/jlib
+    ./../../system/security/shared 
+    ./../../system/mp
+    ./../../dali/base 
+    ./cpp-driver/include)
 
-      add_definitions(-D_USRDLL -DCASSANDRAEMBED_EXPORTS)
+  add_definitions(-D_USRDLL -DCASSANDRAEMBED_EXPORTS)
 
-      HPCC_ADD_LIBRARY(cassandraembed SHARED ${SRCS})
-      if(NOT FORCE_WORKUNITS_TO_CASSANDRA)
-        if(${CMAKE_VERSION} VERSION_LESS "2.8.9")
-          message(WARNING "Cannot set NO_SONAME. shlibdeps will give warnings when package is installed")
-        elseif(NOT APPLE)
-          set_target_properties(cassandraembed PROPERTIES NO_SONAME 1)
-        endif()
-      endif()
-
-      install(
-        TARGETS cassandraembed
-        DESTINATION plugins
-        COMPONENT Runtime )
-
-      install(
-        TARGETS cassandraembed
-        DESTINATION ${LIB_DIR}
-        COMPONENT Runtime )
-
-      target_link_libraries(
-        cassandraembed
-        cassandra
-        eclrtl
-        roxiemem
-        dalibase
-        workunit
-        jlib)
+  HPCC_ADD_LIBRARY(cassandraembed SHARED ${SRCS})
+  if(NOT FORCE_WORKUNITS_TO_CASSANDRA)
+    if(${CMAKE_VERSION} VERSION_LESS "2.8.9")
+      message(WARNING "Cannot set NO_SONAME. shlibdeps will give warnings when package is installed")
+    elseif(NOT APPLE)
+      set_target_properties(cassandraembed PROPERTIES NO_SONAME 1)
     endif()
   endif()
+
+  install(
+    TARGETS cassandraembed
+    DESTINATION plugins
+    COMPONENT Runtime )
+
+  install(
+    TARGETS cassandraembed
+    DESTINATION ${LIB_DIR}
+    COMPONENT Runtime )
+
+  target_link_libraries(
+    cassandraembed
+    cassandra
+    eclrtl
+    roxiemem
+    dalibase
+    workunit
+    jlib)
 
   if(PLATFORM OR CLIENTTOOLS_ONLY)
     install(
@@ -146,3 +141,4 @@ endif()
       DESTINATION plugins
       COMPONENT Runtime)
   endif()
+endif(USE_CASSANDRA)


### PR DESCRIPTION
Code was testing old CMake variables that are no longer set anywhere.

Also fixed the cassandra logging agent to link to the cassandraembed plugin
rather than including one of its sources.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
