### PR TITLE
HPCC-16109 WsEsdlConfig OSX build break

### DIFF
--- a/esp/services/ws_esdlconfig/CMakeLists.txt
+++ b/esp/services/ws_esdlconfig/CMakeLists.txt
@@ -65,4 +65,5 @@ target_link_libraries ( ws_esdlconfig
          esphttp
          environment
          dllserver
+         SMCLib
     )


### PR DESCRIPTION
- Addresses build break in osx due to SMCLib not explicitly included

Signed-off-by: rpastrana rodrigo.pastrana@lexisnexis.com
