### PR TITLE
HPCC-16086 Security permissions values are hardcoded

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -3950,17 +3950,17 @@ void CLocalWorkUnit::remoteCheckAccess(IUserDescriptor *user, bool writeaccess) 
     unsigned auditflags = DALI_LDAP_AUDIT_REPORT|DALI_LDAP_READ_WANTED;
     if (writeaccess)
         auditflags |= DALI_LDAP_WRITE_WANTED;
-    int perm = 255;
+    int perm = SecAccess_Full;
     const char *scopename = p->queryProp("@scope");
     if (scopename&&*scopename) {
         if (!user)
             user = queryUserDescriptor();
         perm = querySessionManager().getPermissionsLDAP("workunit",scopename,user,auditflags);
         if (perm<0) {
-            if (perm==-1) 
-                perm = 255;
+            if (perm == SecAccess_Unavailable)
+                perm = SecAccess_Full;
             else 
-                perm = 0;
+                perm = SecAccess_None;
         }
     }
     if (!HASREADPERMISSION(perm))

--- a/dali/base/CMakeLists.txt
+++ b/dali/base/CMakeLists.txt
@@ -63,6 +63,7 @@ include_directories (
          ./../../system/include 
          ./../../system/jlib 
          ./../../rtl/include 
+         ./../../system/security/shared
     )
 
 ADD_DEFINITIONS( -DLOGMSGCOMPONENT=3 -D_USRDLL -DDALI_EXPORTS )

--- a/dali/base/dasess.cpp
+++ b/dali/base/dasess.cpp
@@ -31,7 +31,7 @@
 #include "dasds.hpp"
 #include "daclient.hpp"
 #include "daldap.hpp"
-
+#include "seclib.hpp"
 #include "dasess.hpp"
 
 #ifdef _MSC_VER
@@ -887,10 +887,10 @@ public:
         if (err)
             *err = 0;
         if (securitydisabled)
-            return -1;
+            return SecAccess_Unavailable;
         if (queryDaliServerVersion().compare("1.8") < 0) {
             securitydisabled = true;
-            return -1;
+            return SecAccess_Unavailable;
         }
         CMessageBuffer mb;
         mb.append((int)MSR_LOOKUP_LDAP_PERMISSIONS);
@@ -922,7 +922,7 @@ public:
                     throw new CDaliLDAP_Exception(e);
             }
         }
-        if (ret==-1)
+        if (ret == SecAccess_Unavailable)
             securitydisabled = true;
         return ret;
     }
@@ -1405,9 +1405,9 @@ public:
         if (err)
             *err = 0;
         if (!ldapconn)
-            return -1;
+            return SecAccess_Unavailable;
 #ifdef _NO_LDAP
-        return -1;
+        return SecAccess_Unavailable;
 #else
 #ifdef NULL_DALIUSER_STACKTRACE
         StringBuffer sb;

--- a/dali/daliadmin/CMakeLists.txt
+++ b/dali/daliadmin/CMakeLists.txt
@@ -39,6 +39,7 @@ include_directories (
          ./../ft 
          ./../../common/workunit
          ./../../common/dllserver
+         ./../../system/security/shared
     )
 
 ADD_DEFINITIONS( -D_CONSOLE )

--- a/dali/daliadmin/daliadmin.cpp
+++ b/dali/daliadmin/daliadmin.cpp
@@ -45,6 +45,7 @@
 
 #include "workunit.hpp"
 #include "dllserver.hpp"
+#include "seclib.hpp"
 
 #ifdef _WIN32
 #include <conio.h>
