### PR TITLE
HPCC-16248 Fix minor leak in splitter

### DIFF
--- a/thorlcr/thorutil/thbuf.cpp
+++ b/thorlcr/thorutil/thbuf.cpp
@@ -1065,14 +1065,10 @@ public:
     }
     ~CSharedWriteAheadBase()
     {
-        ForEachItemIn(o, outputs)
-        {
-            COutput &output = queryCOutput(o);
-            output.outputOwnedRows.clear();
-        }
+        // clear outputs ahead of inMemRows, because that will prevent reuse() caching inMemRows
+        outputs.kill();
         inMemRows.clear();
     }
-
 
     unsigned anyReaderBehind()
     {


### PR DESCRIPTION
Was leaking one CRowSet object.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
