### PR TITLE
HPCC-15748 HThor virtual(logicalfilename) fails on superfile with 1 subfile

### DIFF
--- a/ecl/hthor/hthor.cpp
+++ b/ecl/hthor/hthor.cpp
@@ -7999,7 +7999,9 @@ void CHThorDiskReadBaseActivity::resolve()
                         }
                         assertex(fdesc);
                         superfile.set(fdesc->querySuperFileDescriptor());
-                        assertex(superfile);
+                        if (!superfile && numsubs>0)
+                            logicalFileName.set(subfileLogicalFilenames.item(0));
+
                     }
                 }
                 if((helper.getFlags() & (TDXtemporary | TDXjobtemp)) == 0)


### PR DESCRIPTION
Signed-off-by: Richard Chapman rchapman@hpccsystems.com
