### PR TITLE
HPCC-15734 ConfigMgr to add LDAPServer field for columnsBasedn

### DIFF
--- a/initfiles/componentfiles/configxml/dali.xsl
+++ b/initfiles/componentfiles/configxml/dali.xsl
@@ -297,7 +297,7 @@
             </xsl:attribute>
 
             <xsl:for-each select="$ldapServerNode">
-              <xsl:copy-of select="@ldapPort | @ldapSecurePort | @cacheTimeout | @workunitsBasedn | @modulesBasedn | @systemBasedn | @systemCommonName | @systemUser | @systemPassword | @usersBasedn | @groupsBasedn | @serverType"/>
+              <xsl:copy-of select="@ldapPort | @ldapSecurePort | @cacheTimeout | @workunitsBasedn | @modulesBasedn | @systemBasedn | @systemCommonName | @systemUser | @systemPassword | @usersBasedn | @groupsBasedn| @viewsBasedn | @serverType"/>
             </xsl:for-each>
           </xsl:element>
         </xsl:if>

--- a/initfiles/componentfiles/configxml/ldapserver.xsd
+++ b/initfiles/componentfiles/configxml/ldapserver.xsd
@@ -213,6 +213,13 @@
                     </xs:appinfo>
                 </xs:annotation>
             </xs:attribute>
+            <xs:attribute name="viewsBasedn" type="xs:string" use="required"  default="ou=views,ou=ecl">
+              <xs:annotation>
+                <xs:appinfo>
+                  <tooltip>The ldap "base distinguished name" that ecl server should use when looking up views in the ldap (ActiveDirectory) server.</tooltip>
+                </xs:appinfo>
+              </xs:annotation>
+            </xs:attribute>
             <xs:attribute name="usersBasedn" type="xs:string" use="required"  default="ou=users,ou=ecl">
                 <xs:annotation>
                     <xs:appinfo>


### PR DESCRIPTION
Config Manager needs to add a "viewsBasedn" field to the LDAPServer
configuration. This follows the exact same pattern as groupsBasedn, and the
variable should be called viewsBasedn. Default should be "ou=views,ou=ecl"

Signed-off-by: Russ Whitehead william.whitehead@lexisnexis.com
