### PR TITLE
HPCC-15952 Execute void transactions up-front

### DIFF
--- a/plugins/mysql/mysqlembed.cpp
+++ b/plugins/mysql/mysqlembed.cpp
@@ -1446,6 +1446,9 @@ public:
         if (nextParam != stmtInfo->queryInputBindings().numColumns())
             failx("Not enough parameters supplied (%d parameters supplied, but statement has %d bound columns)", nextParam, stmtInfo->queryInputBindings().numColumns());
         // We actually do the execute later, when the result is fetched
+        // Unless, there is no expected result, in that case execute query now
+        if (stmtInfo->queryResultBindings().numColumns() == 0)
+            lazyExecute();
     }
 protected:
     void lazyExecute()


### PR DESCRIPTION
Avoids lazy execution for transactions without a declared/expected resultset

Signed-off-by: rpastrana rodrigo.pastrana@lexisnexis.com
