### PR TITLE
HPCC-15903 Archived WU filter does not work

### DIFF
--- a/esp/src/eclwatch/WUQueryWidget.js
+++ b/esp/src/eclwatch/WUQueryWidget.js
@@ -220,18 +220,18 @@ define([
                 lang.mixin(retVal, {
                     StartDate: this.getISOString("FromDate", "FromTime")
                 });
-            } else if (retVal.StartDate) {
+            } else if (retVal.StartDate && !retVal.FromTime) {
                 lang.mixin(retVal, {
-                    StartDate: registry.byId(this.id + "FromDate").attr("value").toISOString()
+                    StartDate: registry.byId(this.id + "FromDate").attr("value").toISOString().replace(/T.*Z/, '') + "T00:00:00Z"
                 });
             }
             if (retVal.EndDate && retVal.ToTime) {
                 lang.mixin(retVal, {
                     EndDate: this.getISOString("ToDate", "ToTime")
                 });
-            } else if (retVal.EndDate) {
+            } else if (retVal.EndDate && !retVal.ToTime) {
                 lang.mixin(retVal, {
-                    EndDate: registry.byId(this.id + "ToDate").attr("value").toISOString()
+                    EndDate: registry.byId(this.id + "ToDate").attr("value").toISOString().replace(/T.*Z/, '') + "T23:59:59Z"
                 });
             }
             if (retVal.StartDate && retVal.EndDate) {


### PR DESCRIPTION
Whenever a user chooses a filter to list archived workunits and they do not enter a time no default times are used. By default the application was inserting T04:00:00.000Z and T04:00:00.000Z respectively. I have added default times if no range is chosen.

Signed-off by: Miguel Vazquez miguel.vazquez@lexisnexis.com
