### PR TITLE
HPCC-15954 ESP crash with 389DS LDAP and creating default OU

### DIFF
--- a/system/security/LdapSecurity/ldapsecurity.cpp
+++ b/system/security/LdapSecurity/ldapsecurity.cpp
@@ -528,8 +528,8 @@ void CLdapSecManager::init(const char *serviceName, IPropertyTree* cfg)
     else
         throwUnexpected();
 
-    ldap_client->init(pp);
     pp->setLdapClient(ldap_client);
+    ldap_client->init(pp);
 
     m_ldap_client.setown(ldap_client);
     m_pp.setown(pp);


### PR DESCRIPTION
When ESP starts, the LDAP security manager creates the base OU structure
on the LDAP server. If the LDAP is 389DS and the base OU does not already
exist, ESP security manager will core derefrerencing a NULL pointer. This
PR sets the securty manager config pointer before calling initialize.

Signed-off-by: Russ Whitehead william.whitehead@lexisnexis.com
