### PR TITLE
HPCC-15966 Master activity needs reseting on init request.

### DIFF
--- a/thorlcr/graph/thgraphmaster.cpp
+++ b/thorlcr/graph/thgraphmaster.cpp
@@ -233,6 +233,7 @@ void CSlaveMessageHandler::main()
                         assertex(element);
                         try
                         {
+                            element->reset();
                             element->doCreateActivity(parentExtractSz, parentExtract);
                         }
                         catch (IException *e)


### PR DESCRIPTION
The master activity needs to be reset, inparticular the
onStartCalled flag. If it is not reset, onStart() is only called
on the 1st child query execution/request.

In activities that use the context to intialize meta info, e.g.
a dataset read with dynamic filename inside a child query, the
consequence is that the 2nd execution/request can crash since it
will be using old (released) context info.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
