### PR TITLE
HPCC-16257 SecManager should provide binding node to plugins

### DIFF
--- a/docs/HPCCSystemAdmin/SA-Mods/SecMgrMod.xml
+++ b/docs/HPCCSystemAdmin/SA-Mods/SecMgrMod.xml
@@ -31,7 +31,7 @@
 { 
     ISecManager * createInstance(const char *serviceName,
                                  IPropertyTree &amp;secMgrCfg,
-                                 IPropertyTree &amp;authCfg); 
+                                 IPropertyTree &amp;bndCfg);
 } </programlisting>
 
           <para>The framework expects to have access to the "createInstance()"

--- a/esp/bindings/http/platform/httpbinding.cpp
+++ b/esp/bindings/http/platform/httpbinding.cpp
@@ -196,7 +196,7 @@ EspHttpBinding::EspHttpBinding(IPropertyTree* tree, const char *bindname, const 
                 if (secMgrCfg)
                 {
                     //This is a Pluggable Security Manager
-                    m_secmgr.setown(SecLoader::loadPluggableSecManager(bindname, authcfg, secMgrCfg));
+                    m_secmgr.setown(SecLoader::loadPluggableSecManager(bindname, bnd_cfg, secMgrCfg));
                     m_authmap.setown(m_secmgr->createAuthMap(authcfg));
                 }
                 else

--- a/system/security/plugins/htpasswdSecurity/htpasswdSecurity.cpp
+++ b/system/security/plugins/htpasswdSecurity/htpasswdSecurity.cpp
@@ -32,20 +32,24 @@ public:
         if(pwFile.isEmpty())
             throw MakeStringException(-1, "htpasswdFile not found in configuration");
 
-        Owned<IPropertyTree> authcfg = bindConfig->getPropTree("Authenticate");
-        if(authcfg != nullptr)
         {
-            StringBuffer authxml;
-            toXML(authcfg, authxml);
-            DBGLOG("HTPASS Authenticate Config: %s", authxml.str());
+            Owned<IPropertyTree> authcfg = bindConfig->getPropTree("Authenticate");
+            if(authcfg != nullptr)
+            {
+                StringBuffer authxml;
+                toXML(authcfg, authxml);
+                DBGLOG("HTPASS Authenticate Config: %s", authxml.str());
+            }
         }
 
-        Owned<IPropertyTree> custombindingconfig = bindConfig->getPropTree("CustomBindingParameters");
-        if(custombindingconfig != nullptr)
         {
-            StringBuffer custconfigxml;
-            toXML(custombindingconfig, custconfigxml);
-            DBGLOG("HTPASS Custom Binding Config: %s", custconfigxml.str());
+            Owned<IPropertyTree> custombindingconfig = bindConfig->getPropTree("CustomBindingParameters");
+            if(custombindingconfig != nullptr)
+            {
+                StringBuffer custconfigxml;
+                toXML(custombindingconfig, custconfigxml);
+                DBGLOG("HTPASS Custom Binding Config: %s", custconfigxml.str());
+            }
         }
 
         apr_initialized = false;

--- a/system/security/plugins/htpasswdSecurity/htpasswdSecurity.cpp
+++ b/system/security/plugins/htpasswdSecurity/htpasswdSecurity.cpp
@@ -25,12 +25,29 @@
 class CHtpasswdSecurityManager : public CBaseSecurityManager
 {
 public:
-    CHtpasswdSecurityManager(const char *serviceName, IPropertyTree *secMgrCfg, IPropertyTree *authConfig) : CBaseSecurityManager(serviceName, (IPropertyTree *)NULL)
+    CHtpasswdSecurityManager(const char *serviceName, IPropertyTree *secMgrCfg, IPropertyTree *bindConfig) : CBaseSecurityManager(serviceName, (IPropertyTree *)NULL)
 	{
         if (secMgrCfg)
             pwFile.set(secMgrCfg->queryProp("@htpasswdFile"));
         if(pwFile.isEmpty())
             throw MakeStringException(-1, "htpasswdFile not found in configuration");
+
+        Owned<IPropertyTree> authcfg = bindConfig->getPropTree("Authenticate");
+        if(authcfg != nullptr)
+        {
+            StringBuffer authxml;
+            toXML(authcfg, authxml);
+            DBGLOG("HTPASS Authenticate Config: %s", authxml.str());
+        }
+
+        Owned<IPropertyTree> custombindingconfig = bindConfig->getPropTree("CustomBindingParameters");
+        if(custombindingconfig != nullptr)
+        {
+            StringBuffer custconfigxml;
+            toXML(custombindingconfig, custconfigxml);
+            DBGLOG("HTPASS Custom Binding Config: %s", custconfigxml.str());
+        }
+
         apr_initialized = false;
 	}
 
@@ -259,9 +276,9 @@ private:
 
 extern "C"
 {
-    HTPASSWDSECURITY_API ISecManager * createInstance(const char *serviceName, IPropertyTree &secMgrCfg, IPropertyTree &authCfg)
+    HTPASSWDSECURITY_API ISecManager * createInstance(const char *serviceName, IPropertyTree &secMgrCfg, IPropertyTree &bndCfg)
     {
-        return new CHtpasswdSecurityManager(serviceName, &secMgrCfg, &authCfg);
+        return new CHtpasswdSecurityManager(serviceName, &secMgrCfg, &bndCfg);
     }
 
 }

--- a/system/security/plugins/htpasswdSecurity/htpasswdSecurity.hpp
+++ b/system/security/plugins/htpasswdSecurity/htpasswdSecurity.hpp
@@ -34,7 +34,7 @@
 
 extern "C" 
 {
-    HTPASSWDSECURITY_API ISecManager * createInstance(const char *serviceName, IPropertyTree &secMgrCfg, IPropertyTree &authCfg);
+    HTPASSWDSECURITY_API ISecManager * createInstance(const char *serviceName, IPropertyTree &secMgrCfg, IPropertyTree &bndCfg);
 }
 
 #endif // HTPASSWDSECURITY_HPP_

--- a/system/security/shared/secloader.hpp
+++ b/system/security/shared/secloader.hpp
@@ -35,12 +35,12 @@ public:
     /// for the given ESP service
     ///
     /// @param  bindingName     Binding name ie 'WsTopology_smc_myesp'
-    /// @param  bnd_cfg         'Binding' IPropertyTree associated with ESPService
+    /// @param  bindingCfg      'Binding' IPropertyTree associated with ESPService
     /// @param  secMgrCfg       'SecurityManager' IPropertyTree from component config file
     ///
     /// @return an ISecManager Security Manager instance
     ///
-    static ISecManager* loadPluggableSecManager(const char * bindingName, IPropertyTree* bnd_cfg, IPropertyTree* secMgrCfg)
+    static ISecManager* loadPluggableSecManager(const char * bindingName, IPropertyTree* bindingCfg, IPropertyTree* secMgrCfg)
     {
         const char * lsm = "Load Security Manager :";
 
@@ -67,7 +67,7 @@ public:
 
         //Call ISecManager instance factory and return the new instance
         DBGLOG("Calling '%s' in pluggable security manager '%s'", instFactory.str(), libName.str());
-        return xproc(bindingName, *secMgrCfg, *bnd_cfg);
+        return xproc(bindingName, *secMgrCfg, *bindingCfg);
     }
 
     static ISecManager* loadSecManager(const char* model_name, const char* servicename, IPropertyTree* cfg)

--- a/system/security/shared/secloader.hpp
+++ b/system/security/shared/secloader.hpp
@@ -35,12 +35,12 @@ public:
     /// for the given ESP service
     ///
     /// @param  bindingName     Binding name ie 'WsTopology_smc_myesp'
-    /// @param  authCfg         'Authenticate' IPropertyTree from EspService component binding
+    /// @param  bnd_cfg         'Binding' IPropertyTree associated with ESPService
     /// @param  secMgrCfg       'SecurityManager' IPropertyTree from component config file
     ///
     /// @return an ISecManager Security Manager instance
     ///
-    static ISecManager* loadPluggableSecManager(const char * bindingName, IPropertyTree* authCfg, IPropertyTree* secMgrCfg)
+    static ISecManager* loadPluggableSecManager(const char * bindingName, IPropertyTree* bnd_cfg, IPropertyTree* secMgrCfg)
     {
         const char * lsm = "Load Security Manager :";
 
@@ -67,7 +67,7 @@ public:
 
         //Call ISecManager instance factory and return the new instance
         DBGLOG("Calling '%s' in pluggable security manager '%s'", instFactory.str(), libName.str());
-        return xproc(bindingName, *secMgrCfg, *authCfg);
+        return xproc(bindingName, *secMgrCfg, *bnd_cfg);
     }
 
     static ISecManager* loadSecManager(const char* model_name, const char* servicename, IPropertyTree* cfg)


### PR DESCRIPTION
- Provide binding subtree to plugins
- Rename parameter to reflect new tree content
- Add sample use in HTPass plugin (template security plugin)

Signed-off-by: rpastrana rodrigo.pastrana@lexisnexis.com
