### PR TITLE
HPCC-15541 ESDL Publish binding usage update

### DIFF
--- a/tools/esdlcmd/esdl-publish.cpp
+++ b/tools/esdlcmd/esdl-publish.cpp
@@ -160,7 +160,7 @@ public:
     void usage()
     {
         printf("\nUsage:\n\n"
-                "esdl publish <servicename> <filename.(ecm|esdl)> [command options]\n\n"
+                "esdl publish <servicename> <filename.(ecm|esdl|xml)> [command options]\n\n"
                 "   <servicename>               The ESDL defined ESP service to publish\n"
                 "   <filename.(ecm|esdl|xml)>   The ESDL file containing service definition in esdl format (.ecm |.esdl) or in esxdl format (.xml) \n"
                 "Options (use option flag followed by appropriate value):\n"
@@ -178,7 +178,7 @@ public:
            return false;
        }
 
-       //First x parameter's order is fixed.
+       //First 2 parameter's order is fixed.
        //<servicename>
        //<filename.(ecm|esdl|xml)>       The ESDL file containing service definition\n"
        for (int cur = 0; cur < 2 && !iter.done(); cur++)
@@ -234,7 +234,7 @@ public:
         }
 
         if (optSource.isEmpty())
-            throw MakeStringException( 0, "Source ESDL XML definition file must be provided" );
+            throw MakeStringException( 0, "Source ESDL definition file (ecm|esdl|xml) must be provided" );
 
         if (optESDLService.isEmpty())
             throw MakeStringException( 0, "Name of ESDL based service must be provided" );


### PR DESCRIPTION
- ESDL publish binding usage should convey that it accepts ECM/ESDL or EXSDL

Signed-off-by: rpastrana rodrigo.pastrana@lexisnexis.com
