### PR TITLE
HPCC-16040 Fix regression in HPCC-15985

### DIFF
--- a/thorlcr/activities/loop/thloopslave.cpp
+++ b/thorlcr/activities/loop/thloopslave.cpp
@@ -36,7 +36,7 @@ protected:
     bool global;
     bool sentEndLooping = true;
     unsigned maxIterations;
-    unsigned loopCounter;
+    unsigned loopCounter = 0;
     rtlRowBuilder extractBuilder;
     bool lastMaxEmpty;
     unsigned maxEmptyLoopIterations;

--- a/thorlcr/activities/nsplitter/thnsplitterslave.cpp
+++ b/thorlcr/activities/nsplitter/thnsplitterslave.cpp
@@ -344,7 +344,16 @@ public:
     {
         initMetaInfo(info);
         info.fastThrough = true;
-        calcMetaInfoSize(info, queryInput(0));
+        info.unknownRowsOutput = true;  // remove once calcMetaInfoSize() is called
+
+        //GH->JCS I think the following line is correct and may remove some downstream spilling streams
+        //info.canBufferInput = spill;
+
+        //GH->JCS.  This should call calcMetaInfoSize, but that hits a race condition.
+        //The splitter does not start its input until the first row is requested, but some activities (e.g.,
+        //inline dataset) rely on information in getMetaInfo that is set up in start.
+        //If calcMetaInfoSize() is called, then the result should really be cached in the class
+        //calcMetaInfoSize(info, queryInput(0));
     }
 
 friend class CInputWrapper;

--- a/thorlcr/activities/thdiskbaseslave.ipp
+++ b/thorlcr/activities/thdiskbaseslave.ipp
@@ -88,7 +88,7 @@ protected:
     ThorDataLinkMetaInfo cachedMetaInfo;
     Owned<CDiskPartHandlerBase> partHandler;
     Owned<IExpander> eexp;
-    rowcount_t diskProgress;
+    rowcount_t diskProgress = 0;
 
 public:
     CDiskReadSlaveActivityBase(CGraphElementBase *_container);

--- a/thorlcr/graph/thgraphslave.cpp
+++ b/thorlcr/graph/thgraphslave.cpp
@@ -282,7 +282,7 @@ void CSlaveActivity::startAllInputs()
 
 void CSlaveActivity::startInput(unsigned index, const char *extra)
 {
-    StringBuffer s("Starting input");
+    VStringBuffer s("Starting input %u", index);
     if (extra)
         s.append(" ").append(extra);
     ActPrintLog("%s", s.str());

--- a/thorlcr/thorutil/thmem.cpp
+++ b/thorlcr/thorutil/thmem.cpp
@@ -1580,7 +1580,7 @@ protected:
     bool mmRegistered;
     Owned<CSharedSpillableRowSet> spillableRowSet;
     unsigned options;
-    unsigned spillCompInfo;
+    unsigned spillCompInfo = 0;
     __uint64 spillCycles;
     __uint64 sortCycles;
     roxiemem::IRowManager *rowManager;


### PR DESCRIPTION
Also initialise a few variables which were uninitialised, one of which
could have caused compressed spilling even if it was disabled.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
