### PR TITLE
HPCC-14563 Fetch trxid from logging manager if available

### DIFF
--- a/esp/logging/loggingagent/espserverloggingagent/loggingagent.hpp
+++ b/esp/logging/loggingagent/espserverloggingagent/loggingagent.hpp
@@ -76,7 +76,7 @@ public:
         {
             add(transIDFields, sTransactionDateTime, id);
             add(transIDFields, sTransactionMethod, id);
-            add(transIDFields, sTransactionESPIP, id);
+            add(transIDFields, sTransactionIdentifier, id);
         }
         if (localSeed)
             id.append(seed.get()).append("-X").append(++seq);

--- a/esp/logging/logginglib/loggingagentbase.hpp
+++ b/esp/logging/logginglib/loggingagentbase.hpp
@@ -32,7 +32,7 @@
 //used in CTransIDBuilder::getTransID() -> add().
 static const char* sTransactionDateTime = "TransactionDateTime";
 static const char* sTransactionMethod = "TransactionMethod";
-static const char* sTransactionESPIP = "TransactionESPIP";
+static const char* sTransactionIdentifier = "TransactionIdentifier";
 
 interface IEspUpdateLogRequestWrap : extends IInterface
 {

--- a/esp/platform/espcontext.cpp
+++ b/esp/platform/espcontext.cpp
@@ -83,6 +83,8 @@ private:
 
     Owned<IEspSecureContext> m_secureContext;
 
+    StringAttr   m_transactionID;
+
 public:
     IMPLEMENT_IINTERFACE;
 
@@ -483,6 +485,15 @@ public:
     IEspSecureContext* querySecureContext() override
     {
         return m_secureContext.get();
+    }
+
+    virtual void setTransactionID(const char * trxid)
+    {
+        m_transactionID.set(trxid);
+    }
+    virtual const char * queryTransactionID()
+    {
+        return m_transactionID.get();
     }
 };
 

--- a/esp/scm/esp.ecm
+++ b/esp/scm/esp.ecm
@@ -163,6 +163,9 @@ interface IEspContext : extends IInterface
     virtual IEspSecureContext* querySecureContext() = 0;
     virtual void setHTTPMethod(const char *method) = 0;
     virtual void setServiceMethod(const char *method) = 0;
+
+    virtual void setTransactionID(const char * trxid) = 0;
+    virtual const char * queryTransactionID() = 0;
 };
 
 

--- a/esp/services/esdl_svc_engine/esdl_binding.cpp
+++ b/esp/services/esdl_svc_engine/esdl_binding.cpp
@@ -35,6 +35,7 @@
 #include "wuwebview.hpp"
 #include "build-config.h"
 
+#include "loggingagentbase.hpp"
 /*
  * trim xpath at first instance of element
  */
