### PR TITLE
HPCC-15768 Attach the archive to ZAP using IP/Name

### DIFF
--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -4385,19 +4385,30 @@ void CWsWorkunitsEx::createZAPECLQueryArchiveFiles(Owned<IConstWorkUnit>& cwu, c
     ForEach(*iter)
     {
         IConstWUAssociatedFile & cur = iter->query();
-        SCMStringBuffer ssb;
+        SCMStringBuffer ssb, ip;
         cur.getDescription(ssb);
         if (!strieq(ssb.str(), "archive"))
             continue;
 
         cur.getName(ssb);
-        if (!ssb.length())
+        cur.getIp(ip);
+        if (!ssb.length() || !ip.length())
             continue;
 
         StringBuffer fileName, archiveContents;
         try
         {
-            archiveContents.loadFile(ssb.str());
+            SocketEndpoint ep(ip.str());
+            RemoteFilename rfn;
+            rfn.setRemotePath(ssb.str());
+            rfn.setIp(ep);
+            Owned<IFile> rFile = createIFile(rfn);
+            if (!rFile)
+            {
+                DBGLOG("Cannot open %s on %s", ssb.str(), ip.str());
+                continue;
+            }
+            archiveContents.loadFile(rFile);
         }
         catch (IException *e)
         {


### PR DESCRIPTION
This fix 'createIFile' using both IP and Name of the archive.
Then, read the archive and add it to ZAP report.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
