### PR TITLE
HPCC-15873 Add FileUploadAccess to default permissions

### DIFF
--- a/initfiles/componentfiles/configxml/buildsetCC.xml.in
+++ b/initfiles/componentfiles/configxml/buildsetCC.xml.in
@@ -162,6 +162,10 @@
                           path="FileDkcAccess"
                           resource="FileDkcAccess"
                           service="ws_fs"/>
+     <AuthenticateFeature description="Access to upload files to dropzone"
+                          path="FileUploadAccess"
+                          resource="FileUploadAccess"
+                          service="ws_fs" />
      <AuthenticateFeature description="Access to files in dropzone"
                           path="FileIOAccess"
                           resource="FileIOAccess"

--- a/initfiles/etc/DIR_NAME/environment.xml.in
+++ b/initfiles/etc/DIR_NAME/environment.xml.in
@@ -363,6 +363,11 @@
                          resource="FileDkcAccess"
                          service="ws_fs"/>
     <AuthenticateFeature authenticate="Yes"
+                         description="Access to upload files to dropzone"
+                         path="FileUploadAccess"
+                         resource="FileUploadAccess"
+                         service="ws_fs"/>
+    <AuthenticateFeature authenticate="Yes"
                          description="Access to files in dropzone"
                          path="FileIOAccess"
                          resource="FileIOAccess"
@@ -607,6 +612,10 @@
     <AuthenticateFeature description="Access to dkcing of key files"
                          path="FileDkcAccess"
                          resource="FileDkcAccess"
+                         service="ws_fs"/>
+    <AuthenticateFeature description="Access to upload files to dropzone"
+                         path="FileUploadAccess"
+                         resource="FileUploadAccess"
                          service="ws_fs"/>
     <AuthenticateFeature description="Access to files in dropzone"
                          path="FileIOAccess"
@@ -904,6 +913,10 @@
      <AuthenticateFeature description="Access to dkcing of key files"
                           path="FileDkcAccess"
                           resource="FileDkcAccess"
+                          service="ws_fs"/>
+     <AuthenticateFeature description="Access to upload files to dropzone"
+                          path="FileUploadAccess"
+                          resource="FileUploadAccess"
                           service="ws_fs"/>
      <AuthenticateFeature description="Access to files in dropzone"
                           path="FileIOAccess"


### PR DESCRIPTION
When ESP SMC service is started, the service reads feature
permission settings from esp.xml and add the permission to
LDAP server if the permission is not in the LDAP server.
In this fix, FileUploadAccess is added to environment
configuration files which creates the FileUploadAccess
permission setting in esp.xml.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
