### PR TITLE
HPCC-15744 Allow to '~file::<ip_address>::<filepath>' opens an external file with any character that's invalid to a logical file path.

### DIFF
--- a/dali/base/dautils.hpp
+++ b/dali/base/dautils.hpp
@@ -139,7 +139,10 @@ public:
     void setAllowWild(bool b=true) { allowWild = b; } // allow wildcards
     bool isExpanded() const;
     void expand(IUserDescriptor *user);
+
+protected:
     void normalizeName(const char * name, StringAttr &res, bool strict);
+    bool normalizeExternal(const char * name, StringAttr &res, bool strict);
 };
 
 // abstract class, define getCmdText to return tracing text of commands


### PR DESCRIPTION
Separate external file and logical file handling.

Add unit test

Signed-off-by: Attila Vamos attila.vamos@gmail.com
