### PR TITLE
Systemd hpcc startup file perms cause kernel msgs

### DIFF
--- a/initfiles/bash/etc/init.d/CMakeLists.txt
+++ b/initfiles/bash/etc/init.d/CMakeLists.txt
@@ -34,13 +34,19 @@ FOREACH( oFILES
     ${CMAKE_CURRENT_SOURCE_DIR}/lock.sh
     ${CMAKE_CURRENT_SOURCE_DIR}/init-functions
     ${CMAKE_CURRENT_SOURCE_DIR}/export-path
+)
+    install ( PROGRAMS ${oFILES} DESTINATION etc/init.d COMPONENT Runtime )
+ENDFOREACH ( oFILES )
+
+FOREACH( sFILES
     ${CMAKE_CURRENT_BINARY_DIR}/hpcc-init.service
     ${CMAKE_CURRENT_BINARY_DIR}/hpcc-init@.service
     ${CMAKE_CURRENT_BINARY_DIR}/dafilesrv.service
     ${CMAKE_CURRENT_BINARY_DIR}/dafilesrv@.service
 )
-    install ( PROGRAMS ${oFILES} DESTINATION etc/init.d COMPONENT Runtime )
-ENDFOREACH ( oFILES )
+    install ( FILES ${sFILES} DESTINATION etc/init.d COMPONENT Runtime
+        PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ )
+ENDFOREACH ( sFILES )
 
 install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/dafilesrv ${CMAKE_CURRENT_BINARY_DIR}/hpcc-init
     DESTINATION ${CONFIG_PREFIX}/init.d COMPONENT Runtime)

--- a/initfiles/bash/etc/init.d/install-init.in
+++ b/initfiles/bash/etc/init.d/install-init.in
@@ -286,16 +286,12 @@ distrib_check
 if [ "${DISTRIB_NAME}" = "ubuntu" ] &&
    [ ${DISTRIB_MAJOR_VERSION} -ge 15 ]; then
 
-   dpkg -l | grep -q -e "^ii[[:space:]]*systemd "
+   dpkg -S /sbin/init | grep -q systemd
    if [ $? -eq 0 ]; then
       cp ${INSTALL_DIR}/etc/init.d/hpcc-init.service /lib/systemd/system/
-      chmod 644 /lib/systemd/system/hpcc-init.service
       cp ${INSTALL_DIR}/etc/init.d/hpcc-init@.service /lib/systemd/system/
-      chmod 644 /lib/systemd/system/hpcc-init@.service
       cp ${INSTALL_DIR}/etc/init.d/dafilesrv.service /lib/systemd/system/
-      chmod 644 /lib/systemd/system/dafilesrv.service
       cp ${INSTALL_DIR}/etc/init.d/dafilesrv@.service /lib/systemd/system/
-      chmod 644 /lib/systemd/system/dafilesrv@.service
       systemctl daemon-reload
    fi
 fi

--- a/initfiles/bash/etc/init.d/install-init.in
+++ b/initfiles/bash/etc/init.d/install-init.in
@@ -289,9 +289,13 @@ if [ "${DISTRIB_NAME}" = "ubuntu" ] &&
    dpkg -l | grep -q -e "^ii[[:space:]]*systemd "
    if [ $? -eq 0 ]; then
       cp ${INSTALL_DIR}/etc/init.d/hpcc-init.service /lib/systemd/system/
+      chmod 644 /lib/systemd/system/hpcc-init.service
       cp ${INSTALL_DIR}/etc/init.d/hpcc-init@.service /lib/systemd/system/
+      chmod 644 /lib/systemd/system/hpcc-init@.service
       cp ${INSTALL_DIR}/etc/init.d/dafilesrv.service /lib/systemd/system/
+      chmod 644 /lib/systemd/system/dafilesrv.service
       cp ${INSTALL_DIR}/etc/init.d/dafilesrv@.service /lib/systemd/system/
+      chmod 644 /lib/systemd/system/dafilesrv@.service
       systemctl daemon-reload
    fi
 fi


### PR DESCRIPTION
This changes permissions on /lib/systemd/system hpcc files to not have exec perms so as to not cause kernel log messages 

Previous PR review is at: https://github.com/hpcc-systems/HPCC-Platform/pull/9058

@xwang2713, @Michael-Gardner please review.
