### PR TITLE
HPCC-16049 DOCS:Add Proper ID Attributes

### DIFF
--- a/docs/InstantCloud/AWS-Mods/AWSIncludes.xml
+++ b/docs/InstantCloud/AWS-Mods/AWSIncludes.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
-<sect2>
+<sect2 id="FindAmazonKey">
   <title>Find your Amazon Access Key ID and Secret Access Key</title>
 
   <para><orderedlist>
@@ -52,13 +52,13 @@
           <row>
             <entry>Access Key ID</entry>
 
-            <entry> </entry>
+            <entry></entry>
           </row>
 
           <row>
             <entry>Secret Access Key</entry>
 
-            <entry> </entry>
+            <entry></entry>
           </row>
         </tbody>
       </tgroup>

--- a/docs/InstantCloud/InstantCloud.xml
+++ b/docs/InstantCloud/InstantCloud.xml
@@ -69,7 +69,7 @@
     </mediaobject>
   </bookinfo>
 
-  <chapter>
+  <chapter id="InstaCloud_Intro">
     <title>Introduction</title>
 
     <para>This guide provides details and guidance in running an HPCC
@@ -144,7 +144,7 @@
       </tgroup>
     </informaltable>
 
-    <sect1>
+    <sect1 id="InstaCloud_PreReqs">
       <title>Prerequisites and Assumptions</title>
 
       <para>You will need:</para>
@@ -227,10 +227,10 @@
     </sect1>
   </chapter>
 
-  <chapter id="Collect">
+  <chapter id="InstaCloudLaunch">
     <title>Using Instant Cloud Launch</title>
 
-    <sect1 role="nobrk">
+    <sect1 id="InstaCloud_PreLaunch" role="nobrk">
       <title>Before you begin</title>
 
       <para>In this section, you will gather some information you need before
@@ -252,7 +252,7 @@
                   xmlns:xi="http://www.w3.org/2001/XInclude" />
     </sect1>
 
-    <sect1>
+    <sect1 id="InstaCloud_Login">
       <title>Login</title>
 
       <para><orderedlist>
@@ -314,7 +314,7 @@
         </orderedlist></para>
     </sect1>
 
-    <sect1>
+    <sect1 id="InstaCloud_LaunchNewHPCC">
       <title>Launch a New HPCC Cluster</title>
 
       <para>In this section, you will launch a set of Ubuntu 12.04 machines to
@@ -369,7 +369,7 @@
         </listitem>
       </itemizedlist>
 
-      <sect2 role="brk">
+      <sect2 id="IC_LaunchThor" role="brk">
         <title>Launch a New Thor Cluster</title>
 
         <orderedlist numeration="arabic">
@@ -452,7 +452,7 @@
         </orderedlist>
       </sect2>
 
-      <sect2 role="brk">
+      <sect2 id="IC_TerminatingInstances" role="brk">
         <title>Terminating your instances</title>
 
         <para>If you need to save your data, you must to despray it first and
@@ -536,7 +536,7 @@
         <para></para>
       </sect2>
 
-      <sect2 role="brk">
+      <sect2 id="InstaCloudOtherTasks" role="brk">
         <title>Other Tasks</title>
 
         <para></para>
@@ -544,7 +544,7 @@
         <para><!--***  Log Out Comments FAQs Forum AWS Access Keys AWS Management Console AWS Health Dashboard AWS Limit Increase Request
 --></para>
 
-        <sect3>
+        <sect3 id="IC_ViewClusters">
           <title>View Clusters</title>
 
           <para>The <emphasis role="bold">View Clusters</emphasis> page
@@ -566,7 +566,7 @@
             </figure></para>
         </sect3>
 
-        <sect3>
+        <sect3 id="IC_ManageSSHKeys">
           <title>Manage your SSH keys</title>
 
           <para>The SSH Key management page allows you to download your
@@ -631,7 +631,7 @@
     </sect1>
   </chapter>
 
-  <chapter>
+  <chapter id="InstaCloud_RunningECL">
     <title>Running ECL</title>
 
     <para></para>
@@ -651,7 +651,7 @@
         </footnote> code using either ECL IDE, the command line ECL compiler,
       or the ECLPlus tool.</para>
 
-      <sect2>
+      <sect2 id="IC_InstallECLIDEandClienTools">
         <title>Install the ECL IDE and HPCC Client Tools</title>
 
         <para>You only need to install the ECL IDE once. If you have already
