### PR TITLE
HPCC-15980 Foreign file request honored to unauthenticated user

### DIFF
--- a/dali/server/daldap.cpp
+++ b/dali/server/daldap.cpp
@@ -142,14 +142,25 @@ public:
             }
             unsigned start = msTick();
             Owned<ISecUser> user = ldapsecurity->createUser(username);
+            bool authenticated = false;
             if (user) {
                 user->credentials().setPassword(password);
-                if (filescope)
-                    perm=ldapsecurity->authorizeFileScope(*user, obj);
-                else if (wuscope)
-                    perm=ldapsecurity->authorizeWorkunitScope(*user, obj);
-                if (perm==-1)
-                    perm = 0;
+                bool superUser;
+                if (!ldapsecurity->authenticateUser(*user, superUser))
+                {
+                    PROGLOG("LDAP: getPermissions(%s) scope=%s user=%s fails authentication",key?key:"NULL",obj?obj:"NULL",username.str());
+                    perm = SecAccess_None;//deny
+                }
+                else
+                {
+                    authenticated = true;
+                    if (filescope)
+                        perm=ldapsecurity->authorizeFileScope(*user, obj);
+                    else if (wuscope)
+                        perm=ldapsecurity->authorizeWorkunitScope(*user, obj);
+                    if (perm==-1)
+                        perm = 0;
+                }
             }
             unsigned taken = msTick()-start;
 #ifndef _DEBUG


### PR DESCRIPTION
Foreign file requests do not authenticate the requesting user. Therefore
if an unauthorized user requests to access a file not restricted by a file
scope, they will be able to do so. This PR adds authentication checks to
file scope requests

Signed-off-by: Russ Whitehead william.whitehead@lexisnexis.com
