### PR TITLE
HPCC-15922 Despray to a single Landing Zone fails

### DIFF
--- a/common/environment/environment.cpp
+++ b/common/environment/environment.cpp
@@ -35,7 +35,6 @@
 #define DROPZONE_BY_MACHINE_SUFFIX  "-dropzoneByMachine-"
 #define DROPZONE_SUFFIX             "dropzone-"
 #define MACHINE_PREFIX              "machine-"
-#define NUMBER_OF_DROPZONES_SUFFIX  "-numberOfDropZones"
 
 static int environmentTraceLevel = 1;
 static Owned <IConstEnvironment> cache;
@@ -122,6 +121,12 @@ private:
     void buildMachineCache() const;
     void buildDropZoneCache() const;
     void init();
+    StringBuffer & createComputerNameXpath(const char * computer, StringBuffer &xpath) const
+    {
+        xpath.append("numberOfDropZones[@name=\"");
+        xpath.append(computer).append("\"]/number");
+        return xpath;
+    }
 
 public:
     IMPLEMENT_IINTERFACE;
@@ -168,10 +173,9 @@ public:
     unsigned getNumberOfDropZonesByComputer(const char * computer) const
     {
         buildDropZoneCache();
-        StringBuffer xpath("@");
-        xpath.append(computer).append(NUMBER_OF_DROPZONES_SUFFIX);
-        unsigned numOfDropZoneByComputer = numOfDropzonesByComputer->getPropInt(xpath, -1);
-        return (numOfDropZoneByComputer != -1 ? numOfDropZoneByComputer : 0);
+        StringBuffer xpath;
+        createComputerNameXpath(computer, xpath);
+        return numOfDropzonesByComputer->getPropInt(xpath);
     }
     IConstDropZoneInfo * getDropZoneByComputerByIndex(const char * computer, unsigned index) const;
 
@@ -1152,16 +1156,19 @@ void CLocalEnvironment::buildDropZoneCache() const
             const char * computer = it->query().queryProp("@computer");
             if (computer)
             {
-                StringBuffer xpath("@");
-                xpath.append(computer).append(NUMBER_OF_DROPZONES_SUFFIX);
-                unsigned numOfDropZoneByComputer = numOfDropzonesByComputer->getPropInt(xpath, -1);
+                StringBuffer xpath;
+                createComputerNameXpath(computer, xpath);
+                unsigned numOfDropZoneByComputer = numOfDropzonesByComputer->getPropInt(xpath.str(), -1);
                 if (numOfDropZoneByComputer == -1)
                 {
                     numOfDropZoneByComputer = 0;
-                    numOfDropzonesByComputer->addPropInt(xpath, numOfDropZoneByComputer );
+                    IPropertyTree * val = createPTree("numberOfDropZones");
+                    val->addPropInt("@number",numOfDropZoneByComputer);
+                    val->addProp("@name", computer);
+                    numOfDropzonesByComputer->addPropTree("numberOfDropZones",val);
                 }
                 numOfDropZoneByComputer++;
-                numOfDropzonesByComputer->setPropInt(xpath, numOfDropZoneByComputer);
+                numOfDropzonesByComputer->setPropInt(xpath.str(), numOfDropZoneByComputer);
 
                 StringBuffer x("Software/DropZone[@computer=\"");
                 x.append(computer);
@@ -1310,8 +1317,8 @@ IConstDropZoneInfo * CLocalEnvironment::getDropZoneByComputer(const char * compu
         return nullptr;
     buildDropZoneCache();
 
-    StringBuffer x("@");
-    x.append(computer).append(NUMBER_OF_DROPZONES_SUFFIX);
+    StringBuffer x;
+    createComputerNameXpath(computer, x);
     unsigned numOfDropZoneByComputer = numOfDropzonesByComputer->getPropInt(x, -1);
     if (numOfDropZoneByComputer == -1)
         return nullptr;


### PR DESCRIPTION
Add a valid prefix to computer name when it used to create Xpath.

Signed-off-by: Attila Vamos attila.vamos@gmail.com
