### PR TITLE
HPCC-14499 Allow WsECL VIP DNS cache timeout to be configurable

### DIFF
--- a/esp/services/ws_ecl/ws_ecl_service.cpp
+++ b/esp/services/ws_ecl/ws_ecl_service.cpp
@@ -254,6 +254,7 @@ bool CWsEclService::init(const char * name, const char * type, IPropertyTree * c
             continue;
         const char *vip = NULL;
         bool includeTargetInURL = true;
+        unsigned dnsInterval = (unsigned) -1;
         if (vips)
         {
             IPropertyTree *pc = vips->queryPropTree(xpath.clear().appendf("ProcessCluster[@name='%s']", process.str()));
@@ -261,6 +262,7 @@ bool CWsEclService::init(const char * name, const char * type, IPropertyTree * c
             {
                 vip = pc->queryProp("@vip");
                 includeTargetInURL = pc->getPropBool("@includeTargetInURL", true);
+                dnsInterval = (unsigned) pc->getPropInt("@dnsInterval", -1);
 
             }
         }
@@ -285,7 +287,7 @@ bool CWsEclService::init(const char * name, const char * type, IPropertyTree * c
         if (list.length())
         {
             StringAttr alias(clusterInfo->getAlias());
-            Owned<ISmartSocketFactory> sf = new RoxieSocketFactory(list.str(), !loadBalanced, includeTargetInURL, loadBalanced ? alias.str() : NULL);
+            Owned<ISmartSocketFactory> sf = new RoxieSocketFactory(list.str(), !loadBalanced, includeTargetInURL, loadBalanced ? alias.str() : NULL, dnsInterval);
             connMap.setValue(target.str(), sf.get());
             if (alias.length() && !connMap.getValue(alias.str())) //only need one vip per alias for routing purposes
                 connMap.setValue(alias.str(), sf.get());

--- a/esp/services/ws_ecl/ws_ecl_service.hpp
+++ b/esp/services/ws_ecl/ws_ecl_service.hpp
@@ -93,7 +93,7 @@ public:
     bool includeTargetInURL;
     StringAttr alias;
 
-    RoxieSocketFactory(const char *_socklist, bool _retry, bool includeTarget, const char *_alias) : CSmartSocketFactory(_socklist, _retry), includeTargetInURL(includeTarget), alias(_alias)
+    RoxieSocketFactory(const char *_socklist, bool _retry, bool includeTarget, const char *_alias, unsigned _dnsInterval) : CSmartSocketFactory(_socklist, _retry, 60, _dnsInterval), includeTargetInURL(includeTarget), alias(_alias)
     {
     }
 };

--- a/initfiles/componentfiles/configxml/@temp/esp_service.xsl
+++ b/initfiles/componentfiles/configxml/@temp/esp_service.xsl
@@ -912,7 +912,13 @@ xmlns:seisint="http://seisint.com"  xmlns:set="http://exslt.org/sets" exclude-re
                                     <xsl:otherwise>true</xsl:otherwise>
                                 </xsl:choose>
                             </xsl:variable>
-                            <ProcessCluster name="{$roxie}" vip="{$vip}" includeTargetInURL="{$sendTarget}"></ProcessCluster>
+                            <xsl:variable name="dnsInterval">
+                              <xsl:choose>
+                                <xsl:when test="@dnsInterval and @dnsInterval!=''"><xsl:value-of select="@dnsInterval"/></xsl:when>
+                                <xsl:otherwise>-1</xsl:otherwise>
+                              </xsl:choose>
+                            </xsl:variable>
+                            <ProcessCluster name="{$roxie}" vip="{$vip}" includeTargetInURL="{$sendTarget}" dnsInterval="{$dnsInterval}"></ProcessCluster>
                         </xsl:if>
                     </xsl:for-each>
                 </VIPS>

--- a/initfiles/componentfiles/configxml/esp_service_wsecl2.xsd
+++ b/initfiles/componentfiles/configxml/esp_service_wsecl2.xsd
@@ -58,12 +58,21 @@
                       </xs:appinfo>
                     </xs:annotation>
                   </xs:attribute>
+                  <xs:attribute name="dnsInterval" type="xs:integer" use="optional" default="-1">
+                      <xs:annotation>
+                          <xs:appinfo>
+                              <tooltip>DNS lookup cache timeout in seconds. Set to 0 to resolve DNS for every transaction.  Set to -1 (default) to keep DNS lookup cached indefinitely.</tooltip>
+                              <title>DNS Cache timeout interval</title>
+                              <colIndex>3</colIndex>
+                          </xs:appinfo>
+                      </xs:annotation>
+                  </xs:attribute>
                   <xs:attribute name="sendTargetToRoxie" use="optional" default="true">
                       <xs:annotation>
                           <xs:appinfo>
                               <tooltip>Send roxie the target from which to run query (disable for backward compatibility issues)</tooltip>
                               <title>Send Target To Roxie</title>
-                              <colIndex>3</colIndex>
+                              <colIndex>4</colIndex>
                           </xs:appinfo>
                       </xs:annotation>
                       <xs:simpleType>


### PR DESCRIPTION
The DNS cache timeout interval will now be configurable for WsECL VIPS. You can set it to 0 to mean resolve the DNS everytime, -1 to mean keep cached indefinitely, or the number of seconds to keep the DNS resolution cached.

From environment.xml, see dnsInterval attribute:

`<EspService build="_"
              buildSet="ws_ecl"
              description="WS ECL Service"
              name="myws_ecl"
              roxieTimeout="300"
              workunitTimeout="600">
   <ProcessCluster name="ProcessCluster"
                   roxie="myroxie"
                   sendTargetToRoxie="true"
                   dnsInterval="77"
`vip="localhost"/>
`

Signed-off-by: Anthony Fishbeck anthony.fishbeck@lexisnexis.com
