### PR TITLE
HPCC-15953 Ordering fix for Local wuid write with EXTEND

### DIFF
--- a/thorlcr/activities/wuidwrite/thwuidwrite.cpp
+++ b/thorlcr/activities/wuidwrite/thwuidwrite.cpp
@@ -250,8 +250,6 @@ public:
         if (!receiveMsg(replyMsg, sender, mpTag, NULL, 5*60000))
             throwUnexpected();
         replyMsg.swapWith(msg);
-        queryJobChannel().queryJobComm().reply(replyMsg); // ack
-        
         unsigned numGot;
         msg.read(numGot);
         unsigned l=msg.remaining();
@@ -266,6 +264,7 @@ public:
             totalSize += resultData.length();
             flushResults(0 == numGot);
         }
+        queryJobChannel().queryJobComm().reply(replyMsg); // ack
     }
     virtual void handleSlaveMessage(CMessageBuffer &msg)
     {


### PR DESCRIPTION
If OUTPUT is used in a child query (e.g. via APPLY) and there
are multiple outputs writnig to the same named workunit result
with EXTEND, then the output order was not deterministic.

Fix is to avoid acknowledging data packets read from slave
workunit writes until data flushed to workunit.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
