### PR TITLE
HPCC-15797 Restrict spray source to designated dropzones

### DIFF
--- a/dali/ft/daft.cpp
+++ b/dali/ft/daft.cpp
@@ -78,7 +78,7 @@ void CDistributedFileSystem::exportFile(IDistributedFile * from, IFileDescriptor
     sprayer->setAbort(abort);
     sprayer->setPartFilter(filter);
     sprayer->setSource(from);
-    sprayer->checkTarget(to);
+    sprayer->checkSourceTarget(to);
     sprayer->setTarget(to);
     sprayer->spray();
 }
@@ -96,6 +96,7 @@ void CDistributedFileSystem::import(IFileDescriptor * from, IDistributedFile * t
     sprayer->setAbort(abort);
     sprayer->setPartFilter(filter);
     sprayer->setSource(from);
+    sprayer->checkSourceTarget(from);
     sprayer->setTarget(to);
     sprayer->spray();
 }

--- a/dali/ft/filecopy.cpp
+++ b/dali/ft/filecopy.cpp
@@ -2628,27 +2628,27 @@ void FileSprayer::setTarget(IDistributedFile * target)
     }
 }
 
-void FileSprayer::checkTargetPath(RemoteFilename & filename)
+void FileSprayer::checkFilePath(RemoteFilename & filename)
 {
-    StringBuffer targetFilePath;
-    filename.getLocalPath(targetFilePath);
-    const char * ptargetFilePath = targetFilePath.str();
+    StringBuffer filePath;
+    filename.getLocalPath(filePath);
+    const char * pfilePath = filePath.str();
 
     if (filename.queryIP().isLoopBack())
-        throwError1(DFTERR_LocalhostAddressUsed, ptargetFilePath);
+        throwError1(DFTERR_LocalhostAddressUsed, pfilePath);
 
 #ifdef _DEBUG
-    LOG(MCdebugInfo, unknownJob, "Target file path is '%s'", targetFilePath.str());
+    LOG(MCdebugInfo, unknownJob, "File path is '%s'", filePath.str());
 #endif
 
     const char pathSep = filename.getPathSeparator();
     const char dotString[]    = {pathSep, '.', pathSep, '\0'};
     const char dotDotString[] = {pathSep, '.', '.', pathSep, '\0'};
 
-    const char * isDotString = strstr(ptargetFilePath, dotString);
-    const char * isDotDotString = strstr(ptargetFilePath, dotDotString);
+    const char * isDotString = strstr(pfilePath, dotString);
+    const char * isDotDotString = strstr(pfilePath, dotDotString);
     if ((isDotDotString != nullptr) || (isDotString != nullptr))
-        throwError3(DFTERR_InvalidTargetPath, ptargetFilePath, dotDotString, dotString);
+        throwError3(DFTERR_InvalidFilePath, pfilePath, dotDotString, dotString);
 
     Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
     if (factory)
@@ -2659,21 +2659,21 @@ void FileSprayer::checkTargetPath(RemoteFilename & filename)
             StringBuffer netaddress;
             filename.queryIP().getIpText(netaddress);
 
-            Owned<IConstDropZoneInfo> targetDropZone = env->getDropZoneByAddressPath(netaddress.str(), ptargetFilePath);
-            if (!targetDropZone)
-                LOG(MCdebugInfo, unknownJob, "No matching drop zone path to target file path: '%s'", targetFilePath.str());
+            Owned<IConstDropZoneInfo> dropZone = env->getDropZoneByAddressPath(netaddress.str(), pfilePath);
+            if (!dropZone)
+                LOG(MCdebugInfo, unknownJob, "No matching drop zone path to file path: '%s'", filePath.str());
         }
     }
 }
 
