### PR TITLE
HPCC-16147 Fix keyedjoin skip bug.

### DIFF
--- a/thorlcr/activities/keyedjoin/thkeyedjoinslave.cpp
+++ b/thorlcr/activities/keyedjoin/thkeyedjoinslave.cpp
@@ -2182,22 +2182,26 @@ public:
                         {
                             case TAKkeyedjoin:
                             {
-                                if (currentMatchIdx < currentMatched)
+                                row.ensureRow();
+                                loop
                                 {
+                                    if (currentMatchIdx >= currentMatched)
+                                    {
+                                        djg.clear();
+                                        break;
+                                    }
                                     offset_t fpos;
                                     const void *rhs = djg->queryRow(currentMatchIdx, fpos);
-                                    row.ensureRow();
-                                    transformedSize = helper->transform(row, djg->queryLeft(), rhs, fpos, currentMatchIdx+1);
+                                    currentMatchIdx++;
+                                    transformedSize = helper->transform(row, djg->queryLeft(), rhs, fpos, currentMatchIdx);
                                     if (transformedSize)
                                     {
                                         currentAdded++;
                                         if (currentAdded==keepLimit)
                                             djg.clear();
+                                        break;
                                     }
-                                    currentMatchIdx++;
                                 }
-                                else
-                                    djg.clear();
                                 break;
                             }
                             case TAKkeyeddenormalize:


### PR DESCRIPTION
A SKIP in a keyed join transform would skip all RHS matches in
the right group.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
