### PR TITLE
HPCC-16076 DOCS: Fix Errors generating docs

### DIFF
--- a/docs/InstantCloud/AWS-Mods/AWSIncludes.xml
+++ b/docs/InstantCloud/AWS-Mods/AWSIncludes.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
-<sect2 id="FindAmazonKey">
+<sect2>
   <title>Find your Amazon Access Key ID and Secret Access Key</title>
 
   <para><orderedlist>


### PR DESCRIPTION
FIX HPCC-16076 DOCS: Fix Errors generating docs
Fixing Errors causing build to fail.

This critical fix needs to get merged into 6.0.4 to facilitate the build. 
Signed-off-by: G Panagiotatos greg.panagiotatos@lexisnexis.com
@JamesDeFabia please review. 
@xwang2713 please watch - when merged - 6.0.4 will build. 
