### PR TITLE
HPCC-16051 Fix problems with child act. initialization

### DIFF
--- a/testing/regress/ecl/key/loopvar.xml
+++ b/testing/regress/ecl/key/loopvar.xml
@@ -1,0 +1,14 @@
+<Dataset name='Result 1'>
+</Dataset>
+<Dataset name='Result 2'>
+</Dataset>
+<Dataset name='Result 3'>
+</Dataset>
+<Dataset name='Result 4'>
+</Dataset>
+<Dataset name='dsLoop'>
+ <Row><id>100</id><val>val from dsVal2=100</val></Row>
+</Dataset>
+<Dataset name='dsLoop2'>
+ <Row><id>100</id><val>val from dsVal2=100</val></Row>
+</Dataset>

--- a/testing/regress/ecl/loopvar.ecl
+++ b/testing/regress/ecl/loopvar.ecl
@@ -1,0 +1,73 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+//noroxie
+
+import Std;
+
+filename1 := '~someflatfile1';
+filename2 := '~someflatfile2';
+keyname1 := '~somekey' : STORED('keyname1');
+keyname2 := '~someotherkey' : STORED('keyname2');
+
+dummy := 0;
+keynamecalc := IF(Std.System.thorlib.Daliserver() = 'dummy', '~somekey' , '~someotherkey');
+
+lVal := RECORD
+ INTEGER id := 0;
+ STRING val := '';
+END;
+
+lValKey := RECORD
+ lVal;
+ Unsigned8 fpos {virtual(fileposition)} ;
+END;
+
+dsVal1 := DATASET(10000, TRANSFORM(lVal, SELF.id := COUNTER; SELF.val := 'val from dsVal1=' + COUNTER;), DISTRIBUTED);
+dsVal2 := DATASET(10000, TRANSFORM(lVal, SELF.id := COUNTER; SELF.val := 'val from dsVal2=' + COUNTER;), DISTRIBUTED);
+
+saveit1 := OUTPUT(SORT(DISTRIBUTE(dsVal1, id), id, LOCAL), , filename1, OVERWRITE);
+saveit2 := OUTPUT(SORT(DISTRIBUTE(dsVal2, id), id, LOCAL), , filename2, OVERWRITE);
+
+dsKey1 := DATASET(filename1, lValKey, THOR);
+dsKey2 := DATASET(filename2, lValKey, THOR);
+
+buildit1 := BUILDINDEX(INDEX(dsKey1,{id}, {val, fpos}, keyname1), SORTED, OVERWRITE);
+buildit2 := BUILDINDEX(INDEX(dsKey2,{id}, {val, fpos}, keyname2), SORTED, OVERWRITE);
+
+dsQry := DATASET([{100, ''}], lVal);
+
+lVal loopBody(dataset(lVal) inVal, unsigned4 c) := FUNCTION
+ keyname := IF(c%2=1, keyname1, keyname2);
+ valKey := INDEX(DATASET([], lValKey), {id}, {val, fpos}, keyname);
+ RETURN JOIN(inVal, valKey, LEFT.id = RIGHT.id, TRANSFORM(lVal, SELF := RIGHT));
+END;
+
+dsLoop := LOOP(dsQry, 2, loopBody(rows(left), counter));
+
+lVal loopBody2(dataset(lVal) inVal, unsigned4 c) := FUNCTION
+ valKey := INDEX(DATASET([], lValKey), {id}, {val, fpos}, keynamecalc);
+ RETURN JOIN(inVal, valKey, LEFT.id = RIGHT.id, TRANSFORM(lVal, SELF := RIGHT));
+END;
+
+dsLoop2 := LOOP(dsQry, 2, loopBody2(rows(left), counter));
+
+SEQUENTIAL(
+ saveit1, saveit2, buildit1, buildit2,
+ OUTPUT(dsLoop, named('dsLoop'));
+ OUTPUT(dsLoop2, named('dsLoop2'));
+);

