### PR TITLE
HPCC-15696 Add column-level security support for Security Managers

### DIFF
--- a/system/security/LdapSecurity/ldapconnection.hpp
+++ b/system/security/LdapSecurity/ldapconnection.hpp
@@ -234,7 +234,7 @@ interface ILdapClient : extends IInterface
     virtual void init(IPermissionProcessor* pp) = 0;
     virtual LdapServerType getServerType() = 0;
     virtual bool authenticate(ISecUser& user) = 0;
-    virtual bool authorize(SecResourceType rtype, ISecUser&, IArrayOf<ISecResource>& resources) = 0;
+    virtual bool authorize(SecResourceType rtype, ISecUser&, IArrayOf<ISecResource>& resources, const char * resName = nullptr) = 0;
     virtual bool addResources(SecResourceType rtype, ISecUser& user, IArrayOf<ISecResource>& resources, SecPermissionType ptype, const char* basedn) = 0;
     virtual bool addUser(ISecUser& user) = 0;
     virtual void getGroups(const char *user, StringArray& groups) = 0;
@@ -248,7 +248,7 @@ interface ILdapClient : extends IInterface
     virtual IPropertyTreeIterator* getUserIterator(const char* userName) = 0;
     virtual ISecItemIterator* getUsersSorted(const char* userName, UserField* sortOrder, const unsigned pageStartFrom, const unsigned pageSize,
         unsigned *total, __int64 *cachehint) = 0;
-    virtual void getAllGroups(StringArray & groups, StringArray & managedBy, StringArray & descriptions) = 0;
+    virtual void getAllGroups(StringArray & groups, StringArray & managedBy, StringArray & descriptions, const char * baseDN = nullptr) = 0;
     virtual IPropertyTreeIterator* getGroupIterator() = 0;
     virtual ISecItemIterator* getGroupsSorted(GroupField* sortOrder, const unsigned pageStartFrom, const unsigned pageSize,
         unsigned *total, __int64 *cachehint) = 0;
@@ -269,11 +269,11 @@ interface ILdapClient : extends IInterface
         ResourceField* sortOrder, const unsigned pageStartFrom, const unsigned pageSize, unsigned *total, __int64 *cachehint) = 0;
     virtual bool getPermissionsArray(const char* basedn, SecResourceType rtype, const char* name, IArrayOf<CPermission>& permissions) = 0;
     virtual bool changePermission(CPermissionAction& action) = 0;
-    virtual void changeUserGroup(const char* action, const char* username, const char* groupname) = 0;
+    virtual void changeUserGroup(const char* action, const char* username, const char* groupname, const char * groupDN=nullptr) = 0;
     virtual bool deleteUser(ISecUser* user) = 0;
     virtual void addGroup(const char* groupname, const char * groupOwner, const char * groupDesc) = 0;
-    virtual void deleteGroup(const char* groupname) = 0;
-    virtual void getGroupMembers(const char* groupname, StringArray & users) = 0;
+    virtual void deleteGroup(const char* groupname, const char * groupsDN=nullptr) = 0;
+    virtual void getGroupMembers(const char* groupname, StringArray & users, const char * groupsDN=nullptr) = 0;
     virtual void deleteResource(SecResourceType rtype, const char* name, const char* basedn) = 0;
     virtual void renameResource(SecResourceType rtype, const char* oldname, const char* newname, const char* basedn) = 0;
     virtual void copyResource(SecResourceType rtype, const char* oldname, const char* newname, const char* basedn) = 0;
@@ -287,6 +287,20 @@ interface ILdapClient : extends IInterface
     virtual bool createUserScope(ISecUser& user) = 0;
     virtual aindex_t getManagedFileScopes(IArrayOf<ISecResource>& scopes) = 0;
     virtual int queryDefaultPermission(ISecUser& user) = 0;
+
+    //Data View related interfaces
+    virtual void createView(const char * viewName, const char * viewDescription) = 0;
+    virtual void deleteView(const char * viewName) = 0;
+    virtual void queryAllViews(StringArray & viewNames, StringArray & viewDescriptions) = 0;
+
+    virtual void addViewColumns(const char * viewName, StringArray & files, StringArray & columns) = 0;
+    virtual void removeViewColumns(const char * viewName, StringArray & files, StringArray & columns) = 0;
+    virtual void queryViewColumns(const char * viewName, StringArray & files, StringArray & columns) = 0;
+
+    virtual void addViewMembers(const char * viewName, StringArray & viewUsers, StringArray & viewGroups) = 0;
+    virtual void removeViewMembers(const char * viewName, StringArray & viewUsers, StringArray & viewGroups) = 0;
+    virtual void queryViewMembers(const char * viewName, StringArray & viewUsers, StringArray & viewGroups) = 0;
+    virtual bool userInView(const char * user, const char* viewName) = 0;
 };
 
 ILdapClient* createLdapClient(IPropertyTree* cfg);

--- a/system/security/LdapSecurity/ldapsecurity.ipp
+++ b/system/security/LdapSecurity/ldapsecurity.ipp
@@ -359,6 +359,7 @@ public:
     int authorizeEx(SecResourceType rtype, ISecUser& sec_user, const char* resourcename, IEspSecureContext* secureContext = NULL);
     virtual int authorizeFileScope(ISecUser & user, const char * filescope);
     virtual bool authorizeFileScope(ISecUser & user, ISecResourceList * resources);
