### PR TITLE
HPCC-15950 Race condition in firstn inside child query

### DIFF
--- a/thorlcr/activities/firstn/thfirstnslave.cpp
+++ b/thorlcr/activities/firstn/thfirstnslave.cpp
@@ -34,11 +34,6 @@ protected:
     bool stopped;
     IHThorFirstNArg *helper;
 
-    virtual void doStop()
-    {
-        PARENT::stop();
-    }
-
 public:
     CFirstNSlaveBase(CGraphElementBase *_container) : CSlaveActivity(_container)
     {
@@ -58,7 +53,7 @@ public:
         {
             abortSoon = true;
             stopped = true;
-            doStop();
+            PARENT::stop();
         }
     }
     virtual void getMetaInfo(ThorDataLinkMetaInfo &info)
@@ -215,14 +210,6 @@ class CFirstNSlaveGlobal : public CFirstNSlaveBase, implements ILookAheadStopNot
     ThorDataLinkMetaInfo inputMeta;
     Owned<IEngineRowStream> originalInputStream;
 
-protected:
-    virtual void doStop()
-    {
-        limitgot.signal(); // JIC not previously signalled by lookahead
-        onInputFinished(getDataLinkCount()+skipped);
-        PARENT::doStop();
-    }
-
 public:
     CFirstNSlaveGlobal(CGraphElementBase *container) : CFirstNSlaveBase(container)
     {
@@ -268,7 +255,7 @@ public:
     {
         CMessageBuffer msgMb;
         if (!receiveMsg(msgMb, 0, mpTag))
-            return false; // NB: can be triggered by onInputFinished with count==0, or abort()
+            return false; // NB: can be triggered by abort()
         msgMb.read(limit);
         msgMb.read(skipCount);
         skipped = 0;
@@ -295,7 +282,7 @@ public:
     void sendCount()
     {
         limitgot.wait();
-        
+
         rowcount_t read = 0;
         rowcount_t skip = skipCount;
         if (limit > 0)
@@ -329,7 +316,8 @@ public:
     CATCH_NEXTROW()
     {
         ActivityTimer t(totalCycles, timeActivities);
-        if (!abortSoon) {
+        if (!abortSoon)
+        {
             if (firstget)
             {
                 firstget = false;
@@ -377,12 +365,6 @@ public:
             sendCount();
         }
         ActPrintLog("FIRSTN: maximum row count %" RCPF "d", count);
-        if (0 == count)
-        {
-            limit = 0;
-            CriticalBlock b(crit);
-            cancelReceiveMsg(RANK_ALL, mpTag);
-        }
     }
 };
 


### PR DESCRIPTION
The race causes a global firstn inside a child query to
potentially hit an assert(read <= limit) in the master.
The bug was caused by the firstn slave signalling a semaphore
twice, once when it hit the end of input via lookahead and once
via stop(). The result was that subsequent executions of the
same activity would spuriously fire early and could report to the
master that they were going to read more than the limit.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
