### PR TITLE
HPCC-15991 HTPasswd sec mgr needs to implement authorizeUser

### DIFF
--- a/system/security/plugins/htpasswdSecurity/htpasswdSecurity.cpp
+++ b/system/security/plugins/htpasswdSecurity/htpasswdSecurity.cpp
@@ -122,6 +122,12 @@ protected:
         return "HTPASSWD Security Manager";
     }
 
+    bool authenticateUser(ISecUser & user, bool &superUser)
+    {
+        superuser = IsPasswordValid(user);//superUser if password is valid
+        return Superuser;
+    }
+
     bool authorize(ISecUser & user, ISecResourceList * resources, IEspSecureContext* secureContext) override
     {
         return IsPasswordValid(user);


### PR DESCRIPTION
CHtpasswdSecurityManager should implement authorizeUser to avoid
compile errors on certain platforms. This PR overrides implementation
in CBaseSecurityManager and verifies password against password file

Signed-off-by: Russ Whitehead william.whitehead@lexisnexis.com
