### PR TITLE
HPCC-15894 Need to use primary comparitor if no key serializer

### DIFF
--- a/thorlcr/activities/join/thjoinslave.cpp
+++ b/thorlcr/activities/join/thjoinslave.cpp
@@ -546,7 +546,7 @@ public:
         }
         else
         {
-            sorter->Gather(primaryRowIf, primaryInputStream, primaryCompare, NULL, NULL, primaryKeySerializer, NULL, false, isUnstable(), abortSoon, NULL);
+            sorter->Gather(primaryRowIf, primaryInputStream, primaryCompare, NULL, NULL, primaryKeySerializer, NULL, NULL, false, isUnstable(), abortSoon, NULL);
             stopPartitionInput();
             if (abortSoon)
             {
@@ -571,7 +571,7 @@ public:
             sorter->stopMerge();
         }
         // NB: on secondary sort, the primaryKeySerializer is used
-        sorter->Gather(secondaryRowIf, secondaryInputStream, secondaryCompare, primarySecondaryCompare, primarySecondaryUpperCompare, primaryKeySerializer, partitionRow, noSortOtherSide(), isUnstable(), abortSoon, primaryRowIf); // primaryKeySerializer *is* correct
+        sorter->Gather(secondaryRowIf, secondaryInputStream, secondaryCompare, primarySecondaryCompare, primarySecondaryUpperCompare, primaryKeySerializer, primaryCompare, partitionRow, noSortOtherSide(), isUnstable(), abortSoon, primaryRowIf); // primaryKeySerializer *is* correct
         mergeStats(spillStats, sorter);
         //MORE: Stats from spilling the primaryStream??
         partitionRow.clear();

--- a/thorlcr/activities/msort/thmsortslave.cpp
+++ b/thorlcr/activities/msort/thmsortslave.cpp
@@ -113,6 +113,7 @@ public:
                 helper->queryCompareLeftRight(),
                 NULL,helper->querySerialize(),
                 NULL,
+                NULL,
                 false,
                 isUnstable(),
                 abortSoon,

--- a/thorlcr/activities/selfjoin/thselfjoinslave.cpp
+++ b/thorlcr/activities/selfjoin/thselfjoinslave.cpp
@@ -77,7 +77,7 @@ private:
 #if THOR_TRACE_LEVEL > 5
         ActPrintLog("SELFJOIN: Performing global self-join");
 #endif
-        sorter->Gather(::queryRowInterfaces(input), inputStream, compare, NULL, NULL, keyserializer, NULL, false, isUnstable(), abortSoon, NULL);
+        sorter->Gather(::queryRowInterfaces(input), inputStream, compare, NULL, NULL, keyserializer, NULL, NULL, false, isUnstable(), abortSoon, NULL);
         PARENT::stop();
         if (abortSoon)
         {

--- a/thorlcr/msort/tsorts.cpp
+++ b/thorlcr/msort/tsorts.cpp
@@ -1177,6 +1177,7 @@ public:
         ICompare *_primarySecondaryCompare,
         ICompare *_primarySecondaryUpperCompare,
         ISortKeySerializer *_keyserializer,
+        ICompare *primaryCompare, // needed if no key serializer
         const void *_partitionrow,
         bool _nosort,
         bool _unstable,
@@ -1219,7 +1220,7 @@ public:
             ActPrintLog(activity, "No key serializer");
             keyIf.set(auxrowif);
             rowToKeySerializer.set(keyIf->queryRowSerializer());
-            keyRowCompare = rowCompare;
+            keyRowCompare = primaryCompare ? primaryCompare : rowCompare;
         }
         nosort = _nosort;
         if (nosort)

--- a/thorlcr/msort/tsorts.hpp
+++ b/thorlcr/msort/tsorts.hpp
@@ -42,6 +42,7 @@ public:
         ICompare *icollate,
         ICompare *icollateupper,
         ISortKeySerializer *keyserializer, 
+        ICompare *primaryCompare,
         const void *partitionrow, 
         bool nosort, 
         bool unstable, 


### PR DESCRIPTION
Spurious partitioned results (e.g. skew reported), because using
the wrong comparison helper when partitioning RHS with no key
serializer. In that case, must pass/use the LHS compare helper.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
