### PR TITLE
HPCC-15945 Thor slave hang in countproject

### DIFF
--- a/thorlcr/activities/countproject/thcountprojectslave.cpp
+++ b/thorlcr/activities/countproject/thcountprojectslave.cpp
@@ -167,12 +167,12 @@ public:
     }
     virtual void stop()
     {
-        PARENT::stop();
         if (first) // nextRow, therefore getPrevCount()/sendCount() never called
         {
             prevRecCount = count = getPrevCount();
             signalNext();
         }
+        PARENT::stop();
     }
     virtual void abort()
     {


### PR DESCRIPTION
If a slave countproject calls stop() before nextRow()
(ie if one slave hits CHOSEN limit others will be told to stop)
a deadlock could occur.  This change moves PARENT::stop() call to
after check for first in stop() so that signalNext() can signal
the semaphore inInputFinished() is waiting for.  Thus PARENT::stop()
does not deadlock waiting for onInputFinished to end.

@jakesmith please review.

Passes 100+ mergededup regression runs without hang

Signed-off-by: Mark Kelly mark.kelly@lexisnexis.com