@@ -288,7 +289,7 @@ bool loadDefinitions(const char * espServiceName, IEsdlDefinition * esdl, IPrope
 
 bool EsdlServiceImpl::loadLogggingManager()
 {
-    if (!loggingManager)
+    if (!m_oLoggingManager)
     {
         StringBuffer realName;
         realName.append(SharedObjectPrefix).append(LOGGINGMANAGERLIB).append(SharedObjectExtension);
@@ -310,7 +311,7 @@ bool EsdlServiceImpl::loadLogggingManager()
             return false;
         }
 
-        loggingManager.setown((ILoggingManager*) xproc());
+        m_oLoggingManager.setown((ILoggingManager*) xproc());
     }
 
     return true;
@@ -322,6 +323,7 @@ void EsdlServiceImpl::init(const IPropertyTree *cfg,
 {
     m_espServiceName.set(service);
     m_espProcName.set(process);
+    m_bGenerateLocalTrxId = true;
 
     StringBuffer xpath;
     xpath.appendf("Software/EspProcess[@name=\"%s\"]/EspService[@name=\"%s\"]", process, service);
@@ -333,13 +335,15 @@ void EsdlServiceImpl::init(const IPropertyTree *cfg,
         if (m_espServiceType.length() <= 0)
             throw MakeStringException(-1, "Could not determine ESDL service configuration type: esp process '%s' service name '%s'", process, service);
 
-        //Rodrigo: this will depend on how Kevin/Gleb structure the configuration
         IPropertyTree* loggingConfig = srvcfg->queryPropTree("LoggingManager");
         if (loggingConfig)
         {
-            ESPLOG(LogNormal, "ESP Service %s attempting to load configured logging manager.", service);
+            ESPLOG(LogMin, "ESP Service %s attempting to load configured logging manager.", service);
             if (loadLogggingManager())
-                loggingManager->init(loggingConfig, service);
+            {
+                m_oLoggingManager->init(loggingConfig, service);
+                m_bGenerateLocalTrxId = false;
+            }
             else
                 throw MakeStringException(-1, "ESDL Service %s could not load logging manager", service);
         }
@@ -522,6 +526,40 @@ void EsdlServiceImpl::handleServiceRequest(IEspContext &context,
     const char *mthName = mthdef.queryName();
     context.addTraceSummaryValue("method", mthName);
 
+    StringBuffer trxid;
+    if (!m_bGenerateLocalTrxId)
+    {
+        if (m_oLoggingManager)
+        {
+            StringBuffer wsaddress;
+            short int port;
+            context.getServAddress(wsaddress, port);
+            VStringBuffer uniqueId("%s:%d-%u", wsaddress.str(), port, (unsigned) (memsize_t) GetCurrentThreadId());
+
+            StringAttrMapping trxidbasics;
+            StringBuffer creationTime;
+            creationTime.setf("%u", context.queryCreationTime());
+
+            trxidbasics.setValue(sTransactionDateTime, creationTime.str());
+            trxidbasics.setValue(sTransactionMethod, mthName);
+            trxidbasics.setValue(sTransactionIdentifier, uniqueId.str());
+
+            StringBuffer trxidstatus;
+            if (!m_oLoggingManager->getTransactionID(&trxidbasics,trxid, trxidstatus))
+                ESPLOG(LogMin,"DESDL: Logging Agent generated Transaction ID failed: %s", trxidstatus.str());
+        }
+        else
+            ESPLOG(LogMin,"DESDL: Transaction ID could not be fetched from logging manager!");
+    }
+
+    if (!trxid.length())                       //either there's no logging agent providing trxid, or it failed to generate an id
+        generateTransactionId(context, trxid); //in that case, the failure is logged and we generate a local trxid
+
+    if (trxid.length())
+        context.setTransactionID(trxid.str());
+    else
+        ESPLOG(LogMin,"DESDL: Transaction ID could not be generated!");
+
     StringBuffer origResp;
     EsdlMethodImplType implType = EsdlMethodImplUnknown;
 
@@ -612,17 +650,17 @@ void EsdlServiceImpl::handleServiceRequest(IEspContext &context,
         }
     }
 
-    handleResultLogging(context, tgtcfg.get(), req,  origResp.str(), out.str());
+    handleResultLogging(context, tgtctx.get(), req,  origResp.str(), out.str());
     ESPLOG(LogMax,"Customer Response: %s", out.str());
 }
 
 bool EsdlServiceImpl::handleResultLogging(IEspContext &espcontext, IPropertyTree * reqcontext, IPropertyTree * request,  const char * rawresp, const char * finalresp)
 {
     bool success = true;
-    if (loggingManager)
+    if (m_oLoggingManager)
     {
         StringBuffer logresp;
-        success = loggingManager->updateLog(LOGGINGDBSINGLEINSERT, espcontext, reqcontext, request, rawresp, finalresp, logresp);
+        success = m_oLoggingManager->updateLog(LOGGINGDBSINGLEINSERT, espcontext, reqcontext, request, rawresp, finalresp, logresp);
         ESPLOG(LogMin,"ESDLService: Attempted to log ESP transaction: %s", logresp.str());
     }
 
@@ -2469,6 +2507,7 @@ int EsdlBindingImpl::onGetRoxieBuilder(CHttpRequest* request, CHttpResponse* res
 
     StringBuffer roxiemsg, serviceQName, methodQName;
     IEspContext * context = request->queryContext();
+    context->setTransactionID("ROXIETEST-NOTRXID");
     IEsdlDefService *defsrv = m_esdl->queryService(queryServiceType());
     IEsdlDefMethod *defmth;
     if(defsrv)

--- a/esp/services/esdl_svc_engine/esdl_binding.hpp
+++ b/esp/services/esdl_svc_engine/esdl_binding.hpp
@@ -74,7 +74,9 @@ private:
     IEspContainer *container;
     MapStringToMyClass<ISmartSocketFactory> connMap;
     MapStringToMyClass<IEmbedServiceContext> javaServiceMap;
-    Owned<ILoggingManager> loggingManager;
+    Owned<ILoggingManager> m_oLoggingManager;
+    bool m_bGenerateLocalTrxId;
+
 #ifndef LINK_STATICALLY
     Owned<ILoadedDllEntry> javaPluginDll;
 #endif

--- a/esp/services/esdl_svc_engine/esdl_svc_engine.cpp
+++ b/esp/services/esdl_svc_engine/esdl_svc_engine.cpp
@@ -41,28 +41,20 @@ CEsdlSvcEngineSoapBindingEx::CEsdlSvcEngineSoapBindingEx(IPropertyTree* cfg, con
 
 IPropertyTree *CEsdlSvcEngine::createTargetContext(IEspContext &context, IPropertyTree *tgtcfg, IEsdlDefService &srvdef, IEsdlDefMethod &mthdef, IPropertyTree *req_pt)
 {
-    const char *querytype = tgtcfg->queryProp("@querytype");
-    if (!querytype || !strieq(querytype, "ROXIE")) //only roxie?
-        return NULL;
-
-    StringBuffer trxid;
-    generateTransactionId(context, trxid);
-
     Owned<IPropertyTree> localCtx(createPTreeFromIPT(m_service_ctx, ipt_none));
     ensurePTree(localCtx, "Row/Common");
-    localCtx->setProp("Row/Common/TransactionId", trxid.str());
+    localCtx->setProp("Row/Common/TransactionId", context.queryTransactionID());
+    ensurePTree(localCtx, "Row/Common/ESP");
+    localCtx->setProp("Row/Common/ESP/ServiceName", context.queryServiceName(""));
+    localCtx->setProp("Row/Common/ESP/MethodName", mthdef.queryMethodName());
 
     return localCtx.getLink();
 }
 
 void CEsdlSvcEngine::generateTransactionId(IEspContext & context, StringBuffer & trxid)
 {
-    //RANDOMNUM_DATE for now.
-    CriticalBlock b(trxIdCritSec);
-    Owned<IJlibDateTime> _timeNow =  createDateTimeNow();
-    SCMStringBuffer _dateString;
-    _timeNow->getDateString(_dateString);
-    trxid.appendf("%u_%s",getRandom(),_dateString.str());
+    //creationtime_threadid_RANDOMNUM for now.
+    trxid.appendf("%u_%u_%u",context.queryCreationTime(), ((unsigned) (memsize_t) GetCurrentThreadId()), getRandom());
 }
 
 void CEsdlSvcEngine::esdl_log(IEspContext &context, IEsdlDefService &srvdef, IEsdlDefMethod &mthdef, IPropertyTree *tgtcfg, IPropertyTree *tgtctx, IPropertyTree *req_pt, const char *rawresp, const char *logdata, unsigned int timetaken)


### PR DESCRIPTION
```
Utilize Loggingmanager transactionid logic if available
Extend legacy ESP generated transaction id
Store trxid in ESP context for duration of request
Utilize context creation time stamp
```

Signed-off-by: rpastrana rodrigo.pastrana@lexisnexis.com
