### PR TITLE
HPCC-14207 Make sure graphids returned by WUQueryDetails are unique

### DIFF
--- a/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
+++ b/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
@@ -1258,7 +1258,7 @@ unsigned CWsWorkunitsEx::getGraphIdsByQueryId(const char *target, const char *qu
         IPropertyTree &graph = graphs->query();
         const char* graphId = graph.queryProp("@id");
         if (graphId && *graphId)
-            graphIds.append(graphId);
+            graphIds.appendUniq(graphId);
     }
     return graphIds.length();
 }


### PR DESCRIPTION
Signed-off-by: Anthony Fishbeck anthony.fishbeck@lexisnexis.com
