### PR TITLE
HPCC-15864 Investigate improvements to LDAP cache

### DIFF
--- a/system/security/shared/caching.hpp
+++ b/system/security/shared/caching.hpp
@@ -113,8 +113,8 @@ public:
         const char* pw = user->credentials().getPassword();
         if(pw && *pw)
         {
-            StringBuffer pbuf(pw), md5pbuf;
-            md5_string(pbuf, md5pbuf);
+            StringBuffer md5pbuf;
+            md5_string2(pw, md5pbuf);
             user->credentials().setPassword(md5pbuf.str());
         }
 


### PR DESCRIPTION
In a previous code review, the following recommendations were made for
permissions cache improvements.

Use a map to a CachedUser instead of a CachedUser *
Avoid some appending to temporary buffers
Examine why clone() is called on the user instead of LINK()

Although the CachedUser is already stored in a map, the other two
bullets are areas that needed improvement. This PR removes
numerous unnecessary intermediate buffers, and LINKs the
cached_user instead of cloning it

Signed-off-by: Russ Whitehead william.whitehead@lexisnexis.com
