### PR TITLE
HPCC-15569 Send 'No matching query' error when query not found

### DIFF
--- a/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
+++ b/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
@@ -1605,7 +1605,7 @@ bool CWsWorkunitsEx::onWUQueryDetails(IEspContext &context, IEspWUQueryDetailsRe
     if (!query)
     {
         DBGLOG("No matching Query");
-        return false;
+        throw MakeStringException(ECLWATCH_QUERYID_NOT_FOUND,"No matching query for query ID %s.", queryId);
     }
 
     const char* queryName = query->queryProp("@name");


### PR DESCRIPTION
This fix is for WsWorkuints.WUQueryDetails. When a user sends a request with a query ID and the query does not exist, the existing code echos the query ID (other attribute empty). The user may get confused. 

Signed-off-by: wangkx kevin.wang@lexisnexis.com
