### PR TITLE
HPCC-15801 Advanced menu context enabling

### DIFF
--- a/esp/src/eclwatch/UserQueryWidget.js
+++ b/esp/src/eclwatch/UserQueryWidget.js
@@ -704,6 +704,9 @@ define([
                     check: selector({
                         width: 27,
                         disabled: function (row) {
+                            if (row.name === "File Scopes" || row.name === "Workunit Scopes" || row.name === "Repository Modules") {
+                                return false;
+                            }
                             return row.children ? true : false;
                         }
                     }, "checkbox"),
@@ -816,14 +819,6 @@ define([
         },
 
         refreshActionState: function (event) {
-            registry.byId(this.id + "EnableScopeScans").set("disabled", true);
-            registry.byId(this.id + "DisableScopeScans").set("disabled", true);
-            registry.byId(this.id + "FileScopeDefaultPermissions").set("disabled", true);
-            registry.byId(this.id + "WorkUnitScopeDefaultPermissions").set("disabled", true);
-            registry.byId(this.id + "PhysicalFiles").set("disabled", true);
-            registry.byId(this.id + "CheckFilePermissions").set("disabled", true);
-            registry.byId(this.id + "CodeGenerator").set("disabled", true);
-
             var userSelection = this.usersGrid.getSelected();
             var hasUserSelection = userSelection.length;
             registry.byId(this.id + "EditUsers").set("disabled", !hasUserSelection);
@@ -838,20 +833,38 @@ define([
 
             var permissionSelection = this.permissionsGrid.getSelected();
             var hasPermissionSelection = permissionSelection.length;
+            registry.byId(this.id + "EnableScopeScans").set("disabled", true);
+            registry.byId(this.id + "DisableScopeScans").set("disabled", true);
+            registry.byId(this.id + "FileScopeDefaultPermissions").set("disabled", true);
+            registry.byId(this.id + "WorkUnitScopeDefaultPermissions").set("disabled", true);
+            registry.byId(this.id + "PhysicalFiles").set("disabled", true);
+            registry.byId(this.id + "CheckFilePermissions").set("disabled", true);
+            registry.byId(this.id + "CodeGenerator").set("disabled", true);
+            registry.byId(this.id + "AdvancedPermissions").set("disabled", true);
             registry.byId(this.id + "DeletePermissions").set("disabled", !hasPermissionSelection);
 
-            if (hasPermissionSelection && event.rows[0].data.__hpcc_parent.DisplayName === "File Scopes") {
-                registry.byId(this.id + "EnableScopeScans").set("disabled", !hasPermissionSelection);
-                registry.byId(this.id + "DisableScopeScans").set("disabled", !hasPermissionSelection);
-                registry.byId(this.id + "PhysicalFiles").set("disabled", !hasPermissionSelection);
-                registry.byId(this.id + "FileScopeDefaultPermissions").set("disabled", !hasPermissionSelection);
-                registry.byId(this.id + "CheckFilePermissions").set("disabled", !hasPermissionSelection);
-            }
-            if (hasPermissionSelection && event.rows[0].data.__hpcc_parent.DisplayName === "Workunit Scopes") {
-                registry.byId(this.id + "WorkUnitScopeDefaultPermissions").set("disabled", !hasPermissionSelection);
-            }
-            if (hasPermissionSelection && event.rows[0].data.__hpcc_parent.DisplayName === "Repository Modules") {
-                registry.byId(this.id + "CodeGenerator").set("disabled", !hasPermissionSelection);
+            for (var i = 0; i < permissionSelection.length; ++i) {
+                if (permissionSelection[i].children) {
+                    registry.byId(this.id + "DeletePermissions").set("disabled", true);
+                }
+                switch (permissionSelection[i].name) {
+                    case "File Scopes":
+                        registry.byId(this.id + "EnableScopeScans").set("disabled", !hasPermissionSelection);
+                        registry.byId(this.id + "DisableScopeScans").set("disabled", !hasPermissionSelection);
+                        registry.byId(this.id + "PhysicalFiles").set("disabled", !hasPermissionSelection);
+                        registry.byId(this.id + "FileScopeDefaultPermissions").set("disabled", !hasPermissionSelection);
+                        registry.byId(this.id + "CheckFilePermissions").set("disabled", !hasPermissionSelection);
+                        registry.byId(this.id + "AdvancedPermissions").set("disabled", !hasPermissionSelection);
+                    break;
+                    case "Workunit Scopes":
+                        registry.byId(this.id + "WorkUnitScopeDefaultPermissions").set("disabled", !hasPermissionSelection);
+                        registry.byId(this.id + "AdvancedPermissions").set("disabled", !hasPermissionSelection);
+                    break;
+                    case "Repository Modules":
+                        registry.byId(this.id + "CodeGenerator").set("disabled", !hasPermissionSelection);
+                        registry.byId(this.id + "AdvancedPermissions").set("disabled", !hasPermissionSelection);
+                    break;
+                }
             }
         }
     });

--- a/esp/src/eclwatch/templates/UserQueryWidget.html
+++ b/esp/src/eclwatch/templates/UserQueryWidget.html
@@ -111,7 +111,7 @@
                     <span data-dojo-type="dijit.ToolbarSeparator"></span>
                     <div data-dojo-attach-event="onClick:_onClearPermissionsCache" data-dojo-type="dijit.form.Button">${i18n.ClearPermissionsCache}</div>
                     <span data-dojo-type="dijit.ToolbarSeparator"></span>
-                    <div data-dojo-type="dijit.form.DropDownButton">
+                    <div id="${id}AdvancedPermissions" data-dojo-type="dijit.form.DropDownButton">
                         <span>${i18n.Advanced}</span>
                         <div data-dojo-type="dijit.DropDownMenu">
                             <div data-dojo-attach-event="onClick:_onEnableScopeScans "id="${id}EnableScopeScans" data-dojo-type="dijit.MenuItem">${i18n.EnableScopeScans}</div>


### PR DESCRIPTION
You should be able to click on any of the advanced menu items within permissions if clicking on the category not the individual file scope, workunit scope, or repository module line item.

Signed-off: Miguel Vazquez miguel.vazquez@lexisnexis.com