@@ -727,7 +727,7 @@
           </orderedlist></para>
       </sect2>
 
-      <sect2 role="brk">
+      <sect2 id="InsCloud_RunningBasicECLprogram" role="brk">
         <title>Running a basic ECL program from the ECL IDE</title>
 
         <para><orderedlist>
@@ -913,14 +913,14 @@
     </sect1>
   </chapter>
 
-  <chapter>
+  <chapter id="InstaCloud_MoreECLExamplesChap">
     <title>More ECL Examples</title>
 
     <para>This section contains additional ECL examples you can use on your
     HPCC Systems Thor platform. You can run these on a single-node system or a
     larger multi-node cluster.</para>
 
-    <sect1 role="nobrk">
+    <sect1 id="InstaCloud_ECLAnagram1Example" role="nobrk">
       <title>ECL Example: Anagram1</title>
 
       <para>This example takes a STRING and produces every possible anagram
@@ -1004,7 +1004,7 @@ OUTPUT(L);</programlisting></para>
       <?hard-pagebreak ?>
     </sect1>
 
-    <sect1>
+    <sect1 id="InstaCloud_ECLAnagram2Example">
       <title>Anagram2</title>
 
       <para>In this example, we will download an open source data file of
@@ -1257,7 +1257,7 @@ OUTPUT(L);</programlisting></para>
         </orderedlist>
       </sect2>
 
-      <sect2 role="brk">
+      <sect2 id="InstaCloud_RunTheECLonThor" role="brk">
         <title>Run the ECL program on Thor<parameter></parameter></title>
 
         <para><orderedlist>
@@ -1340,14 +1340,14 @@ OUTPUT(ValidWords)
     </sect1>
   </chapter>
 
-  <chapter>
+  <chapter id="InstaCloud_DataHandling_Chap">
     <title>Data Handling</title>
 
     <para>This section explains data handling in an AWS configuration. More
     information about Data Handling in an HPCC Systems platform are available
     in the <emphasis>Data Handling</emphasis> manual.</para>
 
-    <sect1 role="nobrk">
+    <sect1 id="InstaCloud_UsingS3Buckets" role="nobrk">
       <title>Using S3 buckets</title>
 
       <para>S3 buckets provide a means of persistent storage inside Amazon Web
@@ -1361,7 +1361,7 @@ OUTPUT(ValidWords)
       <xi:include href="InstantCloud/AWS-Mods/AWSIncludes.xml"
                   xmlns:xi="http://www.w3.org/2001/XInclude" />
 
-      <sect2>
+      <sect2 id="InstaCloud_InstallS3Pkgs">
         <title role="brk">Install and Configure S3 packages on your Landing
         Zone node</title>
 
@@ -1431,7 +1431,7 @@ s3cmd --configure
           </orderedlist></para>
       </sect2>
 
-      <sect2>
+      <sect2 id="InstaCloud_CreatingUsingS3Buckets">
         <title>Creating and Using S3 Buckets</title>
 
         <para>To store data on S3, you must create a bucket that is unique to
@@ -1445,26 +1445,26 @@ s3cmd --configure
         platform are available in the <emphasis>Data Handling</emphasis>
         manual.</para>
 
-        <sect3>
+        <sect3 id="InstaCloud_CreateABucket">
           <title>Create a bucket</title>
 
           <para><programlisting>s3cmd mb s3://your-unique-bucket-name</programlisting></para>
         </sect3>
 
-        <sect3>
+        <sect3 id="InstaCloud_ListBuckets">
           <title>List Buckets</title>
 
           <para><programlisting>s3cmd ls</programlisting></para>
         </sect3>
 
-        <sect3>
+        <sect3 id="InstaCloud_UploadAFileToBucket">
           <title>Upload a file to a bucket</title>
 
           <para><programlisting>s3cmd put myfile.csv s3://your-unique-bucket-name
 </programlisting></para>
         </sect3>
 
-        <sect3>
+        <sect3 id="InstaCloud_RetrieveFileFromBucket">
           <title>Retrieve a file from a bucket</title>
 
           <para><programlisting>s3cmd get s3://your-unique-bucket-name/myfile.csv myfile.csv
@@ -1476,7 +1476,7 @@ s3cmd --configure
     </sect1>
   </chapter>
 
-  <chapter id="NextSteps">
+  <chapter id="InstaCloud_NextSteps">
     <title>Next Steps</title>
 
     <para>To familiarize yourself with what your system can do, we recommend

