### PR TITLE
HPCC-16260 Support new public parameter per DZ

### DIFF
--- a/esp/services/ws_fs/ws_fsBinding.cpp
+++ b/esp/services/ws_fs/ws_fsBinding.cpp
@@ -233,6 +233,8 @@ IPropertyTree* CFileSpraySoapBindingEx::createPTreeForXslt(const char* method, c
         Owned<IPropertyTreeIterator> it = pEnvSoftware->getElements("DropZone");
         ForEach(*it)
         {
+            if (!it->query().getPropBool("@ECLWatchVisible", true))
+                continue;
             IPropertyTree* pDropZone = pSoftware->addPropTree("DropZone", &it->get());
             //get IP Address of the computer associated with this drop zone
             const char* pszComputer = it->query().queryProp("@computer");

--- a/esp/services/ws_fs/ws_fsService.cpp
+++ b/esp/services/ws_fs/ws_fsService.cpp
@@ -3177,6 +3177,8 @@ bool CFileSprayEx::onDropZoneFiles(IEspContext &context, IEspDropZoneFilesReques
             ForEach(*it)
             {
                 IPropertyTree& pDropZone = it->query();
+                if (!pDropZone.getPropBool("@ECLWatchVisible", true))
+                    continue;
 
                 //get IP Address of the computer associated with this drop zone
                 const char* pszName = pDropZone.queryProp("@name");

--- a/esp/smc/SMCLib/TpWrapper.cpp
+++ b/esp/smc/SMCLib/TpWrapper.cpp
@@ -608,6 +608,8 @@ void CTpWrapper::getTpDropZones(IArrayOf<IConstTpDropZone>& list)
     ForEach(*services)
     {
         IPropertyTree& serviceTree = services->query();
+        if (!serviceTree.getPropBool("@ECLWatchVisible", true))
+            continue;
 
         Owned<IEspTpDropZone> pService = createTpDropZone("","");
         pService->setName(serviceTree.queryProp("@name"));


### PR DESCRIPTION
Read @ECLWatchVisible from a DropZone section of environment.xml.
If it is set to false, the dropzone will not be retrieved by
the following calls used by ECLWatch.

the calls to display spray/despray pages.
FileSpray.DropZoneFiles for uploading files.
WsTopology.TpServiceQuery for server list page.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
