### PR TITLE
HPCC-13041 No error message when uploading a file

### DIFF
--- a/esp/src/eclwatch/LZBrowseWidget.js
+++ b/esp/src/eclwatch/LZBrowseWidget.js
@@ -124,6 +124,17 @@ define([
                 context.fileListDialog.hide();
                 context.refreshGrid();
             });
+
+            this.connect(this.uploader, "onError", function (response) {
+                if (response.type === 'error') {
+                    topic.publish("hpcc/brToaster", {
+                        Severity: "Error",
+                        Source: "FileSpray.UploadFile",
+                        Exceptions: [{ Message: this.i18n.ErrorUploadingFile }]
+                    });
+                    this.uploader.reset();
+                }
+            });
         },
 
         startup: function (args) {

--- a/esp/src/eclwatch/nls/hpcc.js
+++ b/esp/src/eclwatch/nls/hpcc.js
@@ -144,6 +144,7 @@ define({root:
     Errorparsingserverresult: "Error parsing server result",
     Errors: "Error(s)",
     ErrorsStatus: "Errors/Status",
+    ErrorUploadingFile: "Error uploading file(s). Try checking permissions.",
     ErrorWarnings: "Error/Warning(s)",
     Escape: "Escape",
     ESPBuildVersion: "ESP Build Version",


### PR DESCRIPTION
Whenever a user tries to upload a file to a directory that they do no have permissions they do not get a failed error or anything of the sort. The exception is thrown by the client side and we are capturing it and testing against it.

Signed-off by: Miguel Vazquez miguel.vazquez@lexisnexis.com
