### PR TITLE
HPCC-15818 Chained stop from condtionals regression effecting LIMIT

### DIFF
--- a/thorlcr/activities/limit/thlimitslave.cpp
+++ b/thorlcr/activities/limit/thlimitslave.cpp
@@ -46,7 +46,7 @@ public:
     CLimitSlaveActivityBase(CGraphElementBase *_container) : CSlaveActivity(_container)
     {
         helper = (IHThorLimitArg *)queryHelper();
-        resultSent = container.queryLocal(); // i.e. local, so don't send result to master
+        resultSent = true; // unless started suppress result send
         eos = stopped = anyThisGroup = eogNext = false;
         rowLimit = RCMAX;
         appendOutputLinked(this);


### PR DESCRIPTION
A regression introduced by strand refactoring.
When conditionals call stop through their inputs, some activities
didn't deal with the fact their stop was being called without
their start ever having been called.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
