### PR TITLE
HPCC-14655 Handle environment connection reload failure

### DIFF
--- a/common/environment/environment.cpp
+++ b/common/environment/environment.cpp
@@ -1552,7 +1552,20 @@ void CLocalEnvironment::clearCache()
     if (conn)
     {
         p.clear();
-        conn->reload();
+        unsigned mode;
+        try
+        {
+            conn->reload();
+        }
+        catch (IException *e)
+        {
+            EXCLOG(e, "Failed to reload connection");
+            e->Release();
+            mode = conn->queryMode();
+            conn.clear();
+        }
+        if (!conn)
+            conn.setown(querySDS().connect(xPath, myProcessSession(), mode, SDS_LOCK_TIMEOUT));
         p.setown(conn->getRoot());
     }
     cache.kill();


### PR DESCRIPTION
Re-establish the environment connection if it's unable to reload
on a clearCache call. reload can fail if the Environment has
been renewed and the connection to the old node has been
invalidated.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
