### PR TITLE
HPCC-15831 Fix truncated file name when DFU search

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -12189,7 +12189,8 @@ IPropertyTreeIterator *deserializeFileAttrIterator(MemoryBuffer& mb, DFUQResultF
         {
             mb.reset();
             mb.read(numfiles);
-            mb.read(allMatchingFilesReceived);
+            if (queryDaliServerVersion().compare("6.0") >= 0)
+                mb.read(allMatchingFilesReceived);
 
             return next();
         }
@@ -12259,7 +12260,8 @@ IPropertyTreeIterator *CDistributedFileDirectory::getDFAttributesTreeIterator(co
 
     unsigned numfiles;
     mb.read(numfiles);
-    mb.read(allMatchingFilesReceived);
+    if (queryDaliServerVersion().compare("6.0") >= 0)
+        mb.read(allMatchingFilesReceived);
     return deserializeFileAttrIterator(mb, localFilters, localFilterBuf);
 }
 


### PR DESCRIPTION
The problem happens when DFU search from 6.0 ESP to non-6.0
dali. In 6.0, a new field had been added into the DFU Search
response from dali to ESP. ESP should check the version of
dali and, read that field only if dali's version >= 6.0.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
