### PR TITLE
HPCC-16116 - Improve tracing when setting thread priorities

### DIFF
--- a/roxie/udplib/udpsha.cpp
+++ b/roxie/udplib/udpsha.cpp
@@ -297,9 +297,9 @@ void setLinuxThreadPriority(int level)
         param.sched_priority = level;
     }
     if(( rc = pthread_setschedparam(self, policy, &param)) != 0) 
-        DBGLOG("pthread_setschedparam error: %d policy=%i pr=%i id=%" I64F "i PID=%i", rc, policy, param.sched_priority, (unsigned __int64) self, getpid());
+        DBGLOG("pthread_setschedparam error: %d policy=%i pr=%i id=%" I64F "i TID=%i", rc, policy, param.sched_priority, (unsigned __int64) self, threadLogID());
     else
-        DBGLOG("priority set id=%" I64F "i policy=%i pri=%i PID=%i", (unsigned __int64) self, policy, param.sched_priority, getpid());
+        DBGLOG("priority set id=%" I64F "i policy=%i pri=%i TID=%i", (unsigned __int64) self, policy, param.sched_priority, threadLogID());
 }
 #endif
 


### PR DESCRIPTION
Log the thread id not the process id.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
