### PR TITLE
HPCC-16254 Fix regression in child group master activity.

### DIFF
--- a/thorlcr/activities/group/thgroup.cpp
+++ b/thorlcr/activities/group/thgroup.cpp
@@ -26,12 +26,12 @@ class CGroupBaseActivityMaster : public CMasterActivity
 public:
     CGroupBaseActivityMaster(CMasterGraphElement *info) : CMasterActivity(info)
     {
+        statNumGroups.setown(new CThorStats(queryJob(), StNumGroups));
+        statNumGroupMax.setown(new CThorStats(queryJob(), StNumGroupMax));
     }
     virtual void init()
     {
         CMasterActivity::init();
-        statNumGroups.setown(new CThorStats(queryJob(), StNumGroups));
-        statNumGroupMax.setown(new CThorStats(queryJob(), StNumGroupMax));
     }
     virtual void deserializeStats(unsigned node, MemoryBuffer &mb)
     {


### PR DESCRIPTION
Regression caused by changes in HPCC-16051 caused a child group
activity in thormaster to crash during stats deserialization.

Move stats helper objects to the constructor.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
