### PR TITLE
HPCC-15980 Foreign file request honored to unauthenticated user

### DIFF
--- a/dali/server/daldap.cpp
+++ b/dali/server/daldap.cpp
@@ -144,7 +144,7 @@ public:
             Owned<ISecUser> user = ldapsecurity->createUser(username);
             if (user) {
                 user->credentials().setPassword(password);
-                if (!ldapsecurity->authenticateUser(*user, nullptr))
+                if (!ldapsecurity->authenticateUser(*user, NULL))
                 {
                     PROGLOG("LDAP: getPermissions(%s) scope=%s user=%s fails authentication",key?key:"NULL",obj?obj:"NULL",username.str());
                     perm = SecAccess_None;//deny

--- a/dali/server/daldap.cpp
+++ b/dali/server/daldap.cpp
@@ -144,8 +144,7 @@ public:
             Owned<ISecUser> user = ldapsecurity->createUser(username);
             if (user) {
                 user->credentials().setPassword(password);
-                bool superUser;
-                if (!ldapsecurity->authenticateUser(*user, superUser))
+                if (!ldapsecurity->authenticateUser(*user, nullptr))
                 {
                     PROGLOG("LDAP: getPermissions(%s) scope=%s user=%s fails authentication",key?key:"NULL",obj?obj:"NULL",username.str());
                     perm = SecAccess_None;//deny
@@ -206,7 +205,7 @@ public:
         udesc->getPassword(password);
         Owned<ISecUser> user = ldapsecurity->createUser(username);
         user->credentials().setPassword(password);
-        if (!ldapsecurity->authenticateUser(*user,superUser) || !superUser)
+        if (!ldapsecurity->authenticateUser(*user, &superUser) || !superUser)
         {
             *err = -1;
             return false;

--- a/system/security/LdapSecurity/ldapsecurity.cpp
+++ b/system/security/LdapSecurity/ldapsecurity.cpp
@@ -1284,11 +1284,12 @@ bool CLdapSecManager::clearPermissionsCache(ISecUser& user)
     }
     return true;
 }
-bool CLdapSecManager::authenticateUser(ISecUser & user, bool &superUser)
+bool CLdapSecManager::authenticateUser(ISecUser & user, bool *superUser)
 {
     if (!authenticate(&user))
         return false;
-    superUser = isSuperUser(&user);
+    if (superUser)
+        *superUser = isSuperUser(&user);
     return true;
 }
 

--- a/system/security/LdapSecurity/ldapsecurity.ipp
+++ b/system/security/LdapSecurity/ldapsecurity.ipp
@@ -441,7 +441,7 @@ public:
     virtual aindex_t getManagedFileScopes(IArrayOf<ISecResource>& scopes);
     virtual int queryDefaultPermission(ISecUser& user);
     virtual bool clearPermissionsCache(ISecUser &user);
-    virtual bool authenticateUser(ISecUser & user, bool &superUser);
+    virtual bool authenticateUser(ISecUser & user, bool * superUser);
     virtual secManagerType querySecMgrType() { return SMT_LDAP; }
 };
 

--- a/system/security/shared/basesecurity.hpp
+++ b/system/security/shared/basesecurity.hpp
@@ -288,7 +288,7 @@ public:
     virtual aindex_t getManagedFileScopes(IArrayOf<ISecResource>& scopes) {UNIMPLEMENTED; }
     virtual int queryDefaultPermission(ISecUser& user) {UNIMPLEMENTED; }
     virtual bool clearPermissionsCache(ISecUser& user) {return false;}
-    virtual bool authenticateUser(ISecUser & user, bool &superUser) {return false;}
+    virtual bool authenticateUser(ISecUser & user, bool * superUser) {return false;}
 protected:
     const char* getServer(){return m_dbserver.toCharArray();}
     const char* getUser(){return m_dbuser.toCharArray();}

--- a/system/security/shared/seclib.hpp
+++ b/system/security/shared/seclib.hpp
@@ -309,7 +309,7 @@ interface ISecManager : extends IInterface
     virtual aindex_t getManagedFileScopes(IArrayOf<ISecResource>& scopes) = 0;
     virtual int queryDefaultPermission(ISecUser& user) = 0;
     virtual bool clearPermissionsCache(ISecUser & user) = 0;
-    virtual bool authenticateUser(ISecUser & user, bool &superUser) = 0;
+    virtual bool authenticateUser(ISecUser & user, bool * superUser) = 0;
     virtual secManagerType querySecMgrType() = 0;
 };
 


### PR DESCRIPTION
Foreign file requests do not authenticate the requesting user. Therefore
if an unauthorized user requests to access a file not restricted by a file
scope, they will be able to do so. This PR adds authentication checks to
file scope requests

Signed-off-by: Russ Whitehead william.whitehead@lexisnexis.com
