### PR TITLE
HPCC-15831 Fix truncated filename backward compatibility issue.

### DIFF
--- a/dali/base/dacoven.cpp
+++ b/dali/base/dacoven.cpp
@@ -37,7 +37,7 @@ extern void closedownDFS();
 // base is saved in store whenever block exhausted, so replacement coven servers can restart 
 
 // server side versioning.
-#define ServerVersion    "3.12"
+#define ServerVersion    "3.13"
 #define MinClientVersion "1.5"
 
 

--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -78,6 +78,7 @@ enum MDFSRequestKind
     MDFS_ITERATE_RELATIONSHIPS,
     MDFS_SET_FILE_PROTECT,
     MDFS_ITERATE_FILTEREDFILES,
+    MDFS_ITERATE_FILTEREDFILES2,
     MDFS_MAX
 };
 
@@ -9837,10 +9838,8 @@ public:
         mb.writeDirect(0,sizeof(count),&count);
     }
 
-    void iterateFilteredFiles(CMessageBuffer &mb,StringBuffer &trc)
+    void iterateFilteredFiles(TransactionLog &transactionLog, CMessageBuffer &mb,StringBuffer &trc, bool returnAllFilesFlag)
     {
-        TransactionLog transactionLog(*this, MDFS_ITERATE_FILTEREDFILES, mb.getSender());
-
         Owned<IUserDescriptor> udesc;
         StringAttr filters;
         bool recursive;
@@ -9886,7 +9885,8 @@ public:
             e->Release();
             returnAllMatchingFiles = false;
         }
-        mb.append(returnAllMatchingFiles);
+        if (returnAllFilesFlag)
+            mb.append(returnAllMatchingFiles);
 
         tookMs = msTick()-start;
         if (tookMs>100)
@@ -9904,6 +9904,18 @@ public:
             PROGLOG("TIMING(filescan-serialization): %s: took %dms, %d files",trc.str(), tookMs, count);
 
         mb.writeDirect(0,sizeof(count),&count);
+    }
+
+    void iterateFilteredFiles(CMessageBuffer &mb,StringBuffer &trc)
+    {
+        TransactionLog transactionLog(*this, MDFS_ITERATE_FILTEREDFILES, mb.getSender());
+        iterateFilteredFiles(transactionLog, mb, trc, false);
+    }
+
+    void iterateFilteredFiles2(CMessageBuffer &mb,StringBuffer &trc)
+    {
+        TransactionLog transactionLog(*this, MDFS_ITERATE_FILTEREDFILES2, mb.getSender());
+        iterateFilteredFiles(transactionLog, mb, trc, true);
     }
 
     void iterateRelationships(CMessageBuffer &mb,StringBuffer &trc)
@@ -10124,54 +10136,71 @@ public:
         int fn;
         mb.read(fn);
 
