### PR TITLE
HPCC-15899 Change WsDeployService string literal STANDARD_CONFIG_STAGED_PATH

### DIFF
--- a/esp/services/WsDeploy/WsDeployService.cpp
+++ b/esp/services/WsDeploy/WsDeployService.cpp
@@ -32,7 +32,7 @@
 
 #define STANDARD_CONFIG_BACKUPDIR CONFIG_DIR"/backup"
 #define STANDARD_CONFIG_SOURCEDIR CONFIG_DIR
-#define STANDARD_CONFIG_STAGED_PATH "/etc/HPCCSystems/environment.xml"
+#define STANDARD_CONFIG_STAGED_PATH CONFIG_DIR "/" ENV_XML_FILE
 
 #define DEFAULT_DIRECTORIES "<Directories name=\"" DIR_NAME "\">\
       <Category dir=\"" EXEC_PREFIX "/log/[NAME]/[INST]\" name=\"log\"/>\


### PR DESCRIPTION
On line 35 of /esp/services/WsDeploy/WsDeployServices.cpp there is a #define for STANDARD_CONFIG_STAGED_PATH. This string literal is hard coded to /etc/HPCCSystems/environment.xml which causes configmgr to break if you are running the platform from an alternate location.

Quick fix to make it variable at compile time, to use the values set in the build-config.h header file.

Signed-off-by: Michael Gardner michael.gardner@lexisnexis.com
