### PR TITLE
HPCC-16121 Problems with virtual logicalfilename in superfiles

### DIFF
--- a/thorlcr/activities/csvread/thcsvrslave.cpp
+++ b/thorlcr/activities/csvread/thcsvrslave.cpp
@@ -92,10 +92,10 @@ class CCsvReadSlaveActivity : public CDiskReadSlaveActivityBase
             csvSplitter.init(activity.helper->getMaxColumns(), csvInfo, activity.csvQuote, activity.csvSeparate, activity.csvTerminate, activity.csvEscape);
             maxRowSize = activity.getOptInt(OPT_MAXCSVROWSIZE, defaultMaxCsvRowSize) * 1024 * 1024;
         }
-        virtual void setPart(IPartDescriptor *partDesc, unsigned partNoSerialized)
+        virtual void setPart(IPartDescriptor *partDesc)
         {
             inputCRC.reset();
-            CDiskPartHandlerBase::setPart(partDesc, partNoSerialized);
+            CDiskPartHandlerBase::setPart(partDesc);
         }
         virtual void open() 
         {

--- a/thorlcr/activities/diskread/thdiskreadslave.cpp
+++ b/thorlcr/activities/diskread/thdiskreadslave.cpp
@@ -780,7 +780,7 @@ public:
         unsigned part = 0;
         while (!abortSoon && part<partDescs.ordinality())
         {
-            partHandler->setPart(&partDescs.item(part), part);
+            partHandler->setPart(&partDescs.item(part));
             ++part;
             loop
             {
@@ -908,7 +908,7 @@ public:
             unsigned part = 0;
             while (!abortSoon && part<partDescs.ordinality())
             {
-                partHandler->setPart(&partDescs.item(part), part);
+                partHandler->setPart(&partDescs.item(part));
                 ++part;
                 loop {
                     OwnedConstThorRow nextrow = partHandler->nextRow();
@@ -1023,7 +1023,7 @@ public:
                 unsigned part = 0;
                 while (!abortSoon && part<partDescs.ordinality())
                 {
-                    partHandler->setPart(&partDescs.item(part), part);
+                    partHandler->setPart(&partDescs.item(part));
                     ++part;
                     loop
                     {

--- a/thorlcr/activities/indexread/thindexreadslave.cpp
+++ b/thorlcr/activities/indexread/thindexreadslave.cpp
@@ -76,7 +76,7 @@ public:
     const void *nextKey();  // NB not link counted row
     const void *getKeyPtr(); // nor this
 
-    void setPart(IPartDescriptor *_partDesc, unsigned partNoSerialized);
+    void setPart(IPartDescriptor *_partDesc);
 
     void reset();
 
@@ -238,7 +238,7 @@ rowcount_t CIndexPartHandlerHelper::getCount(const rowcount_t &keyedLimit)
     return (rowcount_t)count;
 }
 
-void CIndexPartHandlerHelper::setPart(IPartDescriptor *_partDesc, unsigned partNoSerialized)
+void CIndexPartHandlerHelper::setPart(IPartDescriptor *_partDesc)
 {
     reset();
     partDesc.set(_partDesc);
@@ -1067,7 +1067,7 @@ public:
             keyedLimitCount = 0;
             ForEachItemIn(p, partDescs)
             {
-                partHelper.setPart(&partDescs.item(p), p);
+                partHelper.setPart(&partDescs.item(p));
                 keyedLimitCount += partHelper.getCount(keyedLimit);
                 if (keyedLimitCount > keyedLimit) break;
             }
@@ -1075,7 +1075,7 @@ public:
         if (partDescs.ordinality())
         {
             eoi = false;
-            partHelper.setPart(&partDescs.item(0), 0);
+            partHelper.setPart(&partDescs.item(0));
         }
         else
             eoi = true;
@@ -1173,7 +1173,7 @@ public:
                         eoi = true;
                         return NULL;
                     }
-                    partHelper.setPart(&partDescs.item(currentPart), currentPart);
+                    partHelper.setPart(&partDescs.item(currentPart));
                 }
             }
         }
@@ -1207,7 +1207,7 @@ class CIndexAggregateSlaveActivity : public CIndexReadSlaveBase
                 ++partn;
                 if (partn>=partDescs.ordinality())
                     return NULL;
-                partHelper.setPart(&partDescs.item(partn), partn);
+                partHelper.setPart(&partDescs.item(partn));
             }
         }
     }