@@ -1521,7 +1522,7 @@ static void listrelationships(const char *primary,const char *secondary)
 
 int dfsperm(const char *obj,IUserDescriptor *user)
 {
-    int perm =0;
+    int perm = SecAccess_None;
     if (strchr(obj,'\\')||strchr(obj,'/')) {
         Owned<IFileDescriptor> fd = createFileDescriptor();
         RemoteFilename rfn;

--- a/dali/server/daldap.cpp
+++ b/dali/server/daldap.cpp
@@ -120,13 +120,13 @@ public:
     int getPermissions(const char *key,const char *obj,IUserDescriptor *udesc,unsigned auditflags)
     {
         if (!ldapsecurity||((getLDAPflags()&DLF_ENABLED)==0)) 
-            return 255;
+            return SecAccess_Full;
         bool filescope = stricmp(key,"Scope")==0;
         bool wuscope = stricmp(key,"workunit")==0;
         if (filescope||wuscope) {
             StringBuffer username;
             StringBuffer password;
-            int perm = 0;
+            int perm = SecAccess_None;
             if (udesc) {
                 udesc->getUserName(username);
                 udesc->getPassword(password);
@@ -155,8 +155,8 @@ public:
                         perm=ldapsecurity->authorizeFileScope(*user, obj);
                     else if (wuscope)
                         perm=ldapsecurity->authorizeWorkunitScope(*user, obj);
-                    if (perm==-1)
-                        perm = 0;
+                    if (perm == SecAccess_Unavailable)
+                        perm = SecAccess_None;
                 }
             }
             unsigned taken = msTick()-start;
@@ -181,7 +181,7 @@ public:
             }
             return perm;
         }
-        return 255;
+        return SecAccess_Full;
     }
     bool clearPermissionsCache(IUserDescriptor *udesc)
     {

--- a/esp/services/ws_access/ws_accessService.cpp
+++ b/esp/services/ws_access/ws_accessService.cpp
@@ -3791,7 +3791,7 @@ bool Cws_accessEx::onFilePermission(IEspContext &context, IEspFilePermissionRequ
         if ((!groupName || !*groupName) && (!userName || !*userName))
             throw MakeStringException(ECLWATCH_INVALID_ACCOUNT_NAME, "Either user name or group name has to be specified.");
 
-        int access = -1;
+        int access = SecAccess_Unavailable;
         if (userName && *userName) //for user
         {
             resp.setFileName(fileName);

--- a/plugins/workunitservices/CMakeLists.txt
+++ b/plugins/workunitservices/CMakeLists.txt
@@ -44,6 +44,7 @@ include_directories (
          ./../../system/jhtree 
          ./../../system/jlib 
          ./../../dali/sasha 
+         ./../../system/security/shared
     )
 
 ADD_DEFINITIONS( -D_USRDLL -DWORKUNITSERVICES_EXPORTS )

--- a/plugins/workunitservices/workunitservices.cpp
+++ b/plugins/workunitservices/workunitservices.cpp
@@ -53,6 +53,7 @@ Persists changed?
 #include "workunitservices.hpp"
 #include "workunitservices.ipp"
 #include "environment.hpp"
+#include "seclib.hpp"
 
 #define WORKUNITSERVICES_VERSION "WORKUNITSERVICES 1.0.2"
 
@@ -221,19 +222,19 @@ static bool checkScopeAuthorized(IUserDescriptor *user, const char *scopename)
     if (securityDisabled)
         return true;
     unsigned auditflags = DALI_LDAP_AUDIT_REPORT|DALI_LDAP_READ_WANTED;
-    int perm = 255;
+    int perm = SecAccess_Full;
     if (scopename && *scopename)
     {
         perm = querySessionManager().getPermissionsLDAP("workunit",scopename,user,auditflags);
         if (perm<0)
         {
-            if (perm==-1)
+            if (perm == SecAccess_Unavailable)
             {
-                perm = 255;
+                perm = SecAccess_Full;
                 securityDisabled = true;
             }
             else 
-                perm = 0;
+                perm = SecAccess_None;
         }
         if (!HASREADPERMISSION(perm)) 
             return false;

--- a/system/security/LdapSecurity/aci.cpp
+++ b/system/security/LdapSecurity/aci.cpp
@@ -587,11 +587,12 @@ public:
     }
 };
 
+//Translates ACI permission settings to SecAccessFlags
 int NewSec2Sec(int newsec)
 {
     int sec = 0;
     if(newsec == -1)
-        return -1;
+        return SecAccess_Unavailable;
     if(newsec == NewSecAccess_Full)
         return SecAccess_Full;
 
@@ -655,7 +656,7 @@ public:
         int perm = 0;
         if(m_acilist.length() == 0)
         {
-            perm = -1;
+            perm = SecAccess_Unavailable;
         }
         else
         {
@@ -1049,7 +1050,7 @@ CSecurityDescriptor* AciProcessor::changePermission(CSecurityDescriptor* initial
 
 StringBuffer& CIPlanetAciProcessor::sec2aci(int secperm, StringBuffer& aciperm)
 {
-    if(secperm == -1 || secperm == SecAccess_None)
+    if(secperm == SecAccess_Unavailable || secperm == SecAccess_None)
         return aciperm;
 
     if(secperm >= SecAccess_Full)
@@ -1134,7 +1135,7 @@ CSecurityDescriptor* CIPlanetAciProcessor::createDefaultSD(ISecUser * const user
 
 StringBuffer& COpenLdapAciProcessor::sec2aci(int secperm, StringBuffer& aciperm)
 {
-    if(secperm == -1 || secperm == SecAccess_None)
+    if(secperm == SecAccess_Unavailable || secperm == SecAccess_None)
         return aciperm;
 
     if(secperm >= SecAccess_Full)

--- a/system/security/shared/caching.cpp
+++ b/system/security/shared/caching.cpp
@@ -133,7 +133,7 @@ void CResPermissionsCache::add( IArrayOf<ISecResource>& resources )
         if(resource == NULL)
             continue;
         int permissions = secResource->getAccessFlags();
-        if(permissions == -1)
+        if(permissions == SecAccess_Unavailable)
             continue;
 
         MapResAccess::iterator it = m_resAccessMap.find(SecCacheKeyEntry(resource, resourcetype));

--- a/system/security/shared/seclib.hpp
+++ b/system/security/shared/seclib.hpp
@@ -50,6 +50,7 @@ enum NewSecAccessFlags
 
 enum SecAccessFlags
 {
+    SecAccess_Unavailable = -1,
     SecAccess_Unknown = -255,
     SecAccess_None = 0,
     SecAccess_Access = 1,


### PR DESCRIPTION
The code for Dali, workunit and plugins etc includes hardcoded values for
permission settings. Instead of using mysterious values like 255, -255, -1
and 0, we should specify the named SecAccess_\* enumerations found in
seclib.hpp

Signed-off-by: Russ Whitehead william.whitehead@lexisnexis.com
