### PR TITLE
HPCC-16013 Add a config option to enable/disable Views Security Feature

### DIFF
--- a/initfiles/componentfiles/configxml/esp.xsd.in
+++ b/initfiles/componentfiles/configxml/esp.xsd.in
@@ -314,6 +314,13 @@
                                 </xs:appinfo>
                             </xs:annotation>
                         </xs:attribute>
+                        <xs:attribute name="checkViewPermissions" type="xs:boolean" use="optional" default="false">
+                          <xs:annotation>
+                            <xs:appinfo>
+                              <tooltip>Enable file and column access permission checking for all view enabled queries</tooltip>
+                            </xs:appinfo>
+                          </xs:annotation>
+                        </xs:attribute>
                     </xs:complexType>
                 </xs:element>
                 <xs:element name="HTTPS" minOccurs="0">

--- a/initfiles/componentfiles/configxml/esp.xsl
+++ b/initfiles/componentfiles/configxml/esp.xsl
@@ -91,6 +91,7 @@
                         <xsl:with-param name="ldapAuthMethod" select="@ldapAuthMethod"/>
                         <xsl:with-param name="ldapConnections" select="@ldapConnections"/>
                         <xsl:with-param name="passwordExpirationWarningDays" select="@passwordExpirationWarningDays"/>
+                        <xsl:with-param name="checkViewPermissions" select="@checkViewPermissions"/>
                         <xsl:with-param name="localDomain" select="/Environment/Hardware/Computer[@name=$computerName]/@domain"/>
                     </xsl:call-template>
                 </xsl:if>
@@ -321,6 +322,7 @@
         <xsl:param name="ldapConnections"/>
         <xsl:param name="localDomain"/>
         <xsl:param name="passwordExpirationWarningDays"/>
+        <xsl:param name="checkViewPermissions"/>
         <xsl:variable name="ldapServerNode" select="/Environment/Software/LDAPServerProcess[@name=$ldapServer]"/>
         <xsl:if test="not($ldapServerNode)">
            <xsl:message terminate="yes">LDAP server is either not specified or is invalid!</xsl:message>
@@ -330,6 +332,7 @@
                 <xsl:attribute name="name">ldapserver</xsl:attribute>
                 <xsl:attribute name="ldapProtocol"><xsl:value-of select="$method"/></xsl:attribute>
                 <xsl:attribute name="localDomain"><xsl:value-of select="$localDomain"/></xsl:attribute>
+                <xsl:attribute name="checkViewPermissions"><xsl:value-of select="$checkViewPermissions"/></xsl:attribute>
                 <xsl:attribute name="authMethod">
                    <xsl:choose>
                       <xsl:when test="string($ldapAuthMethod) != ''">

--- a/initfiles/etc/DIR_NAME/environment.xml.in
+++ b/initfiles/etc/DIR_NAME/environment.xml.in
@@ -285,6 +285,7 @@
                    ldapConnections="10"
                    ldapServer=""
                    method="none"
+                   checkViewPermissions="false"
                    passwordExpirationWarningDays="10"/>
    <EspBinding defaultForPort="true"
                defaultServiceVersion=""


### PR DESCRIPTION
Added a new boolean "checkViewPermissions" flag to configuration. When set,
this signals ESP to enable the view scope feature that verifies users have permission to
access file/column pairs referenced in a view-enabled query (ESP modifications via
a different Jira/PR)

Signed-off-by: Russ Whitehead william.whitehead@lexisnexis.com
