### PR TITLE
HPCC-16023 ecl-test only supports a single -f argument

### DIFF
--- a/testing/regress/ecl-test
+++ b/testing/regress/ecl-test
@@ -148,8 +148,9 @@ class RegressMain:
                             action='store_true')
         commonParser.add_argument('-X', help="sets the stored input value (stored('name')).",
                             nargs=1, type=checkXParam,  default='None',  metavar="name1=value1[,name2=value2...]")
-        commonParser.add_argument('-f', help="set an ECL option (equivalent to #option).",
-                            nargs=1, type=checkXParam,  default='None',  metavar="optionA=valueA[,optionB=valueB...]")
+        commonParser.add_argument('-f', help="set an ECL option (equivalent to #option and multiple -f can be use in a command line).", action="append",
+                            type=checkXParam,  metavar="optionA=valueA[,optionB=valueB...]")
+
         commonParser.add_argument('--pq', help="Parallel query execution with threadNumber threads. (If threadNumber is '-1' on a single node system then threadNumber = numberOfLocalCore * 2 )",
                                 type=checkPqParam,  default = 0,   metavar="threadNumber")
         commonParser.add_argument('--noversion', help="Avoid version expansion of queries. Execute them as a standard test.",

--- a/testing/regress/hpcc/util/ecl/file.py
+++ b/testing/regress/hpcc/util/ecl/file.py
@@ -135,11 +135,12 @@ class ECLFile:
 
         self.optF =[]
         self.optFHash={}
-        #process -f CLI parameters
-        if args.f != 'None':
-            args.f[0]=self.removeQuote(args.f[0])
-            optFs = ("-f"+args.f[0].replace(',',  ',-f')).split(',')
-            self.processKeyValPairs(optFs,  self.optFHash)
+        #process -f CLI parameters (multiple -f enabled)
+        if args.f != None:
+            for argf in args.f:
+                argf=self.removeQuote(argf)
+                optFs = ("-f"+argf.replace(',',  ',-f')).split(',')
+                self.processKeyValPairs(optFs,  self.optFHash)
             pass
 
         self.mergeHashToStrArray(self.optFHash,  self.optF)


### PR DESCRIPTION
Enable multiple '-f' parameters in a command line.

Signed-off-by: Attila Vamos attila.vamos@gmail.com
