### PR TITLE
HPCC-15822 Uninitialized member preventing spilling

### DIFF
--- a/thorlcr/thorutil/thmem.cpp
+++ b/thorlcr/thorutil/thmem.cpp
@@ -1237,6 +1237,8 @@ CThorSpillableRowArray::CThorSpillableRowArray(CActivityBase &activity)
     : CThorExpandingRowArray(activity)
 {
     initCommon();
+    commitDelta = CommitStep;
+    throwOnOom = false;
 }
 
 CThorSpillableRowArray::CThorSpillableRowArray(CActivityBase &activity, IThorRowInterfaces *rowIf, bool allowNulls, StableSortFlag stableSort, rowidx_t initialSize, size32_t _commitDelta)


### PR DESCRIPTION
An uninitialized member of CThorSpillableRowArray (commitDelta)
could cause the spilling to in effect be disabled and lead to
OOM's (seen as "Memory limit exceeded" exceptions)

Also noticed that the default setting for throwOnOom for
CThorSpillableRowArray could be wrong, should have been false, but
was not overriden in one of the constructors.
This may not have any negative side-effects, as long as
the arrays were used with callbacks.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
