### PR TITLE
HPCC-16004 UPDATE regression fix

### DIFF
--- a/thorlcr/graph/thgraph.cpp
+++ b/thorlcr/graph/thgraph.cpp
@@ -466,6 +466,7 @@ IThorGraphDependencyIterator *CGraphElementBase::getDependsIterator() const
 
 void CGraphElementBase::reset()
 {
+    alreadyUpdated = false;
     onStartCalled = false;
 //  prepared = false;
     if (activity)
@@ -552,6 +553,8 @@ void CGraphElementBase::serializeCreateContext(MemoryBuffer &mb)
     DelayedSizeMarker sizeMark(mb);
     queryHelper()->serializeCreateContext(mb);
     sizeMark.write();
+    if (isSink())
+        mb.append(alreadyUpdated);
 }
 
 void CGraphElementBase::serializeStartContext(MemoryBuffer &mb)
@@ -568,6 +571,8 @@ void CGraphElementBase::deserializeCreateContext(MemoryBuffer &mb)
     mb.read(createCtxLen);
     createCtxMb.clear().append(createCtxLen, mb.readDirect(createCtxLen));
     haveCreateCtx = true;
+    if (isSink())
+        mb.read(alreadyUpdated);
 }
 
 void CGraphElementBase::deserializeStartContext(MemoryBuffer &mb)
@@ -666,7 +671,6 @@ bool CGraphElementBase::prepareContext(size32_t parentExtractSz, const byte *par
                     return false;
             }
             whichBranch = (unsigned)-1;
-            alreadyUpdated = false;
             switch (getKind())
             {
                 case TAKindexwrite:

--- a/thorlcr/graph/thgraph.hpp
+++ b/thorlcr/graph/thgraph.hpp
@@ -263,7 +263,7 @@ public:
 
     const void *queryFindParam() const { return &queryId(); } // for SimpleHashTableOf
 
-    bool alreadyUpdated;
+    bool alreadyUpdated = false;
     EclHelperFactory helperFactory;
 
     CIOConnectionArray inputs, outputs, connectedInputs, connectedOutputs;
@@ -300,7 +300,7 @@ public:
     virtual void deserializeStartContext(MemoryBuffer &mb);
     virtual void serializeCreateContext(MemoryBuffer &mb); // called after onCreate and create() (of activity)
     virtual void serializeStartContext(MemoryBuffer &mb);
-    virtual bool checkUpdate() { return false; }
+    virtual bool checkUpdate() { return alreadyUpdated; }
     virtual void reset();
     void onStart(size32_t parentExtractSz, const byte *parentExtract);
     void onCreate();


### PR DESCRIPTION
A regression introduced in 6.0 could cause a graph to segfault
if the sink was up to date.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