+    virtual bool authorizeViewScope(ISecUser & user, ISecResourceList * resources);
     virtual int authorizeWorkunitScope(ISecUser & user, const char * wuscope);
     virtual bool authorizeWorkunitScope(ISecUser & user, ISecResourceList * resources);
     virtual bool addResources(ISecUser& sec_user, ISecResourceList * resources);
@@ -449,6 +450,20 @@ public:
     virtual bool authenticateUser(ISecUser & user, bool &superUser);
     virtual secManagerType querySecMgrType() { return SMT_LDAP; }
     inline virtual const char* querySecMgrTypeName() { return "LdapSecurity"; }
+
+    //Data View related interfaces
+    virtual void createView(const char * viewName, const char * viewDescription);
+    virtual void deleteView(const char * viewName);
+    virtual void queryAllViews(StringArray & viewNames, StringArray & viewDescriptions);
+
+    virtual void addViewColumns(const char * viewName, StringArray & files, StringArray & columns);
+    virtual void removeViewColumns(const char * viewName, StringArray & files, StringArray & columns);
+    virtual void queryViewColumns(const char * viewName, StringArray & files, StringArray & columns);
+
+    virtual void addViewMembers(const char * viewName, StringArray & viewUsers, StringArray & viewGroups);
+    virtual void removeViewMembers(const char * viewName, StringArray & viewUsers, StringArray & viewGroups);
+    virtual void queryViewMembers(const char * viewName, StringArray & viewUsers, StringArray & viewGroups);
+    virtual bool userInView(const char * user, const char* viewName);
 };
 
 #endif

--- a/system/security/plugins/htpasswdSecurity/htpasswdSecurity.cpp
+++ b/system/security/plugins/htpasswdSecurity/htpasswdSecurity.cpp
@@ -147,6 +147,21 @@ protected:
         return SecAccess_Full;//grant full access to authenticated users
     }
 
+    bool authorizeViewScope(ISecUser & user, ISecResourceList * resources)
+    {
+        int nResources = resources->count();
+        for (int ri = 0; ri < nResources; ri++)
+        {
+            ISecResource* res = resources->queryResource(ri);
+            if(res != nullptr)
+            {
+                assertex(res->getResourceType() == RT_VIEW_SCOPE);
+                res->setAccessFlags(SecAccess_Full);//grant full access to authenticated users
+            }
+        }
+        return true;//success
+    }
+
     int authorizeWorkunitScope(ISecUser & user, const char * filescope) override
     {
         return SecAccess_Full;//grant full access to authenticated users

--- a/system/security/shared/authmap.cpp
+++ b/system/security/shared/authmap.cpp
@@ -178,6 +178,7 @@ const char* resTypeDesc(SecResourceType type)
     case RT_WORKUNIT_SCOPE: return "Workunit_Scope";
     case RT_SUDOERS: return "Sudoers";
     case RT_TRIAL: return "Trial";
+    case RT_VIEW_SCOPE: return "View";
     default: return "<unknown>";
     }
 }       

--- a/system/security/shared/basesecurity.hpp
+++ b/system/security/shared/basesecurity.hpp
@@ -106,6 +106,12 @@ public:
         return false;
     }
 
+    bool authorizeViewScope(ISecUser & user, ISecResourceList * resources)
+    {
+        UNIMPLEMENTED;
+        return false;
+    }
+
     bool addResources(ISecUser & user, ISecResourceList * resources)
     {
         UNIMPLEMENTED;

--- a/system/security/shared/seclib.hpp
+++ b/system/security/shared/seclib.hpp
@@ -69,7 +69,8 @@ enum SecResourceType
     RT_WORKUNIT_SCOPE = 4,
     RT_SUDOERS = 5,
     RT_TRIAL = 6,
-    RT_SCOPE_MAX = 7
+    RT_VIEW_SCOPE = 7,
+    RT_SCOPE_MAX = 8
 };
 
 
@@ -280,6 +281,7 @@ interface ISecManager : extends IInterface
     virtual int getAccessFlagsEx(SecResourceType rtype, ISecUser & user, const char * resourcename) = 0;
     virtual int authorizeFileScope(ISecUser & user, const char * filescope) = 0;
     virtual bool authorizeFileScope(ISecUser & user, ISecResourceList * resources) = 0;
+    virtual bool authorizeViewScope(ISecUser & user, ISecResourceList * resources) = 0;
     virtual bool addResources(ISecUser & user, ISecResourceList * resources) = 0;
     virtual bool addResourcesEx(SecResourceType rtype, ISecUser & user, ISecResourceList * resources, SecPermissionType ptype, const char * basedn) = 0;
     virtual bool addResourceEx(SecResourceType rtype, ISecUser & user, const char * resourcename, SecPermissionType ptype, const char * basedn) = 0;


### PR DESCRIPTION
Add new LDAP Security Manager interfaces for View support. WIth these a
service can create/enum/delete views, add/enum/delete users from a view, and
add/enum/delete lfn/column pairs from a view. Also added an authenticate
method where a service can see if a given user/view allows access to a
set of lfn/columns

Signed-off-by: Russ Whitehead william.whitehead@lexisnexis.com