--- a/thorlcr/activities/aggregate/thaggregateslave.cpp
+++ b/thorlcr/activities/aggregate/thaggregateslave.cpp
@@ -119,6 +119,8 @@ public:
     {
         hadElement = inputStopped = false;
         appendOutputLinked(this);
+        if (container.queryLocal())
+            setRequireInitData(false);
     }
     virtual void init(MemoryBuffer &data, MemoryBuffer &slaveData)
     {

--- a/thorlcr/activities/aggregate/thgroupaggregateslave.cpp
+++ b/thorlcr/activities/aggregate/thgroupaggregateslave.cpp
@@ -29,13 +29,9 @@ public:
         : CSlaveActivity(_container)
     { 
         helper = static_cast <IHThorAggregateArg *> (queryHelper());
+        setRequireInitData(false);
         appendOutputLinked(this);
     }
-
-    virtual void init(MemoryBuffer &data, MemoryBuffer &slaveData) override
-    {
-    }
-
     virtual void start() override
     {
         ActivityTimer s(totalCycles, timeActivities);

--- a/thorlcr/activities/apply/thapplyslave.cpp
+++ b/thorlcr/activities/apply/thapplyslave.cpp
@@ -23,10 +23,11 @@ class CApplySlaveActivity : public ProcessSlaveActivity
     IHThorApplyArg *helper;
 
 public:
-    CApplySlaveActivity(CGraphElementBase *container) 
-        : ProcessSlaveActivity(container)
+    CApplySlaveActivity(CGraphElementBase *_container)
+        : ProcessSlaveActivity(_container)
     { 
         helper = static_cast <IHThorApplyArg *> (queryHelper());
+        setRequireInitData(false);
     }
 // IThorSlaveProcess overloaded methods
     virtual void process()

--- a/thorlcr/activities/catch/thcatchslave.cpp
+++ b/thorlcr/activities/catch/thcatchslave.cpp
@@ -33,6 +33,7 @@ public:
     CCatchSlaveActivityBase(CGraphElementBase *_container) : CSlaveActivity(_container)
     {
         helper = static_cast <IHThorCatchArg *> (queryHelper());
+        setRequireInitData(false);
         appendOutputLinked(this);
     }
     virtual void start() override
@@ -187,10 +188,12 @@ class CSkipCatchSlaveActivity : public CCatchSlaveActivityBase
     }
 
 public:
-    CSkipCatchSlaveActivity(CGraphElementBase *container) 
-        : CCatchSlaveActivityBase(container)
+    CSkipCatchSlaveActivity(CGraphElementBase *_container)
+        : CCatchSlaveActivityBase(_container)
     {
-        global = !container->queryLocalOrGrouped();
+        global = !container.queryLocalOrGrouped();
+        if (!global)
+            setRequireInitData(false);
     }
     virtual void init(MemoryBuffer & data, MemoryBuffer &slaveData) override
     {

--- a/thorlcr/activities/choosesets/thchoosesetsslave.cpp
+++ b/thorlcr/activities/choosesets/thchoosesetsslave.cpp
@@ -260,6 +260,8 @@ public:
         totalCounts = NULL;
         limits = NULL;
         inputCounter.setown(new CInputCounter(*this));
+        if (container.queryLocalOrGrouped())
+            setRequireInitData(false);
         appendOutputLinked(this);
     }
     ~ChooseSetsPlusActivity()

--- a/thorlcr/activities/countproject/thcountprojectslave.cpp
+++ b/thorlcr/activities/countproject/thcountprojectslave.cpp
@@ -47,8 +47,9 @@ class LocalCountProjectActivity : public BaseCountProjectActivity
     bool anyThisGroup;
 
 public:
-    LocalCountProjectActivity(CGraphElementBase *container) : BaseCountProjectActivity(container)
+    LocalCountProjectActivity(CGraphElementBase *_container) : BaseCountProjectActivity(_container)
     {
+        setRequireInitData(false);
     }
     virtual void start()
     {

--- a/thorlcr/activities/degroup/thdegroupslave.cpp
+++ b/thorlcr/activities/degroup/thdegroupslave.cpp
@@ -27,6 +27,7 @@ public:
     CDegroupSlaveActivity(CGraphElementBase *_container) 
         : CSlaveActivity(_container), CThorSteppable(this)
     { 
+        setRequireInitData(false);
         appendOutputLinked(this);
     }
     virtual void start() override

--- a/thorlcr/activities/enth/thenthslave.cpp
+++ b/thorlcr/activities/enth/thenthslave.cpp
@@ -129,10 +129,11 @@ class CLocalEnthSlaveActivity : public BaseEnthActivity
 
     bool localCountReq;
 public:
-    CLocalEnthSlaveActivity(CGraphElementBase *container) : BaseEnthActivity(container)
+    CLocalEnthSlaveActivity(CGraphElementBase *_container) : BaseEnthActivity(_container)
     {
         actStr.append("LOCALENTH");
         localCountReq = false;
+        setRequireInitData(false);
     }
     virtual void start()
     {

--- a/thorlcr/activities/fetch/thfetchslave.cpp
+++ b/thorlcr/activities/fetch/thfetchslave.cpp
@@ -516,10 +516,6 @@ class CFetchSlaveActivity : public CFetchSlaveBase
 {
 public:
     CFetchSlaveActivity(CGraphElementBase *container) : CFetchSlaveBase(container) { }
-    virtual void init(MemoryBuffer &data, MemoryBuffer &slaveData)
-    {
-        CFetchSlaveBase::init(data, slaveData);
-    }
     virtual size32_t fetch(ARowBuilder & rowBuilder, const void *keyRow, unsigned filePartIndex, unsigned __int64 localFpos, unsigned __int64 fpos)
     {
         Owned<ISerialStream> stream = createFileSerialStream(fetchStream->queryPartIO(filePartIndex), localFpos);

--- a/thorlcr/activities/filter/thfilterslave.cpp
+++ b/thorlcr/activities/filter/thfilterslave.cpp
@@ -28,6 +28,7 @@ public:
     explicit CFilterSlaveActivityBase(CGraphElementBase *_container)
         : CSlaveActivity(_container)
     {
+        setRequireInitData(false);
         appendOutputLinked(this);
     }
     virtual void start() override
@@ -177,10 +178,6 @@ public:
         : CFilterSlaveActivityBase(container)
     {
         helper = static_cast <IHThorFilterProjectArg *> (queryHelper());
-    }
-    virtual void init(MemoryBuffer &data, MemoryBuffer &slaveData) override
-    {
-        PARENT::init(data,slaveData);
         allocator.set(queryRowAllocator());
     }
     virtual void start() override

--- a/thorlcr/activities/firstn/thfirstnslave.cpp
+++ b/thorlcr/activities/firstn/thfirstnslave.cpp
@@ -72,8 +72,9 @@ class CFirstNSlaveLocal : public CFirstNSlaveBase
     bool firstget;
     rowcount_t skipped;
 public:
-    CFirstNSlaveLocal(CGraphElementBase *container) : CFirstNSlaveBase(container)
+    CFirstNSlaveLocal(CGraphElementBase *_container) : CFirstNSlaveBase(_container)
     {
+        setRequireInitData(false);
     }
 
 // IRowStream overrides
@@ -126,8 +127,9 @@ class CFirstNSlaveGrouped : public CFirstNSlaveBase
 
     unsigned countThisGroup;
 public:
-    CFirstNSlaveGrouped(CGraphElementBase *container) : CFirstNSlaveBase(container)
+    CFirstNSlaveGrouped(CGraphElementBase *_container) : CFirstNSlaveBase(_container)
     {
+        setRequireInitData(false);
     }
 
 // IRowStream overrides

--- a/thorlcr/activities/group/thgroupslave.cpp
+++ b/thorlcr/activities/group/thgroupslave.cpp
@@ -61,6 +61,8 @@ public:
         numGroups = 0;
         numGroupMax = 0;
         startLastGroup = 0;
+        if (container.queryLocalOrGrouped())
+            setRequireInitData(false);
         appendOutputLinked(this);
     }
     virtual void init(MemoryBuffer &data, MemoryBuffer &slaveData)

--- a/thorlcr/activities/iterate/thgroupiterateslave.cpp
+++ b/thorlcr/activities/iterate/thgroupiterateslave.cpp
@@ -35,6 +35,7 @@ public:
     GroupIterateSlaveActivity(CGraphElementBase *_container) : CSlaveActivity(_container)
     {
         helper = static_cast <IHThorGroupIterateArg *> (queryHelper());
+        setRequireInitData(false);
         appendOutputLinked(this);   // adding 'me' to outputs array
     }
     virtual void start() override
@@ -117,12 +118,9 @@ public:
     GroupProcessSlaveActivity(CGraphElementBase *_container) : CSlaveActivity(_container)
     {
         helper = static_cast <IHThorProcessArg *> (queryHelper());
-        appendOutputLinked(this);   // adding 'me' to outputs array
-    }
-    virtual void init(MemoryBuffer &data, MemoryBuffer &slaveData)
-    {
         rightrowif.setown(createThorRowInterfaces(queryRowManager(), helper->queryRightRecordSize(),queryId(),queryCodeContext()));
         rightAllocator.set(rightrowif->queryRowAllocator());
+        appendOutputLinked(this);   // adding 'me' to outputs array
     }
     virtual void start() override
     {

--- a/thorlcr/activities/iterate/thiterateslave.cpp
+++ b/thorlcr/activities/iterate/thiterateslave.cpp
@@ -36,6 +36,8 @@ public:
     IterateSlaveActivityBase(CGraphElementBase *_container, bool _global) : CSlaveActivity(_container)
     {
         global = _global;
+        if (!global)
+            setRequireInitData(false);
         appendOutputLinked(this);   // adding 'me' to outputs array
     }
     virtual void init(MemoryBuffer &data, MemoryBuffer &slaveData)
@@ -189,11 +191,7 @@ public:
         : IterateSlaveActivityBase(_container,_global)
     {
         helper = static_cast <IHThorProcessArg *> (queryHelper());
-    }
-    virtual void init(MemoryBuffer &data, MemoryBuffer &slaveData) override
-    {
         rightRowAllocator.setown(getRowAllocator(helper->queryRightRecordSize()));
-        IterateSlaveActivityBase::init(data,slaveData);
     }
     CATCH_NEXTROW()
     {
@@ -275,6 +273,7 @@ public:
     CChildIteratorSlaveActivity(CGraphElementBase *_container) : CSlaveActivity(_container)
     {
         helper = static_cast <IHThorChildIteratorArg *> (queryHelper());
+        setRequireInitData(false);
         appendOutputLinked(this);   // adding 'me' to outputs array
     }
     virtual void start() override
@@ -325,11 +324,9 @@ public:
         : CSlaveActivity(_container)
     {
         helper = static_cast <IHThorLinkedRawIteratorArg *> (queryHelper());
-        appendOutputLinked(this);   // adding 'me' to outputs array
-    }
-    virtual void init(MemoryBuffer &data, MemoryBuffer &slaveData)
-    {
         grouped = helper->queryOutputMeta()->isGrouped();
+        setRequireInitData(false);
+        appendOutputLinked(this);   // adding 'me' to outputs array
     }
     virtual void start() override
     {
@@ -384,6 +381,7 @@ public:
         : CSlaveActivity(_container)
     {
         helper = static_cast <IHThorStreamedIteratorArg *> (queryHelper());
+        setRequireInitData(false);
         appendOutputLinked(this);   // adding 'me' to outputs array
     }
     virtual void start() override

--- a/thorlcr/activities/join/thjoinslave.cpp
+++ b/thorlcr/activities/join/thjoinslave.cpp
@@ -165,6 +165,8 @@ public:
         leftKeySerializer = helper->querySerializeLeft();
         rightKeySerializer = helper->querySerializeRight();
         rightpartition = (container.getKind()==TAKjoin)&&((helper->getJoinFlags()&JFpartitionright)!=0);
+        if (islocal)
+            setRequireInitData(false);
         appendOutputLinked(this);
     }
 
@@ -636,9 +638,10 @@ protected:
 public:
     IMPLEMENT_IINTERFACE_USING(PARENT);
 
-    CMergeJoinSlaveBaseActivity(CGraphElementBase *container, CMergeJoinProcessor &_processor) : CThorNarySlaveActivity(container), CThorSteppable(this), processor(_processor)
+    CMergeJoinSlaveBaseActivity(CGraphElementBase *_container, CMergeJoinProcessor &_processor) : CThorNarySlaveActivity(_container), CThorSteppable(this), processor(_processor)
     {
         helper = (IHThorNWayMergeJoinArg *)queryHelper();
+        setRequireInitData(false);
         inputAllocator.setown(getRowAllocator(helper->queryInputMeta()));
         outputAllocator.setown(getRowAllocator(helper->queryOutputMeta()));
         appendOutputLinked(this);

--- a/thorlcr/activities/keyedjoin/thkeyedjoin.cpp
+++ b/thorlcr/activities/keyedjoin/thkeyedjoin.cpp
@@ -58,7 +58,7 @@ public:
         localKey = false;
         numTags = 0;
         tags[0] = tags[1] = tags[2] = tags[3] = TAG_NULL;
-        reInit = 0 != (helper->getFetchFlags() & (FFvarfilename|FFdynamicfilename));
+        reInit = 0 != (helper->getFetchFlags() & (FFvarfilename|FFdynamicfilename)) || (helper->getJoinFlags() & JFvarindexfilename);
         remoteDataFiles = false;
     }
     ~CKeyedJoinMaster()

--- a/thorlcr/activities/keyedjoin/thkeyedjoinslave.cpp
+++ b/thorlcr/activities/keyedjoin/thkeyedjoinslave.cpp
@@ -1598,7 +1598,7 @@ public:
         lastTick = 0;
 #endif
         helper = (IHThorKeyedJoinArg *)queryHelper();
-        reInit = 0 != (helper->getFetchFlags() & (FFvarfilename|FFdynamicfilename));
+        reInit = 0 != (helper->getFetchFlags() & (FFvarfilename|FFdynamicfilename)) || (helper->getJoinFlags() & JFvarindexfilename);
         appendOutputLinked(this);
     }
     ~CKeyedJoinSlave()

--- a/thorlcr/activities/limit/thlimitslave.cpp
+++ b/thorlcr/activities/limit/thlimitslave.cpp
@@ -49,6 +49,8 @@ public:
         resultSent = true; // unless started suppress result send
         eos = stopped = anyThisGroup = eogNext = false;
         rowLimit = RCMAX;
+        if (container.queryLocal())
+            setRequireInitData(false);
         appendOutputLinked(this);
     }
     virtual void init(MemoryBuffer &data, MemoryBuffer &slaveData) override
@@ -231,18 +233,14 @@ public:
         limitChecked = eof = false;
         rowTransform = _rowTransform;
         helperex = NULL;
+        if (rowTransform)
+            helperex = static_cast<IHThorLimitTransformExtra *>(queryHelper()->selectInterface(TAIlimittransformextra_1));
     }
     void abort()
     {
         if (!container.queryLocal())
             cancelReceiveMsg(0, mpTag);
         CLimitSlaveActivityBase::abort();
-    }
-    virtual void init(MemoryBuffer &data, MemoryBuffer &slaveData) override
-    {
-        CLimitSlaveActivityBase::init(data,slaveData);
-        if (rowTransform)
-            helperex = static_cast<IHThorLimitTransformExtra *>(queryHelper()->selectInterface(TAIlimittransformextra_1));
     }
     virtual void start() override
     {

--- a/thorlcr/activities/lookupjoin/thlookupjoinslave.cpp
+++ b/thorlcr/activities/lookupjoin/thlookupjoinslave.cpp
@@ -1352,6 +1352,8 @@ public:
             rightThorAllocator = queryJobChannel().queryThorAllocator();
         rightRowManager = rightThorAllocator->queryRowManager();
         broadcastLock = NULL;
+        if (!isGlobal())
+            setRequireInitData(false);
         appendOutputLinked(this);
     }
     ~CInMemJoinBase()

--- a/thorlcr/activities/loop/thloopslave.cpp
+++ b/thorlcr/activities/loop/thloopslave.cpp
@@ -76,10 +76,12 @@ protected:
         sendLoopingCount(0, 0);
     }
 public:
-    CLoopSlaveActivityBase(CGraphElementBase *container) : CSlaveActivity(container)
+    CLoopSlaveActivityBase(CGraphElementBase *_container) : CSlaveActivity(_container)
     {
         mpTag = TAG_NULL;
         maxEmptyLoopIterations = getOptUInt(THOROPT_LOOP_MAX_EMPTY, 1000);
+        if (container.queryLocalOrGrouped())
+            setRequireInitData(false);
         appendOutputLinked(this);
     }
     void init(MemoryBuffer &data, MemoryBuffer &slaveData)
@@ -528,6 +530,7 @@ public:
         helper = (IHThorLocalResultReadArg *)queryHelper();
         curRow = 0;
         replyTag = queryMPServer().createReplyTag();
+        setRequireInitData(false);
         appendOutputLinked(this);
     }
     void init(MemoryBuffer &data, MemoryBuffer &slaveData)
@@ -704,8 +707,9 @@ public:
 class CLocalResultWriteActivity : public CLocalResultWriteActivityBase
 {
 public:
-    CLocalResultWriteActivity(CGraphElementBase *container) : CLocalResultWriteActivityBase(container)
+    CLocalResultWriteActivity(CGraphElementBase *_container) : CLocalResultWriteActivityBase(_container)
     {
+        setRequireInitData(false);
     }
     virtual IThorResult *createResult()
     {
@@ -733,6 +737,7 @@ public:
     CDictionaryResultWriteActivity(CGraphElementBase *_container) : ProcessSlaveActivity(_container)
     {
         helper = (IHThorDictionaryResultWriteArg *)queryHelper();
+        setRequireInitData(false);
     }
     virtual void process()
     {
@@ -800,6 +805,7 @@ protected:
 public:
     CConditionalActivity(CGraphElementBase *_container) : CSlaveActivity(_container)
     {
+        setRequireInitData(false);
         appendOutputLinked(this);
     }
     virtual void start() override
@@ -905,6 +911,7 @@ public:
     CIfActionActivity(CGraphElementBase *_container) : ProcessSlaveActivity(_container)
     {
         helper = (IHThorIfArg *)baseHelper.get();
+        setRequireInitData(false);
     }
     // IThorSlaveProcess overloaded methods
     virtual void process() override
@@ -959,11 +966,9 @@ public:
     CChildNormalizeSlaveActivity(CGraphElementBase *_container) : CSlaveActivity(_container)
     {
         helper = (IHThorChildNormalizeArg *)queryHelper();
-        appendOutputLinked(this);
-    }
-    void init(MemoryBuffer &data, MemoryBuffer &slaveData)
-    {
         allocator.set(queryRowAllocator());
+        setRequireInitData(false);
+        appendOutputLinked(this);
     }
     virtual void start()
     {
@@ -1031,6 +1036,7 @@ public:
     CChildAggregateSlaveActivity(CGraphElementBase *_container) : CSlaveActivity(_container)
     {
         helper = (IHThorChildAggregateArg *)queryHelper();
+        setRequireInitData(false);
         appendOutputLinked(this);
     }
     virtual void start()
@@ -1079,11 +1085,9 @@ public:
     CChildGroupAggregateActivitySlave(CGraphElementBase *_container) : CSlaveActivity(_container)
     {
         helper = (IHThorChildGroupAggregateArg *)queryHelper();
-        appendOutputLinked(this);
-    }
-    void init(MemoryBuffer &data, MemoryBuffer &slaveData)
-    {
+        setRequireInitData(false);
         allocator.set(queryRowAllocator());
+        appendOutputLinked(this);
     }
     virtual void start() override
     {
@@ -1148,12 +1152,10 @@ public:
     CChildThroughNormalizeSlaveActivity(CGraphElementBase *_container) : CSlaveActivity(_container), nextOutput(NULL)
     {
         helper = (IHThorChildThroughNormalizeArg *)queryHelper();
-        appendOutputLinked(this);
-    }
-    void init(MemoryBuffer &data, MemoryBuffer &slaveData)
-    {
         allocator.set(queryRowAllocator());
         nextOutput.setAllocator(allocator);
+        setRequireInitData(false);
+        appendOutputLinked(this);
     }
     virtual void start()
     {
@@ -1224,9 +1226,10 @@ class CGraphLoopResultReadSlaveActivity : public CSlaveActivity
     Owned<IRowStream> resultStream;
 
 public:
-    CGraphLoopResultReadSlaveActivity(CGraphElementBase *container) : CSlaveActivity(container)
+    CGraphLoopResultReadSlaveActivity(CGraphElementBase *_container) : CSlaveActivity(_container)
     {
         helper = (IHThorGraphLoopResultReadArg *)queryHelper();
+        setRequireInitData(false);
         appendOutputLinked(this);
     }
     virtual void kill()
@@ -1361,8 +1364,9 @@ activityslaves_decl CActivityBase *createGraphLoopResultReadSlave(CGraphElementB
 class CGraphLoopResultWriteSlaveActivity : public CLocalResultWriteActivityBase
 {
 public:
-    CGraphLoopResultWriteSlaveActivity(CGraphElementBase *container) : CLocalResultWriteActivityBase(container)
+    CGraphLoopResultWriteSlaveActivity(CGraphElementBase *_container) : CLocalResultWriteActivityBase(_container)
     {
+        setRequireInitData(false);
     }
     virtual IThorResult *createResult()
     {

--- a/thorlcr/activities/merge/thmergeslave.cpp
+++ b/thorlcr/activities/merge/thmergeslave.cpp
@@ -421,6 +421,7 @@ public:
     LocalMergeSlaveActivity(CGraphElementBase *_container) : CSlaveActivity(_container)
     {
         helper = (IHThorMergeArg *)queryHelper();
+        setRequireInitData(false);
         appendOutputLinked(this);
     }
     void abort()

--- a/thorlcr/activities/msort/thgroupsortslave.cpp
+++ b/thorlcr/activities/msort/thgroupsortslave.cpp
@@ -46,14 +46,12 @@ public:
     CLocalSortSlaveActivity(CGraphElementBase *_container)
         : CSlaveActivity(_container), spillStats(spillStatistics)
     {
-        appendOutputLinked(this);
-    }
-    virtual void init(MemoryBuffer &data, MemoryBuffer &slaveData)
-    {
         helper = (IHThorSortArg *)queryHelper();
         iCompare = helper->queryCompare();
         IHThorAlgorithm * algo = helper?(static_cast<IHThorAlgorithm *>(helper->selectInterface(TAIalgorithm_1))):NULL;
         unstable = (algo&&(algo->getAlgorithmFlags()&TAFunstable));
+        setRequireInitData(false);
+        appendOutputLinked(this);
     }
     virtual void start()
     {
@@ -138,12 +136,8 @@ public:
     {
         helper = (IHThorSortedArg *)queryHelper();
         icompare = helper->queryCompare();
+        setRequireInitData(false);
         appendOutputLinked(this);
-    }
-    virtual void init(MemoryBuffer &data, MemoryBuffer &slaveData) override
-    {
-        helper = (IHThorSortedArg *)queryHelper();
-        icompare = helper->queryCompare();
     }
     virtual void start() override
     {

--- a/thorlcr/activities/normalize/thnormalizeslave.cpp
+++ b/thorlcr/activities/normalize/thnormalizeslave.cpp
@@ -43,11 +43,9 @@ public:
         : CSlaveActivity(_container)
     {
         helper = static_cast <IHThorNormalizeArg *> (queryHelper());
-        appendOutputLinked(this);
-    }
-    virtual void init(MemoryBuffer &data, MemoryBuffer &slaveData)
-    {
         allocator.set(queryRowAllocator());
+        setRequireInitData(false);
+        appendOutputLinked(this);
     }
     virtual void start() override
     { 
@@ -117,14 +115,12 @@ public:
         : CSlaveActivity(_container)
     { 
         helper = static_cast <IHThorNormalizeChildArg *> (queryHelper());
+        cursor = helper->queryIterator();
+        allocator.set(queryRowAllocator());
+        setRequireInitData(false);
         appendOutputLinked(this);
     }
     virtual bool isGrouped() const override { return queryInput(0)->isGrouped(); }
-    virtual void init(MemoryBuffer &data, MemoryBuffer &slaveData) override
-    {
-        cursor = helper->queryIterator();
-        allocator.set(queryRowAllocator());
-    }
     virtual void start() override
     {
         ActivityTimer s(totalCycles, timeActivities);
@@ -209,6 +205,7 @@ public:
         : CSlaveActivity(_container)
     { 
         helper = static_cast <IHThorNormalizeLinkedChildArg *> (queryHelper());
+        setRequireInitData(false);
         appendOutputLinked(this);
     }
     virtual bool isGrouped() const override { return queryInput(0)->isGrouped(); }

--- a/thorlcr/activities/nsplitter/thnsplitterslave.cpp
+++ b/thorlcr/activities/nsplitter/thnsplitterslave.cpp
@@ -143,6 +143,13 @@ public:
     {
         activeOutputs = container.getOutputs();
         ActPrintLog("Number of connected outputs: %u", activeOutputs);
+        setRequireInitData(false);
+        IHThorSplitArg *helper = (IHThorSplitArg *)queryHelper();
+        int dV = getOptInt(THOROPT_SPLITTER_SPILL, -1);
+        if (-1 == dV)
+            spill = !helper->isBalanced();
+        else
+            spill = dV>0;
         ForEachItemIn(o, container.outputs)
             appendOutput(new CSplitterOutput(*this, o));
     }
@@ -161,15 +168,6 @@ public:
             if (output)
                 output->reset();
         }
-    }
-    virtual void init(MemoryBuffer &data, MemoryBuffer &slaveData) override
-    {
-        IHThorSplitArg *helper = (IHThorSplitArg *)queryHelper();
-        int dV = getOptInt(THOROPT_SPLITTER_SPILL, -1);
-        if (-1 == dV)
-            spill = !helper->isBalanced();
-        else
-            spill = dV>0;
     }
     bool prepareInput()
     {

--- a/thorlcr/activities/null/thnullslave.cpp
+++ b/thorlcr/activities/null/thnullslave.cpp
@@ -21,13 +21,11 @@
 class CNullSinkSlaveActivity : public ProcessSlaveActivity
 {
 public:
-    CNullSinkSlaveActivity(CGraphElementBase *container) : ProcessSlaveActivity(container)
+    CNullSinkSlaveActivity(CGraphElementBase *_container) : ProcessSlaveActivity(_container)
     {
+        setRequireInitData(false);
     }
 // IThorSlaveActivity
-    virtual void init(MemoryBuffer & data, MemoryBuffer &slaveData)
-    {       
-    }
     virtual void process() override
     {
         start();
@@ -84,13 +82,9 @@ class CThroughSlaveActivity : public CSlaveActivity
 public:
     CThroughSlaveActivity(CGraphElementBase *_container) : CSlaveActivity(_container)
     {
+        setRequireInitData(false);
         appendOutputLinked(this);
     }
-// IThorSlaveActivity
-    virtual void init(MemoryBuffer & data, MemoryBuffer &slaveData)
-    {       
-    }
-
 // IThorDataLink
     virtual void start() override
     {

--- a/thorlcr/activities/nullaction/thnullactionslave.cpp
+++ b/thorlcr/activities/nullaction/thnullactionslave.cpp
@@ -31,6 +31,7 @@ class CNullActionSlaveActivity : public CSlaveActivity
 public:
     CNullActionSlaveActivity(CGraphElementBase *_container) : CSlaveActivity(_container)
     {
+        setRequireInitData(false);
         appendOutputLinked(this);
     }
     ~CNullActionSlaveActivity()

--- a/thorlcr/activities/parse/thparseslave.cpp
+++ b/thorlcr/activities/parse/thparseslave.cpp
@@ -49,6 +49,11 @@ public:
         anyThisGroup = false;
         curSearchTextLen = 0;
         curSearchText = NULL;
+        algorithm.setown(createThorParser(queryCodeContext(), *helper));
+        parser.setown(algorithm->createParser(queryCodeContext(), (unsigned)container.queryId(), helper->queryHelper(), helper));
+        rowIter = parser->queryResultIter();
+        allocator.set(queryRowAllocator());
+        setRequireInitData(false);
         appendOutputLinked(this);
     }
     ~CParseSlaveActivity()
@@ -56,13 +61,6 @@ public:
         if (helper->searchTextNeedsFree())
             rtlFree(curSearchText);
     }
-    virtual void init(MemoryBuffer &data, MemoryBuffer &slaveData) override
-    {
-        algorithm.setown(createThorParser(queryCodeContext(), *helper));
-        parser.setown(algorithm->createParser(queryCodeContext(), (unsigned)container.queryId(), helper->queryHelper(), helper));
-        rowIter = parser->queryResultIter();
-        allocator.set(queryRowAllocator());
-    } 
     virtual void start() override
     {
         ActivityTimer s(totalCycles, timeActivities);

--- a/thorlcr/activities/piperead/thprslave.cpp
+++ b/thorlcr/activities/piperead/thprslave.cpp
@@ -190,6 +190,12 @@ public:
         : CPipeSlaveBase(_container)
     {
         helper = static_cast <IHThorPipeReadArg *> (queryHelper());
+        flags = helper->getPipeFlags();
+        needTransform = false;
+
+        if (needTransform)
+            inrowif.setown(createThorRowInterfaces(queryRowManager(), helper->queryDiskRecordSize(), queryId(), queryCodeContext()));
+        setRequireInitData(false);
         appendOutputLinked(this);
     }
     CATCH_NEXTROW()
@@ -228,14 +234,6 @@ public:
         }
         eof = true;
         return NULL;
-    }
-    virtual void init(MemoryBuffer &data, MemoryBuffer &slaveData)
-    {
-        flags = helper->getPipeFlags();
-        needTransform = false;
-
-        if (needTransform)
-            inrowif.setown(createThorRowInterfaces(queryRowManager(), helper->queryDiskRecordSize(), queryId(), queryCodeContext()));
     }
     virtual void start() override
     {
@@ -343,17 +341,15 @@ public:
         helper = static_cast <IHThorPipeThroughArg *> (queryHelper());
         pipeWriter = NULL;
         grouped = false;
+        flags = helper->getPipeFlags();
+        recreate = helper->recreateEachRow();
+        grouped = 0 != (flags & TPFgroupeachrow);
+        setRequireInitData(false);
         appendOutputLinked(this);
     }
     ~CPipeThroughSlaveActivity()
     {
         ::Release(pipeWriter);
-    }
-    virtual void init(MemoryBuffer &data, MemoryBuffer &slaveData) override
-    {
-        flags = helper->getPipeFlags();
-        recreate = helper->recreateEachRow();
-        grouped = 0 != (flags & TPFgroupeachrow);
     }
     virtual void start() override
     {

--- a/thorlcr/activities/pipewrite/thpwslave.cpp
+++ b/thorlcr/activities/pipewrite/thpwslave.cpp
@@ -37,18 +37,13 @@ private:
     bool pipeOpen;
 
 public:
-    CPipeWriteSlaveActivity(CGraphElementBase *container) : ProcessSlaveActivity(container)
+    CPipeWriteSlaveActivity(CGraphElementBase *_container) : ProcessSlaveActivity(_container)
     {
         helper = static_cast <IHThorPipeWriteArg *> (queryHelper());
         pipe.setown(createPipeProcess(globals->queryProp("@allowedPipePrograms")));
         pipeOpen = false;
-    }
-    ~CPipeWriteSlaveActivity()
-    {
-    }
-    void init(MemoryBuffer &data, MemoryBuffer &slaveData)
-    {
         recreate = helper->recreateEachRow();
+        setRequireInitData(false);
     }
     void open()
     {

--- a/thorlcr/activities/project/thprojectslave.cpp
+++ b/thorlcr/activities/project/thprojectslave.cpp
@@ -84,6 +84,7 @@ public:
     explicit CProjectSlaveActivity(CGraphElementBase *_container) : CThorStrandedActivity(_container)
     {
         helper = static_cast <IHThorProjectArg *> (queryHelper());
+        setRequireInitData(false);
         appendOutputLinked(this);
     }
 
@@ -248,11 +249,9 @@ public:
     {
         helper = (IHThorPrefetchProjectArg *) queryHelper();
         parallel = 0 != (helper->getFlags() & PPFparallel);
-        appendOutputLinked(this);
-    }
-    virtual void init(MemoryBuffer &data, MemoryBuffer &slaveData) override
-    {
+        setRequireInitData(false);
         allocator.set(queryRowAllocator());
+        appendOutputLinked(this);
     }
     virtual void start() override
     {

--- a/thorlcr/activities/pull/thpullslave.cpp
+++ b/thorlcr/activities/pull/thpullslave.cpp
@@ -28,6 +28,7 @@ class PullSlaveActivity : public CSlaveActivity
 public:
     PullSlaveActivity(CGraphElementBase *_container) : CSlaveActivity(_container)
     {
+        setRequireInitData(false);
         appendOutputLinked(this);
     }
 

--- a/thorlcr/activities/rollup/throllupslave.cpp
+++ b/thorlcr/activities/rollup/throllupslave.cpp
@@ -170,12 +170,14 @@ protected:
 
     unsigned numKept; // not used by rollup
 public:
-    CDedupRollupBaseActivity(CGraphElementBase *container, bool _rollup, bool _global, bool _groupOp) 
-        : CSlaveActivity(container)
+    CDedupRollupBaseActivity(CGraphElementBase *_container, bool _rollup, bool _global, bool _groupOp)
+        : CSlaveActivity(_container)
     {
         rollup = _rollup;
         global = _global;
         groupOp = _groupOp;
+        if (!global)
+            setRequireInitData(false);
     }
     virtual void stopInput()
     {
@@ -295,6 +297,7 @@ public:
         : CDedupRollupBaseActivity(_container, false, global, groupOp)
     {
         ddhelper = static_cast <IHThorDedupArg *>(queryHelper());
+        setRequireInitData(false);
         appendOutputLinked(this);   // adding 'me' to outputs array
     }
     virtual void start() override
@@ -401,10 +404,6 @@ public:
         : CDedupBaseSlaveActivity(_container, false, groupOp)
     {
         lastEog = false;
-    }
-    void init(MemoryBuffer &data, MemoryBuffer &slaveData)
-    {
-        CDedupBaseSlaveActivity::init(data, slaveData);
     }
     virtual void start()
     {
@@ -555,11 +554,9 @@ public:
     {
         helper = (IHThorRollupGroupArg *)queryHelper();
         eoi = false;
-        appendOutputLinked(this);   // adding 'me' to outputs array
-    }
-    void init(MemoryBuffer &data, MemoryBuffer &slaveData)
-    {
         groupLoader.setown(createThorRowLoader(*this, NULL, stableSort_none, rc_allMem));
+        setRequireInitData(false);
+        appendOutputLinked(this);   // adding 'me' to outputs array
     }
     virtual void start()
     {

--- a/thorlcr/activities/sample/thsampleslave.cpp
+++ b/thorlcr/activities/sample/thsampleslave.cpp
@@ -31,6 +31,7 @@ public:
     SampleSlaveActivity(CGraphElementBase *_container) : CSlaveActivity(_container)
     {
         helper = static_cast <IHThorSampleArg *> (queryHelper());
+        setRequireInitData(false);
         appendOutputLinked(this);
     }
     virtual void start() override

--- a/thorlcr/activities/selectnth/thselectnthslave.cpp
+++ b/thorlcr/activities/selectnth/thselectnthslave.cpp
@@ -69,6 +69,8 @@ public:
         helper = static_cast <IHThorSelectNArg *> (queryHelper());
         isLocal = _isLocal;
         createDefaultIfFail = isLocal || lastNode();
+        if (container.queryLocalOrGrouped())
+            setRequireInitData(false);
         appendOutputLinked(this);
     }
 

--- a/thorlcr/activities/selfjoin/thselfjoinslave.cpp
+++ b/thorlcr/activities/selfjoin/thselfjoinslave.cpp
@@ -111,6 +111,8 @@ public:
         keyserializer = NULL;
         inputStopped = false;
         mpTagRPC = TAG_NULL;
+        if (isLocal)
+            setRequireInitData(false);
         appendOutputLinked(this);
     }
 
@@ -123,7 +125,7 @@ public:
 // IThorSlaveActivity
     virtual void init(MemoryBuffer & data, MemoryBuffer &slaveData) override
     {       
-        if(!isLocal)
+        if (!isLocal)
         {
             mpTagRPC = container.queryJobChannel().deserializeMPTag(data);
             mptag_t barrierTag = container.queryJobChannel().deserializeMPTag(data);

--- a/thorlcr/activities/soapcall/thsoapcallslave.cpp
+++ b/thorlcr/activities/soapcall/thsoapcallslave.cpp
@@ -45,14 +45,11 @@ public:
 
     CWscRowCallSlaveActivity(CGraphElementBase *_container) : CSlaveActivity(_container)
     {
+        buildAuthToken(queryJob().queryUserDescriptor(), authToken);
+        setRequireInitData(false);
         appendOutputLinked(this);
     }
 
-    // IThorSlaveActivity overloaded methods
-    virtual void init(MemoryBuffer &data, MemoryBuffer &slaveData)
-    {
-        buildAuthToken(queryJob().queryUserDescriptor(), authToken);
-    }
     // IThorDataLink methods
     virtual void start()
     {
@@ -140,6 +137,7 @@ public:
 
     SoapDatasetCallSlaveActivity(CGraphElementBase *_container) : CSlaveActivity(_container)
     {
+        setRequireInitData(false);
         appendOutputLinked(this);
     }
 
@@ -223,7 +221,10 @@ class SoapRowActionSlaveActivity : public ProcessSlaveActivity, implements IWSCR
 public:
     IMPLEMENT_IINTERFACE_USING(PARENT);
 
-    SoapRowActionSlaveActivity(CGraphElementBase *container) : ProcessSlaveActivity(container) { }
+    SoapRowActionSlaveActivity(CGraphElementBase *_container) : ProcessSlaveActivity(_container)
+    {
+        setRequireInitData(false);
+    }
 
     // IThorSlaveActivity overloaded methods
     virtual void init(MemoryBuffer &data, MemoryBuffer &slaveData)
@@ -276,7 +277,10 @@ class SoapDatasetActionSlaveActivity : public ProcessSlaveActivity, implements I
 public:
     IMPLEMENT_IINTERFACE_USING(PARENT);
 
-    SoapDatasetActionSlaveActivity(CGraphElementBase *container) : ProcessSlaveActivity(container) { }
+    SoapDatasetActionSlaveActivity(CGraphElementBase *_container) : ProcessSlaveActivity(_container)
+    {
+        setRequireInitData(false);
+    }
 
     // IThorSlaveActivity overloaded methods
     virtual void init(MemoryBuffer &data, MemoryBuffer &slaveData)

--- a/thorlcr/activities/temptable/thtmptableslave.cpp
+++ b/thorlcr/activities/temptable/thtmptableslave.cpp
@@ -46,6 +46,7 @@ public:
         startRow = 0;
         currentRow = 0;
         maxRow = 0;
+        setRequireInitData(false);
         appendOutputLinked(this);
     }
     virtual bool isGrouped() const override { return false; }

--- a/thorlcr/activities/thdiskbaseslave.ipp
+++ b/thorlcr/activities/thdiskbaseslave.ipp
@@ -133,7 +133,7 @@ protected:
 
 public:
     CDiskWriteSlaveActivityBase(CGraphElementBase *container);
-    void init(MemoryBuffer &data, MemoryBuffer &slaveData);
+    virtual void init(MemoryBuffer &data, MemoryBuffer &slaveData);
     virtual void abort();
     virtual void serializeStats(MemoryBuffer &mb);
 

--- a/thorlcr/activities/topn/thtopnslave.cpp
+++ b/thorlcr/activities/topn/thtopnslave.cpp
@@ -87,6 +87,8 @@ public:
         assertex(!(global && grouped));
         helper = (IHThorTopNArg *) queryHelper();
         eog = eos = false;
+        if (container.queryLocalOrGrouped())
+            setRequireInitData(false);
         appendOutputLinked(this);
     }
     ~TopNSlaveActivity()

--- a/thorlcr/activities/trace/thtraceslave.cpp
+++ b/thorlcr/activities/trace/thtraceslave.cpp
@@ -39,11 +39,8 @@ public:
           keepLimit(0), skip(0), sample(0), traceEnabled(false)
     {
         helper = (IHThorTraceArg *) queryHelper();
-        appendOutputLinked(this);
-    }
-    virtual void init(MemoryBuffer &data, MemoryBuffer &slaveData) override
-    {
         traceEnabled = getOptBool(THOROPT_TRACE_ENABLED, false);
+        appendOutputLinked(this);
     }
     virtual void start() override
     {

--- a/thorlcr/activities/when/thwhenslave.cpp
+++ b/thorlcr/activities/when/thwhenslave.cpp
@@ -34,6 +34,8 @@ public:
     CDependencyExecutorSlaveActivity(CGraphElementBase *_container) : CSlaveActivity(_container)
     {
         global = !queryContainer().queryOwner().queryOwner() || queryContainer().queryOwner().isGlobal();
+        if (!global)
+            setRequireInitData(false);
     }
     virtual void init(MemoryBuffer &data, MemoryBuffer &slaveData) override
     {

--- a/thorlcr/activities/wuidread/thwuidreadslave.cpp
+++ b/thorlcr/activities/wuidread/thwuidreadslave.cpp
@@ -45,12 +45,10 @@ public:
         replyTag = queryMPServer().createReplyTag();
         replyStream.setown(createMemoryBufferSerialStream(masterReplyMsg));
         rowSource.setStream(replyStream);
+        grouped = helper->queryOutputMeta()->isGrouped();
+        setRequireInitData(false);
         appendOutputLinked(this);
     }
-    virtual void init(MemoryBuffer &data, MemoryBuffer &slaveData) override
-    {
-        grouped = helper->queryOutputMeta()->isGrouped();
-    } 
     virtual void start() override
     {
         ActivityTimer s(totalCycles, timeActivities);

--- a/thorlcr/graph/thgraph.hpp
+++ b/thorlcr/graph/thgraph.hpp
@@ -548,7 +548,7 @@ protected:
     Owned<IPropertyTree> node;
     IBarrier *startBarrier, *waitBarrier, *doneBarrier;
     mptag_t mpTag, startBarrierTag, waitBarrierTag, doneBarrierTag;
-    bool connected, started, aborted, graphDone, prepared, sequential;
+    bool connected, started, aborted, graphDone, sequential;
     CJobBase &job;
     CJobChannel &jobChannel;
     graph_id graphId;
@@ -587,7 +587,6 @@ public:
     inline void setInitialized() { initialized = true; }
     inline bool isInitialized() const { return initialized; }
     bool isComplete() const { return complete; }
-    bool isPrepared() const { return prepared; }
     bool isGlobal() const { return global; }
     bool isStarted() const { return started; }
     bool isLocalOnly() const; // this graph and all upstream dependencies
@@ -1008,7 +1007,7 @@ protected:
     bool timeActivities; // purely for access efficiency
     size32_t parentExtractSz;
     const byte *parentExtract;
-    bool receiving, cancelledReceive, reInit;
+    bool receiving, cancelledReceive, initialized, reInit;
     Owned<IThorGraphResults> ownedResults; // NB: probably only to be used by loop results
 
 public:
@@ -1026,6 +1025,8 @@ public:
     inline bool queryAbortSoon() const { return abortSoon; }
     inline IHThorArg *queryHelper() const { return baseHelper; }
     inline bool needReInit() const { return reInit; }
+    inline bool queryInitialized() const { return initialized; }
+    inline void setInitialized(bool tf) { initialized = tf; }
     inline bool queryTimeActivities() const { return timeActivities; }
     void onStart(size32_t _parentExtractSz, const byte *_parentExtract) { parentExtractSz = _parentExtractSz; parentExtract = _parentExtract; }
     bool receiveMsg(ICommunicator &comm, CMessageBuffer &mb, const rank_t rank, const mptag_t mpTag, rank_t *sender=NULL, unsigned timeout=MP_WAIT_FOREVER);

--- a/thorlcr/graph/thgraphmaster.ipp
+++ b/thorlcr/graph/thgraphmaster.ipp
@@ -327,7 +327,7 @@ class graphmaster_decl CMasterGraphElement : public CGraphElementBase
     bool initialized = false;
 public:
     CMasterGraphElement(CGraphBase &owner, IPropertyTree &xgmml);
-    void doCreateActivity(size32_t parentExtractSz=0, const byte *parentExtract=NULL);
+    void doCreateActivity(size32_t parentExtractSz=0, const byte *parentExtract=NULL, MemoryBuffer *startCtx=nullptr);
     virtual bool checkUpdate();
 
     virtual void initActivity() override;

--- a/thorlcr/graph/thgraphslave.hpp
+++ b/thorlcr/graph/thgraphslave.hpp
@@ -159,6 +159,11 @@ public:
 
     CSlaveActivity(CGraphElementBase *container);
     ~CSlaveActivity();
+    void setRequireInitData(bool tf)
+    {
+        // If not required sets sentActInitdata to true, to prevent it being request at graph initialization time.
+        container.sentActInitData->set(0, !tf);
+    }
     virtual void clearConnections();
     virtual void releaseIOs();
     virtual MemoryBuffer &queryInitializationData(unsigned slave) const;
@@ -218,7 +223,7 @@ public:
     virtual void resetEOF() override { throwUnexpected(); }
 
 // IThorSlaveActivity
-    virtual void init(MemoryBuffer &in, MemoryBuffer &out) override { }
+    virtual void init(MemoryBuffer &in, MemoryBuffer &out) { }
     virtual void setInputStream(unsigned index, CThorInput &input, bool consumerOrdered) override;
     virtual void processDone(MemoryBuffer &mb) override { };
     virtual void reset() override;

--- a/thorlcr/slave/slave.ipp
+++ b/thorlcr/slave/slave.ipp
@@ -98,8 +98,9 @@ protected:
     PointerArrayOf<IStrandJunction> expandedJunctions;
 
 public:
-    CThorNarySlaveActivity(CGraphElementBase *container) : CSlaveActivity(container)
+    CThorNarySlaveActivity(CGraphElementBase *_container) : CSlaveActivity(_container)
     {
+        setRequireInitData(false);
     }
     virtual void start() override
     {


### PR DESCRIPTION
Activities with variant initialization, e.g. dynamic filenames
were not being initialized correctly if in loop or child queries.
In some cases it could cause a crash (this JIRA was an incident of
that), in others it would fail to re-initialize based on the
context. Also changed so that only the child activities that
need initialization, request it, which in many cases means none.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