@@ -1249,7 +1249,7 @@ public:
         helper->clearAggregate(row);
         if (partDescs.ordinality())
         {
-            partHelper.setPart(&partDescs.item(0), 0);
+            partHelper.setPart(&partDescs.item(0));
             loop
             {
                 const void *r = nextKey();

--- a/thorlcr/activities/thactivityutil.cpp
+++ b/thorlcr/activities/thactivityutil.cpp
@@ -860,7 +860,7 @@ IRowStream *createSequentialPartHandler(CPartHandler *partHandler, IArrayOf<IPar
             else
             {
                 eof = false;
-                partHandler->setPart(&partDescs.item(0), 0);
+                partHandler->setPart(&partDescs.item(0));
             }
         }
         virtual void stop()
@@ -898,7 +898,7 @@ IRowStream *createSequentialPartHandler(CPartHandler *partHandler, IArrayOf<IPar
                     eof = true;
                     return NULL;
                 }
-                partHandler->setPart(&partDescs.item(part), part);
+                partHandler->setPart(&partDescs.item(part));
             }
         }
     };

--- a/thorlcr/activities/thactivityutil.ipp
+++ b/thorlcr/activities/thactivityutil.ipp
@@ -44,7 +44,7 @@ public:
     IMPLEMENT_IINTERFACE_USING(CSimpleInterface);
 
     virtual ~CPartHandler() { }
-    virtual void setPart(IPartDescriptor *partDesc, unsigned partNoSerialized) = 0;
+    virtual void setPart(IPartDescriptor *partDesc) = 0;
     virtual void getMetaInfo(ThorDataLinkMetaInfo &info, IPartDescriptor *partDesc) { }
     virtual void stop() = 0;
 };

--- a/thorlcr/activities/thdiskbaseslave.cpp
+++ b/thorlcr/activities/thdiskbaseslave.cpp
@@ -74,7 +74,7 @@ CDiskPartHandlerBase::CDiskPartHandlerBase(CDiskReadSlaveActivityBase &_activity
 
 }
 
-void CDiskPartHandlerBase::setPart(IPartDescriptor *_partDesc, unsigned partNoSerialized)
+void CDiskPartHandlerBase::setPart(IPartDescriptor *_partDesc)
 {
     partDesc.set(_partDesc);
     compressed = partDesc->queryOwner().isCompressed(&blockCompressed);
@@ -83,6 +83,7 @@ void CDiskPartHandlerBase::setPart(IPartDescriptor *_partDesc, unsigned partNoSe
     checkFileCrc = activity.checkFileCrc?partDesc->getCrc(storedCrc):false;
     fileBaseOffset = partDesc->queryProperties().getPropInt64("@offset");
 
+    which = partDesc->queryPartIndex();
     if (0 != (activity.helper->getFlags() & TDRfilenamecallback)) // only get/serialize if using virtual file name fields
     {
         IFileDescriptor &fileDesc = partDesc->queryOwner();
@@ -91,7 +92,7 @@ void CDiskPartHandlerBase::setPart(IPartDescriptor *_partDesc, unsigned partNoSe
         {
             unsigned subfile;
             unsigned lnum;
-            if (superFDesc->mapSubPart(partNoSerialized, subfile, lnum))
+            if (superFDesc->mapSubPart(which, subfile, lnum))
                 logicalFilename.set(activity.queryLogicalFilename(subfile));
             else
                 logicalFilename.set("UNKNOWN"); // shouldn't happen, but will prevent query fault if did.
@@ -105,7 +106,6 @@ void CDiskPartHandlerBase::setPart(IPartDescriptor *_partDesc, unsigned partNoSe
         logicalFilename.set(activity.logicalFilename);
     eoi = false;
     firstInGroup = true;
-    which = partDesc->queryPartIndex();
 
     activity.helper->setCallback(this); // NB, if we were to have >1 of these objects, would prob. need separate helper instances also
     open();

--- a/thorlcr/activities/thdiskbaseslave.ipp
+++ b/thorlcr/activities/thdiskbaseslave.ipp
@@ -63,7 +63,7 @@ public:
     virtual const char * queryLogicalFilename(const void * row);
 
 // CPartHandler
-    virtual void setPart(IPartDescriptor *_partDesc, unsigned partNoSerialized);
+    virtual void setPart(IPartDescriptor *_partDesc);
 
     virtual offset_t getLocalOffset()=0;
 };


### PR DESCRIPTION
If a superfile was being read on a cluster that was larger than
the width of the subfiles it was composed of, the wrong subfile
names were being returned for virtual logicalfilename fields.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
