### PR TITLE
HPCC-16036 Add option to bypass cached WUResult in WsWorkunits

### DIFF
--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -778,6 +778,7 @@ ESPrequest WUResultRequest
     string LogicalName;
     string Cluster;
     bool SuppressXmlSchema(0);
+    [min_ver("1.60")] bool BypassCachedResult(false);
     [min_ver("1.50")] ESParray<ESPstruct NamedValue> FilterBy;
 
     int64 Start(0);
@@ -1767,7 +1768,7 @@ ESPresponse [exceptions_inline, nil_remove] WUGetArchiveFileResponse
 };
 
 ESPservice [
-    version("1.59"), default_client_version("1.59"),
+    version("1.60"), default_client_version("1.60"),
     noforms,exceptions_inline("./smc_xslt/exceptions.xslt"),use_method_name] WsWorkunits
 {
     ESPmethod [resp_xsl_default("/esp/xslt/workunits.xslt")]     WUQuery(WUQueryRequest, WUQueryResponse);

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -3069,10 +3069,12 @@ bool CWsWorkunitsEx::onWUResult(IEspContext &context, IEspWUResultRequest &req, 
         const char* clusterName = req.getCluster();
         const char* resultName = req.getResultName();
 
-        PROGLOG("WUResult: %s", filter.str());
-        Owned<DataCacheElement> data = dataCache->lookup(context, filter, awusCacheMinutes);
+        Owned<DataCacheElement> data;
+        if (!req.getBypassCachedResult())
+            data.setown(dataCache->lookup(context, filter, awusCacheMinutes));
         if (data)
         {
+            PROGLOG("Retrieving Cached WUResult: %s", filter.str());
             mb.append(data->m_data.c_str());
             name.set(data->m_name.c_str());
             logicalName = data->m_logicalName.c_str();
@@ -3095,6 +3097,7 @@ bool CWsWorkunitsEx::onWUResult(IEspContext &context, IEspWUResultRequest &req, 
         }
         else
         {
+            PROGLOG("Retrieving WUResult: %s", filter.str());
             WUState wuState = WUStateUnknown;
             if(logicalName && *logicalName)
             {


### PR DESCRIPTION
WUResult may be cached for better performance. When a workunit
is resubmitted, new WUResult may not be retrieved before old
WUResult cache is timed out. In this fix, an option is added to
bypass the cached WUResult.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
