### PR TITLE
HPCC-16250 Fix leaking JOIN LHS if LHS already sorted

### DIFF
--- a/thorlcr/activities/join/thjoinslave.cpp
+++ b/thorlcr/activities/join/thjoinslave.cpp
@@ -485,7 +485,7 @@ public:
         if (noSortPartitionSide())
         {
             partitionRow.setown(primaryInput->ungroupedNextRow());
-            primaryStream.set(new cRowStreamPlus1Adaptor(primaryInput, partitionRow));
+            primaryStream.setown(new cRowStreamPlus1Adaptor(primaryInput, partitionRow));
         }
         else
         {


### PR DESCRIPTION
This was seen to cause a thread leak in some cases.
In particular if LHS involved a splitter with a write ahead
thread, then that thread leaked.
Over time with a lot of these threads leaked it could lead to
resource problems.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