-void FileSprayer::checkTarget(IFileDescriptor * target)
+void FileSprayer::checkSourceTarget(IFileDescriptor * file)
 {
-    unsigned numParts = target->numParts();
+    unsigned numParts = file->numParts();
     RemoteFilename filename;
     for (unsigned idx=0; idx < numParts; idx++)
     {
-        target->getFilename(idx, 0, filename);
-        checkTargetPath(filename);
+        file->getFilename(idx, 0, filename);
+        checkFilePath(filename);
     }
 }
 

--- a/dali/ft/filecopy.hpp
+++ b/dali/ft/filecopy.hpp
@@ -127,7 +127,7 @@ public:
     virtual void setTarget(IGroup * target) = 0;
     virtual void setTarget(INode * target) = 0;
     virtual void spray() = 0;
-    virtual void checkTarget(IFileDescriptor * target) = 0;
+    virtual void checkSourceTarget(IFileDescriptor * file) = 0;
 };
 
 extern DALIFT_API IFileSprayer * createFileSprayer(IPropertyTree * _options, IPropertyTree * _progress, IRemoteConnection * recoveryConnection, const char *wuid);

--- a/dali/ft/filecopy.ipp
+++ b/dali/ft/filecopy.ipp
@@ -202,7 +202,7 @@ public:
     unsigned numParallelSlaves();
     void setError(const SocketEndpoint & ep, IException * e);
     bool canLocateSlaveForNode(const IpAddress &ip);
-    void checkTarget(IFileDescriptor * target);
+    void checkSourceTarget(IFileDescriptor * file);
 
 protected:
     void addEmptyFilesToPartition(unsigned from, unsigned to);
@@ -264,7 +264,7 @@ protected:
     void waitForTransferSem(Semaphore & sem);
     void addPrefix(size32_t len, const void * data, unsigned idx, PartitionPointArray & partitionWork);
     bool isSameSizeHeaderFooter();
-    void checkTargetPath(RemoteFilename & filename);
+    void checkFilePath(RemoteFilename & filename);
     
 private:
     bool calcUsePull();

--- a/dali/ft/fterror.hpp
+++ b/dali/ft/fterror.hpp
@@ -81,7 +81,7 @@
 #define DFTERR_WrongSplitRecordSize             8108
 #define DFTERR_CannotFindFirstJsonRecord        8109
 #define DFTERR_InvalidXmlPartSize               8110
-#define DFTERR_InvalidTargetPath                8111
+#define DFTERR_InvalidFilePath                  8111
 #define DFTERR_NoMatchingDropzonePath           8112
 #define DFTERR_LocalhostAddressUsed             8113
 
@@ -152,7 +152,7 @@
 #define DFTERR_WrongRECFMvRecordSize_Text       "Invalid RECFMv file Record Size (%d) or the file is not RECFMv format!"
 #define DFTERR_WrongSplitRecordSize_Text        "Invalid Record Size (%d, 0x%08x)!"
 #define DFTERR_InvalidXmlPartSize_Text          "Invalid XML part size:%" I64F "d! Size is less than XML Header (%" I64F "d) + Footer (%" I64F "d)) size!"
-#define DFTERR_InvalidTargetPath_Text           "Invalid target path: '%s'. For security reason it is forbidden to use '%s' or '%s' to build a path!"
+#define DFTERR_InvalidFilePath_Text             "Invalid file path: '%s'. For security reason it is forbidden to use '%s' or '%s' to build a path!"
 #define DFTERR_NoMatchingDropzonePath_Text      "No matching drop zone path to target path: '%s'."
 #define DFTERR_LocalhostAddressUsed_Text        "Localhost address used in remote file name: '%s'"
 

--- a/testing/regress/ecl/despray.ecl
+++ b/testing/regress/ecl/despray.ecl
@@ -13,7 +13,7 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
-############################################################################## */
+############################################################################# */
 
 //nothor
 


### PR DESCRIPTION
Add source file path checking into spray

Modify functions and variables name to reflect both source and target
file path checking

Touch despray.ecl to force its execution in smoketest

Signed-off-by: Attila Vamos attila.vamos@gmail.com