--- a/docs/RunningHPCCinaVirtualMachine/RunningHPCCinaVirtualMachine.xml
+++ b/docs/RunningHPCCinaVirtualMachine/RunningHPCCinaVirtualMachine.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
-<book lang="en_US" xml:base="../">
+<book id="Running_HPCC_In_A_Virtual_Machine" lang="en_US" xml:base="../">
   <title>Running HPCC in a Virtual Machine</title>
 
   <bookinfo>
@@ -60,7 +60,7 @@
     </mediaobject>
   </bookinfo>
 
-  <chapter>
+  <chapter id="VM_Intro">
     <title>Introduction</title>
 
     <para>These instructions will guide you through installing and running an
@@ -115,7 +115,7 @@
         </tgroup>
       </informaltable></para>
 
-    <sect1>
+    <sect1 id="VM_Requirements">
       <title>System Requirements</title>
 
       <para>Running HPCC in a virtual machine requires (at minimum):</para>
@@ -161,7 +161,7 @@
     </sect1>
   </chapter>
 
-  <chapter>
+  <chapter id="VM_GettingTheTools">
     <title>Getting the Tools and the VM Image</title>
 
     <para>To run the virtual machine version of the HPCC System, you need
@@ -170,7 +170,7 @@
     virtualization software, while any or all of these could work, we support
     Oracle VM VirtualBox<superscript>®</superscript> .</para>
 
-    <sect1>
+    <sect1 id="VM_VirtualBox">
       <title>VM VirtualBox</title>
 
       <para>Oracle's virtualization software, VM VirtualBox is supported for
@@ -290,7 +290,7 @@
         </orderedlist>
       </sect2>
 
-      <sect2>
+      <sect2 id="VM_ImportVirtualImage">
         <title id="get_HPCC">Import the HPCC Virtual Image File</title>
 
         <para><orderedlist>
@@ -503,7 +503,7 @@
             </listitem>
           </orderedlist></para>
 
-        <sect3>
+        <sect3 id="VM_GuestAdditions">
           <title>Guest Additions</title>
 
           <para>The HPCC VM Images include Guest Additions. Guest Additions
@@ -521,7 +521,7 @@
     </sect1>
   </chapter>
 
-  <chapter>
+  <chapter id="VM_RunningHPCC_VM">
     <title>Running the HPCC VM</title>
 
     <para>In this section, we will access the HPCC using the web-based
@@ -607,7 +607,7 @@
         </listitem>
       </orderedlist></para>
 
-    <sect1>
+    <sect1 id="VM_RunningTheIDE">
       <title>Running the ECL IDE for the first time</title>
 
       <para>In this section, we will configure the ECL IDE.</para>
@@ -706,7 +706,7 @@
       </orderedlist>
     </sect1>
 
-    <sect1>
+    <sect1 id="VM_RunningtheIDE_wPreviousVersion">
       <title>Running the HPCC ECL IDE when you had a previous version
       installed</title>
 
@@ -804,7 +804,7 @@
       </orderedlist>
     </sect1>
 
-    <sect1>
+    <sect1 id="VM_WriteSomeECL">
       <title>Write some ECL</title>
 
       <para>Let's write, compile, and execute a simple "Hello World" program
@@ -929,7 +929,7 @@
       </orderedlist>
     </sect1>
 
-    <sect1>
+    <sect1 id="VM_WorkingWithECL">
       <title>Working with ECL</title>
 
       <para>Now that you have submitted some ECL code, it's time to try some
@@ -937,7 +937,7 @@
 
       <para>The following examples are provided to get you started.</para>
 
-      <sect2>
+      <sect2 id="VM_ECL_exampleAnagram1">
         <title>ECL Example: Anagram1</title>
 
         <para>This example takes a STRING and produces every possible anagram
@@ -1022,7 +1022,7 @@ OUTPUT(L);</programlisting></para>
 
       <?hard-pagebreak ?>
 
-      <sect2>
+      <sect2 id="VM_RoxieExampleAnagram2">
         <title>Roxie Example: Anagram2</title>
 
         <para>In this example, we will download an open source data file of
@@ -1032,7 +1032,7 @@ OUTPUT(L);</programlisting></para>
         dictionary file. Using an index and a keyed join would be more
         efficient, but this serves as a simple example.</para>
 
-        <sect3>
+        <sect3 id="VM_DownloadTheWordList">
           <title>Download the word list</title>
 
           <para>We will download the word list from <ulink
