### PR TITLE
HPCC-15956 LDAP base OU not created in Active Directory

### DIFF
--- a/system/security/LdapSecurity/ldapconnection.cpp
+++ b/system/security/LdapSecurity/ldapconnection.cpp
@@ -1348,11 +1348,11 @@ public:
     virtual void init(IPermissionProcessor* pp)
     {
         m_pp = pp;
-        if(m_ldapconfig->getServerType() == OPEN_LDAP)
+        static bool createdOU = false;
+        CriticalBlock block(lcCrit);
+        if (!createdOU)
         {
-            static bool createdOU = false;
-            CriticalBlock block(lcCrit);
-            if (!createdOU)
+            if(m_ldapconfig->getServerType() == OPEN_LDAP)
             {
                 try
                 {
@@ -1363,7 +1363,7 @@ public:
                 }
                 try
                 {
-                addGroup("Directory Administrators", NULL, NULL, m_ldapconfig->getBasedn());
+                    addGroup("Directory Administrators", NULL, NULL, m_ldapconfig->getBasedn());
                 }
                 catch(...)
                 {


### PR DESCRIPTION
On a new LDAP system without any HPCC OU, ESP startup is supposed to
create the base OUs but it does not. This PR corrects a test for OPEN_LDAP
to allow them to be created

Signed-off-by: Russ Whitehead william.whitehead@lexisnexis.com
