### PR TITLE
HPCC-16105 Fileservices checkExternalFileRights() incorrect check

### DIFF
--- a/plugins/fileservices/fileservices.cpp
+++ b/plugins/fileservices/fileservices.cpp
@@ -2147,22 +2147,21 @@ FILESERVICES_API char *  FILESERVICES_CALL fsfResolveHostName(const char *hostna
 
 static void checkExternalFileRights(ICodeContext *ctx, CDfsLogicalFileName &lfn, bool rd,bool wr)
 {
-    StringAttr extpath(lfn.get());
     Linked<IUserDescriptor> udesc = ctx->queryUserDescriptor();
     unsigned auditflags = 0;
     if (rd)
         auditflags |= (DALI_LDAP_AUDIT_REPORT|DALI_LDAP_READ_WANTED);
     if (wr)
         auditflags |= (DALI_LDAP_AUDIT_REPORT|DALI_LDAP_WRITE_WANTED);
-    int perm = queryDistributedFileDirectory().getFilePermissions(extpath.get(),udesc,auditflags);
+    int perm = queryDistributedFileDirectory().getFilePermissions(lfn.get(),udesc,auditflags);
     if (wr) {
         if (!HASWRITEPERMISSION(perm)) {
-            throw MakeStringException(-1,"Write permission denied for %s",extpath.get());
+            throw MakeStringException(-1,"Write permission denied for %s", lfn.get());
         }
     }
     if (rd) {
         if (!HASREADPERMISSION(perm)) {
-            throw MakeStringException(-1,"Read permission denied for %s",extpath.get());
+            throw MakeStringException(-1,"Read permission denied for %s", lfn.get());
         }
     }
 }

--- a/plugins/fileservices/fileservices.cpp
+++ b/plugins/fileservices/fileservices.cpp
@@ -2147,7 +2147,7 @@ FILESERVICES_API char *  FILESERVICES_CALL fsfResolveHostName(const char *hostna
 
 static void checkExternalFileRights(ICodeContext *ctx, CDfsLogicalFileName &lfn, bool rd,bool wr)
 {
-    StringAttr extpath;
+    StringAttr extpath(lfn.get());
     Linked<IUserDescriptor> udesc = ctx->queryUserDescriptor();
     unsigned auditflags = 0;
     if (rd)
@@ -2160,13 +2160,12 @@ static void checkExternalFileRights(ICodeContext *ctx, CDfsLogicalFileName &lfn,
             throw MakeStringException(-1,"Write permission denied for %s",extpath.get());
         }
     }
-    else if (rd) {
+    if (rd) {
         if (!HASREADPERMISSION(perm)) {
             throw MakeStringException(-1,"Read permission denied for %s",extpath.get());
         }
     }
 }
-
 
 FILESERVICES_API void  FILESERVICES_CALL fsMoveExternalFile(ICodeContext * ctx,const char *location,const char *frompath,const char *topath)
 {


### PR DESCRIPTION
In fileservices.cpp, method checkExternalFileRights accepts 2 flags indicating
it should test for read, and one for write. The "if" statement presumes that
only one of these can be true. Additionally, the "extpath" variable is never
set, so the code never checks the specified file. This PR sets the path
variable correctly, and checks for both read and write perms independently.

Signed-off-by: Russ Whitehead william.whitehead@lexisnexis.com
