### PR TITLE
HPCC-16016 CheckAbnormalTermination could incorrectly report job failed

### DIFF
--- a/common/workunit/workunit.ipp
+++ b/common/workunit/workunit.ipp
@@ -626,7 +626,7 @@ public:
     }
 
 protected:
-    bool checkAbnormalTermination(const char *wuid, WUState &state, SessionId agent);
+    void reportAbnormalTermination(const char *wuid, WUState initState, WUState &finalstate, SessionId agent);
 
     // These need to be implemented by the derived classes
     virtual CLocalWorkUnit* _createWorkUnit(const char *wuid, ISecManager *secmgr, ISecUser *secuser) = 0;

--- a/plugins/cassandra/cassandrawu.cpp
+++ b/plugins/cassandra/cassandrawu.cpp
@@ -3528,9 +3528,37 @@ public:
             case WUStateDebugRunning:
             case WUStateBlocked:
             case WUStateAborting:
-                SessionId agent = getUnsignedResult(NULL, cass_row_get_column(row, 1));
-                if (agent && checkAbnormalTermination(wuid, state, agent))
-                    return state;
+                if (queryDaliServerVersion().compare("2.1")>=0)
+                {
+                    SessionId agent = getUnsignedResult(NULL, cass_row_get_column(row, 1));
+                    if(agent && querySessionManager().sessionStopped(agent, 0))
+                    {
+                        // MCK - does checking state after sessionStopped reveal meaningful info ?
+                        CassandraFuture future(cass_session_execute(querySession(), statement));
+                        future.wait("Lookup wu state");
+                        CassandraResult result(cass_future_get_result(future));
+                        WUState finalState = WUStateUnknown;
+                        row = cass_result_first_row(result);
+                        if (!row)
+                        {
+                            reportAbnormalTermination(wuid, state, finalState, agent);
+                            return finalState;
+                        }
+                        stateVal = cass_row_get_column(row, 0);
+                        if (!stateVal)
+                        {
+                            reportAbnormalTermination(wuid, state, finalState, agent);
+                            return finalState;
+                        }
+                        getCassString(stateStr, stateVal);
+                        finalState = getWorkUnitState(stateStr);
+                        if ( (WUStateCompleted != finalState) &&
+                             (WUStateFailed    != finalState) &&
+                             (WUStateAborted   != finalState) )
+                            reportAbnormalTermination(wuid, state, finalState, agent);
+                        return finalState;
+                    }
+                }
                 break;
             }
             unsigned waited = msTick() - start;


### PR DESCRIPTION
This is one method to solve the issue.  But I am not sure of real reason for checking session stopped instead of just continuing to check state.
@jakesmith please review.
Signed-off-by: Mark Kelly mark.kelly@lexisnexis.com
