### PR TITLE
HPCC-16132 Missing foreign subfiles cause problems to superfile ops.

### DIFF
--- a/dali/base/dadfs.hpp
+++ b/dali/base/dadfs.hpp
@@ -584,7 +584,7 @@ interface IDistributedFileDirectory: extends IInterface
     virtual IFileDescriptor *getFileDescriptor(const char *lname,IUserDescriptor *user,const INode *foreigndali=NULL, unsigned foreigndalitimeout=FOREIGN_DALI_TIMEOUT) =0;
 
     virtual IDistributedSuperFile *createSuperFile(const char *logicalname,IUserDescriptor *user,bool interleaved,bool ifdoesnotexist=false,IDistributedFileTransaction *transaction=NULL) = 0;
-    virtual IDistributedSuperFile *createNewSuperFile(IPropertyTree *tree) = 0;
+    virtual IDistributedSuperFile *createNewSuperFile(IPropertyTree *tree, const char *optionamName=nullptr) = 0;
     virtual IDistributedSuperFile *lookupSuperFile(const char *logicalname,IUserDescriptor *user,
                                                     IDistributedFileTransaction *transaction=NULL, // transaction only used for looking up sub files
                                                     unsigned timeout=INFINITE) = 0;  // NB lookup will also return superfiles


### PR DESCRIPTION
If a foreign subfile is deleted, the superfile removed the entry
(for the purposes of ignoring it) from the meta info temporarilty
whilst the superfile was in use.
Unfortunately that caused problems if the use context was
manipulating the superfile, e.g. adding/removing subfiles.

It also prevented that missing superfile being removed from the
superfile for the same reason.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
