### PR TITLE
Hpcc 14563 Support for custom transaction id formats

### DIFF
--- a/esp/logging/datafieldmap.cpp
+++ b/esp/logging/datafieldmap.cpp
@@ -18,13 +18,13 @@
 #include "datafieldmap.hpp"
 const char* const defaultLogSourcePath = "Source";
 
-void ensureInputString(const char* input, bool lowerCase, StringBuffer& inputStr, int code, const char* msg)
+void ensureInputString(const char* input, bool lowerCase, StringBuffer& outputStr, int code, const char* msg)
 {
-    inputStr.set(input).trim();
-    if (inputStr.isEmpty())
+    outputStr.set(input).trim();
+    if (outputStr.isEmpty())
         throw MakeStringException(code, "%s", msg);
     if (lowerCase)
-        inputStr.toLowerCase();
+        outputStr.toLowerCase();
 }
 
 void readLogGroupCfg(IPropertyTree* cfg, StringAttr& defaultLogGroup, MapStringToMyClass<CLogGroup>& logGroups)
@@ -45,10 +45,10 @@ void readLogGroupCfg(IPropertyTree* cfg, StringAttr& defaultLogGroup, MapStringT
 void readLogSourceCfg(IPropertyTree* cfg, unsigned& logSourceCount, StringAttr& logSourcePath, MapStringToMyClass<CLogSource>& logSources)
 {
     logSourceCount = 0;
+    StringBuffer name, groupName, dbName;
     Owned<IPropertyTreeIterator> iter = cfg->getElements("LogSourceMap/LogSource");
     ForEach(*iter)
     {
-        StringBuffer name, groupName, dbName;
         ensureInputString(iter->query().queryProp("@name"), false, name, -1, "LogSource @name required");
         ensureInputString(iter->query().queryProp("@maptologgroup"), true, groupName, -1, "LogSource @maptologgroup required");
         ensureInputString(iter->query().queryProp("@maptodb"), true, dbName, -1, "LogSource @maptodb required");

--- a/esp/logging/datafieldmap.cpp
+++ b/esp/logging/datafieldmap.cpp
@@ -1,0 +1,101 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2016 HPCC Systems.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include "datafieldmap.hpp"
+const char* const defaultLogSourcePath = "Source";
+
+void ensureInputString(const char* input, bool lowerCase, StringBuffer& inputStr, int code, const char* msg)
+{
+    inputStr.set(input).trim();
+    if (inputStr.isEmpty())
+        throw MakeStringException(code, "%s", msg);
+    if (lowerCase)
+        inputStr.toLowerCase();
+}
+
+void readLogGroupCfg(IPropertyTree* cfg, StringAttr& defaultLogGroup, MapStringToMyClass<CLogGroup>& logGroups)
+{
+    StringBuffer groupName;
+    Owned<IPropertyTreeIterator> iter = cfg->getElements("LogGroup");
+    ForEach(*iter)
+    {
+        ensureInputString(iter->query().queryProp("@name"), true, groupName, -1, "LogGroup @name required");
+        Owned<CLogGroup> logGroup = new CLogGroup(groupName.str());
+        logGroup->loadMappings(iter->query());
+        logGroups.setValue(groupName.str(), logGroup);
+        if (defaultLogGroup.isEmpty())
+            defaultLogGroup.set(groupName.str());
+    }
+}
+
+void readLogSourceCfg(IPropertyTree* cfg, unsigned& logSourceCount, StringAttr& logSourcePath, MapStringToMyClass<CLogSource>& logSources)
+{
+    logSourceCount = 0;
+    Owned<IPropertyTreeIterator> iter = cfg->getElements("LogSourceMap/LogSource");
+    ForEach(*iter)
+    {
+        StringBuffer name, groupName, dbName;
+        ensureInputString(iter->query().queryProp("@name"), false, name, -1, "LogSource @name required");
+        ensureInputString(iter->query().queryProp("@maptologgroup"), true, groupName, -1, "LogSource @maptologgroup required");
+        ensureInputString(iter->query().queryProp("@maptodb"), true, dbName, -1, "LogSource @maptodb required");
+        Owned<CLogSource> logSource = new CLogSource(name.str(), groupName.str(), dbName.str());
+        logSources.setValue(name.str(), logSource);
+        logSourceCount++;
+    }
+
+    //xpath to read log source from log request
+    logSourcePath.set(cfg->hasProp("LogSourcePath") ? cfg->queryProp("LogSourcePath") : defaultLogSourcePath);
+}
+
+void CLogTable::loadMappings(IPropertyTree& fieldList)
+{
+    StringBuffer name, mapTo, fieldType, defaultValue;
+    Owned<IPropertyTreeIterator> itr = fieldList.getElements("Field");
+    ForEach(*itr)
+    {
+        IPropertyTree &map = itr->query();
+
+        ensureInputString(map.queryProp("@name"), false, name, -1, "Field @name required");
+        ensureInputString(map.queryProp("@mapto"), true, mapTo, -1, "Field @mapto required");
+        ensureInputString(map.queryProp("@type"), true, fieldType, -1, "Field @type required");
+        defaultValue = map.queryProp("@default");
+        defaultValue.trim();
+
+        Owned<CLogField> field = new CLogField(name.str(), mapTo.str(), fieldType.str());
+        if (!defaultValue.isEmpty())
+            field->setDefault(defaultValue.str());
+        logFields.append(*field.getClear());
+    }
+}
+
+void CLogGroup::loadMappings(IPropertyTree& fieldList)
+{
+    StringBuffer tableName;
+    Owned<IPropertyTreeIterator> itr = fieldList.getElements("Fieldmap");
+    ForEach(*itr)
+    {
+        ensureInputString(itr->query().queryProp("@table"), true, tableName, -1, "Fieldmap @table required");
+
+        Owned<CLogTable> table = new CLogTable(tableName.str());
+        table->loadMappings(itr->query());
+        CIArrayOf<CLogField>& logFields = table->getLogFields();
+        if (logFields.length() < 1)
+            throw MakeStringException(-1,"No Fieldmap for %s", tableName.str());
+
+        logTables.append(*table.getClear());
+    }
+}

--- a/esp/logging/datafieldmap.hpp
+++ b/esp/logging/datafieldmap.hpp
@@ -1,0 +1,95 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2016 HPCC Systems.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef _DATAFIELDMAP_HPP__
+#define _DATAFIELDMAP_HPP__
+
+#pragma warning (disable : 4786)
+
+#include "jiface.hpp"
+#include "jstring.hpp"
+#include "jptree.hpp"
+
+class CLogField : public CInterface, implements IInterface
+{
+    StringAttr  name;
+    StringAttr  mapTo;
+    StringAttr  type;
+    StringAttr  defaultValue;
+
+public:
+    IMPLEMENT_IINTERFACE;
+    CLogField(const char* _name, const char* _mapTo, const char* _type)
+        : name(_name), mapTo(_mapTo), type(_type) {};
+    virtual ~CLogField() {};
+
+    const char* getName() { return name.get(); };
+    const char* getMapTo() { return mapTo.get(); };
+    const char* getType() { return type.get(); };
+    const char* getDefault() { return defaultValue.get(); };
+    void setDefault(const char* value) { defaultValue.set(value); };
+};
+
+class CLogTable : public CInterface
+{
+    StringAttr tableName;
+    CIArrayOf<CLogField> logFields;
+public:
+    IMPLEMENT_IINTERFACE;
+    CLogTable(const char* _tableName) : tableName(_tableName) {};
+    virtual ~CLogTable() {};
+
+    const char* getTableName() { return tableName.get(); };
+    void setTableName(const char* _tableName) { return tableName.set(_tableName); };
+    void loadMappings(IPropertyTree& cfg);
+    CIArrayOf<CLogField>& getLogFields() { return logFields; };
+};
+
+class CLogGroup : public CInterface, implements IInterface
+{
+    StringAttr name;
+    CIArrayOf<CLogTable> logTables;
+public:
+    IMPLEMENT_IINTERFACE;
+    CLogGroup(const char* _name) : name(_name) {};
+    virtual ~CLogGroup() {};
+
+    void loadMappings(IPropertyTree& cfg);
+    CIArrayOf<CLogTable>& getLogTables() { return logTables; };
+};
+
+class CLogSource : public CInterface, implements IInterface
+{
+    StringAttr name;
+    StringAttr groupName;
+    StringAttr dbName;
+public:
+    IMPLEMENT_IINTERFACE;
+    CLogSource(const char* _name, const char* _groupName, const char* _dbName)
+        : name(_name), groupName(_groupName), dbName(_dbName) {};
+    virtual ~CLogSource() {};
+
+    const char* getName() { return name.get(); };
+    const char* getGroupName() { return groupName.get(); };
+    const char* getDBName() { return dbName.get(); };
+};
+
+void ensureInputString(const char* input, bool lowerCase, StringBuffer& inputStr, int code, const char* msg);
+void readLogGroupCfg(IPropertyTree* cfg, StringAttr& defaultLogGroup, MapStringToMyClass<CLogGroup>& logGroups);
+void readLogSourceCfg(IPropertyTree* cfg, unsigned& logSourceCount, StringAttr& logSourcePath, MapStringToMyClass<CLogSource>& logGroups);
+
+#endif // !_DATAFIELDMAP_HPP__

--- a/esp/logging/datafieldmap.hpp
+++ b/esp/logging/datafieldmap.hpp
@@ -88,7 +88,7 @@ public:
     const char* getDBName() { return dbName.get(); };
 };
 
-void ensureInputString(const char* input, bool lowerCase, StringBuffer& inputStr, int code, const char* msg);
+void ensureInputString(const char* input, bool lowerCase, StringBuffer& outputStr, int code, const char* msg);
 void readLogGroupCfg(IPropertyTree* cfg, StringAttr& defaultLogGroup, MapStringToMyClass<CLogGroup>& logGroups);
 void readLogSourceCfg(IPropertyTree* cfg, unsigned& logSourceCount, StringAttr& logSourcePath, MapStringToMyClass<CLogSource>& logGroups);
 

--- a/esp/logging/loggingagent/cassandraloggingagent/CMakeLists.txt
+++ b/esp/logging/loggingagent/cassandraloggingagent/CMakeLists.txt
@@ -43,6 +43,8 @@ if(USE_CASSANDRA)
   ADD_DEFINITIONS( -D_USRDLL -DCASSANDRALOGAGENT_EXPORTS )
 
   set ( SRCS
+    ${HPCC_SOURCE_DIR}/esp/logging/datafieldmap.cpp
+    ${HPCC_SOURCE_DIR}/esp/logging/loggingagentbase.cpp
     cassandralogagent.cpp
   )
 

--- a/esp/logging/loggingagent/cassandraloggingagent/cassandralogagent.hpp
+++ b/esp/logging/loggingagent/cassandraloggingagent/cassandralogagent.hpp
@@ -42,12 +42,13 @@ using namespace cassandraembed;
 
 class CCassandraLogAgent : public CDBLogAgentBase
 {
+    StringBuffer dbServer, dbUserID, dbPassword;
     Owned<CassandraClusterSession> cassSession;
     CriticalSection transactionSeedCrit;
 
-    void initKeySpace(StringBuffer& dbServer, StringBuffer& dbUserID, StringBuffer& dbPassword);
+    void initKeySpace();
     void ensureDefaultKeySpace();
-    void setKeySpace(const char *keyspace);
+    void setSessionOptions(const char *keyspace);
     void ensureTransSeedTable();
     void createTable(const char *dbName, const char *tableName, StringArray& columnNames, StringArray& columnTypes, const char* keys);
     void executeSimpleStatement(const char *st);

--- a/esp/logging/loggingagent/cassandraloggingagent/cassandralogagent.hpp
+++ b/esp/logging/loggingagent/cassandraloggingagent/cassandralogagent.hpp
@@ -42,13 +42,12 @@ using namespace cassandraembed;
 
 class CCassandraLogAgent : public CDBLogAgentBase
 {
-    StringBuffer dbServer, dbUserID, dbPassword;
     Owned<CassandraClusterSession> cassSession;
     CriticalSection transactionSeedCrit;
 
-    void initKeySpace();
+    void initKeySpace(StringBuffer& dbServer, StringBuffer& dbUserID, StringBuffer& dbPassword);
     void ensureDefaultKeySpace();
-    void setSessionOptions(const char *keyspace);
+    void setKeySpace(const char *keyspace);
     void ensureTransSeedTable();
     void createTable(const char *dbName, const char *tableName, StringArray& columnNames, StringArray& columnTypes, const char* keys);
     void executeSimpleStatement(const char *st);
@@ -57,6 +56,11 @@ class CCassandraLogAgent : public CDBLogAgentBase
 
     virtual void queryTransactionSeed(const char* appName, StringBuffer& seed);
     virtual void addField(CLogField& logField, const char* name, StringBuffer& value, StringBuffer& fields, StringBuffer& values);
+    virtual void setUpdateLogStatement(const char* dbName, const char* tableName,
+        const char* fields, const char* values, StringBuffer& statement);
+    virtual void executeUpdateLogStatement(StringBuffer& statement);
+
+    virtual void queryTransactionSeed(const char* appName, StringBuffer& seed);
     virtual void setUpdateLogStatement(const char* dbName, const char* tableName,
         const char* fields, const char* values, StringBuffer& statement);
     virtual void executeUpdateLogStatement(StringBuffer& statement);

--- a/esp/logging/loggingagent/espserverloggingagent/CMakeLists.txt
+++ b/esp/logging/loggingagent/espserverloggingagent/CMakeLists.txt
@@ -25,6 +25,7 @@
 project( espserverloggingagent )
 
 set ( SRCS
+    ${HPCC_SOURCE_DIR}/esp/logging/datafieldmap.cpp
     loggingagent.cpp
 )
 

--- a/esp/logging/loggingagent/espserverloggingagent/loggingagent.hpp
+++ b/esp/logging/loggingagent/espserverloggingagent/loggingagent.hpp
@@ -76,7 +76,7 @@ public:
         {
             add(transIDFields, sTransactionDateTime, id);
             add(transIDFields, sTransactionMethod, id);
-            add(transIDFields, sTransactionESPIP, id);
+            add(transIDFields, sTransactionIdentifier, id);
         }
         if (localSeed)
             id.append(seed.get()).append("-X").append(++seq);

--- a/esp/logging/loggingagent/espserverloggingagent/loggingagent.hpp
+++ b/esp/logging/loggingagent/espserverloggingagent/loggingagent.hpp
@@ -72,7 +72,7 @@ public:
         {
             add(transIDFields, sTransactionDateTime, id);
             add(transIDFields, sTransactionMethod, id);
-            add(transIDFields, sTransactionESPIP, id);
+            add(transIDFields, sTransactionIdentifier, id);
         }
         id.append(seed.get()).append('-').append(++seq);
     };

--- a/esp/logging/loggingagentbase.cpp
+++ b/esp/logging/loggingagentbase.cpp
@@ -1,6 +1,6 @@
 /*##############################################################################
 
-    HPCC SYSTEMS software Copyright (C) 2014 HPCC Systems.
+    HPCC SYSTEMS software Copyright (C) 2016 HPCC Systems.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -309,7 +309,7 @@ void CDBLogAgentBase::addMissingFields(CIArrayOf<CLogField>& logFields, BoolHash
     }
 }
 
-void CDBLogAgentBase::getTransactionID(const char* source, StringArray& prefix, StringBuffer& transactionID)
+void CDBLogAgentBase::getTransactionID(StringAttrMapping* transFields, StringBuffer& transactionID)
 {
     //Not implemented
 }

--- a/esp/logging/loggingagentbase.cpp
+++ b/esp/logging/loggingagentbase.cpp
@@ -1,0 +1,320 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2014 HPCC Systems.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include "LoggingErrors.hpp"
+#include "esploggingservice_esp.ipp"
+#include "loggingagentbase.hpp"
+
+const char* const defaultTransactionTable = "transactions";
+const char* const defaultTransactionAppName = "accounting_log";
+const char* const defaultLoggingTransactionAppName = "logging_transaction";
+
+void CDBLogAgentBase::readDBCfg(IPropertyTree* cfg, StringBuffer& server, StringBuffer& dbUser, StringBuffer& dbPassword)
+{
+    ensureInputString(cfg->queryProp("@server"), true, server, -1, "Database server required");
+    ensureInputString(cfg->queryProp("@dbName"), true, defaultDB, -1, "Database name required");
+
+    transactionTable.set(cfg->hasProp("@dbTableName") ? cfg->queryProp("@dbTableName") : defaultTransactionTable);
+    dbUser.set(cfg->queryProp("@dbUser"));
+    const char* encodedPassword = cfg->queryProp("@dbPassWord");
+    if(encodedPassword && *encodedPassword)
+        decrypt(dbPassword, encodedPassword);
+}
+
+void CDBLogAgentBase::readTransactionCfg(IPropertyTree* cfg)
+{
+    //defaultTransactionApp: if no APP name is given, which APP name (TableName) should be used to get a transaction seed?
+    //loggingTransactionApp: the TableName used to get a transaction seed for this logging agent
+    defaultTransactionApp.set(cfg->hasProp("defaultTransaction") ? cfg->queryProp("defaultTransaction") : defaultTransactionAppName);
+    loggingTransactionApp.set(cfg->hasProp("loggingTransaction") ? cfg->queryProp("loggingTransaction") : defaultLoggingTransactionAppName);
+    loggingTransactionCount = 0;
+}
+
+bool CDBLogAgentBase::getTransactionSeed(IEspGetTransactionSeedRequest& req, IEspGetTransactionSeedResponse& resp)
+{
+    bool bRet = false;
+    StringBuffer appName = req.getApplication();
+    appName.trim();
+    if (appName.length() == 0)
+        appName = defaultTransactionApp.get();
+
+    unsigned retry = 1;
+    while (1)
+    {
+        try
+        {
+            StringBuffer logSeed;
+            queryTransactionSeed(appName, logSeed);
+            if (!logSeed.length())
+                throw MakeStringException(EspLoggingErrors::GetTransactionSeedFailed, "Failed to get TransactionSeed");
+
+            resp.setSeedId(logSeed.str());
+            resp.setStatusCode(0);
+            bRet = true;
+            break;
+        }
+        catch (IException* e)
+        {
+            StringBuffer errorStr, errorMessage;
+            errorMessage.append("Failed to get TransactionSeed: error code ").append(e->errorCode()).append(", error message ").append(e->errorMessage(errorStr));
+            ERRLOG("%s -- try %d", errorMessage.str(), retry);
+            e->Release();
+            if (retry < maxTriesGTS)
+            {
+                Sleep(retry*3000);
+                retry++;
+            }
+            else
+            {
+                resp.setStatusCode(-1);
+                resp.setStatusMessage(errorMessage.str());
+                break;
+            }
+        }
+    }
+    return bRet;
+}
+
+bool CDBLogAgentBase::updateLog(IEspUpdateLogRequestWrap& req, IEspUpdateLogResponse& resp)
+{
+    bool ret = false;
+    try
+    {
+        const char* updateLogReq = req.getUpdateLogRequest();
+        if (!updateLogReq || !*updateLogReq)
+            throw MakeStringException(EspLoggingErrors::UpdateLogFailed, "Failed to read log request.");
+
+        StringBuffer requestBuf, logDB, logSource;
+        requestBuf.append("<LogRequest>").append(updateLogReq).append("</LogRequest>");
+        Owned<IPropertyTree> logRequestTree = createPTreeFromXMLString(requestBuf.length(), requestBuf.str());
+        if (!logRequestTree)
+            throw MakeStringException(EspLoggingErrors::UpdateLogFailed, "Failed to read log request.");
+
+        CLogGroup* logGroup = checkLogSource(logRequestTree, logSource, logDB);
+        if (!logGroup)
+            throw MakeStringException(EspLoggingErrors::UpdateLogFailed, "Log Group %s undefined.", logSource.str());
+
+        StringBuffer logID;
+        getLoggingTransactionID(logID);
+
+        CIArrayOf<CLogTable>& logTables = logGroup->getLogTables();
+        ForEachItemIn(i, logTables)
+        {
+            CLogTable& table = logTables.item(i);
+
+            StringBuffer updateDBStatement;
+            if(!buildUpdateLogStatement(logRequestTree, logDB.str(), table, logID, updateDBStatement))
+                throw MakeStringException(EspLoggingErrors::UpdateLogFailed, "Failed in creating SQL statement.");
+
+            if (getEspLogLevel() >= LogMax)
+                DBGLOG("UpdateLog: %s\n", updateDBStatement.str());
+
+            executeUpdateLogStatement(updateDBStatement);
+        }
+        resp.setStatusCode(0);
+        ret = true;
+    }
+    catch (IException* e)
+    {
+        StringBuffer errorStr, errorMessage;
+        errorMessage.append("Failed to update log: error code ").append(e->errorCode()).append(", error message ").append(e->errorMessage(errorStr));
+        ERRLOG("%s", errorMessage.str());
+        e->Release();
+        resp.setStatusCode(-1);
+        resp.setStatusMessage(errorMessage.str());
+    }
+    return ret;
+}
+
+CLogGroup* CDBLogAgentBase::checkLogSource(IPropertyTree* logRequest, StringBuffer& source, StringBuffer& logDB)
+{
+    if (logSourceCount == 0)
+    {//if no log source is configured, use default Log Group and DB
+        logDB.set(defaultDB.str());
+        source.set(defaultLogGroup.get());
+        return logGroups.getValue(defaultLogGroup.get());
+    }
+    source = logRequest->queryProp(logSourcePath.get());
+    if (source.isEmpty())
+        throw MakeStringException(EspLoggingErrors::UpdateLogFailed, "Failed to read log Source from request.");
+    CLogSource* logSource = logSources.getValue(source.str());
+    if (!logSource)
+        throw MakeStringException(EspLoggingErrors::UpdateLogFailed, "Log Source %s undefined.", source.str());
+
+    logDB.set(logSource->getDBName());
+    return logGroups.getValue(logSource->getGroupName());
+}
+
+void CDBLogAgentBase::getLoggingTransactionID(StringBuffer& id)
+{
+    id.set(loggingTransactionSeed.str()).append("-").append(++loggingTransactionCount);
+}
+
+bool CDBLogAgentBase::buildUpdateLogStatement(IPropertyTree* logRequest, const char* logDB,
+    CLogTable& table, StringBuffer& logID, StringBuffer& updateDBStatement)
+{
+    StringBuffer fields, values;
+    BoolHash handledFields;
+    CIArrayOf<CLogField>& logFields = table.getLogFields();
+    ForEachItemIn(i, logFields) //Go through data items to be logged
+    {
+        CLogField& logField = logFields.item(i);
+
+        StringBuffer colName = logField.getMapTo();
+        bool* found = handledFields.getValue(colName.str());
+        if (found && *found)
+            continue;
+
+        StringBuffer path = logField.getName();
+        if (path.charAt(path.length() - 1) == ']')
+        {//Attr filter. Separate the last [] from the path.
+            const char* pTr = path.str();
+            const char* ppTr = strrchr(pTr, '[');
+            if (!ppTr)
+                continue;
+
+            StringBuffer attr;
+            attr.set(ppTr+1);
+            attr.setLength(attr.length() - 1);
+            path.setLength(ppTr - pTr);
+
+            StringBuffer colValue;
+            Owned<IPropertyTreeIterator> itr = logRequest->getElements(path.str());
+            ForEach(*itr)
+            {//Log the first valid match just in case more than one matches.
+                IPropertyTree& ppTree = itr->query();
+                colValue.set(ppTree.queryProp(attr.str()));
+                if (colValue.length())
+                {
+                    addField(logField, colName.str(), colValue, fields, values);
+                    handledFields.setValue(colName.str(), true);
+                    break;
+                }
+            }
+            continue;
+        }
+
+        Owned<IPropertyTreeIterator> itr = logRequest->getElements(path.str());
+        ForEach(*itr)
+        {
+            IPropertyTree& ppTree = itr->query();
+
+            StringBuffer colValue;
+            if (ppTree.hasChildren()) //This is a tree branch.
+                toXML(&ppTree, colValue);
+            else
+                ppTree.getProp(NULL, colValue);
+
+            if (colValue.length())
+            {
+                addField(logField, colName.str(), colValue, fields, values);
+                handledFields.setValue(colName.str(), true);
+                break;
+            }
+        }
+    }
+
+    //add any default fields that may be required but not in request.
+    addMissingFields(logFields, handledFields, fields, values);
+    appendFieldInfo("log_id", logID, fields, values, true);
+
+    setUpdateLogStatement(logDB, table.getTableName(), fields.str(), values.str(), updateDBStatement);
+    return true;
+}
+
+void CDBLogAgentBase::addField(CLogField& logField, const char* name, StringBuffer& value, StringBuffer& fields, StringBuffer& values)
+{
+    const char* fieldType = logField.getType();
+    if(strieq(fieldType, "int"))
+    {
+        appendFieldInfo(logField.getMapTo(), value, fields, values, false);
+        return;
+    }
+
+    if(strieq(fieldType, "raw"))
+    {
+        appendFieldInfo(logField.getMapTo(), value, fields, values, true);;
+        return;
+    }
+
+    if(strieq(fieldType, "varchar") || strieq(fieldType, "text"))
+    {
+        if(fields.length() != 0)
+            fields.append(',');
+        fields.append(logField.getMapTo());
+
+        if(values.length() != 0)
+            values.append(',');
+        values.append('\'');
+
+        const char* str = value.str();
+        int length = value.length();
+        for(int i = 0; i < length; i++)
+        {
+            unsigned char c = str[i];
+            if(c == '\t' || c == '\n' || c== '\r')
+                values.append(' ');
+            else if(c < 32 || c > 126)
+                values.append('?');
+            else
+                values.append(c);
+        }
+        values.append('\'');
+        return;
+    }
+
+    DBGLOG("Unknown format %s", fieldType);
+}
+
+void CDBLogAgentBase::appendFieldInfo(const char* field, StringBuffer& value, StringBuffer& fields, StringBuffer& values, bool quoted)
+{
+    if(values.length() != 0)
+        values.append(',');
+    if (quoted)
+        values.append('\'').append(value.length(), value.str()).append('\'');
+    else
+        values.append(value.length(), value.str());
+
+    if(fields.length() != 0)
+        fields.append(',');
+    fields.append(field);
+}
+
+void CDBLogAgentBase::addMissingFields(CIArrayOf<CLogField>& logFields, BoolHash& handledFields, StringBuffer& fields, StringBuffer& values)
+{
+    ForEachItemIn(i, logFields) //Go through data items to be logged
+    {
+        CLogField& logField = logFields.item(i);
+        const char* colName = logField.getMapTo();
+        bool* found = handledFields.getValue(colName);
+        if (found && *found)
+            continue;
+        StringBuffer value = logField.getDefault();
+        if (!value.isEmpty())
+            addField(logField, colName, value, fields, values);
+    }
+}
+
+void CDBLogAgentBase::getTransactionID(const char* source, StringArray& prefix, StringBuffer& transactionID)
+{
+    //Not implemented
+}
+
+void CDBLogAgentBase::filterLogContent(IEspUpdateLogRequestWrap* req)
+{
+    //No filter in CDBSQLLogAgent
+}

--- a/esp/logging/logginglib/loggingagentbase.hpp
+++ b/esp/logging/logginglib/loggingagentbase.hpp
@@ -32,7 +32,7 @@
 //used in CTransIDBuilder::getTransID() -> add().
 static const char* sTransactionDateTime = "TransactionDateTime";
 static const char* sTransactionMethod = "TransactionMethod";
-static const char* sTransactionESPIP = "TransactionESPIP";
+static const char* sTransactionIdentifier = "TransactionIdentifier";
 
 interface IEspUpdateLogRequestWrap : extends IInterface
 {

--- a/esp/logging/logginglib/loggingagentbase.hpp
+++ b/esp/logging/logginglib/loggingagentbase.hpp
@@ -120,7 +120,7 @@ interface IEspLogAgent : extends IInterface
 {
     virtual bool init(const char * name, const char * type, IPropertyTree * cfg, const char * process) = 0;
     virtual bool getTransactionSeed(IEspGetTransactionSeedRequest& req, IEspGetTransactionSeedResponse& resp) = 0;
-    virtual void getTransactionID(const char* source, StringArray& prefix, StringBuffer& transactionID) = 0;
+    virtual void getTransactionID(StringAttrMapping* transFields, StringBuffer& transactionID) = 0;
     virtual bool updateLog(IEspUpdateLogRequestWrap& req, IEspUpdateLogResponse& resp) = 0;
     virtual void filterLogContent(IEspUpdateLogRequestWrap* req) = 0;
 };
@@ -155,7 +155,7 @@ public:
     virtual ~CDBLogAgentBase() {};
 
     virtual bool getTransactionSeed(IEspGetTransactionSeedRequest& req, IEspGetTransactionSeedResponse& resp);
-    virtual void getTransactionID(const char* source, StringArray& prefix, StringBuffer& transactionID);
+    virtual void getTransactionID(StringAttrMapping* transFields, StringBuffer& transactionID);
     virtual bool updateLog(IEspUpdateLogRequestWrap& req, IEspUpdateLogResponse& resp);
     virtual void filterLogContent(IEspUpdateLogRequestWrap* req);
 };

--- a/esp/logging/logginglib/loggingagentbase.hpp
+++ b/esp/logging/logginglib/loggingagentbase.hpp
@@ -120,12 +120,12 @@ interface IEspLogAgent : extends IInterface
 {
     virtual bool init(const char * name, const char * type, IPropertyTree * cfg, const char * process) = 0;
     virtual bool getTransactionSeed(IEspGetTransactionSeedRequest& req, IEspGetTransactionSeedResponse& resp) = 0;
-    virtual void getTransactionID(StringAttrMapping* transFields, StringBuffer& transactionID) = 0;
+    virtual void getTransactionID(const char* source, StringArray& prefix, StringBuffer& transactionID) = 0;
     virtual bool updateLog(IEspUpdateLogRequestWrap& req, IEspUpdateLogResponse& resp) = 0;
     virtual void filterLogContent(IEspUpdateLogRequestWrap* req) = 0;
 };
 
-class LOGGINGCOMMON_API CDBLogAgentBase : public CInterface, implements IEspLogAgent
+class CDBLogAgentBase : public CInterface, implements IEspLogAgent
 {
 protected:
     StringBuffer defaultDB, transactionTable, loggingTransactionSeed;
@@ -138,12 +138,12 @@ protected:
     void readDBCfg(IPropertyTree* cfg, StringBuffer& server, StringBuffer& dbUser, StringBuffer& dbPassword);
     void readTransactionCfg(IPropertyTree* cfg);
     bool buildUpdateLogStatement(IPropertyTree* logRequest, const char* logDB, CLogTable& table, StringBuffer& logID, StringBuffer& cqlStatement);
+    void addField(CLogField& logField, const char* name, StringBuffer& value, StringBuffer& fields, StringBuffer& values);
     void appendFieldInfo(const char* field, StringBuffer& value, StringBuffer& fields, StringBuffer& values, bool quoted);
     void addMissingFields(CIArrayOf<CLogField>& logFields, BoolHash& HandledFields, StringBuffer& fields, StringBuffer& values);
     CLogGroup* checkLogSource(IPropertyTree* logRequest, StringBuffer& source, StringBuffer& logDB);
     void getLoggingTransactionID(StringBuffer& id);
 
-    virtual void addField(CLogField& logField, const char* name, StringBuffer& value, StringBuffer& fields, StringBuffer& values) = 0;
     virtual void queryTransactionSeed(const char* appName, StringBuffer& seed) = 0;
     virtual void executeUpdateLogStatement(StringBuffer& statement) = 0;
     virtual void setUpdateLogStatement(const char* dbName, const char* tableName,
@@ -155,7 +155,7 @@ public:
     virtual ~CDBLogAgentBase() {};
 
     virtual bool getTransactionSeed(IEspGetTransactionSeedRequest& req, IEspGetTransactionSeedResponse& resp);
-    virtual void getTransactionID(StringAttrMapping* transFields, StringBuffer& transactionID);
+    virtual void getTransactionID(const char* source, StringArray& prefix, StringBuffer& transactionID);
     virtual bool updateLog(IEspUpdateLogRequestWrap& req, IEspUpdateLogResponse& resp);
     virtual void filterLogContent(IEspUpdateLogRequestWrap* req);
 };

--- a/esp/logging/loggingmanager/loggingmanager.cpp
+++ b/esp/logging/loggingmanager/loggingmanager.cpp
@@ -264,8 +264,11 @@ bool CLoggingManager::getTransactionSeed(IEspGetTransactionSeedRequest& req, IEs
     return bRet;
 }
 
-bool CLoggingManager::hasTransactionID()
+bool CLoggingManager::providesTransactionID()
 {
+    if (!initialized)
+        throw MakeStringException(-1,"LoggingManager not initialized");
+
     for (unsigned int x = 0; x < loggingAgentThreads.size(); x++)
     {
         IUpdateLogThread* loggingThread = loggingAgentThreads[x];
@@ -276,8 +279,11 @@ bool CLoggingManager::hasTransactionID()
     return false;
 }
 
-bool CLoggingManager::getTransactionID(const char* source, StringArray& prefix, StringBuffer& transactionID, StringBuffer& status)
+bool CLoggingManager::getTransactionID(StringAttrMapping* transFields, StringBuffer& transactionID, StringBuffer& status)
 {
+    if (!initialized)
+        throw MakeStringException(-1,"LoggingManager not initialized");
+
     try
     {
         for (unsigned int x = 0; x < loggingAgentThreads.size(); x++)
@@ -287,7 +293,7 @@ bool CLoggingManager::getTransactionID(const char* source, StringArray& prefix, 
                 continue;
 
             IEspLogAgent* loggingAgent = loggingThread->getLogAgent();
-            loggingAgent->getTransactionID(source, prefix, transactionID);
+            loggingAgent->getTransactionID(transFields, transactionID);
             return true;
         }
     }

--- a/esp/logging/loggingmanager/loggingmanager.cpp
+++ b/esp/logging/loggingmanager/loggingmanager.cpp
@@ -264,11 +264,20 @@ bool CLoggingManager::getTransactionSeed(IEspGetTransactionSeedRequest& req, IEs
     return bRet;
 }
 
-bool CLoggingManager::getTransactionID(StringAttrMapping* transFields, StringBuffer& transactionID, StringBuffer& status)
+bool CLoggingManager::hasTransactionID()
 {
-    if (!initialized)
-        throw MakeStringException(-1,"LoggingManager not initialized");
+    for (unsigned int x = 0; x < loggingAgentThreads.size(); x++)
+    {
+        IUpdateLogThread* loggingThread = loggingAgentThreads[x];
+        if (loggingThread->hasService(LGSTGetTransactionID))
+            return true;
+    }
 
+    return false;
+}
+
+bool CLoggingManager::getTransactionID(const char* source, StringArray& prefix, StringBuffer& transactionID, StringBuffer& status)
+{
     try
     {
         for (unsigned int x = 0; x < loggingAgentThreads.size(); x++)
@@ -278,7 +287,7 @@ bool CLoggingManager::getTransactionID(StringAttrMapping* transFields, StringBuf
                 continue;
 
             IEspLogAgent* loggingAgent = loggingThread->getLogAgent();
-            loggingAgent->getTransactionID(transFields, transactionID);
+            loggingAgent->getTransactionID(source, prefix, transactionID);
             return true;
         }
     }

--- a/esp/logging/loggingmanager/loggingmanager.h
+++ b/esp/logging/loggingmanager/loggingmanager.h
@@ -34,7 +34,8 @@ interface ILoggingManager : implements IInterface
     virtual bool updateLog(IEspUpdateLogRequestWrap& req, IEspUpdateLogResponse& resp) = 0;
     virtual bool getTransactionSeed(StringBuffer& transactionSeed, StringBuffer& status) = 0;
     virtual bool getTransactionSeed(IEspGetTransactionSeedRequest& req, IEspGetTransactionSeedResponse& resp) = 0;
-    virtual bool getTransactionID(StringAttrMapping* transFields, StringBuffer& transactionID, StringBuffer& status) = 0;
+    virtual bool hasTransactionID() = 0;
+    virtual bool getTransactionID(const char* source, StringArray& prefix, StringBuffer& transactionID, StringBuffer& status) = 0;
 };
 
 typedef ILoggingManager* (*newLoggingManager_t_)();

--- a/esp/logging/loggingmanager/loggingmanager.h
+++ b/esp/logging/loggingmanager/loggingmanager.h
@@ -34,8 +34,8 @@ interface ILoggingManager : implements IInterface
     virtual bool updateLog(IEspUpdateLogRequestWrap& req, IEspUpdateLogResponse& resp) = 0;
     virtual bool getTransactionSeed(StringBuffer& transactionSeed, StringBuffer& status) = 0;
     virtual bool getTransactionSeed(IEspGetTransactionSeedRequest& req, IEspGetTransactionSeedResponse& resp) = 0;
-    virtual bool hasTransactionID() = 0;
-    virtual bool getTransactionID(const char* source, StringArray& prefix, StringBuffer& transactionID, StringBuffer& status) = 0;
+    virtual bool providesTransactionID() = 0;
+    virtual bool getTransactionID(StringAttrMapping* transFields, StringBuffer& transactionID, StringBuffer& status) = 0;
 };
 
 typedef ILoggingManager* (*newLoggingManager_t_)();

--- a/esp/logging/loggingmanager/loggingmanager.hpp
+++ b/esp/logging/loggingmanager/loggingmanager.hpp
@@ -59,7 +59,8 @@ public:
     virtual bool updateLog(IEspUpdateLogRequestWrap& req, IEspUpdateLogResponse& resp);
     virtual bool getTransactionSeed(StringBuffer& transactionSeed, StringBuffer& status);
     virtual bool getTransactionSeed(IEspGetTransactionSeedRequest& req, IEspGetTransactionSeedResponse& resp);
-    virtual bool getTransactionID(StringAttrMapping* transFields, StringBuffer& transactionID, StringBuffer& status);
+    virtual bool hasTransactionID();
+    virtual bool getTransactionID(const char* source, StringArray& prefix, StringBuffer& transactionID, StringBuffer& status);
 };
 
 #endif // !defined(__LOGGINGMANAGER_HPP__)

--- a/esp/logging/loggingmanager/loggingmanager.hpp
+++ b/esp/logging/loggingmanager/loggingmanager.hpp
@@ -59,8 +59,8 @@ public:
     virtual bool updateLog(IEspUpdateLogRequestWrap& req, IEspUpdateLogResponse& resp);
     virtual bool getTransactionSeed(StringBuffer& transactionSeed, StringBuffer& status);
     virtual bool getTransactionSeed(IEspGetTransactionSeedRequest& req, IEspGetTransactionSeedResponse& resp);
-    virtual bool hasTransactionID();
-    virtual bool getTransactionID(const char* source, StringArray& prefix, StringBuffer& transactionID, StringBuffer& status);
+    virtual bool providesTransactionID();
+    virtual bool getTransactionID(StringAttrMapping* transFields, StringBuffer& transactionID, StringBuffer& status);
 };
 
 #endif // !defined(__LOGGINGMANAGER_HPP__)

--- a/esp/platform/espcontext.cpp
+++ b/esp/platform/espcontext.cpp
@@ -83,6 +83,8 @@ private:
 
     Owned<IEspSecureContext> m_secureContext;
 
+    StringAttr   m_transactionID;
+
 public:
     IMPLEMENT_IINTERFACE;
 
@@ -483,6 +485,15 @@ public:
     IEspSecureContext* querySecureContext() override
     {
         return m_secureContext.get();
+    }
+
+    virtual void setTransactionID(const char * trxid)
+    {
+        m_transactionID.set(trxid);
+    }
+    virtual const char * queryTransactionID()
+    {
+        return m_transactionID.get();
     }
 };
 

--- a/esp/scm/esp.ecm
+++ b/esp/scm/esp.ecm
@@ -163,6 +163,9 @@ interface IEspContext : extends IInterface
     virtual IEspSecureContext* querySecureContext() = 0;
     virtual void setHTTPMethod(const char *method) = 0;
     virtual void setServiceMethod(const char *method) = 0;
+
+    virtual void setTransactionID(const char * trxid) = 0;
+    virtual const char * queryTransactionID() = 0;
 };
 
 

--- a/esp/services/esdl_svc_engine/esdl_binding.cpp
+++ b/esp/services/esdl_svc_engine/esdl_binding.cpp
@@ -35,6 +35,7 @@
 #include "wuwebview.hpp"
 #include "build-config.h"
 
+#include "loggingagentbase.hpp"
 /*
  * trim xpath at first instance of element
  */
@@ -288,7 +289,7 @@ bool loadDefinitions(const char * espServiceName, IEsdlDefinition * esdl, IPrope
 
 bool EsdlServiceImpl::loadLogggingManager()
 {
-    if (!loggingManager)
+    if (!m_oLoggingManager)
     {
         StringBuffer realName;
         realName.append(SharedObjectPrefix).append(LOGGINGMANAGERLIB).append(SharedObjectExtension);
@@ -310,7 +311,7 @@ bool EsdlServiceImpl::loadLogggingManager()
             return false;
         }
 
-        loggingManager.setown((ILoggingManager*) xproc());
+        m_oLoggingManager.setown((ILoggingManager*) xproc());
     }
 
     return true;
@@ -322,6 +323,7 @@ void EsdlServiceImpl::init(const IPropertyTree *cfg,
 {
     m_espServiceName.set(service);
     m_espProcName.set(process);
+    m_bGenerateLocalTrxId = true;
 
     StringBuffer xpath;
     xpath.appendf("Software/EspProcess[@name=\"%s\"]/EspService[@name=\"%s\"]", process, service);
@@ -333,13 +335,15 @@ void EsdlServiceImpl::init(const IPropertyTree *cfg,
         if (m_espServiceType.length() <= 0)
             throw MakeStringException(-1, "Could not determine ESDL service configuration type: esp process '%s' service name '%s'", process, service);
 
-        //Rodrigo: this will depend on how Kevin/Gleb structure the configuration
         IPropertyTree* loggingConfig = srvcfg->queryPropTree("LoggingManager");
         if (loggingConfig)
         {
-            ESPLOG(LogNormal, "ESP Service %s attempting to load configured logging manager.", service);
+            ESPLOG(LogMin, "ESP Service %s attempting to load configured logging manager.", service);
             if (loadLogggingManager())
-                loggingManager->init(loggingConfig, service);
+            {
+                m_oLoggingManager->init(loggingConfig, service);
+                m_bGenerateLocalTrxId = false;
+            }
             else
                 throw MakeStringException(-1, "ESDL Service %s could not load logging manager", service);
         }
@@ -522,6 +526,40 @@ void EsdlServiceImpl::handleServiceRequest(IEspContext &context,
     const char *mthName = mthdef.queryName();
     context.addTraceSummaryValue("method", mthName);
 
+    StringBuffer trxid;
+    if (!m_bGenerateLocalTrxId)
+    {
+        if (m_oLoggingManager)
+        {
+            StringBuffer wsaddress;
+            short int port;
+            context.getServAddress(wsaddress, port);
+            VStringBuffer uniqueId("%s:%d-%u", wsaddress.str(), port, (unsigned) (memsize_t) GetCurrentThreadId());
+
+            StringAttrMapping trxidbasics;
+            StringBuffer creationTime;
+            creationTime.setf("%u", context.queryCreationTime());
+
+            trxidbasics.setValue(sTransactionDateTime, creationTime.str());
+            trxidbasics.setValue(sTransactionMethod, mthName);
+            trxidbasics.setValue(sTransactionIdentifier, uniqueId.str());
+
+            StringBuffer trxidstatus;
+            if (!m_oLoggingManager->getTransactionID(&trxidbasics,trxid, trxidstatus))
+                ESPLOG(LogMin,"DESDL: Logging Agent generated Transaction ID failed: %s", trxidstatus.str());
+        }
+        else
+            ESPLOG(LogMin,"DESDL: Transaction ID could not be fetched from logging manager!");
+    }
+
+    if (!trxid.length())                       //either there's no logging agent providing trxid, or it failed to generate an id
+        generateTransactionId(context, trxid); //in that case, the failure is logged and we generate a local trxid
+
+    if (trxid.length())
+        context.setTransactionID(trxid.str());
+    else
+        ESPLOG(LogMin,"DESDL: Transaction ID could not be generated!");
+
     StringBuffer origResp;
     EsdlMethodImplType implType = EsdlMethodImplUnknown;
 
@@ -612,17 +650,17 @@ void EsdlServiceImpl::handleServiceRequest(IEspContext &context,
         }
     }
 
-    handleResultLogging(context, tgtcfg.get(), req,  origResp.str(), out.str());
+    handleResultLogging(context, tgtctx.get(), req,  origResp.str(), out.str());
     ESPLOG(LogMax,"Customer Response: %s", out.str());
 }
 
 bool EsdlServiceImpl::handleResultLogging(IEspContext &espcontext, IPropertyTree * reqcontext, IPropertyTree * request,  const char * rawresp, const char * finalresp)
 {
     bool success = true;
-    if (loggingManager)
+    if (m_oLoggingManager)
     {
         StringBuffer logresp;
-        success = loggingManager->updateLog(LOGGINGDBSINGLEINSERT, espcontext, reqcontext, request, rawresp, finalresp, logresp);
+        success = m_oLoggingManager->updateLog(LOGGINGDBSINGLEINSERT, espcontext, reqcontext, request, rawresp, finalresp, logresp);
         ESPLOG(LogMin,"ESDLService: Attempted to log ESP transaction: %s", logresp.str());
     }
 
@@ -2469,6 +2507,7 @@ int EsdlBindingImpl::onGetRoxieBuilder(CHttpRequest* request, CHttpResponse* res
 
     StringBuffer roxiemsg, serviceQName, methodQName;
     IEspContext * context = request->queryContext();
+    context->setTransactionID("ROXIETEST-NOTRXID");
     IEsdlDefService *defsrv = m_esdl->queryService(queryServiceType());
     IEsdlDefMethod *defmth;
     if(defsrv)

--- a/esp/services/esdl_svc_engine/esdl_binding.hpp
+++ b/esp/services/esdl_svc_engine/esdl_binding.hpp
@@ -74,7 +74,9 @@ private:
     IEspContainer *container;
     MapStringToMyClass<ISmartSocketFactory> connMap;
     MapStringToMyClass<IEmbedServiceContext> javaServiceMap;
-    Owned<ILoggingManager> loggingManager;
+    Owned<ILoggingManager> m_oLoggingManager;
+    bool m_bGenerateLocalTrxId;
+
 #ifndef LINK_STATICALLY
     Owned<ILoadedDllEntry> javaPluginDll;
 #endif

--- a/esp/services/esdl_svc_engine/esdl_svc_engine.cpp
+++ b/esp/services/esdl_svc_engine/esdl_svc_engine.cpp
@@ -41,28 +41,20 @@ CEsdlSvcEngineSoapBindingEx::CEsdlSvcEngineSoapBindingEx(IPropertyTree* cfg, con
 
 IPropertyTree *CEsdlSvcEngine::createTargetContext(IEspContext &context, IPropertyTree *tgtcfg, IEsdlDefService &srvdef, IEsdlDefMethod &mthdef, IPropertyTree *req_pt)
 {
-    const char *querytype = tgtcfg->queryProp("@querytype");
-    if (!querytype || !strieq(querytype, "ROXIE")) //only roxie?
-        return NULL;
-
-    StringBuffer trxid;
-    generateTransactionId(context, trxid);
-
     Owned<IPropertyTree> localCtx(createPTreeFromIPT(m_service_ctx, ipt_none));
     ensurePTree(localCtx, "Row/Common");
-    localCtx->setProp("Row/Common/TransactionId", trxid.str());
+    localCtx->setProp("Row/Common/TransactionId", context.queryTransactionID());
+    ensurePTree(localCtx, "Row/Common/ESP");
+    localCtx->setProp("Row/Common/ESP/ServiceName", context.queryServiceName(""));
+    localCtx->setProp("Row/Common/ESP/MethodName", mthdef.queryMethodName());
 
     return localCtx.getLink();
 }
 
 void CEsdlSvcEngine::generateTransactionId(IEspContext & context, StringBuffer & trxid)
 {
-    //RANDOMNUM_DATE for now.
-    CriticalBlock b(trxIdCritSec);
-    Owned<IJlibDateTime> _timeNow =  createDateTimeNow();
-    SCMStringBuffer _dateString;
-    _timeNow->getDateString(_dateString);
-    trxid.appendf("%u_%s",getRandom(),_dateString.str());
+    //creationtime_threadid_RANDOMNUM for now.
+    trxid.appendf("%u_%u_%u",context.queryCreationTime(), ((unsigned) (memsize_t) GetCurrentThreadId()), getRandom());
 }
 
 void CEsdlSvcEngine::esdl_log(IEspContext &context, IEsdlDefService &srvdef, IEsdlDefMethod &mthdef, IPropertyTree *tgtcfg, IPropertyTree *tgtctx, IPropertyTree *req_pt, const char *rawresp, const char *logdata, unsigned int timetaken)


### PR DESCRIPTION
- Utilize Loggingmanager transactionid logic if available
- Extend legacy ESP generated transaction id
- Store trxid in ESP context for duration of request
- Utilize context creation time stamp
