### PR TITLE
HPCC-15985 Fix uninitialised variable in CSplitterOutput::getMetaInfo

### DIFF
--- a/thorlcr/activities/nsplitter/thnsplitterslave.cpp
+++ b/thorlcr/activities/nsplitter/thnsplitterslave.cpp
@@ -477,6 +477,8 @@ const void *CSplitterOutput::nextRow()
 
 void CSplitterOutput::getMetaInfo(ThorDataLinkMetaInfo &info)
 {
+    initMetaInfo(info);
+    info.fastThrough = true;
     CThorDataLink::calcMetaInfoSize(info, activity.inputs.item(0));
 }
 


### PR DESCRIPTION
Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
