### PR TITLE
HPCC-15985 Fix uninitialised variable in NSplitterSlaveActivity::getMetaInfo

### DIFF
--- a/thorlcr/activities/nsplitter/thnsplitterslave.cpp
+++ b/thorlcr/activities/nsplitter/thnsplitterslave.cpp
@@ -342,6 +342,8 @@ public:
     }
     virtual void getMetaInfo(ThorDataLinkMetaInfo &info) override
     {
+        initMetaInfo(info);
+        info.fastThrough = true;
         calcMetaInfoSize(info, queryInput(0));
     }
 


### PR DESCRIPTION
Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
