### PR TITLE
HPCC-16206 Thor slaves need MALLOC_ARENA_MAX=8

### DIFF
--- a/initfiles/bash/etc/init.d/hpcc_common.in
+++ b/initfiles/bash/etc/init.d/hpcc_common.in
@@ -412,9 +412,6 @@ startCmd() {
     printf "Starting %-21s" "$compName ..."
     log "compType = $compType"
 
-    # use less heap when threaded
-    export MALLOC_ARENA_MAX=8
-
     # Creating logfiles for component
     logDir=$log/${compName}
 

--- a/initfiles/sbin/hpcc_setenv.in
+++ b/initfiles/sbin/hpcc_setenv.in
@@ -80,6 +80,9 @@ source /etc/profile
 IFS="${OIFS}"
 umask ${OUMASK}
 
+# use less heap when threaded
+export MALLOC_ARENA_MAX=8
+
 PATH_PREFIX=`cat ${HPCC_CONFIG} | sed -n "/\[${SECTION}\]/,/\[/p" | grep "^path *= *" | sed -e 's/^path *= *//'`
 
 export PID=`cat ${HPCC_CONFIG} | sed -n "/\[${SECTION}\]/,/\[/p" | grep "^pid *= *" | sed -e 's/^pid *= *//'`


### PR DESCRIPTION
Remote thor slaves are started via frunssh and thus did not pick up MALLOC_ARENA_MAX env var from parent.
This change moves this env var to hpcc_setenv so that it is in one place but will still get picked up because init_thorslave sources hpcc_setenv no matter if slaves are local or not.

@jakesmith, @Michael-Gardner please review

Signed-off-by: Mark Kelly mark.kelly@lexisnexis.com