@@ -1052,7 +1052,7 @@ OUTPUT(L);</programlisting></para>
             </orderedlist></para>
         </sect3>
 
-        <sect3 id="Load_the_Incoming_Data">
+        <sect3 id="VM_Load_the_Incoming_Data">
           <title>Load the Dictionary File to your Landing Zone</title>
 
           <para>In this step, you will copy the data files to a location from
@@ -1148,7 +1148,7 @@ OUTPUT(L);</programlisting></para>
           </orderedlist>
         </sect3>
 
-        <sect3 id="Spray_the_Data_to_THOR">
+        <sect3 id="VM_Spray_the_Data_to_THOR">
           <title>Spray the Data File to your <emphasis>Data Refinery (Thor)
           Cluster</emphasis></title>
 
@@ -1271,7 +1271,7 @@ OUTPUT(L);</programlisting></para>
           </orderedlist>
         </sect3>
 
-        <sect3>
+        <sect3 id="VM_RunTheQueryOnThor">
           <title>Run the query on Thor<parameter></parameter></title>
 
           <para><orderedlist>
@@ -1357,7 +1357,7 @@ OUTPUT(ValidWords)
 
         <?hard-pagebreak ?>
 
-        <sect3>
+        <sect3 id="VM_Compile-Publish2Roxie">
           <title>Compile and Publish the query to
           Roxie<parameter></parameter></title>
 
@@ -1537,7 +1537,7 @@ OUTPUT(ValidWords)
             </orderedlist></para>
         </sect3>
 
-        <sect3 id="Deploy_the_Query_to_Roxie">
+        <sect3 id="VM_Deploy_the_Query_to_Roxie">
           <title>Publish the Roxie query</title>
 
           <para>Next we will publish the query to a Roxie Cluster.</para>
@@ -1573,7 +1573,7 @@ OUTPUT(ValidWords)
           </orderedlist>
         </sect3>
 
-        <sect3 id="Run_the_Roxie_Query">
+        <sect3 id="VM_Run_the_Roxie_Query">
           <title>Run the Roxie Query in WsECL</title>
 
           <para>Now that the query is published to a Roxie cluster, we can run
@@ -1635,14 +1635,14 @@ OUTPUT(ValidWords)
       </sect2>
     </sect1>
 
-    <sect1 id="Working_with_a_data_file">
+    <sect1 id="VM_Working_with_a_data_file">
       <title>Working with data files</title>
 
       <para>Once you start working with your HPCC system, you will want to
       process some real data, this section shows you how to load data to your
       HPCC system.</para>
 
-      <sect2 id="Cautions_and_Warnings">
+      <sect2 id="VM_Cautions_and_Warnings">
         <title>Before you begin</title>
 
         <para>A typical production HPCC system would have much more data
@@ -1688,7 +1688,7 @@ OUTPUT(ValidWords)
 
       <?hard-pagebreak ?>
 
-      <sect2 id="Uploading_a_file">
+      <sect2 id="VM_Uploading_a_file">
         <title>Uploading a file</title>
 
         <para>For smaller data files, maximum of 2GB, you can use the
@@ -1784,7 +1784,7 @@ OUTPUT(ValidWords)
         <para></para>
       </sect2>
 
-      <sect2 id="Uploading_files_w_secure_client">
+      <sect2 id="VM_Uploading_files_w_secure_client">
         <title>Uploading files with a Secure Copy Client</title>
 
         <para>To upload a large file for processing to your virtual machine,
@@ -1856,7 +1856,7 @@ OUTPUT(ValidWords)
       </sect2>
     </sect1>
 
-    <sect1>
+    <sect1 id="VM_NextSteps">
       <title>Next Steps</title>
 
       <para>Available from the menu in ECL Watch are several documents which
@@ -1944,7 +1944,7 @@ OUTPUT(ValidWords)
     </sect1>
   </chapter>
 
-  <chapter>
+  <chapter id="VM_FAQ_Chap">
     <title>Frequently Asked Questions</title>
 
     <para></para>


### PR DESCRIPTION
FIX HPCC-16049 Add proper ID Attributes to sect1, 2, and 3 sections where missing
as needed to conform to our standard documentation conventions.
Attribute value generates resulting HTML file name, and can be referenced for Inclusion using XINclude.

Signed-off-by: G Panagiotatos greg.panagiotatos@lexisnexis.com
@JamesDeFabia please review