-        try {
-            switch (fn) {
-            case MDFS_ITERATE_FILES: {
-                    iterateFiles(mb,trc);                    
+        try
+        {
+            switch (fn)
+            {
+                case MDFS_ITERATE_FILES:
+                {
+                    iterateFiles(mb, trc);
+                    break;
                 }
-                break;
-            case MDFS_ITERATE_FILTEREDFILES: {
-                    iterateFilteredFiles(mb,trc);
+                case MDFS_ITERATE_FILTEREDFILES: // legacy, newer clients will send MDFS_ITERATE_FILTEREDFILES2
+                {
+                    iterateFilteredFiles(mb, trc);
+                    break;
                 }
-                break;
-            case MDFS_ITERATE_RELATIONSHIPS: {
-                    iterateRelationships(mb,trc);                    
+                case MDFS_ITERATE_FILTEREDFILES2:
+                {
+                    iterateFilteredFiles2(mb, trc);
+                    break;
                 }
-                break;
-            case MDFS_GET_FILE_TREE: {
-                    getFileTree(mb,trc);
+                case MDFS_ITERATE_RELATIONSHIPS:
+                {
+                    iterateRelationships(mb, trc);
+                    break;
                 }
-                break;
-            case MDFS_GET_GROUP_TREE: {
-                    getGroupTree(mb,trc);
+                case MDFS_GET_FILE_TREE:
+                {
+                    getFileTree(mb, trc);
+                    break;
                 }
-                break;
-            case MDFS_SET_FILE_ACCESSED: {
-                    setFileAccessed(mb,trc);
+                case MDFS_GET_GROUP_TREE:
+                {
+                    getGroupTree(mb, trc);
+                    break;
                 }
-                break;
-            case MDFS_SET_FILE_PROTECT: {
-                    setFileProtect(mb,trc);
+                case MDFS_SET_FILE_ACCESSED:
+                {
+                    setFileAccessed(mb, trc);
+                    break;
                 }
-                break;
-            default: {
+                case MDFS_SET_FILE_PROTECT:
+                {
+                    setFileProtect(mb, trc);
+                    break;
+                }
+                default:
+                {
                     mb.clear();
+                    break;
                 }
-                break;
             }
         }
-        catch (IException *e) {
+        catch (IException *e)
+        {
             int err=-1; // exception marker
             mb.clear().append(err); 
             serializeException(e, mb); 
             e->Release();
         }
-        coven.reply(mb);    
-        if (block0.slow()) {
+        coven.reply(mb);
+        if (block0.slow())
+        {
             SocketEndpoint ep = mb.getSender();
             ep.getUrlStr(block0.appendMsg(trc).append(" from "));
         }
-    }   
+    }
 
     void nodeDown(rank_t rank)
     {
@@ -10187,6 +10216,8 @@ public:
             return ret.append("MDFS_ITERATE_FILES");
         case MDFS_ITERATE_FILTEREDFILES:
             return ret.append("MDFS_ITERATE_FILTEREDFILES");
+        case MDFS_ITERATE_FILTEREDFILES2:
+            return ret.append("MDFS_ITERATE_FILTEREDFILES2");
         case MDFS_ITERATE_RELATIONSHIPS:
             return ret.append("MDFS_ITERATE_RELATIONSHIPS");
         case MDFS_GET_FILE_TREE:
@@ -12247,7 +12278,13 @@ IPropertyTreeIterator *CDistributedFileDirectory::getDFAttributesTreeIterator(co
     const char* localFilterBuf, IUserDescriptor* user, bool& allMatchingFilesReceived, INode* foreigndali, unsigned foreigndalitimeout)
 {
     CMessageBuffer mb;
-    mb.append((int)MDFS_ITERATE_FILTEREDFILES).append(filters).append(true);
+    CDaliVersion serverVersionNeeded("3.13");
+    bool legacy = (queryDaliServerVersion().compare(serverVersionNeeded) < 0);
+    if (legacy)
+        mb.append((int)MDFS_ITERATE_FILTEREDFILES);
+    else
+        mb.append((int)MDFS_ITERATE_FILTEREDFILES2);
+    mb.append(filters).append(true);
     if (user)
         user->serialize(mb);
 
@@ -12259,7 +12296,10 @@ IPropertyTreeIterator *CDistributedFileDirectory::getDFAttributesTreeIterator(co
 
     unsigned numfiles;
     mb.read(numfiles);
-    mb.read(allMatchingFilesReceived);
+    if (legacy)
+        allMatchingFilesReceived = true; // din't know any better
+    else
+        mb.read(allMatchingFilesReceived);
     return deserializeFileAttrIterator(mb, localFilters, localFilterBuf);
 }
 

--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -12109,7 +12109,7 @@ IPropertyTreeIterator *deserializeFileAttrIterator(MemoryBuffer& mb, unsigned nu
     {
         Owned<IPropertyTree> cur;
         StringArray fileNodeGroups;
-        unsigned fileDataStart;
+        size32_t fileDataStart;
 
         void setFileNodeGroup(IPropertyTree *attr, const char* group, StringArray& nodeGroupFilter)
         {
@@ -12214,7 +12214,6 @@ IPropertyTreeIterator *deserializeFileAttrIterator(MemoryBuffer& mb, unsigned nu
         IMPLEMENT_IINTERFACE;
         MemoryBuffer mb;
         unsigned numfiles;
-        bool allMatchingFilesReceived;
         StringArray nodeGroupFilter;
 
         CFileAttrIterator(MemoryBuffer &_mb, unsigned _numfiles) : numfiles(_numfiles)
@@ -12302,7 +12301,7 @@ IPropertyTreeIterator *CDistributedFileDirectory::getDFAttributesTreeIterator(co
     unsigned numfiles;
     mb.read(numfiles);
     if (legacy)
-        allMatchingFilesReceived = true; // din't know any better
+        allMatchingFilesReceived = true; // don't know any better
     else
         mb.read(allMatchingFilesReceived);
     return deserializeFileAttrIterator(mb, numfiles, localFilters, localFilterBuf);


### PR DESCRIPTION
When requesting a list of files, the server sent a new flag
back to indicate whether all files were sent.
This caused backward compatibility issues.
Introduce a new request for new clients, so that old request
behaves as it did before.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
