### PR TITLE
HPCC-15785 - Improve connection re-use in MySQL driver

### DIFF
--- a/plugins/mysql/mysqlembed.cpp
+++ b/plugins/mysql/mysqlembed.cpp
@@ -116,7 +116,7 @@ public:
         {
             if (threadCached || globalCached)
             {
-                Owned<MySQLConnection> cacheEntry = new MySQLConnection(*this);. // Note - takes ownership of this->cacheOptions and this->conn
+                Owned<MySQLConnection> cacheEntry = new MySQLConnection(*this); // Note - takes ownership of this->cacheOptions and this->conn
                 cacheOptions = NULL;
                 conn = NULL;
                 if (threadCached)


### PR DESCRIPTION
Typo caused build break

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
