### PR TITLE
HPCC-15744 Allow to '~file::<ip_address>::<filepath>' opens an external file with any character that's invalid to a logical file path.

### DIFF
--- a/dali/base/dautils.cpp
+++ b/dali/base/dautils.cpp
@@ -341,10 +341,15 @@ inline void normalizeScope(const char *name, const char *scope, unsigned len, St
     }
 }
 
-void normalizeNodename(const char *node, unsigned len, SocketEndpoint &ep, bool strict)
+void normalizeNodeName(const char *node, unsigned len, SocketEndpoint &ep, bool strict)
 {
     if (!strict)
-        skipSp(node);
+        while (isspace(*node))
+        {
+            node++;
+            len--;
+        }
+
 
     StringBuffer nodename;
     nodename.append(len, node);
@@ -428,7 +433,7 @@ void CDfsLogicalFileName::normalizeName(const char *name, StringAttr &res, bool 
                 if (ns1)
                 {
                     SocketEndpoint ep;
-                    normalizeNodename(s1, ns1-s1, ep, strict);
+                    normalizeNodeName(s1, ns1-s1, ep, strict);
                     if (!ep.isNull())
                     {
                         ep.getUrlStr(str.append("::"));
@@ -463,7 +468,7 @@ void CDfsLogicalFileName::normalizeName(const char *name, StringAttr &res, bool 
     res.set(str);
 }
 
-bool CDfsLogicalFileName::normalizeExternal(const char * name, bool strict)
+bool CDfsLogicalFileName::normalizeExternal(const char * name, StringAttr &res, bool strict)
 {
     // TODO Should check the name is a valid OS filename
     if ('~' == *name) // allowed 1 leading ~
@@ -487,7 +492,7 @@ bool CDfsLogicalFileName::normalizeExternal(const char * name, bool strict)
         else
         {
             SocketEndpoint ep;
-            normalizeNodename(s1, ns1-s1, ep, strict);
+            normalizeNodeName(s1, ns1-s1, ep, strict);
             if (ep.isNull())
                 retVal = false;
             else
@@ -505,7 +510,7 @@ bool CDfsLogicalFileName::normalizeExternal(const char * name, bool strict)
                     str.append(s);
                     str.toLowerCase();
                 }
-                lfn.set(str);
+                res.set(str);
             }
         }
 
@@ -555,7 +560,7 @@ void CDfsLogicalFileName::set(const char *name, bool removeForeign)
         return;
     }
 
-    if (normalizeExternal(name, false))
+    if (normalizeExternal(name, lfn, false))
         external = true;
     else
     {

--- a/dali/base/dautils.cpp
+++ b/dali/base/dautils.cpp
@@ -344,12 +344,13 @@ inline void normalizeScope(const char *name, const char *scope, unsigned len, St
 void normalizeNodeName(const char *node, unsigned len, SocketEndpoint &ep, bool strict)
 {
     if (!strict)
+    {
         while (isspace(*node))
         {
             node++;
             len--;
         }
-
+    }
 
     StringBuffer nodename;
     nodename.append(len, node);

--- a/dali/base/dautils.hpp
+++ b/dali/base/dautils.hpp
@@ -139,8 +139,10 @@ public:
     void setAllowWild(bool b=true) { allowWild = b; } // allow wildcards
     bool isExpanded() const;
     void expand(IUserDescriptor *user);
+
+protected:
     void normalizeName(const char * name, StringAttr &res, bool strict);
-    bool normalizeExternal(const char * name, bool strict);
+    bool normalizeExternal(const char * name, StringAttr &res, bool strict);
 };
 
 // abstract class, define getCmdText to return tracing text of commands

--- a/dali/base/dautils.hpp
+++ b/dali/base/dautils.hpp
@@ -140,6 +140,7 @@ public:
     bool isExpanded() const;
     void expand(IUserDescriptor *user);
     void normalizeName(const char * name, StringAttr &res, bool strict);
+    bool normalizeExternal(const char * name, bool strict);
 };
 
 // abstract class, define getCmdText to return tracing text of commands

--- a/testing/unittests/dalitests.cpp
+++ b/testing/unittests/dalitests.cpp
@@ -2452,5 +2452,103 @@ public:
 CPPUNIT_TEST_SUITE_REGISTRATION( CDaliUtils );
 CPPUNIT_TEST_SUITE_NAMED_REGISTRATION( CDaliUtils, "DaliUtils" );
 
+class CFileNameNormalizeUnitTest : public CppUnit::TestFixture, CDfsLogicalFileName
+{
+    CPPUNIT_TEST_SUITE(CFileNameNormalizeUnitTest);
+      CPPUNIT_TEST(testFileNameNormalize);
+    CPPUNIT_TEST_SUITE_END();
+
+public:
+    void testFileNameNormalize()
+    {
+        //Columns
+        const int inFileName = 0;
+        const int normalizedFileName = 1;
+
+        const char *validExternalLfns[][2] = {
+                //     input file name                          expected normalized file name
+                {"~file::192.168.16.1::dir1::file1",            "file::192.168.16.1::dir1::file1"},
+                {"~  file::  192.168.16.1::dir1::file1",        "file::192.168.16.1::dir1::file1"},
+                {"~file::192.168.16.1::>some query or another", "file::192.168.16.1::>some query or another"},
+                {"~file::192.168.16.1::>Some Query or Another", "file::192.168.16.1::>Some Query or Another"},
+                {"~file::192.168.16.1::wild?card1",             "file::192.168.16.1::wild?card1"},
+                {"~file::192.168.16.1::wild*card2",             "file::192.168.16.1::wild*card2"},
+                {"~file::192.168.16.1::^C^a^S^e^d",             "file::192.168.16.1::^c^a^s^e^d"},
+                {"~file::192.168.16.1::file@cluster1",          "file::192.168.16.1::file@cluster1"},
+                {nullptr,                                       nullptr }        // terminator
+                 };
+
+         const char *validInternalLfns[][2] = {
+                 //     input file name                    expected normalized file name
+                 {"~foreign::192.168.16.1::scope1::file1", "foreign::192.168.16.1::scope1::file1"},
+                 {".::scope1::file",                       ".::scope1::file"},
+                 {"~ scope1 :: scope2 :: file  ",          "scope1::scope2::file"},
+                 {". :: scope1 :: file nine",              ".::scope1::file nine"},
+                 {". :: scope1 :: file ten  ",             ".::scope1::file ten"},
+                 {". :: scope1 :: file",                   ".::scope1::file"},
+                 {nullptr,                                 nullptr}   // terminator
+                 };
+
+        // Check results
+        const bool externalFile = true;
+        const bool internalFile = false;
+        const bool fileNameMatch = true;
+
+        PROGLOG("Checking external filenames detection and normalization");
+        unsigned nlfn=0;
+        loop
+        {
+            const char *lfn = validExternalLfns[nlfn][inFileName];
+            if (nullptr == lfn)
+                break;
+            PROGLOG("lfn = '%s'", lfn);
+            StringAttr res;
+            try
+            {
+                ASSERT(externalFile == normalizeExternal(lfn, res, false));
+                ASSERT(fileNameMatch == streq(res.str(), validExternalLfns[nlfn][normalizedFileName]))
+
+            }
+            catch (IException *e)
+            {
+                VStringBuffer err("External filename '%s' ('%s') failed.", lfn, res.str());
+                EXCLOG(e, err.str());
+                CPPUNIT_FAIL(err.str());
+                e->Release();
+            }
+            nlfn++;
+        }
+
+        PROGLOG("Checking valid internal filenames");
+        nlfn=0;
+        loop
+        {
+            const char *lfn = validInternalLfns[nlfn][inFileName];
+            if (nullptr == lfn)
+                break;
+            PROGLOG("lfn = %s", lfn);
+            StringAttr res;
+            try
+            {
+                ASSERT(internalFile == normalizeExternal(lfn, res, false));
+                normalizeName(lfn, res, false);
+                ASSERT(fileNameMatch == streq(res.str(), validInternalLfns[nlfn][normalizedFileName]))
+
+            }
+            catch (IException *e)
+            {
+                VStringBuffer err("Internal filename '%s' ('%s') failed.", lfn, res.str());
+                EXCLOG(e, err.str());
+                CPPUNIT_FAIL(err.str());
+                e->Release();
+            }
+            nlfn++;
+        }
+
+    }
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION( CFileNameNormalizeUnitTest );
+CPPUNIT_TEST_SUITE_NAMED_REGISTRATION( CFileNameNormalizeUnitTest, "CFileNameNormalizeUnitTest" );
 
 #endif // _USE_CPPUNIT

--- a/testing/unittests/dalitests.cpp
+++ b/testing/unittests/dalitests.cpp
@@ -2474,7 +2474,6 @@ public:
                 {"~file::192.168.16.1::wild?card1",             "file::192.168.16.1::wild?card1"},
                 {"~file::192.168.16.1::wild*card2",             "file::192.168.16.1::wild*card2"},
                 {"~file::192.168.16.1::^C^a^S^e^d",             "file::192.168.16.1::^c^a^s^e^d"},
-                {"~file::192.168.16.1::file@cluster1",          "file::192.168.16.1::file@cluster1"},
                 {nullptr,                                       nullptr }        // terminator
                  };
 
@@ -2486,6 +2485,10 @@ public:
                  {". :: scope1 :: file nine",              ".::scope1::file nine"},
                  {". :: scope1 :: file ten  ",             ".::scope1::file ten"},
                  {". :: scope1 :: file",                   ".::scope1::file"},
+                 {"~scope1::file@cluster1",                "scope1::file"},
+                 {"~scope::^C^a^S^e^d",                    "scope::^c^a^s^e^d"},
+                 {"~scope::CaSed",                         "scope::cased"},
+                 {"~scope::^CaSed",                         "scope::^cased"},
                  {nullptr,                                 nullptr}   // terminator
                  };
 
@@ -2506,15 +2509,15 @@ public:
             try
             {
                 ASSERT(externalFile == normalizeExternal(lfn, res, false));
+                PROGLOG("res = '%s'", res.str());
                 ASSERT(fileNameMatch == streq(res.str(), validExternalLfns[nlfn][normalizedFileName]))
-
             }
             catch (IException *e)
             {
                 VStringBuffer err("External filename '%s' ('%s') failed.", lfn, res.str());
                 EXCLOG(e, err.str());
-                CPPUNIT_FAIL(err.str());
                 e->Release();
+                CPPUNIT_FAIL(err.str());
             }
             nlfn++;
         }
@@ -2526,25 +2529,24 @@ public:
             const char *lfn = validInternalLfns[nlfn][inFileName];
             if (nullptr == lfn)
                 break;
-            PROGLOG("lfn = %s", lfn);
+            PROGLOG("lfn = '%s'", lfn);
             StringAttr res;
             try
             {
                 ASSERT(internalFile == normalizeExternal(lfn, res, false));
                 normalizeName(lfn, res, false);
+                PROGLOG("res = '%s'", res.str());
                 ASSERT(fileNameMatch == streq(res.str(), validInternalLfns[nlfn][normalizedFileName]))
-
             }
             catch (IException *e)
             {
                 VStringBuffer err("Internal filename '%s' ('%s') failed.", lfn, res.str());
                 EXCLOG(e, err.str());
-                CPPUNIT_FAIL(err.str());
                 e->Release();
+                CPPUNIT_FAIL(err.str());
             }
             nlfn++;
         }
-
     }
 };
 


### PR DESCRIPTION
Separate external file and logical file handling. Step 1

Signed-off-by: Attila Vamos attila.vamos@gmail.com
