### PR TITLE
HPCC-16120 Fix type causing regression in init_thor script

### DIFF
--- a/initfiles/bin/init_thor
+++ b/initfiles/bin/init_thor
@@ -74,7 +74,7 @@ kill_slaves()
         # we want to kill only slaves that have already been started in run_thor
         if [[ -r $instancedir/uslaves ]]; then
             clusternodes=$(cat $instancedir/uslaves 2> /dev/null | wc -l)
-            $deploydir/frunssh $instancedir/slaves "/bin/sh -c '$deploydir/init_thorslave stop localhost $slavespernode $THORSLAVEPORT $slaveportinc $THORMASTER $THORMASTERPORT $LOG_DIR $instancedir $deploydir $THORNAME $PATH_PRE $logredirect'" -i:$SSHidentityfile -u:$SSHusername -pe:$SSHpassword -t:$SSHtimeout -a:$SSHretries -n:$clusternodes 2>&1
+            $deploydir/frunssh $instancedir/uslaves "/bin/sh -c '$deploydir/init_thorslave stop localhost $slavespernode $THORSLAVEPORT $slaveportinc $THORMASTER $THORMASTERPORT $LOG_DIR $instancedir $deploydir $THORNAME $PATH_PRE $logredirect'" -i:$SSHidentityfile -u:$SSHusername -pe:$SSHpassword -t:$SSHtimeout -a:$SSHretries -n:$clusternodes 2>&1
             FRUNSSH_RC=$?
             if [[ ${FRUNSSH_RC} -gt 0 ]]; then
                 log "Error ${FRUNSSH_RC} in frunssh"


### PR DESCRIPTION
The section of code for kill_slaves relies on the uslaves file
being present.  Yet in the frunssh call we use the slaves file
for our ip list, unlike every other frunssh call where we rely on
the uslaves file.  This was causing issues where the uslaves file
would be present, but a previous failure to connect to the slave
machines would erase the slaves file (as was intended), and cause
the startup to always fail.

The fix is to use the uslaves file, as was originally intended.
If there is a failure to connect to the slave machines to stop the
slaves, we want the uslaves file to remain in the instancedir so
we can try again on the next startup attempt.

Signed-off-by: Michael Gardner michael.gardner@lexisnexis.com
