### PR TITLE
HPCC-15810 Build errors with USE_CASSANDRA selected

### DIFF
--- a/esp/logging/loggingagent/cassandraloggingagent/CMakeLists.txt
+++ b/esp/logging/loggingagent/cassandraloggingagent/CMakeLists.txt
@@ -16,11 +16,10 @@
 
 # Component: cassandralogagent
 
-HPCC_ADD_SUBDIRECTORY (${HPCC_SOURCE_DIR}/plugins/cassandra/cpp-driver/ ${PROJECT_BINARY_DIR})
+if(USE_CASSANDRA)
+  project( cassandralogagent )
 
-project( cassandralogagent )
-
-include_directories (
+  include_directories (
      ${HPCC_SOURCE_DIR}/system/include
      ${HPCC_SOURCE_DIR}/system/jlib
      ${HPCC_SOURCE_DIR}/system/security/shared
@@ -39,22 +38,22 @@ include_directories (
      ${HPCC_SOURCE_DIR}/esp/bindings
      ${HPCC_SOURCE_DIR}/esp/bindings/SOAP/xpp
      ${HPCC_SOURCE_DIR}/esp/logging
-)
+  )
 
-ADD_DEFINITIONS( -D_USRDLL  -DMYSQLLOGGINGLISTENER_EXPORTS -DMYSQLLOGAGENT_EXPORTS )
+  ADD_DEFINITIONS( -D_USRDLL -DCASSANDRALOGAGENT_EXPORTS )
 
-set ( SRCS
+  set ( SRCS
     cassandralogagent.cpp
-)
+  )
 
-HPCC_ADD_LIBRARY( cassandralogagent SHARED ${SRCS} )
+  HPCC_ADD_LIBRARY( cassandralogagent SHARED ${SRCS} )
 
-install ( TARGETS cassandralogagent RUNTIME DESTINATION bin LIBRARY DESTINATION lib )
-add_dependencies (cassandralogagent espscm)
-target_link_libraries ( cassandralogagent
+  install ( TARGETS cassandralogagent RUNTIME DESTINATION bin LIBRARY DESTINATION lib )
+  add_dependencies (cassandralogagent espscm)
+  target_link_libraries ( cassandralogagent
     cassandraembed
-    cassandra
     eclrtl
     esphttp
     jlib
-)
+  )
+endif(USE_CASSANDRA)

--- a/esp/logging/loggingagent/cassandraloggingagent/cassandralogagent.cpp
+++ b/esp/logging/loggingagent/cassandraloggingagent/cassandralogagent.cpp
@@ -559,7 +559,7 @@ unsigned CCassandraLogAgent::executeSimpleSelectStatement(const char* st, unsign
 
 extern "C"
 {
-CASSABDRALOGAGENT_API IEspLogAgent* newLoggingAgent()
+CASSANDRALOGAGENT_API IEspLogAgent* newLoggingAgent()
 {
     return new CCassandraLogAgent();
 }

--- a/esp/logging/loggingagent/cassandraloggingagent/cassandralogagent.hpp
+++ b/esp/logging/loggingagent/cassandraloggingagent/cassandralogagent.hpp
@@ -17,8 +17,8 @@
 
 #pragma warning (disable : 4786)
 
-#ifndef _CASSABDRALOGAGENT_HPP__
-#define _CASSABDRALOGAGENT_HPP__
+#ifndef _CASSANDRALOGAGENT_HPP__
+#define _CASSANDRALOGAGENT_HPP__
 
 #include "jmisc.hpp"
 #include "eclhelper.hpp"
@@ -31,13 +31,13 @@
 using namespace cassandraembed;
 
 #ifdef WIN32
-    #ifdef CASSABDRALOGAGENT_EXPORTS
-        #define CASSABDRALOGAGENT_API __declspec(dllexport)
+    #ifdef CASSANDRALOGAGENT_EXPORTS
+        #define CASSANDRALOGAGENT_API __declspec(dllexport)
     #else
-        #define CASSABDRALOGAGENT_API __declspec(dllimport)
+        #define CASSANDRALOGAGENT_API __declspec(dllimport)
     #endif
 #else
-    #define CASSABDRALOGAGENT_API
+    #define CASSANDRALOGAGENT_API
 #endif
 
 class CCassandraLogAgent : public CInterface, implements IEspLogAgent
@@ -80,4 +80,4 @@ public:
     virtual void filterLogContent(IEspUpdateLogRequestWrap* req);
 };
 
-#endif //_CASSABDRALOGAGENT_HPP__
+#endif //_CASSANDRALOGAGENT_HPP__

--- a/plugins/cassandra/CMakeLists.txt
+++ b/plugins/cassandra/CMakeLists.txt
@@ -108,13 +108,6 @@ if(USE_CASSANDRA)
   add_definitions(-D_USRDLL -DCASSANDRAEMBED_EXPORTS)
 
   HPCC_ADD_LIBRARY(cassandraembed SHARED ${SRCS})
-  if(NOT FORCE_WORKUNITS_TO_CASSANDRA)
-    if(${CMAKE_VERSION} VERSION_LESS "2.8.9")
-      message(WARNING "Cannot set NO_SONAME. shlibdeps will give warnings when package is installed")
-    elseif(NOT APPLE)
-      set_target_properties(cassandraembed PROPERTIES NO_SONAME 1)
-    endif()
-  endif()
 
   install(
     TARGETS cassandraembed


### PR DESCRIPTION
Suppressing the SONAME on cassandraembed is not sensible any more, now that it
and all its dependencies are included in the standard build. It also seems to
cause rpm build errors.

Various typos fixed.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
