### PR TITLE
HPCC-16072 retain metadata (atleast the owner) during file copy

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -70,8 +70,8 @@
 
 class CDistributedFile;
 
-enum MDFSRequestKind 
-{ 
+enum MDFSRequestKind
+{
     MDFS_ITERATE_FILES,
     MDFS_UNUSED1,
     MDFS_GET_FILE_TREE,
@@ -91,7 +91,7 @@ static CriticalSection physicalChange;
 
 static int strcompare(const void * left, const void * right)
 {
-    const char * l = (const char *)left; 
+    const char * l = (const char *)left;
     const char * r = (const char *)right;
     return stricmp(l,r);
 }
@@ -111,7 +111,7 @@ inline unsigned groupDistance(IGroup *grp1,IGroup *grp2)
         return (unsigned)-1;
     return grp1->distance(grp2);
 }
-    
+
 
 static StringBuffer &normalizeFormat(StringBuffer &in)
 {
@@ -119,9 +119,9 @@ static StringBuffer &normalizeFormat(StringBuffer &in)
     for (unsigned i = 0;i<in.length();)
     {
         switch (in.charAt(i)) {
-        case '-': 
-        case '_': 
-        case ' ': 
+        case '-':
+        case '_':
+        case ' ':
             in.remove(i,1);
             break;
         default:
@@ -151,7 +151,7 @@ static IPropertyTree *getNamedPropTree(IPropertyTree *parent,const char *sub,con
 }
 
 static IPropertyTree *addNamedPropTree(IPropertyTree *parent,const char *sub,const char *key,const char *name, IPropertyTree* init=NULL)
-{  
+{
     IPropertyTree* ret = init?createPTreeFromIPT(init):createPTree(sub);
     assertex(key[0]=='@');
     ret->setProp(key,name);
@@ -160,7 +160,7 @@ static IPropertyTree *addNamedPropTree(IPropertyTree *parent,const char *sub,con
 }
 
 const char *normalizeLFN(const char *s,StringBuffer &tmp)
-{ 
+{
     CDfsLogicalFileName dlfn;
     dlfn.set(s);
     return dlfn.get(tmp).str();
@@ -183,13 +183,13 @@ RemoteFilename &constructPartFilename(IGroup *grp,unsigned partno,unsigned partm
         name = expandMask(tmp,partmask,partno,partmax).str();
     }
     StringBuffer fullname;
-    if (findPathSepChar(name)==NULL) 
+    if (findPathSepChar(name)==NULL)
         addPathSepChar(fullname.append(partdir));
     fullname.append(name);
     unsigned n;
     unsigned d;
     mspec.calcPartLocation(partno,partmax,copy,grp?grp->ordinality():partmax,n,d);
-    setReplicateFilename(fullname,d);  
+    setReplicateFilename(fullname,d);
     SocketEndpoint ep;
     if (grp)
         ep=grp->queryNode(n).endpoint();
@@ -232,37 +232,37 @@ public:
 
     int             errorCode() const { return errcode; }
     StringBuffer &  errorMessage(StringBuffer &str) const
-    { 
+    {
         if (errcode==DFSERR_ok)
             return str;
         str.append("DFS Exception: ").append(errcode);
         switch(errcode) {
-        case DFSERR_LogicalNameAlreadyExists: 
+        case DFSERR_LogicalNameAlreadyExists:
             return str.append(": logical name ").append(errstr).append(" already exists");
         case DFSERR_CannotFindPartFileSize:
             return str.append(": Cannot find physical file size for ").append(errstr);
         case DFSERR_CannotFindPartFileCrc:
             return str.append(": Cannot find physical file crc for ").append(errstr);
-        case DFSERR_LookupAccessDenied: 
+        case DFSERR_LookupAccessDenied:
             return str.append(" Lookup access denied for scope ").append(errstr);
-        case DFSERR_CreateAccessDenied: 
+        case DFSERR_CreateAccessDenied:
             return str.append(" Create access denied for scope ").append(errstr);
-        case DFSERR_PhysicalPartAlreadyExists: 
+        case DFSERR_PhysicalPartAlreadyExists:
             return str.append(": physical part ").append(errstr).append(" already exists");
-        case DFSERR_PhysicalPartDoesntExist: 
+        case DFSERR_PhysicalPartDoesntExist:
             return str.append(": physical part ").append(errstr).append(" doesnt exist");
-        case DFSERR_ForeignDaliTimeout: 
+        case DFSERR_ForeignDaliTimeout:
             return str.append(": Timeout connecting to Dali Server on ").append(errstr);
-        case DFSERR_ClusterNotFound: 
+        case DFSERR_ClusterNotFound:
             return str.append(": Cluster not found: ").append(errstr);
-        case DFSERR_ClusterAlreadyExists: 
+        case DFSERR_ClusterAlreadyExists:
             return str.append(": Cluster already exists: ").append(errstr);
-        case DFSERR_LookupConnectionTimout: 
+        case DFSERR_LookupConnectionTimout:
             return str.append(": Lookup connection timeout: ").append(errstr);
         case DFSERR_FailedToDeleteFile:
             return str.append(": Failed to delete file: ").append(errstr);
         }
-        return str.append("Unknown DFS Exception"); 
+        return str.append("Unknown DFS Exception");
     }
     MessageAudience errorAudience() const { return MSGAUD_user; }
 
@@ -361,7 +361,7 @@ void ensureFileScope(const CDfsLogicalFileName &dlfn,unsigned timeout)
         IPropertyTree *nr;
         const char *e = strstr(s,"::");
         query.clear();
-        if (e) 
+        if (e)
             query.append(e-s,s);
         else
             query.append(s);
@@ -369,7 +369,7 @@ void ensureFileScope(const CDfsLogicalFileName &dlfn,unsigned timeout)
         if (!nr)
             nr = addNamedPropTree(r,queryDfsXmlBranchName(DXB_Scope),"@name",query.str());
         r->Release();
-        if (!e) { 
+        if (!e) {
             ::Release(nr);
             break;
         }
@@ -397,20 +397,20 @@ void removeFileEmptyScope(const CDfsLogicalFileName &dlfn,unsigned timeout)
                 query.set(head);
                 pt = root->queryPropTree(query.str());
             }
-            else 
+            else
                 pt = root;
             IPropertyTree *t = pt?pt->queryPropTree(tail):NULL;
             if (t) {
-                if (t->hasChildren()) 
+                if (t->hasChildren())
                     break;
-                pt->removeTree(t);  
+                pt->removeTree(t);
                 if (root==pt)
                     break;
             }
             else
                 break;
         }
-        else 
+        else
             break;
     }
 }
@@ -754,7 +754,7 @@ static void foreignDaliSendRecv(const INode *foreigndali,CMessageBuffer &mb, uns
     if (ep.port==0)
         ep.port = DALI_SERVER_PORT;
     Owned<IGroup> grp = createIGroup(1,&ep);
-    Owned<ICommunicator> comm = createCommunicator(grp,true); 
+    Owned<ICommunicator> comm = createCommunicator(grp,true);
     if (!comm->verifyConnection(0,foreigndalitimeout)) {
         StringBuffer tmp;
         IDFS_Exception *e = new CDFS_Exception(DFSERR_ForeignDaliTimeout, foreigndali->endpoint().getUrlStr(tmp).str());
@@ -851,7 +851,7 @@ public:
 
     ClusterPartDiskMapSpec &queryPartDiskMapping(unsigned clusternum)
     {
-        if (clusternum>=ordinality()||(singleclusteroverride&&clusternum)) 
+        if (clusternum>=ordinality()||(singleclusteroverride&&clusternum))
             return defaultmapping;
         return item(clusternum).queryPartDiskMapping();
     }
@@ -901,7 +901,7 @@ public:
             // sort by closest to this node
             const IpAddress &myip = queryMyNode()->endpoint();
             unsigned *d=new unsigned[nc];
-            for (i=0;i<nc;i++) 
+            for (i=0;i<nc;i++)
                 d[i] = ipGroupDistance(myip,item(i).queryGroup());
             // bubble sort it - only a few
             for (i=0;i+1<nc;i++)
@@ -921,7 +921,7 @@ public:
         StringBuffer name2;
         ForEachItemIn(ci,clustlist) {
             const char *cls = clustlist.item(ci);
-            Owned<IGroup> grp = queryNamedGroupStore().lookup(cls); 
+            Owned<IGroup> grp = queryNamedGroupStore().lookup(cls);
             if (!grp) {
                 ERRLOG("IDistributedFile::setPreferred - cannot find cluster %s",cls);
                 return;
@@ -930,10 +930,10 @@ public:
                 firstgrp.set(grp);
             for (i=done;i<nc;i++) {
                 IClusterInfo &info=item(i);
-                if (stricmp(info.getClusterLabel(name2.clear()).str(),name.str())==0) 
+                if (stricmp(info.getClusterLabel(name2.clear()).str(),name.str())==0)
                     break;
                 IGroup *grp2 = info.queryGroup();
-                if (grp2&&(grp->compare(grp2)!=GRdisjoint)) 
+                if (grp2&&(grp->compare(grp2)!=GRdisjoint))
                     break;
             }
             if (i<nc) {
@@ -961,7 +961,7 @@ public:
                         swap(j,j+1);
                     }
             delete [] d;
-        }       
+        }
     }
 
     void setSingleClusterOnly(bool set=true)
@@ -1016,7 +1016,7 @@ class CDistributedFileDirectory: implements IDistributedFileDirectory, public CI
 {
     Owned<IUserDescriptor> defaultudesc;
     Owned<IDFSredirection> redirection;
-    
+
     void resolveForeignFiles(IPropertyTree *tree,const INode *foreigndali);
 
 protected: friend class CDistributedFile;
@@ -1118,9 +1118,9 @@ public:
 
     bool publishMetaFileXML(const CDfsLogicalFileName &logicalname,IUserDescriptor *user);
     IFileDescriptor *createDescriptorFromMetaFile(const CDfsLogicalFileName &logicalname,IUserDescriptor *user);
-    
+
     bool isProtectedFile(const CDfsLogicalFileName &logicalname, unsigned timeout) ;
-    unsigned queryProtectedCount(const CDfsLogicalFileName &logicalname, const char *owner);                    
+    unsigned queryProtectedCount(const CDfsLogicalFileName &logicalname, const char *owner);
     bool getProtectedInfo(const CDfsLogicalFileName &logicalname, StringArray &names, UnsignedArray &counts);
     IDFProtectedIterator *lookupProtectedFiles(const char *owner=NULL,bool notsuper=false,bool superonly=false);
     IDFAttributesIterator* getLogicalFilesSorted(IUserDescriptor* udesc, DFUQResultField *sortOrder, const void *filterBuf, DFUQResultField *specialFilters,
@@ -1244,7 +1244,7 @@ static void setUserDescriptor(Linked<IUserDescriptor> &udesc,IUserDescriptor *us
 static SecAccessFlags getScopePermissions(const char *scopename,IUserDescriptor *user,unsigned auditflags)
 {  // scope must be normalized already
     static bool permissionsavail=true;
-    if (auditflags==(unsigned)-1) 
+    if (auditflags==(unsigned)-1)
         return permissionsavail ? SecAccess_Access : SecAccess_None;
     SecAccessFlags perms = SecAccess_Full;
     if (permissionsavail&&scopename&&*scopename&&((*scopename!='.')||scopename[1])) {
@@ -1263,7 +1263,7 @@ static SecAccessFlags getScopePermissions(const char *scopename,IUserDescriptor 
                 permissionsavail=false;
                 perms = SecAccess_Full;
             }
-            else 
+            else
                 perms = SecAccess_None;
         }
     }
@@ -1290,11 +1290,11 @@ static void checkLogicalScope(const char *scopename,IUserDescriptor *user,bool r
 
     SecAccessFlags perm = getScopePermissions(scopename,user,auditflags);
     IDFS_Exception *e = NULL;
-    if (readreq&&!HASREADPERMISSION(perm)) 
+    if (readreq&&!HASREADPERMISSION(perm))
         e = new CDFS_Exception(DFSERR_LookupAccessDenied,scopename);
-    else if (createreq&&!HASWRITEPERMISSION(perm)) 
+    else if (createreq&&!HASWRITEPERMISSION(perm))
         e = new CDFS_Exception(DFSERR_CreateAccessDenied,scopename);
-    if (e) 
+    if (e)
         throw e;
 }
 
@@ -1312,13 +1312,13 @@ static bool checkLogicalName(CDfsLogicalFileName &dlfn,IUserDescriptor *user,boo
     }
     else {
         if (specialnotallowedmsg) {
-            if (dlfn.isExternal()) { 
+            if (dlfn.isExternal()) {
                 if (dlfn.isQuery()&&allowquery)
                     ret = false;
                 else
                     throw MakeStringException(-1,"cannot %s an external file name (%s)",specialnotallowedmsg,dlfn.get());
             }
-            if (dlfn.isForeign()) { 
+            if (dlfn.isForeign()) {
                 throw MakeStringException(-1,"cannot %s a foreign file name (%s)",specialnotallowedmsg,dlfn.get());
             }
         }
@@ -1604,7 +1604,7 @@ public:
                 else
                     retryActions();
                 PROGLOG("CDistributedFileTransaction: Transaction pausing");
-                Sleep(SDS_TRANSACTION_RETRY/2+(getRandom()%SDS_TRANSACTION_RETRY)); 
+                Sleep(SDS_TRANSACTION_RETRY/2+(getRandom()%SDS_TRANSACTION_RETRY));
             }
             runActions();
             commitAndClearup();
@@ -1898,7 +1898,7 @@ class CDFScopeIterator: implements IDFScopeIterator, public CInterface
 public:
     IMPLEMENT_IINTERFACE;
 
-    CDFScopeIterator(IDistributedFileDirectory *_dir,const char *base,bool recursive, bool _includeempty,unsigned timeout) // attrib not yet implemented 
+    CDFScopeIterator(IDistributedFileDirectory *_dir,const char *base,bool recursive, bool _includeempty,unsigned timeout) // attrib not yet implemented
     {
         includeempty = _includeempty;
         dir = _dir;
@@ -1911,7 +1911,7 @@ public:
         }
         {
             CConnectLock connlock("CDFScopeIterator",querySdsFilesRoot(),false,false,false,timeout);
-            // could use CScopeConnectLock here probably 
+            // could use CScopeConnectLock here probably
             StringBuffer name;
             IPropertyTree *root = connlock.conn->queryRoot();
             if (baseq.length())
@@ -1923,14 +1923,14 @@ public:
             qsortvec(scopes.getArray(),scopes.ordinality(),strcompare);
         index = 0;
     }
-    
+
     ~CDFScopeIterator()
     {
         ForEachItemIn(i,scopes) {
             free(scopes.item(i));
         }
     }
-    
+
 
     bool first()
     {
@@ -1943,14 +1943,14 @@ public:
         index++;
         return isValid();
     }
-                            
+
     bool isValid()
     {
         return (index<scopes.ordinality());
     }
 
     const char *query()
-    {   
+    {
         return (const char *)scopes.item(index);
     }
 };
@@ -2181,7 +2181,7 @@ public:
     {
         clear();
         conn.setown(querySDS().connect("Files",myProcessSession(),0, defaultTimeout));
-        if (!conn) 
+        if (!conn)
             return false;
         IPropertyTree *t = conn->queryRoot();
         if (!superonly) {
@@ -2246,7 +2246,7 @@ public:
         clear();
         return false;
     }
-                            
+
     bool isValid()
     {
         return fiter.get()!=NULL;
@@ -2283,7 +2283,7 @@ class CDistributedFilePart: public CInterface, implements IDistributedFilePart
     Owned<IPropertyTree> attr;
     CriticalSection sect;
     StringAttr overridename;    // may or not be relative to directory
-    bool            dirty;      // whether needs updating in tree 
+    bool            dirty;      // whether needs updating in tree
 
     offset_t getSize(bool checkCompressed);
 
@@ -2301,19 +2301,19 @@ public:
     offset_t getFileSize(bool allowphysical,bool forcephysical);
     offset_t getDiskSize(bool allowphysical,bool forcephysical);
     bool getModifiedTime(bool allowphysical,bool forcephysical,CDateTime &dt);
-    bool getCrc(unsigned &crc); 
-    unsigned getPhysicalCrc();  
+    bool getCrc(unsigned &crc);
+    unsigned getPhysicalCrc();
     IPartDescriptor *getPartDescriptor();
     unsigned numCopies();
     INode *queryNode(unsigned copy);
     unsigned queryDrive(unsigned copy);
-    StringBuffer &getPartName(StringBuffer &name);                          
+    StringBuffer &getPartName(StringBuffer &name);
     StringBuffer &getPartDirectory(StringBuffer &name,unsigned copy);
-    const char *queryOverrideName() { return overridename; }    
-    void clearOverrideName() 
+    const char *queryOverrideName() { return overridename; }
+    void clearOverrideName()
     {
         if (overridename.get()&&overridename.length()) {
-            dirty = true; 
+            dirty = true;
             overridename.clear();
         }
     }
@@ -2321,19 +2321,19 @@ public:
     unsigned bestCopyNum(const IpAddress &ip,unsigned rel=0);
     unsigned copyClusterNum(unsigned copy,unsigned *replicate=NULL);
 
-    void childLink(void)        { CInterface::Link(); }                     
+    void childLink(void)        { CInterface::Link(); }
     bool childRelease(void)     { return CInterface::Release(); }
 
     CDistributedFilePart(CDistributedFile &_parent,unsigned _part,IPartDescriptor *pd);
 
-    unsigned getPartIndex() 
-    { 
-        return partIndex; 
+    unsigned getPartIndex()
+    {
+        return partIndex;
     }
 
     INode *getNode(unsigned copy)
     {
-        INode *ret = queryNode(copy); 
+        INode *ret = queryNode(copy);
         if (ret)
             return LINK(ret);
         return NULL;
@@ -2359,7 +2359,7 @@ public:
     {
         return dirty;
     }
-    
+
     inline bool clearDirty()
     {
         bool ret=dirty;
@@ -2376,7 +2376,7 @@ public:
     virtual ~CDistributedFilePartArray()    // this shouldn't be needed - points to problem in CIArrayOf?
     {
         kill();
-    }   
+    }
     void kill(bool nodel = false)
     {
         if (nodel)
@@ -2387,7 +2387,7 @@ public:
                 part.Release();
             }
         }
-    }   
+    }
 };
 
 // --------------------------------------------------------
@@ -2582,7 +2582,7 @@ public:
 
 //-----------------------------------------------------------------------------
 
-inline void dfCheckRoot(const char *trc,Owned<IPropertyTree> &root,IRemoteConnection *conn) 
+inline void dfCheckRoot(const char *trc,Owned<IPropertyTree> &root,IRemoteConnection *conn)
 {
     if (root.get()!=conn->queryRoot()) {
         WARNLOG("%s - root changed",trc);
@@ -2602,7 +2602,7 @@ static bool setFileProtectTree(IPropertyTree &p,const char *owner, bool protect)
         Owned<IPropertyTree> t = getNamedPropTree(&p,"Protect","@name",owner,false);
         if (t) {
             unsigned c = t->getPropInt("@count");
-            if (protect) 
+            if (protect)
                 c++;
             else {
                 if (c>=1) {
@@ -2668,7 +2668,7 @@ template <class INTERFACE>
 class CDistributedFileBase : implements INTERFACE, public CInterface
 {
 protected:
-    Owned<IPropertyTree> root;    
+    Owned<IPropertyTree> root;
     Owned<IRemoteConnection> conn;                  // kept connected during lifetime for attributes
     CDfsLogicalFileName logicalName;
     CriticalSection sect;
@@ -2736,6 +2736,20 @@ public:
         if (!t)
             t = root->setPropTree("Attr",createPTree("Attr")); // takes ownership
         return *t;
+    }
+
+    IPropertyTree &queryHistory()
+    {
+        IPropertyTree *t = root->queryPropTree("History");
+        if (!t)
+            t = root->setPropTree("History",createPTree("History")); // takes ownership
+        return *t;
+    }
+
+    void eraseHistory()
+    {
+        DistributedFilePropertyLock lock(this);
+        root->setPropTree("History",createPTree("History"));
     }
 
 protected:
@@ -2966,7 +2980,7 @@ public:
                     conn->commit();
                 dfCheckRoot("setProtect.1",root,conn);
             }
-            else 
+            else
                 ERRLOG("setProtect - cannot protect %s (no connection in file)",owner?owner:"");
         }
     }
@@ -3073,11 +3087,11 @@ public:
             else if (!t && link)
                 t.setown(addNamedPropTree(root,"SuperOwner","@name",superfile));
         }
-        else 
+        else
             ERRLOG("linkSuperOwner - cannot link to %s (no connection in file)",superfile);
     }
 
-    void setAccessed()                              
+    void setAccessed()
     {
         CDateTime dt;
         dt.setNow();
@@ -3093,7 +3107,7 @@ public:
     virtual void setColumnMapping(const char *mapping)
     {
         DistributedFilePropertyLock lock(this);
-        if (!mapping||!*mapping) 
+        if (!mapping||!*mapping)
             queryAttributes().removeProp("@columnMapping");
         else
             queryAttributes().setProp("@columnMapping",mapping);
@@ -3598,7 +3612,7 @@ public:
         clusters.clear();
         getClusterInfo(*t,&queryNamedGroupStore(),0,clusters);
     }
-    
+
     void saveClusters()
     {
         // called from CClustersLockedSection
@@ -3635,7 +3649,7 @@ public:
                 else
                     WARNLOG("CFileClusterOwner::saveClusters - empty cluster");
             }
-            if (grplist.length()) 
+            if (grplist.length())
                 t->setProp("@group",grplist.str());
             else
                 t->removeProp("@group");
@@ -3940,8 +3954,8 @@ public:
         return partmask.get();
     }
 
-    bool isAnon() 
-    { 
+    bool isAnon()
+    {
         return (!logicalName.isSet());
     }
 
@@ -4188,7 +4202,7 @@ public:
             }
 #else
              = 0;
-#endif          
+#endif
             void Do(unsigned idx)
             {
                 {
@@ -4228,7 +4242,7 @@ public:
                             StringBuffer s("renamePhysicalPartFiles ");
                             s.append(file->queryLogicalName()).append(" part ").append(newfn);
                             EXCLOG(ex, s.str());
-                            if (mexcept) 
+                            if (mexcept)
                                 mexcept->append(*ex);
                             else {
                                 if (except)
@@ -4252,7 +4266,7 @@ public:
             {
                 done = false;
                 Owned<IFile> src = createIFile(oldrfn);
-                if (src->exists()) 
+                if (src->exists())
                     done = true;
                 else {
                     StringBuffer s;
@@ -4379,7 +4393,7 @@ public:
             }
         }
         if (afor2.except)
-            throw afor2.except; 
+            throw afor2.except;
         return afor2.ok;
     }
 
@@ -4461,7 +4475,7 @@ public:
         return false;
     }
 
-    virtual bool getRecordLayout(MemoryBuffer &layout) 
+    virtual bool getRecordLayout(MemoryBuffer &layout)
     {
         return queryAttributes().getPropBin("_record_layout",layout);
     }
@@ -4546,14 +4560,14 @@ public:
         mb.append((byte)DRQ_REPLICATE).append(queryLogicalName());
         udesc->serialize(mb);
         CDateTime filedt;
-        getModificationTime(filedt);                    
+        getModificationTime(filedt);
         filedt.serialize(mb);
         Owned<INamedQueueConnection> qconn = createNamedQueueConnection(0);
         Owned<IQueueChannel> qchannel = qconn->open(DFS_REPLICATE_QUEUE);
         qchannel->put(mb);
     }
 
-    bool getAccessedTime(CDateTime &dt)                     
+    bool getAccessedTime(CDateTime &dt)
     {
         StringBuffer str;
         if (!root->getProp("@accessed",str))
@@ -4562,7 +4576,7 @@ public:
         return true;
     }
 
-    virtual void setAccessedTime(const CDateTime &dt)       
+    virtual void setAccessedTime(const CDateTime &dt)
     {
         if (logicalName.isForeign())
             parent->setFileAccessed(logicalName,udesc,dt);
@@ -4604,7 +4618,7 @@ static unsigned findSubFileOrd(const char *name)
         const char *n = name+1;
         if (*n) {
             do { n++; } while (*n&&isdigit(*n));
-            if (!*n) 
+            if (!*n)
                 return atoi(name+1)-1;
         }
     }
@@ -4679,13 +4693,13 @@ class CDistributedSuperFile: public CDistributedFileBase<IDistributedSuperFile>
         {
             if (!sub)
                 throw MakeStringException(-1,"addSubFile(2): File %s cannot be found to add",subfile.get());
-            CDistributedSuperFile *sf = QUERYINTERFACE(parent.get(),CDistributedSuperFile);                 
+            CDistributedSuperFile *sf = QUERYINTERFACE(parent.get(),CDistributedSuperFile);
             if (sf)
                 sf->doAddSubFile(LINK(sub),before,other,transaction);
         }
         virtual void commit()
         {
-            CDistributedSuperFile *sf = QUERYINTERFACE(parent.get(),CDistributedSuperFile);                 
+            CDistributedSuperFile *sf = QUERYINTERFACE(parent.get(),CDistributedSuperFile);
             if (sf)
                 sf->updateParentFileAttrs(transaction);
             CDFAction::commit();
@@ -4959,7 +4973,7 @@ class CDistributedSuperFile: public CDistributedFileBase<IDistributedSuperFile>
         }
     };
 
-    void checkModify(const char *title) 
+    void checkModify(const char *title)
     {
         StringBuffer reason;
         if (!canModify(reason)) {
@@ -5163,14 +5177,14 @@ protected:
                 IDistributedSuperFile* super = (interleaved==1)?NULL:subfiles.item(i).querySuperFile();
                 if (super) {
                     Owned<IDistributedFileIterator> iter = super->getSubFileIterator(true);
-                    ForEach(*iter) 
+                    ForEach(*iter)
                         allsubfiles.append(iter->get());
                 }
                 else
                     allsubfiles.append(*LINK(&subfiles.item(i)));
             }
             unsigned *pn = new unsigned[allsubfiles.ordinality()];
-            ForEachItemIn(j,allsubfiles) 
+            ForEachItemIn(j,allsubfiles)
                 pn[j] = allsubfiles.item(j).numParts();
             unsigned f=0;
             bool found=false;
@@ -5263,7 +5277,7 @@ public:
     {
         StringBuffer lfn;
         normalizeLFN(name,lfn);
-        ForEachItemIn(i,subfiles) 
+        ForEachItemIn(i,subfiles)
             if (stricmp(subfiles.item(i).queryLogicalName(),lfn.str())==0)
                 return i;
         return NotFound;
@@ -5291,7 +5305,7 @@ public:
         loadSubFiles(transaction,timeout);
     }
 
-    CDistributedSuperFile(CDistributedFileDirectory *_parent, IPropertyTree *_root,const CDfsLogicalFileName &_name,IUserDescriptor* user) 
+    CDistributedSuperFile(CDistributedFileDirectory *_parent, IPropertyTree *_root,const CDfsLogicalFileName &_name,IUserDescriptor* user)
     {
         init(_parent,_root,_name,user,NULL);
     }
@@ -5341,10 +5355,10 @@ public:
                     break;
                 }
             }
-            else 
+            else
                 subfiles.item(i).getClusterName(clusternum,name);
         }
-        return name; 
+        return name;
     }
 
     IFileDescriptor *getFileDescriptor(const char *clustername)
@@ -5353,7 +5367,7 @@ public:
         if (subfiles.ordinality()==1)
             return subfiles.item(0).getFileDescriptor(clustername);
         // superfiles assume consistant replication & compression
-        UnsignedArray subcounts;  
+        UnsignedArray subcounts;
         bool mixedwidth = false;
         unsigned width = 0;
         bool first = true;
@@ -5485,7 +5499,7 @@ public:
         if (subfiles.ordinality()==1)
             return subfiles.item(0).queryPart(idx);
         if (partscache.ordinality()==0)
-            loadParts(partscache,NULL);     
+            loadParts(partscache,NULL);
         if (idx>=partscache.ordinality())
             return *(IDistributedFilePart *)NULL;
         return partscache.item(idx);
@@ -5549,7 +5563,7 @@ public:
                     return NULL;
             }
         }
-        return ret; 
+        return ret;
     }
 
     const char *queryPartMask()
@@ -5566,7 +5580,7 @@ public:
             else if (stricmp(ret,s)!=0)
                 return NULL;
         }
-        return ret; 
+        return ret;
     }
 
     void attach(const char *_logicalname,IUserDescriptor *user)
@@ -5576,7 +5590,7 @@ public:
         StringBuffer tail;
         StringBuffer lfn;
         logicalName.set(_logicalname);
-        checkLogicalName(logicalName,user,true,true,false,"attach"); 
+        checkLogicalName(logicalName,user,true,true,false,"attach");
         parent->addEntry(logicalName,root.getClear(),true,false);
         conn.clear();
         CFileLock fcl;
@@ -5588,7 +5602,7 @@ public:
     }
 
     void detach(unsigned timeoutMs=INFINITE, ICodeContext *ctx=NULL)
-    {   
+    {
         assertex(conn.get()); // must be attached
         CriticalBlock block(sect);
         checkModify("CDistributedSuperFile::detach");
@@ -5624,13 +5638,13 @@ public:
             if (!f.existsPhysicalPartFiles(port))
                 return false;
         }
-        return true; 
+        return true;
     }
 
     bool renamePhysicalPartFiles(const char *newlfn,const char *cluster,IMultiException *mexcept,const char *newbasedir)
     {
         throw MakeStringException(-1,"renamePhysicalPartFiles not supported for SuperFiles");
-        return false; 
+        return false;
     }
 
     void serialize(MemoryBuffer &mb)
@@ -5755,7 +5769,7 @@ public:
         if ((idx!=NotFound)&&(idx<subfiles.ordinality()))
             return &subfiles.item(idx);
         idx=findSubFile(name);
-        if (idx!=NotFound) 
+        if (idx!=NotFound)
             return &subfiles.item(idx);
         if (sub) {
             ForEachItemIn(i,subfiles) {
@@ -5785,7 +5799,7 @@ public:
             ForEachItemIn(i,subfiles) {
                 IDistributedFile &f=subfiles.item(i);
                 IDistributedSuperFile *super = f.querySuperFile();
-                if (super) 
+                if (super)
                     ret += super->numSubFiles();
                 else
                     ret++;
@@ -5815,7 +5829,7 @@ public:
         return found;
     }
 
-    virtual bool getRecordLayout(MemoryBuffer &layout)  
+    virtual bool getRecordLayout(MemoryBuffer &layout)
     {
         layout.clear();
         if (queryAttributes().getPropBin("_record_layout",layout))
@@ -5828,7 +5842,7 @@ public:
                     if ((b.length()!=layout.length())||(memcmp(b.bufferBase(),layout.bufferBase(),b.length())!=0))
                         return false;
                 }
-                else 
+                else
                     found = true;
             }
         }
@@ -5945,7 +5959,7 @@ public:
         if (getRecordSize(rsz))
             root->setPropInt("Attr/@recordSize", rsz);
         MemoryBuffer mb;
-        if (getRecordLayout(mb)) 
+        if (getRecordLayout(mb))
             root->setPropBin("Attr/_record_layout", mb.length(), mb.bufferBase());
 
     }
@@ -6309,7 +6323,7 @@ public:
                         clusterscache.append(cluster);
                     }
                 }
-            }   
+            }
         }
     }
 
@@ -6326,7 +6340,7 @@ public:
         fillClustersCache();
         return clusterscache.ordinality();
     }
-    
+
     unsigned findCluster(const char *clustername)
     {
         CriticalBlock block (sect);
@@ -6350,7 +6364,7 @@ public:
         ForEachItemIn(i,subfiles) {
             IDistributedFile &f=subfiles.item(i);
             f.updatePartDiskMapping(clustername,spec);
-        }       
+        }
     }
 
     IGroup *queryClusterGroup(unsigned clusternum)
@@ -6384,7 +6398,7 @@ public:
         ForEachItemIn(i,subfiles) {
             IDistributedFile &f=subfiles.item(i);
             clusterRemoved |= f.removeCluster(clustername);
-        }       
+        }
         return clusterRemoved;
     }
 
@@ -6395,10 +6409,10 @@ public:
         ForEachItemIn(i,subfiles) {
             IDistributedFile &f=subfiles.item(i);
             f.setPreferredClusters(clusters);
-        }       
+        }
     }
 
-    virtual bool checkClusterCompatible(IFileDescriptor &fdesc, StringBuffer &err) 
+    virtual bool checkClusterCompatible(IFileDescriptor &fdesc, StringBuffer &err)
     {
         CriticalBlock block (sect);
         if (subfiles.ordinality()!=1) {
@@ -6409,7 +6423,7 @@ public:
             IDistributedFile &f=subfiles.item(i);
             if (!f.checkClusterCompatible(fdesc,err))
                 return false;
-        }       
+        }
         return true;
     }
 
@@ -6420,7 +6434,7 @@ public:
         ForEachItemIn(i,subfiles) {
             IDistributedFile &f=subfiles.item(i);
             f.setSingleClusterOnly();
-        }       
+        }
     }
 
 
@@ -6430,10 +6444,10 @@ public:
         ForEachItemIn(i,subfiles) {
             IDistributedFile &f=subfiles.item(i);
             f.enqueueReplicate();
-        }       
+        }
     }
 
-    bool getAccessedTime(CDateTime &dt)                     
+    bool getAccessedTime(CDateTime &dt)
     {
         bool set=false;
         CriticalBlock block (sect);
@@ -6459,7 +6473,7 @@ public:
             ForEachItemIn(i,subfiles) {
                 IDistributedFile &f=subfiles.item(i);
                 f.setAccessedTime(dt);
-            }       
+            }
         }
     }
 };
@@ -6502,16 +6516,16 @@ CDistributedFilePart::CDistributedFilePart(CDistributedFile &_parent,unsigned _p
         ERRLOG("CDistributedFilePart::CDistributedFilePart no IPartDescriptor for part");
 }
 
-void CDistributedFilePart::Link(void) const 
-{ 
-    parent.Link(); 
-    CInterface::Link(); 
-}                     
+void CDistributedFilePart::Link(void) const
+{
+    parent.Link();
+    CInterface::Link();
+}
 
 bool CDistributedFilePart::Release(void) const
-{ 
-    parent.Release(); 
-    return CInterface::Release(); 
+{
+    parent.Release();
+    return CInterface::Release();
 }
 
 offset_t CDistributedFilePart::getSize(bool checkCompressed)
@@ -6554,7 +6568,7 @@ StringBuffer & CDistributedFilePart::getPartName(StringBuffer &partname)
 {
     if (!overridename.isEmpty()) {
         if (isSpecialPath(overridename)) {
-            // bit of a kludge 
+            // bit of a kludge
             if (isPathSepChar(*overridename)&&partname.length()&&isPathSepChar(partname.charAt(partname.length()-1)))
                 partname.setLength(partname.length()-1);
             return partname.append(overridename);
@@ -6583,10 +6597,10 @@ unsigned CDistributedFilePart::bestCopyNum(const IpAddress &ip,unsigned rel)
     if (rel>=n)
         rel = n-1;
     // do bubble sort as not that many!
-    for (unsigned i=0; i<n-1; i++) 
-        for (unsigned j=0; j<n-1-i; j++) 
-            if (dist[idx[j+1]] < dist[idx[j]]) {  
-                unsigned t = idx[j];         
+    for (unsigned i=0; i<n-1; i++)
+        for (unsigned j=0; j<n-1-i; j++)
+            if (dist[idx[j+1]] < dist[idx[j]]) {
+                unsigned t = idx[j];
                 idx[j] = idx[j+1];
                 idx[j+1] = t;
             }
@@ -6651,14 +6665,14 @@ unsigned CDistributedFilePart::queryDrive(unsigned copy)
 
 bool CDistributedFilePart::isHost(unsigned copy)
 {
-    return (queryNode(copy)->isHost()); 
+    return (queryNode(copy)->isHost());
 }
 
 
 IPropertyTree &CDistributedFilePart::queryAttributes()
-{ 
+{
     CriticalBlock block (sect);     // avoid nested blocks
-    if (attr) 
+    if (attr)
         return *attr;
     WARNLOG("CDistributedFilePart::queryAttributes missing part attributes");
     attr.setown(getEmptyAttr());
@@ -6693,7 +6707,7 @@ unsigned CDistributedFilePart::getPhysicalCrc()
         RemoteFilename rfn;
         try {
             Owned<IFile> partfile = createIFile(getFilename(rfn,copy));
-            if (partfile&&partfile->exists()) 
+            if (partfile&&partfile->exists())
                 return partfile->getCRC();
         }
         catch (IException *e)
@@ -6807,7 +6821,7 @@ public:
             query.append("Group[Node/@ip=\"");
             matchgroup->queryNode(0).endpoint().getUrlStr(query);
             query.append("\"]");
-            pe.setown(conn->getElements(query.str())); 
+            pe.setown(conn->getElements(query.str()));
         }
         else
             pe.setown(conn->queryRoot()->getElements("Group"));
@@ -6823,7 +6837,7 @@ public:
     }
     bool next()
     {
-        while (pe->next()) 
+        while (pe->next())
             if (match())
                 return true;
         return false;
@@ -6930,7 +6944,7 @@ public:
                 isiprange = false;
                 break;
             }
-        if (isiprange) { 
+        if (isiprange) {
             // allow IP or IP list instead of group name
             // I don't think this is a security problem as groups not checked
             // NB ports not allowed here
@@ -6939,7 +6953,7 @@ public:
             char *s = buf;
             while (*s) {
                 char *next = strchr(s,',');
-                if (next) 
+                if (next)
                     *next = 0;
                 SocketEndpoint ep;
                 unsigned n = ep.ipsetrange(s);
@@ -7175,7 +7189,7 @@ public:
         gi.Release();
         connlock.conn->queryRoot()->addPropTree("Group",val);
     }
-    
+
     void addUnique(IGroup *group,StringBuffer &lname, const char *dir)
     {
         if (group->ordinality()==1)
@@ -7194,7 +7208,7 @@ public:
                 name.toLowerCase();
                 lname.clear();
             }
-            else 
+            else
                 name.append("__anon").append(getRandom()%scale);
             prop.clear().appendf("Group[@name=\"%s\"]",name.str());
             if (!connlock.conn->queryRoot()->hasProp(prop.str()))
@@ -7204,7 +7218,7 @@ public:
         doadd(connlock,name.str(),group,false,dir);
         lname.append(name);
     }
-    
+
     void add(const char *logicalgroupname, IGroup *group, bool cluster, const char *dir, GroupType groupType)
     {
         StringBuffer name(logicalgroupname);
@@ -7213,9 +7227,9 @@ public:
         StringBuffer prop;
         prop.appendf("Group[@name=\"%s\"]",name.str());
         CConnectLock connlock("CNamedGroup::add", SDS_GROUPSTORE_ROOT, true, false, false, defaultTimeout);
-        connlock.conn->queryRoot()->removeProp(prop.str()); 
+        connlock.conn->queryRoot()->removeProp(prop.str());
         doadd(connlock,name.str(),group,cluster,dir);
-        {                                                           
+        {
             CriticalBlock block(cachesect);
             cache.kill();
             if (group)
@@ -7239,7 +7253,7 @@ public:
         StringBuffer name;
         ForEach(*iter) {
             bool iscluster = iter->isCluster();
-            if (iscluster||(bestname.isEmpty())) { 
+            if (iscluster||(bestname.isEmpty())) {
                 iter->get(name.clear());
                 if (name.length()) {
                     bestname.set(name);
@@ -7279,7 +7293,7 @@ public:
             xpath.append(froms).append("\"]");
             for (unsigned guard=0; guard<1000; guard++) {
                 Owned<IPropertyTreeIterator> ne = group.getElements(xpath.str());
-                if (!ne->first()) 
+                if (!ne->first())
                     break;
                 ne->query().setProp("@ip",tos.str());
                 PROGLOG("swapNode swapping %s for %s in group %s",froms.str(),tos.str(),name.str());
@@ -7328,7 +7342,7 @@ private:
             if ((ok==(byte)MDFS_GET_GROUP_TREE)&&mb.length()>mbsz) {
                 mb.skip(mbsz-1);
                 mb.read(ok);
-                if (ok!=1) 
+                if (ok!=1)
                     return false;
             }
             else
@@ -7378,7 +7392,7 @@ INamedGroupStore  &queryNamedGroupStore()
 {
     if (!groupStore) {
         CriticalBlock block(groupsect);
-        if (!groupStore) 
+        if (!groupStore)
             groupStore = new CNamedGroupStore();
     }
     return *groupStore;
@@ -7388,7 +7402,7 @@ INamedGroupStore  &queryNamedGroupStore()
 
 IDistributedFile *CDistributedFileDirectory::lookup(const char *_logicalname, IUserDescriptor *user, bool writeattr, bool hold, bool lockSuperOwner, IDistributedFileTransaction *transaction, unsigned timeout)
 {
-    CDfsLogicalFileName logicalname;    
+    CDfsLogicalFileName logicalname;
     logicalname.set(_logicalname);
     return lookup(logicalname, user, writeattr, hold, lockSuperOwner, transaction, timeout);
 }
@@ -7396,7 +7410,7 @@ IDistributedFile *CDistributedFileDirectory::lookup(const char *_logicalname, IU
 IDistributedFile *CDistributedFileDirectory::dolookup(CDfsLogicalFileName &_logicalname, IUserDescriptor *user, bool writeattr, bool hold, bool lockSuperOwner, IDistributedFileTransaction *transaction, unsigned timeout)
 {
     CDfsLogicalFileName *logicalname = &_logicalname;
-    if (logicalname->isMulti()) 
+    if (logicalname->isMulti())
         // don't bother checking because the sub file creation will
         return new CDistributedSuperFile(this,*logicalname,user,transaction); // temp superfile
     if (strchr(logicalname->get(), '*')) // '*' only wildcard supported. NB: This is a temporary fix (See: HPCC-12523)
@@ -7442,7 +7456,7 @@ IDistributedFile *CDistributedFileDirectory::dolookup(CDfsLogicalFileName &_logi
                         {
                             StringBuffer query;
                             query.appendf("Cluster[@name=\"%s\"]",cname.str());
-                            if (!froot->hasProp(query.str())) 
+                            if (!froot->hasProp(query.str()))
                                 break;
                         }
                     }
@@ -7471,7 +7485,7 @@ IDistributedFile *CDistributedFileDirectory::dolookup(CDfsLogicalFileName &_logi
                     e->Release();
                 }
                 PROGLOG("CDistributedSuperFile connect timeout (%dms) pausing",elapsed);
-                Sleep(SDS_TRANSACTION_RETRY/2+(getRandom()%SDS_TRANSACTION_RETRY)); 
+                Sleep(SDS_TRANSACTION_RETRY/2+(getRandom()%SDS_TRANSACTION_RETRY));
             }
         }
         if (redmatch.get()) {
@@ -7480,7 +7494,7 @@ IDistributedFile *CDistributedFileDirectory::dolookup(CDfsLogicalFileName &_logi
         }
         else {
             redmatch.setown(queryRedirection().getMatch(logicalname->get()));
-            if (!redmatch.get()) 
+            if (!redmatch.get())
                 break;
             if (!redmatch->first())
                 break;
@@ -7498,7 +7512,7 @@ IDistributedFile *CDistributedFileDirectory::lookup(CDfsLogicalFileName &logical
 
 IDistributedSuperFile *CDistributedFileDirectory::lookupSuperFile(const char *_logicalname,IUserDescriptor *user,IDistributedFileTransaction *transaction, unsigned timeout)
 {
-    CDfsLogicalFileName logicalname;    
+    CDfsLogicalFileName logicalname;
     logicalname.set(_logicalname);
     IDistributedFile *file = dolookup(logicalname, user, false, false, false, transaction, timeout);
     if (file) {
@@ -7526,7 +7540,7 @@ bool CDistributedFileDirectory::exists(const char *_logicalname,IUserDescriptor 
 
     bool external;
     bool foreign;
-    CDfsLogicalFileName dlfn;   
+    CDfsLogicalFileName dlfn;
     dlfn.set(_logicalname);
     const char *logicalname = dlfn.get();
     external = dlfn.isExternal();
@@ -9725,7 +9739,7 @@ IGroup *getClusterNodeGroup(const char *clusterName, const char *type, unsigned 
 
 class CDaliDFSServer: public Thread, public CTransactionLogTracker, implements IDaliServer, implements IExceptionHandler
 {  // Coven size
-    
+
     bool stopped;
     unsigned defaultTimeout;
     unsigned numThreads;
@@ -9784,7 +9798,7 @@ public:
                 {
                     handler.handleMessage(mb);
                     mb.clear(); // ^ has copied mb
-                }   
+                }
                 else
                     stopped = true;
             }
@@ -9990,7 +10004,7 @@ public:
             transactionLog.log("%s", trc.str());
         mb.clear();
         StringBuffer tail;
-        CDfsLogicalFileName dlfn;   
+        CDfsLogicalFileName dlfn;
         dlfn.set(lname);
         if (!checkLogicalName(dlfn,udesc,true,false,true,"setFileAccessed on"))
             return;
@@ -10021,7 +10035,7 @@ public:
         }
         mb.clear();
         StringBuffer tail;
-        CDfsLogicalFileName dlfn;   
+        CDfsLogicalFileName dlfn;
         dlfn.set(lname);
         if (!checkLogicalName(dlfn,udesc,true,false,true,"setFileProtect"))
             return;
@@ -10033,7 +10047,7 @@ public:
             tree.setown(getNamedPropTree(sroot,queryDfsXmlBranchName(DXB_SuperFile),"@name",tail.str(),false));
         if (tree) {
             IPropertyTree *pt = tree->queryPropTree("Attr");
-            if (pt) 
+            if (pt)
                 setFileProtectTree(*pt,*owner?owner:owner,set);
         }
     }
@@ -10063,7 +10077,7 @@ public:
             udesc->deserialize(mb);
         }
         mb.clear();
-        CDfsLogicalFileName dlfn;   
+        CDfsLogicalFileName dlfn;
         dlfn.set(lname);
         CDfsLogicalFileName *logicalname=&dlfn;
         Owned<IDfsLogicalFileNameIterator> redmatch;
@@ -10113,7 +10127,7 @@ public:
             }
             else {
                 redmatch.setown(queryDistributedFileDirectory().queryRedirection().getMatch(logicalname->get()));
-                if (!redmatch.get()) 
+                if (!redmatch.get())
                     break;
                 if (!redmatch->first())
                     break;
@@ -10207,8 +10221,8 @@ public:
         catch (IException *e)
         {
             int err=-1; // exception marker
-            mb.clear().append(err); 
-            serializeException(e, mb); 
+            mb.clear().append(err);
+            serializeException(e, mb);
             e->Release();
         }
         coven.reply(mb);
@@ -10275,7 +10289,7 @@ IDFAttributesIterator *CDistributedFileDirectory::getDFAttributesIterator(const 
     }
 #endif
 
-    if (foreigndali) 
+    if (foreigndali)
         foreignDaliSendRecv(foreigndali,mb,foreigndalitimeout);
     else
         queryCoven().sendRecv(mb,RANK_RANDOM,MPTAG_DFS_REQUEST);
@@ -10319,15 +10333,15 @@ bool CDistributedFileDirectory::loadScopeContents(const char *scopelfn,
         }
     }
     CConnectLock connlock("CDistributedFileDirectory::loadScopeContents",querySdsFilesRoot(),false,false,false,defaultTimeout);
-    if (!connlock.conn) 
+    if (!connlock.conn)
         return false;
     IPropertyTree *root = connlock.conn->queryRoot();
-    if (!root) 
+    if (!root)
         return false;
 
     if (baseq.length()) {
         root = root->queryPropTree(baseq.str());
-        if (!root) 
+        if (!root)
             return false;
     }
     Owned<IPropertyTreeIterator> iter;
@@ -10344,14 +10358,14 @@ bool CDistributedFileDirectory::loadScopeContents(const char *scopelfn,
     }
     if (!supers&&!files)
         return true;
-        
+
     if (baseq.length()==0) { // bit odd but top level files are in '.'
         CDfsLogicalFileName dlfn;
         dlfn.set(".",".");
         dlfn.makeScopeQuery(baseq,false);
         root = root->queryPropTree(baseq.str());
-        if (!root) 
-            return true;    
+        if (!root)
+            return true;
     }
     if (supers) {
         iter.setown(root->getElements(queryDfsXmlBranchName(DXB_SuperFile)));
@@ -10381,7 +10395,7 @@ void CDistributedFileDirectory::setFileAccessed(CDfsLogicalFileName &dlfn,IUserD
     SocketEndpoint ep;
     const char *lname;
     if (dlfn.isForeign()) {
-        if (!dlfn.getEp(ep)) 
+        if (!dlfn.getEp(ep))
             throw MakeStringException(-1,"cannot resolve dali ip in foreign file name (%s)",dlfn.get());
         fnode.setown(createINode(ep));
         foreigndali = fnode;
@@ -10405,7 +10419,7 @@ void CDistributedFileDirectory::setFileAccessed(CDfsLogicalFileName &dlfn,IUserD
         PrintStackReport();
     }
 #endif
-    if (foreigndali) 
+    if (foreigndali)
         foreignDaliSendRecv(foreigndali,mb,foreigndalitimeout);
     else
         queryCoven().sendRecv(mb,RANK_RANDOM,MPTAG_DFS_REQUEST);
@@ -10419,7 +10433,7 @@ void CDistributedFileDirectory::setFileProtect(CDfsLogicalFileName &dlfn,IUserDe
     SocketEndpoint ep;
     const char *lname;
     if (dlfn.isForeign()) {
-        if (!dlfn.getEp(ep)) 
+        if (!dlfn.getEp(ep))
             throw MakeStringException(-1,"cannot resolve dali ip in foreign file name (%s)",dlfn.get());
         fnode.setown(createINode(ep));
         foreigndali = fnode;
@@ -10444,7 +10458,7 @@ void CDistributedFileDirectory::setFileProtect(CDfsLogicalFileName &dlfn,IUserDe
         PrintStackReport();
     }
 #endif
-    if (foreigndali) 
+    if (foreigndali)
         foreignDaliSendRecv(foreigndali,mb,foreigndalitimeout);
     else
         queryCoven().sendRecv(mb,RANK_RANDOM,MPTAG_DFS_REQUEST);
@@ -10459,7 +10473,7 @@ IPropertyTree *CDistributedFileDirectory::getFileTree(const char *lname, IUserDe
     SocketEndpoint ep;
     dlfn.set(lname);
     if (dlfn.isForeign()) {
-        if (!dlfn.getEp(ep)) 
+        if (!dlfn.getEp(ep))
             throw MakeStringException(-1,"cannot resolve dali ip in foreign file name (%s)",lname);
         fnode.setown(createINode(ep));
         foreigndali = fnode;
@@ -10479,7 +10493,7 @@ IPropertyTree *CDistributedFileDirectory::getFileTree(const char *lname, IUserDe
         PrintStackReport();
     }
 #endif
-    if (foreigndali) 
+    if (foreigndali)
         foreignDaliSendRecv(foreigndali,mb,foreigndalitimeout);
     else
         queryCoven().sendRecv(mb,RANK_RANDOM,MPTAG_DFS_REQUEST);
@@ -10518,7 +10532,7 @@ IPropertyTree *CDistributedFileDirectory::getFileTree(const char *lname, IUserDe
         expandFileTree(ret,true,cname.str());
         CDfsLogicalFileName dlfn2;
         dlfn2.set(dlfn);
-        if (foreigndali) 
+        if (foreigndali)
             dlfn2.setForeign(foreigndali->endpoint(),false);
         ret->setProp("OrigName",dlfn.get());
     }
@@ -10572,7 +10586,7 @@ IDistributedFile *CDistributedFileDirectory::getFile(const char *lname,IUserDesc
         CDateTime dt;
         if (date&&*date)
             dt.setString(date);
-        ret->setModificationTime(dt);   
+        ret->setModificationTime(dt);
     }
     return ret;
 }
@@ -10587,7 +10601,7 @@ static void addForeignName(IPropertyTree &t,const INode *foreigndali,const char 
     logicalname.set(name);
     if (logicalname.isExternal()||logicalname.isQuery())
         return; // how did that get in here?
-    if (logicalname.isForeign()) { 
+    if (logicalname.isForeign()) {
         SocketEndpoint ep;
         Owned<INode> fd = createINode(ep);
         if (logicalname.getEp(ep)&&isLocalDali(fd)) { // see if pointing back at self
@@ -10607,10 +10621,10 @@ void CDistributedFileDirectory::resolveForeignFiles(IPropertyTree *tree,const IN
         return;
     // now add to all sub files
     Owned<IPropertyTreeIterator> pe = tree->getElements("SubFile");
-    ForEach(*pe) 
+    ForEach(*pe)
         addForeignName(pe->query(),foreigndali,"@name");
     pe.setown(tree->getElements("SuperOwner"));
-    ForEach(*pe) 
+    ForEach(*pe)
         addForeignName(pe->query(),foreigndali,"@name");
     // do origname?
 }
@@ -10661,12 +10675,12 @@ SecAccessFlags CDistributedFileDirectory::getFDescPermissions(IFileDescriptor *f
                 fdesc->getFilename(i,0,rfn);
                 StringBuffer localpath;
                 rfn.getLocalPath(localpath);
-                // translate wild cards 
+                // translate wild cards
                 for (unsigned k=0;k<localpath.length();k++)
                     if ((localpath.charAt(k)=='?')||(localpath.charAt(k)=='*'))
                         localpath.setCharAt(k,'_');
                 CDfsLogicalFileName dlfn;
-                dlfn.setExternal(rfn.queryEndpoint(),localpath.str());          
+                dlfn.setExternal(rfn.queryEndpoint(),localpath.str());
                 StringBuffer scopes;
                 dlfn.getScopes(scopes);
                 SecAccessFlags perm = getScopePermissions(scopes.str(),user,auditflags);
@@ -10701,7 +10715,7 @@ void CDistributedFileDirectory::setDefaultPreferredClusters(const char *clusters
 
 bool removePhysicalFiles(IGroup *grp,const char *_filemask,unsigned short port,ClusterPartDiskMapSpec &mspec,IMultiException *mexcept)
 {
-    // TBD this won't remove repeated parts 
+    // TBD this won't remove repeated parts
 
 
     PROGLOG("removePhysicalFiles(%s)",_filemask);
@@ -10751,17 +10765,17 @@ bool removePhysicalFiles(IGroup *grp,const char *_filemask,unsigned short port,C
                 try
                 {
                     unsigned start = msTick();
-#if 1                   
+#if 1
                     if (partfile->remove()) {
                         PROGLOG("Removed '%s'",partfile->queryFilename());
                         unsigned t = msTick()-start;
-                        if (t>5*1000) 
+                        if (t>5*1000)
                             LOG(MCwarning, unknownJob, "Removing %s from %s took %ds", partfile->queryFilename(), rfn.queryEndpoint().getUrlStr(eps).str(), t/1000);
                     }
                     else
                         LOG(MCwarning, unknownJob, "Failed to remove file part %s from %s", partfile->queryFilename(),rfn.queryEndpoint().getUrlStr(eps).str());
 #else
-                    if (partfile->exists()) 
+                    if (partfile->exists())
                         PROGLOG("Would remove '%s'",partfile->queryFilename());
 #endif
 
@@ -10769,7 +10783,7 @@ bool removePhysicalFiles(IGroup *grp,const char *_filemask,unsigned short port,C
                 catch (IException *e)
                 {
                     CriticalBlock block(errcrit);
-                    if (mexcept) 
+                    if (mexcept)
                         mexcept->append(*e);
                     else {
                         StringBuffer s("Failed to remove file part ");
@@ -10806,7 +10820,7 @@ static void encodeCompareResult(DistributedFileCompareResult &ret,bool differs,C
         int cmp = 0;
         if (!newestdt1.isNull()) {
             if (!newestdt2.isNull()) {
-                int cmp = newestdt1.compare(newestdt2,false);   
+                int cmp = newestdt1.compare(newestdt2,false);
                 if (cmp>=0)
                     ret = DFS_COMPARE_RESULT_SAME_NEWER;
                 else
@@ -10815,7 +10829,7 @@ static void encodeCompareResult(DistributedFileCompareResult &ret,bool differs,C
             else
                 ret = DFS_COMPARE_RESULT_SAME_NEWER;
         }
-        else if (!newestdt2.isNull()) 
+        else if (!newestdt2.isNull())
             ret = DFS_COMPARE_RESULT_SAME_OLDER;
         if (differs) {
             if (ret==DFS_COMPARE_RESULT_SAME_OLDER) // ok they could be same but seems rather unlikely!
@@ -10887,8 +10901,8 @@ DistributedFileCompareResult CDistributedFileDirectory::fileCompare(const char *
                     {
                         CriticalBlock block (crit);
                         StringBuffer msg;
-                        Owned<IDistributedFilePart> part1 = file1->getPart(p);  
-                        Owned<IDistributedFilePart> part2 = file2->getPart(p);  
+                        Owned<IDistributedFilePart> part1 = file1->getPart(p);
+                        Owned<IDistributedFilePart> part2 = file2->getPart(p);
                         CDateTime dt1;
                         RemoteFilename rfn;
                         bool ok;
@@ -10937,7 +10951,7 @@ DistributedFileCompareResult CDistributedFileDirectory::fileCompare(const char *
                                 sz1 = part1->getFileSize(true,physdatesize);
                                 sz2 = part2->getFileSize(true,physdatesize);
                             }
-                            if (sz1!=sz2) 
+                            if (sz1!=sz2)
                                 differs = true;
                         }
                         if ((ret!=DFS_COMPARE_RESULT_FAILURE)&&!differs) {
@@ -10951,12 +10965,12 @@ DistributedFileCompareResult CDistributedFileDirectory::fileCompare(const char *
                                 }
                             }
                             else {
-                                if (!part1->getCrc(crc1)) 
+                                if (!part1->getCrc(crc1))
                                     return;
-                                if (!part2->getCrc(crc2)) 
+                                if (!part2->getCrc(crc2))
                                     return;
-                            }   
-                            if (crc1!=crc2) 
+                            }
+                            if (crc1!=crc2)
                                 differs = true;
                         }
                     }
@@ -11013,7 +11027,7 @@ bool CDistributedFileDirectory::filePhysicalVerify(const char *lfn, IUserDescrip
             {
                 CriticalBlock block (crit);
                 StringBuffer msg;
-                Owned<IDistributedFilePart> part = file->getPart(p);    
+                Owned<IDistributedFilePart> part = file->getPart(p);
                 CDateTime dt1; // logical
                 CDateTime dt2; // physical
                 RemoteFilename rfn;
@@ -11102,7 +11116,7 @@ bool CDistributedFileDirectory::filePhysicalVerify(const char *lfn, IUserDescrip
         afor.For(np,10,false,false);
     }
     catch (IException *e) {
-        if (errstr.length()==0) 
+        if (errstr.length()==0)
             e->errorMessage(errstr);
         else
             EXCLOG(e,"CDistributedFileDirectory::fileCompare");
@@ -11137,7 +11151,7 @@ public:
                 Owned<IPropertyTreeIterator> iter = t->getElements("SuperFile/SubFile");
                 ForEach(*iter) {
                     const char *name =  iter->query().queryProp("@name");
-                    if (!sfset.getValue(name)) 
+                    if (!sfset.getValue(name))
                         sfset.setValue(name, true);
                 }
             }
@@ -11179,10 +11193,10 @@ bool decodeChildGroupName(const char *gname,StringBuffer &parentname, StringBuff
     if (!gname||!*gname)
         return false;
     size32_t l = strlen(gname);
-    if (gname[l-1]!=']') 
+    if (gname[l-1]!=']')
         return false;
     const char *ss = strchr(gname,'[');
-    if (!ss||(ss==gname)) 
+    if (!ss||(ss==gname))
         return false;
     range.append(l-(ss-gname)-2,ss+1);
     range.trim();
@@ -11211,7 +11225,7 @@ class CLightWeightSuperFileConn: implements ISimpleSuperFileEnquiry, public CInt
         aname.append(name);
         StringBuffer s;
         StringBuffer o;
-        if (from->getProp(aname.str(),s)) 
+        if (from->getProp(aname.str(),s))
             if ((num==1)||(allowunchanged&&to->getProp(aname.str(),o)&&(strcmp(s.str(),o.str())==0)))
                 newt->setProp(name,s.str());
     }
@@ -11234,7 +11248,7 @@ class CLightWeightSuperFileConn: implements ISimpleSuperFileEnquiry, public CInt
             MemoryBuffer mb;
             MemoryBuffer mbo;
             const char *aname = "Attr/_record_layout";
-            if (from->getPropBin(aname,mb)) 
+            if (from->getPropBin(aname,mb))
                 if ((num==1)||(to->getPropBin(aname,mbo)&&
                               (mb.length()==mbo.length())&&
                               (memcmp(mb.bufferBase(),mbo.bufferBase(),mb.length())==0)))
@@ -11253,14 +11267,14 @@ class CLightWeightSuperFileConn: implements ISimpleSuperFileEnquiry, public CInt
         ForEach(*iter) {
             if (iter->query().getProp("@name",pname.clear())) {
                 CDfsLogicalFileName lfn;
-                lfn.set(pname.str()); 
+                lfn.set(pname.str());
                 lfn.makeFullnameQuery(query.clear(),DXB_SuperFile,true);
                 Owned<IRemoteConnection> conn;
                 try {
                     conn.setown(querySDS().connect(query.str(),myProcessSession(),RTM_LOCK_WRITE,1000*60*5));
                 }
                 catch (ISDSException *e) {
-                    if (SDSExcpt_LockTimeout != e->errorCode()) 
+                    if (SDSExcpt_LockTimeout != e->errorCode())
                         throw;
                     e->Release();
                     WARNLOG("migrateSuperOwnersAttr: Could not lock parent %s",query.str());
@@ -11275,11 +11289,11 @@ class CLightWeightSuperFileConn: implements ISimpleSuperFileEnquiry, public CInt
             }
         }
     }
-    
+
 public:
 
     IMPLEMENT_IINTERFACE;
-    
+
     CLightWeightSuperFileConn(unsigned _defaultTimeout, IUserDescriptor *_udesc)
     {
         defaultTimeout = _defaultTimeout;
@@ -11296,7 +11310,7 @@ public:
         CDfsLogicalFileName lfn;
         if (!lfn.setValidate(name))
             throw MakeStringException(-1,"%s: Invalid superfile name '%s'",title,name);
-        if (lfn.isMulti()||lfn.isExternal()||lfn.isForeign()) 
+        if (lfn.isMulti()||lfn.isExternal()||lfn.isForeign())
             return false;
         unsigned mode = RTM_SUB | (readonly ? RTM_LOCK_READ : RTM_LOCK_WRITE);
         if (!lock.init(lfn, DXB_SuperFile, mode, timeout, title))
@@ -11304,9 +11318,9 @@ public:
             if (!autocreate)        // NB not !*autocreate here !
                 return false;
             IPropertyTree *root = createPTree();
-            root->setPropInt("@interleaved",2); 
-            root->setPropInt("@numsubfiles",0); 
-            root->setPropTree("Attr",getEmptyAttr());   
+            root->setPropInt("@interleaved",2);
+            root->setPropInt("@numsubfiles",0);
+            root->setPropTree("Attr",getEmptyAttr());
             parent->addEntry(lfn,root,true,false);
             mode = RTM_SUB | RTM_LOCK_WRITE;
             if (!lock.init(lfn, DXB_SuperFile, mode, timeout, title))
@@ -11315,7 +11329,7 @@ public:
                 *autocreate = true;
         }
         StringBuffer reason;
-        if (!readonly&&checkProtectAttr(name,lock.queryRoot(),reason)) 
+        if (!readonly&&checkProtectAttr(name,lock.queryRoot(),reason))
             throw MakeStringException(-1,"CDistributedSuperFile::%s %s",title,reason.str());
         return true;
     }
@@ -11350,7 +11364,7 @@ public:
         if ((unsigned)lock.queryRoot()->getPropInt("@numsubfiles")<=num)
             return false;
         StringBuffer xpath;
-        getSubPath(xpath,num); 
+        getSubPath(xpath,num);
         IPropertyTree *sub = lock.queryRoot()->queryPropTree(xpath.str());
         if (!sub)
             return false;
@@ -11377,12 +11391,12 @@ public:
     }
 
     unsigned getContents(StringArray &contents) const
-    {   
+    {
         // slightly inefficient
         unsigned n = lock.queryRoot()->getPropInt("@numsubfiles");
         StringBuffer xpath;
         for (unsigned sni=0;sni<n;sni++) {
-            getSubPath(xpath.clear(),sni); 
+            getSubPath(xpath.clear(),sni);
             IPropertyTree *sub = lock.queryRoot()->queryPropTree(xpath.str());
             if (!sub)
                 break;
@@ -11394,7 +11408,7 @@ public:
 
 // Contention never expected for this function!
 #define PROMOTE_CONN_TIMEOUT (60*1000) // how long to wait for a single superfile
-#define PROMOTE_DELAY   (30*1000)   
+#define PROMOTE_DELAY   (30*1000)
 
 // Check files don't share subfiles (MORE - make this part of swap files action?)
 static int hasCommonSubChildren(IDistributedSuperFile *orig, IDistributedSuperFile *dest)
@@ -11415,7 +11429,7 @@ static int hasCommonSubChildren(IDistributedSuperFile *orig, IDistributedSuperFi
 // MORE - use string arrays, rather than char* arrays or comma-separated strings
 void CDistributedFileDirectory::promoteSuperFiles(unsigned numsf,const char **sfnames,const char *addsubnames,bool delsub,bool createonlyonesuperfile,IUserDescriptor *user,unsigned timeout,StringArray &outunlinked)
 {
-    if (!numsf) 
+    if (!numsf)
         return;
 
     // Create a local transaction that will be destroyed
@@ -11480,7 +11494,7 @@ void CDistributedFileDirectory::promoteSuperFiles(unsigned numsf,const char **sf
 
     // MORE - once deletion of logic files are also in transaction we can move this up (and allow promote within transactions)
     if (delsub) {
-        ForEachItemIn(j,outunlinked) 
+        ForEachItemIn(j,outunlinked)
             removeEntry(outunlinked.item(j),user,transaction,timeout);
     }
 }
@@ -11500,7 +11514,7 @@ bool CDistributedFileDirectory::getFileSuperOwners(const char *logicalname, Stri
     CDfsLogicalFileName lfn;
     if (!lfn.setValidate(logicalname))
         throw MakeStringException(-1,"CDistributedFileDirectory::getFileSuperOwners: Invalid file name '%s'",logicalname);
-    if (lfn.isMulti()||lfn.isExternal()||lfn.isForeign()) 
+    if (lfn.isMulti()||lfn.isExternal()||lfn.isForeign())
         return false;
     CTimeMon tm(defaultTimeout);
     if (!lock.init(lfn, RTM_LOCK_READ, defaultTimeout, "CDistributedFileDirectory::getFileSuperOwners"))
@@ -11684,7 +11698,7 @@ public:
 
     IFileRelationship & query()
     {
-        if (!r) 
+        if (!r)
             r.setown(new CFileRelationship(pt));
         return *r;
     }
@@ -11725,7 +11739,7 @@ static const char *normLFN(const char *name,CDfsLogicalFileName &logicalname,con
         return name;
     if (!logicalname.setValidate(name))
         throw MakeStringException(-1,"%s: invalid logical file name '%s'",title,name);
-    if (logicalname.isForeign()) { 
+    if (logicalname.isForeign()) {
         SocketEndpoint ep;
         Owned<INode> fd = createINode(ep);
         if (logicalname.getEp(ep)&&isLocalDali(fd))  // see if pointing back at self
@@ -11800,7 +11814,7 @@ void CDistributedFileDirectory::addFileRelationship(
     if (isWild(primary,true)||isWild(secondary,true)||isWild(primflds,false)||isWild(secflds,false)||isWild(cardinality,false))
         throw MakeStringException(-1,"Wildcard not allowed in addFileRelation");
     CDfsLogicalFileName pfn;
-    if (!pfn.setValidate(primary))  
+    if (!pfn.setValidate(primary))
         throw MakeStringException(-1,"addFileRelationship invalid primary name '%s'",primary);
     if (pfn.isExternal()||pfn.isForeign()||pfn.isQuery())
         throw MakeStringException(-1,"addFileRelationship primary %s not allowed",pfn.get());
@@ -11808,7 +11822,7 @@ void CDistributedFileDirectory::addFileRelationship(
     if (!exists(primary,user))
         throw MakeStringException(-1,"addFileRelationship primary %s does not exist",primary);
     CDfsLogicalFileName sfn;
-    if (!sfn.setValidate(secondary))  
+    if (!sfn.setValidate(secondary))
         throw MakeStringException(-1,"addFileRelationship invalid secondary name '%s'",secondary);
     if (sfn.isExternal()||sfn.isForeign()||sfn.isQuery())
         throw MakeStringException(-1,"addFileRelationship secondary %s not allowed",sfn.get());
@@ -11840,7 +11854,7 @@ void CDistributedFileDirectory::addFileRelationship(
             Owned<IPropertyTree> ptr = createPTree("Relationships");
             connlock2.conn->queryRoot()->addPropTree("Relationships",ptr.getClear());
             continue;
-        }   
+        }
         StringBuffer query;
         doRemoveFileRelationship(connlock.conn,primary,secondary,primflds,secflds,kind);
         connlock.conn->queryRoot()->addPropTree("Relationship",pt.getClear());
@@ -11953,7 +11967,7 @@ void CDistributedFileDirectory::renameFileRelationships(const char *oldname,cons
 // JCSMORE what was this for, not called by anything afaics
 bool CDistributedFileDirectory::publishMetaFileXML(const CDfsLogicalFileName &logicalname,IUserDescriptor *user)
 {
-    if (logicalname.isExternal()||logicalname.isForeign()||logicalname.isQuery()) 
+    if (logicalname.isExternal()||logicalname.isForeign()||logicalname.isQuery())
         return false;
     Owned<IPropertyTree> file = getFileTree(logicalname.get(),user,NULL,FOREIGN_DALI_TIMEOUT,true);
     if (!file.get())
@@ -12023,7 +12037,7 @@ bool CDistributedFileDirectory::publishMetaFileXML(const CDfsLogicalFileName &lo
                     Owned<IFileIO> outio = out->open(IFOcreate);
                     if (outio)
                         outio->write(0,str.length(),str.str());
-                    
+
                 }
             }
             catch(IException *e)
@@ -12042,7 +12056,7 @@ bool CDistributedFileDirectory::publishMetaFileXML(const CDfsLogicalFileName &lo
     if (exc)
         throw exc.getClear();
     return true;
-    
+
 
 }
 
@@ -12068,7 +12082,7 @@ bool CDistributedFileDirectory::isProtectedFile(const CDfsLogicalFileName &logic
         }
     }
     // timeout retry TBD
-    return prot; 
+    return prot;
 }
 
 unsigned CDistributedFileDirectory::queryProtectedCount(const CDfsLogicalFileName &logicalName, const char *owner)
@@ -12081,7 +12095,7 @@ unsigned CDistributedFileDirectory::queryProtectedCount(const CDfsLogicalFileNam
     ForEach(*wpiter) {
         IPropertyTree &t = wpiter->query();
         const char *name = t.queryProp("@name");
-        if (!owner||!*owner||(name&&(strcmp(owner,name)==0))) 
+        if (!owner||!*owner||(name&&(strcmp(owner,name)==0)))
             count += t.getPropInt("@count");
     }
     return count;

--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -2738,11 +2738,15 @@ public:
         return *t;
     }
 
-    IPropertyTree &queryHistory()
+    IPropertyTree &queryHistory() const
     {
         IPropertyTree *t = root->queryPropTree("History");
-        if (!t)
-            t = root->setPropTree("History",createPTree("History")); // takes ownership
+        return *t;
+    }
+
+    IPropertyTree &createHistory()
+    {
+        IPropertyTree *t = root->setPropTree("History",createPTree("History")); // takes ownership
         return *t;
     }
 

--- a/dali/base/dadfs.hpp
+++ b/dali/base/dadfs.hpp
@@ -399,8 +399,9 @@ interface IDistributedFile: extends IInterface
 
     virtual void validate() = 0;
 
-    virtual IPropertyTree &queryHistory() = 0;                               // DFile History records
+    virtual IPropertyTree &queryHistory() const = 0;                         // DFile History records
     virtual void eraseHistory() = 0;                                         // Erase DFile History records
+    virtual IPropertyTree &createHistory() = 0;
 };
 
 
@@ -460,7 +461,7 @@ interface ISimpleSuperFileEnquiry: extends IInterface // lightweight local
 // ==DISTRIBUTED FILE PROPERTY LOCKS============================================================================
 /*
  * Context-based file property locking mechanism. Allows early unlocking for special cases,
- * stores the reload flag and allows you to query the 'Attr' section of the file property,
+ * stores the reload flag and allows you to query the 'Attr' and 'History' sections of the file property,
  * which is the only part external consumers are allowed to change.
  *
  * Use this instead of locking/unlocking manually. Manual lock is deprecated and will
@@ -499,7 +500,10 @@ public:
     }
     IPropertyTree &queryHistory()
     {
-        return file->queryHistory();
+        IPropertyTree *temp = &file->queryHistory();
+        if (!temp)
+            temp = &file->createHistory(); // takes ownership
+        return *temp;
     }
     bool needsReload()
     {

--- a/dali/base/dadfs.hpp
+++ b/dali/base/dadfs.hpp
@@ -377,27 +377,30 @@ interface IDistributedFile: extends IInterface
     virtual void setPreferredClusters(const char *clusters) = 0;
     virtual void setSingleClusterOnly() = 0;
 
-    virtual bool getFormatCrc(unsigned &crc) =0;   // CRC for record format 
-    virtual bool getRecordSize(size32_t &rsz) =0;   
+    virtual bool getFormatCrc(unsigned &crc) =0;   // CRC for record format
+    virtual bool getRecordSize(size32_t &rsz) =0;
     virtual bool getRecordLayout(MemoryBuffer &layout) =0;
 
 
     virtual void enqueueReplicate()=0;
 
-    virtual StringBuffer &getColumnMapping(StringBuffer &mapping) =0;   
-    virtual void setColumnMapping(const char *mapping) =0;   
+    virtual StringBuffer &getColumnMapping(StringBuffer &mapping) =0;
+    virtual void setColumnMapping(const char *mapping) =0;
 
     virtual bool canModify(StringBuffer &reason) = 0;
     virtual bool canRemove(StringBuffer &reason,bool ignoresub=false) = 0;
-    virtual void setProtect(const char *callerid, bool protect=true, unsigned timeoutms=INFINITE) = 0;                  
+    virtual void setProtect(const char *callerid, bool protect=true, unsigned timeoutms=INFINITE) = 0;
                                                                                             // sets or clears deletion protection
                                                                                             // returns true if locked (by anyone) after action
                                                                                             // if callerid NULL and protect=false, clears all
-    
+
     virtual unsigned setDefaultTimeout(unsigned timems) = 0;                                // sets default timeout for SDS connections and locking
                                                                                             // returns previous value
 
     virtual void validate() = 0;
+
+    virtual IPropertyTree &queryHistory() = 0;                               // DFile History records
+    virtual void eraseHistory() = 0;                                         // Erase DFile History records
 };
 
 
@@ -494,6 +497,10 @@ public:
     {
         return file->queryAttributes();
     }
+    IPropertyTree &queryHistory()
+    {
+        return file->queryHistory();
+    }
     bool needsReload()
     {
         return reload;
@@ -575,7 +582,7 @@ interface IDistributedFileDirectory: extends IInterface
     virtual bool removeEntry(const char *name, IUserDescriptor *user, IDistributedFileTransaction *transaction=NULL, unsigned timeoutms=INFINITE, bool throwException=false) = 0;
     virtual void renamePhysical(const char *oldname,const char *newname,IUserDescriptor *user,IDistributedFileTransaction *transaction) = 0;                         // renames the physical parts as well as entry
     virtual void removeEmptyScope(const char *scope) = 0;   // does nothing if called on non-empty scope
-    
+
 
     virtual bool exists(const char *logicalname,IUserDescriptor *user,bool notsuper=false,bool superonly=false) = 0;                           // logical name exists
     virtual bool existsPhysical(const char *logicalname,IUserDescriptor *user) = 0;                                                    // physical parts exists
@@ -646,11 +653,11 @@ interface IDistributedFileDirectory: extends IInterface
         const char *kind=S_LINK_RELATIONSHIP_KIND
     )=0;
 
-    virtual void removeAllFileRelationships(const char *filename)=0;        
+    virtual void removeAllFileRelationships(const char *filename)=0;
     virtual IFileRelationshipIterator *lookupAllFileRelationships(const char *filename)=0; // either primary or secondary
 
     virtual bool loadScopeContents(const char *scopelfn,
-                                   StringArray *scopes, 
+                                   StringArray *scopes,
                                    StringArray *supers,
                                    StringArray *files,
                                    bool includeemptyscopes=false
@@ -667,7 +674,7 @@ interface IDistributedFileDirectory: extends IInterface
     virtual unsigned queryProtectedCount(const CDfsLogicalFileName &logicalname,
                                   const char *callerid=NULL) = 0;                   // if NULL  then sums all
 
-    virtual bool getProtectedInfo (const CDfsLogicalFileName &logicalname, 
+    virtual bool getProtectedInfo (const CDfsLogicalFileName &logicalname,
                                            StringArray &names, UnsignedArray &counts) = 0;
 
     virtual IDFProtectedIterator *lookupProtectedFiles(const char *owner=NULL,bool notsuper=false,bool superonly=false)=0; // if owner = NULL then all
@@ -788,10 +795,10 @@ extern da_decl IDFAttributesIterator *createSubFileFilter(IDFAttributesIterator 
 
 #define DFS_REPLICATE_QUEUE "dfs_replicate_queue"
 #define DRQ_STOP 0
-#define DRQ_REPLICATE 1 
+#define DRQ_REPLICATE 1
 
 
-// Useful property query functions 
+// Useful property query functions
 
 inline bool isFileKey(IPropertyTree &pt) { const char *kind = pt.queryProp("@kind"); return kind&&strieq(kind,"key"); }
 inline bool isFileKey(IDistributedFile *f) { return isFileKey(f->queryAttributes()); }

--- a/dali/base/dafdesc.cpp
+++ b/dali/base/dafdesc.cpp
@@ -38,7 +38,7 @@
 #define SDS_CONNECT_TIMEOUT  (1000*60*60*2)     // better than infinite
 
 #define SERIALIZATION_VERSION ((byte)0xd4)
-#define SERIALIZATION_VERSION2 ((byte)0xd5) // with trailing superfile info (11010101b)
+#define SERIALIZATION_VERSION2 ((byte)0xd5) // with trailing superfile info
 
 bool isMulti(const char *str)
 {
@@ -1534,6 +1534,8 @@ public:
         t = &queryHistory();
         if (!isEmptyPTree(t))
             pt.addPropTree("History",createPTreeFromIPT(t));
+        else
+            pt.addPropTree("History",createPTree("History"));
     }
 
     IPropertyTree *getFileTree(unsigned flags)
@@ -1737,13 +1739,22 @@ public:
         if (history)
             return history.getLink();
         else
-            return nullptr;
+        {
+            history.setown(createPTree("History"));
+            return history.getLink();
+        }
     }
 
     IPropertyTree &queryHistory()
     {
         closePending();
-        return *history.get();
+        if (history)
+            return *history.get();
+        else
+        {
+            history.setown(createPTree("History"));
+            return *history.get();
+        }
     }
 
     bool isMulti(unsigned partidx=(unsigned)-1)

--- a/dali/base/dafdesc.hpp
+++ b/dali/base/dafdesc.hpp
@@ -62,9 +62,9 @@ enum GroupType { grp_thor, grp_thorspares, grp_roxie, grp_hthor, grp_unknown, __
 // repeatedPart flags
 #define CPDMSRP_lastRepeated     (0x20000000) // repeat last part
 #define CPDMSRP_onlyRepeated     (0x40000000) // or with repeatedPart for only repeated parts
-#define CPDMSRP_allRepeated      (0x80000000) // or with repeatedPart for all parts repeated 
+#define CPDMSRP_allRepeated      (0x80000000) // or with repeatedPart for all parts repeated
 #define CPDMSRP_notRepeated      ((unsigned)-1) // value of no repeated parts (i.e. only normal replication)
-#define CPDMSRP_partMask         (0xffffff) 
+#define CPDMSRP_partMask         (0xffffff)
 
 struct da_decl ClusterPartDiskMapSpec
 {
@@ -76,7 +76,7 @@ public:
     byte startDrv;          // normally 0 (c$)
     byte flags;             // CPDMSF_*
     unsigned interleave;    // for superfiles (1..)
-    unsigned repeatedPart;  // if part is repeated on every node (NB maxCopies does not include) 
+    unsigned repeatedPart;  // if part is repeated on every node (NB maxCopies does not include)
                             // ( | CPDMSRP_onlyRepeated for *only* repeats )
     StringAttr defaultBaseDir; // if set overrides *base* directory (i.e. /c$/dir/x/y becomes odir/x/y)
     StringAttr defaultReplicateDir;
@@ -101,7 +101,7 @@ public:
 #define CPDMSF_wrapToNextDrv    (0x01)      // whether should wrap to next drv
 #define CPDMSF_fillWidth        (0x02)      // replicate copies fill cluster serially (when num parts < clusterwidth/2)
 #define CPDMSF_packParts        (0x04)      // whether to save parts as binary
-#define CPDMSF_repeatedPart     (0x08)      // if repeated parts included 
+#define CPDMSF_repeatedPart     (0x08)      // if repeated parts included
 #define CPDMSF_defaultBaseDir   (0x10)      // set if defaultBaseDir present
 #define CPDMSF_defaultReplicateDir  (0x20)      // set if defaultBaseDir present
 #define CPDMSF_overloadedConfig  (0x40)      // set if overloaded mode
@@ -160,19 +160,19 @@ interface IFileDescriptor: extends IInterface
     for each cluster
         addCluster(grp,mapping) (or addCluster(grpname,mapping,resolver)
 
- or: 
+ or:
 
    for each cluster
         for each part
-            setPart(partnum,file,attr);     
+            setPart(partnum,file,attr);
         endCluster(mapping);
 
  or: (single cluster legacy)
 
     for each part
-        setPart(partnum,file,attr);  
- 
-   
+        setPart(partnum,file,attr);
+
+
 note it is an error to set different filenames for the same part on different clusters
 or to set the same part twice in the same cluster
 if endCluster is not called it will assume only one cluster and not replicated
@@ -241,6 +241,9 @@ if endCluster is not called it will assume only one cluster and not replicated
     virtual StringBuffer &getClusterLabel(unsigned clusternum,StringBuffer &ret) = 0; // node group name
 
     virtual void ensureReplicate() = 0;                                             // make sure a file can be replicated
+
+    virtual IPropertyTree &queryHistory() = 0;                                       // query file history records
+    virtual IPropertyTree *getHistory() = 0;                                         // get file history records
 };
 
 interface ISuperFileDescriptor: extends IFileDescriptor
@@ -257,7 +260,7 @@ interface ISuperFileDescriptor: extends IFileDescriptor
 
 interface IClusterInfo: extends IInterface  // used by IFileDescriptor and IDistributedFile
 {
-    virtual StringBuffer &getGroupName(StringBuffer &name,IGroupResolver *resolver=NULL)=0; 
+    virtual StringBuffer &getGroupName(StringBuffer &name,IGroupResolver *resolver=NULL)=0;
     virtual const char *queryGroupName()=0;     // may be NULL
     virtual IGroup *queryGroup()=0;           // may be NULL
     virtual ClusterPartDiskMapSpec  &queryPartDiskMapping()=0;
@@ -306,11 +309,11 @@ extern da_decl StringBuffer &makePhysicalPartName(
                                 DFD_OS os=DFD_OSdefault,            // os must be specified if no dir specified
                                 const char *diroverride=NULL);      // override default directory
 extern da_decl StringBuffer &makeSinglePhysicalPartName(const char *lname, // single part file
-                                                        StringBuffer &result, 
-                                                        bool allowospath,   // allow an OS (absolute) file path 
+                                                        StringBuffer &result,
+                                                        bool allowospath,   // allow an OS (absolute) file path
                                                         bool &wasdfs,       // not OS path
                                                         const char *diroverride=NULL
-                                                        );    
+                                                        );
 
 // set/get defaults
 extern da_decl const char *queryBaseDirectory(GroupType groupType, unsigned replicateLevel=0, DFD_OS os=DFD_OSdefault);

--- a/dali/dfu/dfuutil.cpp
+++ b/dali/dfu/dfuutil.cpp
@@ -1295,25 +1295,6 @@ public:
             }
         }
     }
-
-    MemoryBuffer &getFileHistory(const char *lfn,MemoryBuffer &out, IUserDescriptor *user)
-    {
-        Owned<IDistributedFile> file = queryDistributedFileDirectory().lookup(lfn, user);
-        if (!file) {
-            throwError1(DFUERR_DFileNotFound, lfn);
-        }
-        else
-        {
-            Owned<IPropertyTree> t = queryDistributedFileDirectory().getFileTree(lfn, user)->getPropTree("History");
-            if (t)
-                t->serialize(out);
-            else
-                // For old file which has not History
-                out.clear().append(0);
-        }
-        return out;
-    }
-
 };
 
 

--- a/dali/dfu/dfuutil.cpp
+++ b/dali/dfu/dfuutil.cpp
@@ -367,7 +367,7 @@ public:
                             got = getFileInfo(dstfn,dstf,dstsize,dstmodtime);
                             // check size/date TBD
                             sem.signal();
-                            if (got&&(srcsize==dstsize)&&srcmodtime.equals(dstmodtime)) 
+                            if (got&&(srcsize==dstsize)&&srcmodtime.equals(dstmodtime))
                                 continue;
                         }
 
@@ -1294,6 +1294,24 @@ public:
                 }
             }
         }
+    }
+
+    MemoryBuffer &getFileHistory(const char *lfn,MemoryBuffer &out, IUserDescriptor *user)
+    {
+        Owned<IDistributedFile> file = queryDistributedFileDirectory().lookup(lfn, user);
+        if (!file) {
+            throwError1(DFUERR_DFileNotFound, lfn);
+        }
+        else
+        {
+            Owned<IPropertyTree> t = queryDistributedFileDirectory().getFileTree(lfn, user)->getPropTree("History");
+            if (t)
+                t->serialize(out);
+            else
+                // For old file which has not History
+                out.clear().append(0);
+        }
+        return out;
     }
 
 };

--- a/dali/dfu/dfuutil.hpp
+++ b/dali/dfu/dfuutil.hpp
@@ -100,6 +100,8 @@ interface IDFUhelper: extends IInterface
         IPropertyTree *relationships,   // if not NULL, tree will have all relationships filled in
         IUserDescriptor *user
     ) = 0;
+
+    virtual MemoryBuffer &getFileHistory(const char *lfn, MemoryBuffer &out, IUserDescriptor *user) = 0;
 };
 
 IDFUhelper *createIDFUhelper();

--- a/dali/dfu/dfuutil.hpp
+++ b/dali/dfu/dfuutil.hpp
@@ -101,7 +101,6 @@ interface IDFUhelper: extends IInterface
         IUserDescriptor *user
     ) = 0;
 
-    virtual MemoryBuffer &getFileHistory(const char *lfn, MemoryBuffer &out, IUserDescriptor *user) = 0;
 };
 
 IDFUhelper *createIDFUhelper();

--- a/dali/dfuplus/dfuplus.cpp
+++ b/dali/dfuplus/dfuplus.cpp
@@ -54,7 +54,7 @@ class CDafsThread: public Thread
     Owned<IException> exc;
 
 public:
-    CDafsThread(SocketEndpoint &_listenep,bool requireauthenticate) 
+    CDafsThread(SocketEndpoint &_listenep,bool requireauthenticate)
         : listenep(_listenep)
     {
         if (listenep.port==0)
@@ -88,7 +88,7 @@ public:
     void stop()
     {
         try {
-            if (server) 
+            if (server)
                 server->stop();
         }
         catch (IException *e) {
@@ -107,7 +107,7 @@ public:
 
 bool CDfuPlusHelper::runLocalDaFileSvr(SocketEndpoint &listenep,bool requireauthenticate, unsigned timeout)
 {
-    Owned<CDafsThread> thr = new CDafsThread(listenep,requireauthenticate); 
+    Owned<CDafsThread> thr = new CDafsThread(listenep,requireauthenticate);
     if (!thr->ok())
         return false;
     thr->start();
@@ -123,7 +123,7 @@ bool CDfuPlusHelper::runLocalDaFileSvr(SocketEndpoint &listenep,bool requireauth
     else {
         loop {
             Sleep(500);
-            if (thr->idleTime()>timeout) { 
+            if (thr->idleTime()>timeout) {
                 thr->stop();
                 break;
             }
@@ -172,7 +172,7 @@ CDfuPlusHelper::CDfuPlusHelper(IProperties* _globals,   CDfuPlusMessagerIntercep
     const char* server = globals->queryProp("server");
     if(server == NULL)
         throw MakeStringException(-1, "Server url not specified");
-    
+
     StringBuffer url;
     if(Utils::strncasecmp(server, "http://", 7) != 0 && Utils::strncasecmp(server, "https://", 8) != 0)
         url.append("http://");
@@ -187,7 +187,7 @@ CDfuPlusHelper::CDfuPlusHelper(IProperties* _globals,   CDfuPlusMessagerIntercep
     StringBuffer fsurl(url.str());
     fsurl.append("FileSpray");
     sprayclient->addServiceUrl(fsurl.str());
-    
+
     dfuclient.setown(createWsDfuClient());
     StringBuffer dfuurl(url.str());
     dfuurl.append("WsDfu");
@@ -264,6 +264,10 @@ int CDfuPlusHelper::doit()
         return resubmit();
     else if(stricmp(action, "monitor") == 0)
         return monitor();
+    else if(stricmp(action, "listhistory") == 0)
+        return listhistory();
+    else if(stricmp(action, "erasehistory") == 0)
+        return erasehistory();
 #ifdef DAFILESRV_LOCAL
     else if(stricmp(action, "dafilesrv") == 0)
         return rundafs();
@@ -277,13 +281,13 @@ bool CDfuPlusHelper::fixedSpray(const char* srcxml,const char* srcip,const char*
 {
     int recordsize;
     if(stricmp(format, "recfmvb") == 0) {
-        recordsize = RECFMVB_RECSIZE_ESCAPE;  // special value for recfmvb 
+        recordsize = RECFMVB_RECSIZE_ESCAPE;  // special value for recfmvb
     }
     else if(stricmp(format, "recfmv") == 0) {
         recordsize = RECFMV_RECSIZE_ESCAPE;  // special value for recfmv
     }
     else if(stricmp(format, "variable") == 0) {
-        recordsize = PREFIX_VARIABLE_RECSIZE_ESCAPE;  // special value for variable 
+        recordsize = PREFIX_VARIABLE_RECSIZE_ESCAPE;  // special value for variable
     }
     else if(stricmp(format, "variablebigendian") == 0) {
         recordsize = PREFIX_VARIABLE_BIGENDIAN_RECSIZE_ESCAPE;  // special value for variable bigendian
@@ -328,14 +332,14 @@ bool CDfuPlusHelper::fixedSpray(const char* srcxml,const char* srcip,const char*
     if(globals->hasProp("push")) {
         if (globals->getPropBool("push"))
             req->setPush(true);
-        else 
+        else
             req->setPull(true);
     }
     if(globals->hasProp("norecover"))
         req->setNorecover(globals->getPropBool("norecover", false));
     else if(globals->hasProp("noRecover"))
         req->setNorecover(globals->getPropBool("noRecover", false));
-    
+
     if(globals->hasProp("connect"))
         req->setMaxConnections(globals->getPropInt("connect"));
     if(globals->hasProp("throttle"))
@@ -439,7 +443,7 @@ bool CDfuPlusHelper::variableSpray(const char* srcxml,const char* srcip,const ch
         if(escape && *escape)
             req->setSourceCsvEscape(escape);
     }
-    else 
+    else
         encoding = format; // may need extra later
 
     req->setSourceFormat(CDFUfileformat::decode(encoding));
@@ -459,7 +463,7 @@ bool CDfuPlusHelper::variableSpray(const char* srcxml,const char* srcip,const ch
     if(globals->hasProp("push")) {
         if (globals->getPropBool("push"))
             req->setPush(true);
-        else 
+        else
             req->setPull(true);
     }
     if(globals->hasProp("compress"))
@@ -509,7 +513,7 @@ int CDfuPlusHelper::spray()
     const char* srcxml = globals->queryProp("srcxml");
     const char* srcip = globals->queryProp("srcip");
     const char* srcfile = globals->queryProp("srcfile");
-    
+
     bool nowait = globals->getPropBool("nowait", false);
 
     MemoryBuffer xmlbuf;
@@ -596,15 +600,15 @@ int CDfuPlusHelper::replicate()
     bool onlyrepeated = repeatlast&&globals->getPropBool("onlyrepeated");
     StringBuffer cluster;
     globals->getProp("cluster",cluster);
-    if (cluster.length()) 
+    if (cluster.length())
         req->setCluster(cluster.str());
     else if (repeatlast) {
         error("replicate repeatlast specified with no cluster\n");
         return 0;
     }
-    if (repeatlast) 
+    if (repeatlast)
         req->setRepeatLast(true);
-    if (onlyrepeated) 
+    if (onlyrepeated)
         req->setOnlyRepeated(true);
 
     Owned<IClientReplicateResponse> result = sprayclient->Replicate(req);
@@ -630,7 +634,7 @@ int CDfuPlusHelper::despray()
     const char* srcname = globals->queryProp("srcname");
     if(srcname == NULL)
         throw MakeStringException(-1, "srcname not specified");
-    
+
     const char* dstxml = globals->queryProp("dstxml");
     const char* dstip = globals->queryProp("dstip");
     const char* dstfile = globals->queryProp("dstfile");
@@ -748,7 +752,7 @@ int CDfuPlusHelper::copy()
     const char* diffkeysrc = globals->queryProp("diffkeydst");
 
     bool nowait = globals->getPropBool("nowait", false);
-    
+
     info("\nCopying from %s to %s\n", srcname, dstname);
 
     Owned<IClientCopy> req = sprayclient->createCopyRequest();
@@ -776,7 +780,7 @@ int CDfuPlusHelper::copy()
     if(globals->hasProp("push")) {
         if (globals->getPropBool("push"))
             req->setPush(true);
-        else 
+        else
             req->setPull(true);
     }
     if(globals->hasProp("compress"))
@@ -842,7 +846,7 @@ int CDfuPlusHelper::copysuper()
     const char* srcpassword = globals->queryProp("srcpassword");
 
     bool nowait = globals->getPropBool("nowait", false);
-    
+
     info("\nCopying superfile from %s to %s\n", srcname, dstname);
 
     Owned<IClientCopy> req = sprayclient->createCopyRequest();
@@ -866,7 +870,7 @@ int CDfuPlusHelper::copysuper()
     if(globals->hasProp("push")) {
         if (globals->getPropBool("push"))
             req->setPush(true);
-        else 
+        else
             req->setPull(true);
     }
     if(globals->hasProp("compress"))
@@ -889,7 +893,7 @@ int CDfuPlusHelper::copysuper()
         req->setNorecover(globals->getPropBool("noRecover", false));
 
     Owned<IClientCopyResponse> result = sprayclient->Copy(req);
-    const char* ret = result->getResult();  
+    const char* ret = result->getResult();
     if(ret == NULL || *ret == '\0')
         exc(result->getExceptions(),"copying");
     else if (stricmp(ret,"OK")==0)
@@ -911,7 +915,7 @@ int CDfuPlusHelper::monitor()
         throw MakeStringException(-1, "neither lfn nor filename specified");
     int shotlimit = globals->getPropInt("shotlimit");
     if (shotlimit == 0)
-        shotlimit = 1;  
+        shotlimit = 1;
     if (lfn)
         info("\nEvent %s: Monitoring logical file name %s\n", eventname?eventname:"", lfn);
     else if (eps)
@@ -925,7 +929,7 @@ int CDfuPlusHelper::monitor()
         req->setEventName(eventname);
     if (lfn)
         req->setLogicalName(lfn);
-    if (eps) 
+    if (eps)
         req->setIp(eps);
     if (filename)
         req->setFilename(filename);
@@ -947,7 +951,7 @@ int CDfuPlusHelper::rundafs()
 {
     unsigned idletimeoutsecs = (unsigned)globals->getPropInt("idletimeout",INFINITE);
     SocketEndpoint listenep;
-    if (runLocalDaFileSvr(listenep,false,(idletimeoutsecs!=INFINITE)?idletimeoutsecs*1000:INFINITE)) 
+    if (runLocalDaFileSvr(listenep,false,(idletimeoutsecs!=INFINITE)?idletimeoutsecs*1000:INFINITE))
         return 0;
     return 1;
 }
@@ -1018,7 +1022,7 @@ int CDfuPlusHelper::remove()
 
     if(files.length() < 1)
         throw MakeStringException(-1, "file name not specified");
-    
+
     Owned<IClientDFUArrayActionRequest> req = dfuclient->createDFUArrayActionRequest();
     req->setType("Delete");
     req->setLogicalFiles(files);
@@ -1085,7 +1089,7 @@ int CDfuPlusHelper::rename()
         throw MakeStringException(-1, "dstname not specified");
 
     bool nowait = globals->getPropBool("nowait", false);
-    
+
     info("\nRenaming from %s to %s\n", srcname, dstname);
 
     Owned<IClientRename> req = sprayclient->createRenameRequest();
@@ -1123,7 +1127,7 @@ int CDfuPlusHelper::list()
     Owned<IClientDFUQueryRequest> req = dfuclient->createDFUQueryRequest();
     if(name != NULL)
         req->setLogicalName(name);
-    
+
     req->setPageSize(-1);
 
     Owned<IClientDFUQueryResponse> resp = dfuclient->DFUQuery(req);
@@ -1180,7 +1184,7 @@ int CDfuPlusHelper::superfile(const char* action)
     const char* superfile = globals->queryProp("superfile");
     if(superfile == NULL || *superfile == '\0')
         throw MakeStringException(-1, "superfile name is not specified");
-    
+
     if(stricmp(action, "add") == 0 || stricmp(action, "remove") == 0)
     {
         const char* before = globals->queryProp("before");
@@ -1236,7 +1240,7 @@ int CDfuPlusHelper::superfile(const char* action)
         Owned<IClientSuperfileListRequest> req = dfuclient->createSuperfileListRequest();
         req->setSuperfile(superfile);
         Owned<IClientSuperfileListResponse> resp = dfuclient->SuperfileList(req);
-        
+
         const IMultiException* excep = &resp->getExceptions();
         if(excep != NULL && excep->ordinality() > 0)
         {
@@ -1261,12 +1265,12 @@ int CDfuPlusHelper::savexml()
     const char* lfn = globals->queryProp("srcname");
     if(lfn == NULL || *lfn == '\0')
         throw MakeStringException(-1, "srcname not specified");
-    
+
     Owned<IClientSavexmlRequest> req = dfuclient->createSavexmlRequest();
     req->setName(lfn);
-    
+
     Owned<IClientSavexmlResponse> resp = dfuclient->Savexml(req);
-    
+
     const IMultiException* excep = &resp->getExceptions();
     if(excep != NULL && excep->ordinality() > 0)
     {
@@ -1284,7 +1288,7 @@ int CDfuPlusHelper::savexml()
         if(ofile == -1)
             throw MakeStringException(-1, "can't open file %s\n", dstxml);
     }
-    
+
     const MemoryBuffer& xmlmap = resp->getXmlmap();
     ssize_t written = write(ofile, xmlmap.toByteArray(), xmlmap.length());
     if (written < 0)
@@ -1300,7 +1304,7 @@ int CDfuPlusHelper::add()
     const char* lfn = globals->queryProp("dstname");
     if(lfn == NULL || *lfn == '\0')
         throw MakeStringException(-1, "dstname not specified");
-    
+
     bool isRemote = false;
     const char* xmlfname = globals->queryProp("srcxml");
     const char* srcname = globals->queryProp("srcname");
@@ -1330,9 +1334,9 @@ int CDfuPlusHelper::add()
         Owned<IClientAddRequest> req = dfuclient->createAddRequest();
         req->setDstname(lfn);
         req->setXmlmap(xmlbuf);
-        
+
         Owned<IClientAddResponse> resp = dfuclient->Add(req);
-        
+
         const IMultiException* excep = &resp->getExceptions();
         if(excep != NULL && excep->ordinality() > 0)
         {
@@ -1354,7 +1358,7 @@ int CDfuPlusHelper::add()
             req->setSrcpassword(srcpassword);
 
         Owned<IClientAddRemoteResponse> resp = dfuclient->AddRemote(req);
-        
+
         const IMultiException* excep = &resp->getExceptions();
         if(excep != NULL && excep->ordinality() > 0)
         {
@@ -1390,7 +1394,7 @@ int CDfuPlusHelper::status()
     }
 
     IConstDFUWorkunit & dfuwu = resp->getResult();
-    
+
     switch(dfuwu.getState())
     {
         case DFUstate_unknown:
@@ -1436,7 +1440,7 @@ int CDfuPlusHelper::abort()
     req->setWuid(wuid);
 
     Owned<IClientAbortDFUWorkunitResponse> resp = sprayclient->AbortDFUWorkunit(req);
-    
+
     const IMultiException* excep = &resp->getExceptions();
     if(excep != NULL && excep->ordinality() > 0)
     {
@@ -1448,7 +1452,256 @@ int CDfuPlusHelper::abort()
     {
         error("Aborted %s\n", wuid);
     }
-    
+
+    return 0;
+}
+
+int CDfuPlusHelper::listhistory()
+{
+    const char* lfn = globals->queryProp("lfn");
+    if(lfn == NULL || *lfn == '\0')
+            throw MakeStringException(-1, "srcname not specified");
+
+    Owned<IClientListHistoryRequest> req = dfuclient->createListHistoryRequest();
+    req->setName(lfn);
+
+    Owned<IClientListHistoryResponse> resp = dfuclient->ListHistory(req);
+
+    const IMultiException* excep = &resp->getExceptions();
+    if(excep != NULL && excep->ordinality() > 0)
+    {
+        StringBuffer errmsg;
+        excep->errorMessage(errmsg);
+        error("%s\n", errmsg.str());
+        return -1;
+    }
+
+    typedef enum
+    {
+        xml = 0,
+        ascii = 1,
+        csv = 2,
+        json = 3,
+    }out_t;
+
+    out_t format;
+
+    const char *formatPar = globals->queryProp("outformat");
+    if(formatPar == nullptr)
+        format = xml;
+    else if (stricmp(formatPar, "csv") == 0)
+        format=csv;
+    else if (stricmp(formatPar, "xml") == 0)
+        format=xml;
+    else if (stricmp(formatPar, "json") == 0)
+        format=json;
+    else if (stricmp(formatPar, "ascii") == 0)
+        format=ascii;
+    else
+    {
+        error("Unsupported output format: '%s'\n",formatPar);
+        return -1;
+    }
+
+    MemoryBuffer tmp;
+    tmp.append(resp->getXmlmap());
+    if (0 == *tmp.toByteArray())
+    {
+        error("%s doesn't have stored history!\n", lfn);
+        return -2;
+    }
+
+    Owned<IPropertyTree>    history;
+    history.setown(createPTree("History"));
+    history->deserialize(tmp);
+    bool sorted = true;
+
+    switch (format)
+    {
+    case xml:
+        {
+            StringBuffer out;
+            toXML(history, out, true);
+            info("\n%s\n",out.trim().str());
+        }
+        break;
+
+    case ascii:
+        {
+            progress("\nHistory of %s:\n", lfn);
+            unsigned index = 1;
+            Owned<IPropertyTreeIterator> historyIter = history->getElements("*");
+            ForEach(*historyIter)
+            {
+                info("%d", index++);
+                Owned<IAttributeIterator> attribIter = historyIter->query().getAttributes(sorted);
+                ForEach(*attribIter)
+                {
+                    info(", ");
+                    const char *propName = attribIter->queryName();
+                    if (*propName == '@')
+                        propName++;
+                    const char *propVal =  attribIter->queryValue();
+                    info("%s=%s",propName, propVal);
+                }
+                info("\n");
+            }
+        }
+        break;
+
+    case csv:
+        {
+            // TODO We need more sophisticated method if the record structure change in the future
+            bool showCsvHeader = globals->getPropBool("csvheader", true);
+            info("\n");
+            unsigned index = 1;
+            Owned<IPropertyTreeIterator> historyIter = history->getElements("*");
+            bool first = true;
+            if (showCsvHeader)
+            {
+                // Get header from the first record
+                (*historyIter).first();
+                Owned<IAttributeIterator> attribIter = historyIter->query().getAttributes(sorted);
+                ForEach(*attribIter)
+                {
+                    if(!first)
+                        info(",");
+                    else
+                        first = false;
+
+                    const char *propName = attribIter->queryName();
+                    if (*propName == '@')
+                        propName++;
+                    info("%s",propName);
+                }
+                info("\n");
+            }
+
+            ForEach(*historyIter)
+            {
+                first = true;
+                Owned<IAttributeIterator> attribIter = historyIter->query().getAttributes(sorted);
+                ForEach(*attribIter)
+                {
+                    if(!first)
+                        info(",");
+                    else
+                        first = false;
+
+                    const char *propVal =  attribIter->queryValue();
+                    info("%s", propVal);
+                }
+                info("\n");
+            }
+        }
+        break;
+
+    case json:
+        {
+            const char * level1 = "   ";        // 3 space 'tab'
+            const char * level2 = "      ";
+            const char * level3 = "         ";
+            //                     123456789
+
+            unsigned index = 1;
+
+            info("{\n");       // Level 0: Start History object
+            StringBuffer temp;
+            history->getName(temp);
+            info("%s\"%s\": [", level1, temp.str());   // Begin History object's array of historical records
+            Owned<IPropertyTreeIterator> historyIter = history->getElements("*");
+            ForEach(*historyIter)
+            {
+                if (index++ != 1)
+                    info(",");
+
+                info("\n%s{\n", level2);    // Historical record object begin
+
+                bool first = true;
+                Owned<IAttributeIterator> attribIter = historyIter->query().getAttributes(sorted);
+                ForEach(*attribIter)
+                {
+                    if (!first)
+                        info(",\n");
+                    else
+                        first = false;
+
+                    const char *propName = attribIter->queryName();
+                    if (*propName == '@')
+                        propName++;
+                    const char *propVal =  attribIter->queryValue();
+                    info("%s\"%s\" : \"%s\"",level3, propName, propVal);    // Historical record item object
+                }
+                info("\n%s}", level2);   // Historical record object end
+            }
+            info("\n%s]\n", level1);   // History object array end
+
+            info("}\n");       // Level 0 : History object end
+        }
+        break;
+    }
+
+    return 0;
+}
+
+int CDfuPlusHelper::erasehistory()
+{
+    const char* lfn = globals->queryProp("lfn");
+    if(lfn == NULL || *lfn == '\0')
+        throw MakeStringException(-1, "srcname not specified");
+
+    bool backup = globals->getPropBool("backup", true);
+    const char* dstxml = globals->queryProp("dstxml");
+    if(backup && (dstxml == NULL || *dstxml == '\0'))
+        throw MakeStringException(-1, "dstxml not specified");
+
+    progress("\nErase history of '%s' with%s backup.\n", lfn, (backup ? "" : "out"));
+
+    Owned<IClientEraseHistoryRequest> req = dfuclient->createEraseHistoryRequest();
+    req->setName(lfn);
+
+    Owned<IClientEraseHistoryResponse> resp = dfuclient->EraseHistory(req);
+
+    const IMultiException* excep = &resp->getExceptions();
+    if(excep != NULL && excep->ordinality() > 0)
+    {
+        StringBuffer errmsg;
+        excep->errorMessage(errmsg);
+        error("%s\n", errmsg.str());
+        return -1;
+    }
+
+    if (backup)
+    {
+        MemoryBuffer tmp;
+        tmp.append(resp->getXmlmap());
+
+        if (0 == *tmp.toByteArray())
+        {
+            error("%s doesn't have stored history!\n", lfn);
+            return -2;
+        }
+
+        int ofile = open(dstxml, _O_WRONLY | _O_CREAT | _O_TRUNC, _S_IREAD | _S_IWRITE);
+        if(ofile == -1)
+            throw MakeStringException(-1, "can't open file %s\n", dstxml);
+
+        Owned<IPropertyTree>    history;
+        history.setown(createPTree("History"));
+        history->deserialize(tmp);
+
+        StringBuffer out;
+        toXML(history, out, true);
+
+        ssize_t written = write(ofile, out.str(), out.length());
+        if (written < 0)
+            throw MakeStringException(-1, "can't write to file %s\n", dstxml);
+        if (written != out.length())
+            throw MakeStringException(-1, "truncated write to file %s\n", dstxml);
+        close(ofile);
+        info("History written into %s.\n",dstxml);
+    }
+
     return 0;
 }
 
@@ -1462,7 +1715,7 @@ int CDfuPlusHelper::resubmit()
     req->setWuid(wuid);
 
     Owned<IClientSubmitDFUWorkunitResponse> resp = sprayclient->SubmitDFUWorkunit(req);
-    
+
     const IMultiException* excep = &resp->getExceptions();
     if(excep != NULL &&  excep->ordinality() > 0)
     {
@@ -1474,7 +1727,7 @@ int CDfuPlusHelper::resubmit()
     {
         info("Resubmitted %s\n", wuid);
     }
-    
+
     return 0;
 }
 
@@ -1501,7 +1754,7 @@ int CDfuPlusHelper::waitToFinish(const char* wuid)
 
         IConstDFUWorkunit & dfuwu = resp->getResult();
 
-        
+
         switch(dfuwu.getState())
         {
             case DFUstate_unknown:
@@ -1588,7 +1841,7 @@ void CDfuPlusHelper::exc(const IMultiException& excep,const char *title)
     error("%s\n",errmsg.str());
 }
 
-void CDfuPlusHelper::info(const char *fmt, ...) 
+void CDfuPlusHelper::info(const char *fmt, ...)
 {
     va_list args;
     va_start(args, fmt);
@@ -1608,7 +1861,7 @@ void CDfuPlusHelper::info(const char *fmt, ...)
         printf("%s",buf.str());
 }
 
-void CDfuPlusHelper::progress(const char *fmt, ...) 
+void CDfuPlusHelper::progress(const char *fmt, ...)
 {
     va_list args;
     va_start(args, fmt);
@@ -1628,7 +1881,7 @@ void CDfuPlusHelper::progress(const char *fmt, ...)
         printf("%s",buf.str());
 }
 
-void CDfuPlusHelper::error(const char *fmt, ...) 
+void CDfuPlusHelper::error(const char *fmt, ...)
 {
     va_list args;
     va_start(args, fmt);

--- a/dali/dfuplus/dfuplus.cpp
+++ b/dali/dfuplus/dfuplus.cpp
@@ -1514,6 +1514,12 @@ int CDfuPlusHelper::listhistory()
     Owned<IPropertyTree>    history;
     history.setown(createPTree("History"));
     history->deserialize(tmp);
+    if (!history->hasProp("Origin"))
+    {
+        error("%s doesn't have stored history!\n", lfn);
+        return -2;
+    }
+
     bool sorted = true;
 
     switch (format)

--- a/dali/dfuplus/dfuplus.hpp
+++ b/dali/dfuplus/dfuplus.hpp
@@ -63,6 +63,8 @@ private:
     int rundafs();
     int copysuper();
     int updatejobname(const char* wuid, const char* jobname);
+    int listhistory();
+    int erasehistory();
 
     bool fixedSpray(const char* srcxml,const char* srcip,const char* srcfile,const MemoryBuffer &xmlbuf,const char* dstcluster,const char* dstname,const char *format,StringBuffer &retwuid,StringBuffer &except );
     bool variableSpray(const char* srcxml,const char* srcip,const char* srcfile,const MemoryBuffer &xmlbuf,const char* dstcluster,const char* dstname,const char *format,StringBuffer &retwuid,StringBuffer &except );

--- a/dali/dfuplus/main.cpp
+++ b/dali/dfuplus/main.cpp
@@ -31,31 +31,36 @@ void handleSyntax()
     StringBuffer out;
 
     out.append("Usage:\n");
-    out.append("    dfuplus [-v|--version] | action=[spray|replicate|despray|copy|remove|rename|list|\n");
-    out.append("                    addsuper|removesuper|listsuper|copysuper|dafilesrv|\n");
-    out.append("                    savexml|add|status|abort|resubmit|monitor] {<options>}\n\n");
-    out.append("        -v | --version -- display version info\n\n");
+    out.append("    dfuplus [-v|--version] | action=[spray|replicate|despray|copy|remove|rename|\n");
+    out.append("                                     list|addsuper|removesuper|listsuper|\n");
+    out.append("                                     copysuper|dafilesrv|savexml|add|status|\n");
+    out.append("                                     abort|resubmit|monitor] {<options>}\n\n");
+    out.append("        -v | --version  -- display version info\n\n");
     out.append("    general options:\n");
     out.append("        server=<esp-server-url> \n");
     out.append("        username=<user-name>\n");
     out.append("        password=<password>\n");
     out.append("        overwrite=0|1\n");
     out.append("        replicate=1|0\n");
-    out.append("        replicateoffset=N -- node relative offset to find replicate (default 1)\n");
-    out.append("        partlist=<part-list> -- for one or more parts   \n");
-    out.append("        @filename -- read options from filename \n");
-    out.append("        nowait=0|1 -- return immediately without waiting for completion.\n");
-    out.append("        connect=<nn> -- restrict to nn connections at a time.\n");
-    out.append("        transferbuffersize=<n> -- use buffer of size n bytes when transferring data.\n");
-    out.append("        throttle=<nnn> -- restrict the entire transfer speed to nnn Mbits/second\n");
-    out.append("        norecover=0|1 -- don't create or restore from recovery information\n");
-    out.append("        nosplit=0|1 -- optional, don't split a file part to multiple target parts\n");
-    out.append("        compress=0|1 -- optional, compress target\n");
-    out.append("        encrypt=<password> -- optional, encrypt target\n");
-    out.append("        decrypt=<password> -- optional, decrypt source\n");
-    out.append("        push=0|1 -- optional override pull/push default\n");
-    out.append("        jobname=<jobname> -- specify the jobname for spray, despray, copy, rename and replicate.\n");
-    out.append("        failifnosourcefile=0|1 -- optional, don't generate exception when source file set is empty.\n");
+    out.append("        replicateoffset=N  -- node relative offset to find replicate (default 1)\n");
+    out.append("        partlist=<part-list>  -- for one or more parts   \n");
+    out.append("        @filename  -- read options from filename \n");
+    out.append("        nowait=0|1  -- return immediately without waiting for completion.\n");
+    out.append("        connect=<nn>  -- restrict to nn connections at a time.\n");
+    out.append("        transferbuffersize=<n>  -- use buffer of size n bytes when transferring\n");
+    out.append("                                   data.\n");
+    out.append("        throttle=<nnn>  -- restrict the entire transfer speed to nnn Mbits/sec\n");
+    out.append("        norecover=0|1  -- don't create or restore from recovery information\n");
+    out.append("        nosplit=0|1  -- optional, don't split a file part to multiple target\n");
+    out.append("                        parts\n");
+    out.append("        compress=0|1  -- optional, compress target\n");
+    out.append("        encrypt=<password>  -- optional, encrypt target\n");
+    out.append("        decrypt=<password>  -- optional, decrypt source\n");
+    out.append("        push=0|1  -- optional override pull/push default\n");
+    out.append("        jobname=<jobname>  -- specify the jobname for spray, despray, copy,\n");
+    out.append("                              rename and replicate.\n");
+    out.append("        failifnosourcefile=0|1  -- optional, don't generate exception when\n");
+    out.append("                                   source file set is empty.\n");
     out.append("    spray options:\n");
     out.append("        srcip=<source-machine-ip>\n");
     out.append("        srcfile=<source-file-path>\n");
@@ -67,47 +72,54 @@ void handleSyntax()
     out.append("        options for fixed:\n");
     out.append("            recordsize=<record-size>\n");
     out.append("        options for csv/delimited:\n");
-    out.append("            encoding=ascii|utf8|utf8n|utf16|utf16le|utf16be|utf32|utf32le|utf32be -- optional, default is ascii\n");
-    out.append("            maxrecordsize=<max-record-size> -- optional, default is 8192\n");
-    out.append("            separator=<separator> -- optional, default is \\,\n");
-    out.append("            terminator=<terminator> -- optional, default is \\r,\\r\\n\n");
-    out.append("            quote=<quote> -- optional, default is \"\n");
-    out.append("            escape=<escape> -- optional, no default value \n");
-    out.append("            recordstructurepresent=0|1 -- optional, default is 0 (no field names in first row) \n");
-    out.append("            quotedTerminator=1|0 -- optional, default is 1 (quoted terminators in rows) \n");
+    out.append("            encoding=ascii|utf8|utf8n|utf16|utf16le|utf16be|utf32|\n");
+    out.append("                     utf32le|utf32be\n");
+    out.append("                -- optional, default is ascii\n");
+    out.append("            maxrecordsize=<max-record-size>  -- optional, default is 8192\n");
+    out.append("            separator=<separator>  -- optional, default is \\,\n");
+    out.append("            terminator=<terminator>  -- optional, default is \\r,\\r\\n\n");
+    out.append("            quote=<quote>  -- optional, default is \"\n");
+    out.append("            escape=<escape>  -- optional, no default value \n");
+    out.append("            recordstructurepresent=0|1  -- optional, default is 0 (no field \n");
+    out.append("                                           names in first row) \n");
+    out.append("            quotedTerminator=1|0  -- optional, default is 1 (quoted terminators\n");
+    out.append("                                     in rows) \n");
     out.append("        options for xml:\n");
-    out.append("            rowtag=rowTag -- required\n");
-    out.append("            encoding=utf8|utf8n|utf16|utf16le|utf16be|utf32|utf32le|utf32be -- optional, default is utf8\n");
-    out.append("            maxrecordsize=<max-record-size> -- optional, default is 8192\n");
+    out.append("            rowtag=rowTag  -- required\n");
+    out.append("            encoding=utf8|utf8n|utf16|utf16le|utf16be|utf32|utf32le|utf32be \n");
+    out.append("                -- optional, default is utf8\n");
+    out.append("            maxrecordsize=<max-record-size>  -- optional, default is 8192\n");
     out.append("        options for json:\n");
-    out.append("            rowpath=rowPath - optional, default is \"/\"\n");
-    out.append("            maxrecordsize=<max-record-size> -- optional, default is 8192\n");
+    out.append("            rowpath=rowPath  -- optional, default is \"/\"\n");
+    out.append("            maxrecordsize=<max-record-size>  -- optional, default is 8192\n");
     out.append("    replicate options:\n");
     out.append("        srcname=<source-logical-name>\n");
-    out.append("        cluster=<cluster-name>     -- replicates to (additional) cluster\n");
-    out.append("        repeatlast=0|1             -- repeats last part on every node (requires cluster)\n");
-    out.append("        onlyrepeated=0|1           -- ignores parts not repeated (e.g. by repeatlast)\n");
+    out.append("        cluster=<cluster-name>  -- replicates to (additional) cluster\n");
+    out.append("        repeatlast=0|1  -- repeats last part on every node (requires cluster)\n");
+    out.append("        onlyrepeated=0|1  -- ignores parts not repeated (e.g. by repeatlast)\n");
     out.append("    despray options:\n");
     out.append("        srcname=<source-logical-name>\n");
     out.append("        dstip=<destination-machine-ip>\n");
     out.append("        dstfile=<destination-file-path>\n");
     out.append("        dstxml=<xml-file> -- replaces dstip and dstfile\n");
     out.append("        splitprefix=... use prefix (same format as /prefix) to split file up\n");
-    out.append("        wrap=0|1 -- desprays as multiple files\n");
-    out.append("        multicopy=0|1   -- each destination part gets whole file\n");
+    out.append("        wrap=0|1  -- desprays as multiple files\n");
+    out.append("        multicopy=0|1  -- each destination part gets whole file\n");
     out.append("    copy options:\n");
     out.append("        srcname=<source-logical-name>\n");
     out.append("        dstname=<destination-logical-name>\n");
     out.append("        dstcluster=<cluster-name>\n");
-    out.append("        dstclusterroxie=No|Yes <destination cluster is a roxie cluster> -- optional\n");
-    out.append("        srcdali=<foreign-dali-ip> -- optional\n");
-    out.append("        srcusername=<username-for-accessing-srcdali> -- optional\n");
-    out.append("        srcpassword=<password-for-accessing-srcdali> -- optional\n");
-    out.append("        wrap=0|1 -- copies from a larger to smaller cluster without spliting parts\n");
-    out.append("        diffkeysrc=<old-key-name>   -- use keydiff/keypatch (src old name)\n");
-    out.append("        diffkeydst=<old-key-name>   -- use keydiff/keypatch (dst old name)\n");
-    out.append("        multicopy=0|1   -- each destination part gets whole file\n");
-    out.append("        preservecompression=1|0 -- optional, default is 1 (preserve compression)\n");
+    out.append("        dstclusterroxie=No|Yes <destination cluster is a roxie cluster>\n");
+    out.append("            -- optional\n");
+    out.append("        srcdali=<foreign-dali-ip>  -- optional\n");
+    out.append("        srcusername=<username-for-accessing-srcdali>  -- optional\n");
+    out.append("        srcpassword=<password-for-accessing-srcdali>  -- optional\n");
+    out.append("        wrap=0|1  -- copies from a larger to smaller cluster without spliting\n");
+    out.append("                     parts\n");
+    out.append("        diffkeysrc=<old-key-name>  -- use keydiff/keypatch (src old name)\n");
+    out.append("        diffkeydst=<old-key-name>  -- use keydiff/keypatch (dst old name)\n");
+    out.append("        multicopy=0|1  -- each destination part gets whole file\n");
+    out.append("        preservecompression=1|0  -- optional, default is 1 (preserve)\n");
     out.append("    remove options:\n");
     out.append("        name=<logical-name>\n");
     out.append("        names=<multiple-logical-names-separated-by-comma>\n");
@@ -121,11 +133,13 @@ void handleSyntax()
     out.append("            (more to be defined)\n");
     out.append("    addsuper options:\n");
     out.append("        superfile=<logical-name>\n");
-    out.append("        subfiles=<logical-name>{,<logical-name>}  -- no spaces between logical-names.\n");
+    out.append("        subfiles=<logical-name>{,<logical-name>}  -- no spaces between \n");
+    out.append("             		                                 logical-names.\n");
     out.append("        before=<logical-name> -- optional\n");
     out.append("    removesuper options:\n");
     out.append("        superfile=<logical-name>\n");
-    out.append("        subfiles=<logical-name>{,<logical-name> -- optional. Can be *, which means all subfiles\n");
+    out.append("        subfiles=<logical-name>{,<logical-name>  -- optional. Can be *, which\n");
+    out.append("                                                    means all subfiles\n");
     out.append("        delete=1|0 -- optional. Whether or not actually remove the files.\n");
     out.append("    copysuper options:\n");
     out.append("        srcname=<source-super-name>\n");
@@ -142,7 +156,8 @@ void handleSyntax()
     out.append("    add options:\n");
     out.append("        srcxml=<xml-file>\n");
     out.append("        dstname=<destination-logical-name>\n");
-    out.append("        -- To add remote files from another dali directly, use these options instead of srcxml:\n");
+    out.append("            -- To add remote files from another dali directly, use these\n");
+    out.append("               options instead of srcxml:\n");
     out.append("        srcname=<source-logical-name>\n");
     out.append("        srcdali=<source-dali-ip>\n");
     out.append("        srcusername=<user-name-for-source-dali>\n");
@@ -162,6 +177,16 @@ void handleSyntax()
     out.append("        shotlimit=<number>\n");
     out.append("    dafilesrv options:  \n");
     out.append("        idletimeout=<idle-timeout-secs> -- how long idle before stops \n");
+    out.append("    listhistory options:  \n");
+    out.append("        lfn=<logical-name>\n");
+    out.append("        outformat=csv|xml|json|ascii  -- optional, default is xml.\n");
+    out.append("        csvheader=1|0   -- optional, enable/disable to put header at the first\n");
+    out.append("                           CSV row, default is enable.\n");
+    out.append("    erasehistory options:  \n");
+    out.append("        lfn=<logical-name>\n");
+    out.append("        backup=1|0  -- optional, enable/disable to write file history into xml\n");
+    out.append("                        file before erase it, default is enable. \n");
+    out.append("        dstxml=<xml-file>  -- effective only if backup enabled.\n");
 
     printf("%s",out.str());
 }
@@ -217,7 +242,7 @@ int main(int argc, const char* argv[])
         return 0;
     }
 
-    if ((argc >= 2) && ((argv[1][0]=='/' || argv[1][0]=='-') && (argv[1][1]=='?' || argv[1][1]=='h'))) 
+    if ((argc >= 2) && ((argv[1][0]=='/' || argv[1][0]=='-') && (argv[1][1]=='?' || argv[1][1]=='h')))
     {
         handleSyntax();
         return 0;
@@ -236,7 +261,7 @@ int main(int argc, const char* argv[])
 
 
 
-    
+
     const char* action = globals->queryProp("action");
     if(!action || !*action)
     {
@@ -250,7 +275,7 @@ int main(int argc, const char* argv[])
     if (!server || !*server) {
         if (stricmp(action,"dafilesrv")==0)
             globals->setProp("server","127.0.0.1"); // dummy
-        else { 
+        else {
             fprintf(stderr, "ERROR: Esp server url not specified.\n");
             releaseAtoms();
             return DFUERR_TooFewArguments;
@@ -268,7 +293,7 @@ int main(int argc, const char* argv[])
         e->errorMessage(errmsg);
         fprintf(stderr, "%s\n", errmsg.str());
     }
-    
+
     releaseAtoms();
     return 0;
 }

--- a/dali/ft/daft.cpp
+++ b/dali/ft/daft.cpp
@@ -52,6 +52,7 @@ void CDistributedFileSystem::copy(IDistributedFile * from, IDistributedFile * to
 
     OwnedIFileSprayer sprayer = createFileSprayer(options, recovery, recoveryConnection, wuid);
 
+    sprayer->setOperation(dfu_copy);
     sprayer->setProgress(progress);
     sprayer->setAbort(abort);
     sprayer->setPartFilter(filter);
@@ -74,6 +75,7 @@ void CDistributedFileSystem::exportFile(IDistributedFile * from, IFileDescriptor
     LOG(MCdebugInfo, unknownJob, "DFS: export(%s,%s)", from->queryLogicalName(), to->getTraceName(temp).str());
 
     OwnedIFileSprayer sprayer = createFileSprayer(options, recovery, recoveryConnection, wuid);
+    sprayer->setOperation(dfu_export);
     sprayer->setProgress(progress);
     sprayer->setAbort(abort);
     sprayer->setPartFilter(filter);
@@ -92,6 +94,7 @@ void CDistributedFileSystem::import(IFileDescriptor * from, IDistributedFile * t
         LOG(MCdebugInfo, unknownJob, "DFS: import(%s)", from->getTraceName(temp).str());
 
     OwnedIFileSprayer sprayer = createFileSprayer(options, recovery, recoveryConnection, wuid);
+    sprayer->setOperation(dfu_import);
     sprayer->setProgress(progress);
     sprayer->setAbort(abort);
     sprayer->setPartFilter(filter);
@@ -109,6 +112,7 @@ void CDistributedFileSystem::move(IDistributedFile * from, IDistributedFile * to
         LOG(MCdebugInfo, unknownJob, "DFS: move(%s)", from->queryLogicalName());
 
     OwnedIFileSprayer sprayer = createFileSprayer(options, recovery, recoveryConnection, wuid);
+    sprayer->setOperation(dfu_move);
     sprayer->setProgress(progress);
     sprayer->setAbort(abort);
     sprayer->setPartFilter(filter);
@@ -124,6 +128,7 @@ void CDistributedFileSystem::replicate(IDistributedFile * from, IGroup *destgrou
     LOG(MCdebugInfo, unknownJob, "DFS: replicate(%s)", from->queryLogicalName());
 
     FileSprayer sprayer(options, recovery, recoveryConnection, wuid);
+    sprayer.setOperation(dfu_replicate_distributed);
     sprayer.setProgress(progress);
     sprayer.setAbort(abort);
     sprayer.setReplicate(true);
@@ -139,6 +144,7 @@ void CDistributedFileSystem::replicate(IFileDescriptor * fd, DaftReplicateMode m
     LOG(MCdebugInfo, unknownJob, "DFS: replicate(%s, %x)", fd->getTraceName(s).str(), (unsigned)mode);
 
     FileSprayer sprayer(options, recovery, recoveryConnection, wuid);
+    sprayer.setOperation(dfu_replicate);
     sprayer.setProgress(progress);
     sprayer.setAbort(abort);
     sprayer.setReplicate(true);
@@ -153,6 +159,7 @@ void CDistributedFileSystem::transfer(IFileDescriptor * from, IFileDescriptor * 
     LOG(MCdebugInfo, unknownJob, "DFS: transfer(%s,%s)", from->getTraceName(s1).str(), to->getTraceName(s1).str());
 
     OwnedIFileSprayer sprayer = createFileSprayer(options, recovery, recoveryConnection, wuid);
+    sprayer->setOperation(dfu_transfer);
     sprayer->setAbort(abort);
     sprayer->setProgress(progress);
     sprayer->setPartFilter(filter);

--- a/dali/ft/filecopy.hpp
+++ b/dali/ft/filecopy.hpp
@@ -110,6 +110,28 @@ public:
 UtfReader::UtfFormat getUtfFormatType(FileFormatType type);
 bool sameEncoding(const FileFormat & src, const FileFormat & tgt);
 
+typedef enum {
+        dfu_unknown,
+        dfu_copy,
+        dfu_export,
+        dfu_import,
+        dfu_move,
+        dfu_replicate_distributed,
+        dfu_replicate,
+        dfu_transfer,
+    } dfu_operation;
+
+static const char * DfuOperatonStr[] =
+    {
+        "DFUunknown",
+        "DFUcopy",
+        "DFUexport",
+        "DFUimport",
+        "DFUmove",
+        "DFUreplicate_distributed",
+        "DFUreplicate",
+        "DFUtransfer"
+    };
 interface IFileSprayer : public IInterface
 {
 public:
@@ -129,6 +151,10 @@ public:
     virtual void setTarget(INode * target) = 0;
     virtual void spray() = 0;
     virtual void checkSourceTarget(IFileDescriptor * file) = 0;
+    virtual void setOperation(dfu_operation op) = 0;
+    virtual dfu_operation getOperation(void) = 0;
+    virtual const char * getOperationTypeString() const = 0;
+
 };
 
 extern DALIFT_API IFileSprayer * createFileSprayer(IPropertyTree * _options, IPropertyTree * _progress, IRemoteConnection * recoveryConnection, const char *wuid);

--- a/dali/ft/filecopy.ipp
+++ b/dali/ft/filecopy.ipp
@@ -274,6 +274,8 @@ protected:
     
 private:
     bool calcUsePull();
+    // Get and store Remote File Name parts into the History record
+    void splitAndStoreFileInfo(IPropertyTree * newRecord, RemoteFilename &remoteFileName, aindex_t idx = 0, bool isDistributedSource = true);
 
 protected:
     CIArrayOf<FilePartInfo> sources;

--- a/dali/ft/filecopy.ipp
+++ b/dali/ft/filecopy.ipp
@@ -203,6 +203,9 @@ public:
     void setError(const SocketEndpoint & ep, IException * e);
     bool canLocateSlaveForNode(const IpAddress &ip);
     void checkSourceTarget(IFileDescriptor * file);
+    void setOperation(dfu_operation op);
+    dfu_operation getOperation(void);
+    const char * getOperationTypeString() const;
 
 protected:
     void addEmptyFilesToPartition(unsigned from, unsigned to);
@@ -326,6 +329,8 @@ protected:
     offset_t                headerSize;
     offset_t                footerSize;
     int                     fileUmask;
+    Owned<IPropertyTree>    srcHistory;
+    dfu_operation           operation = dfu_unknown;
 };
 
 

--- a/esp/scm/ws_dfu.ecm
+++ b/esp/scm/ws_dfu.ecm
@@ -707,6 +707,28 @@ ESPresponse [exceptions_inline, nil_remove, http_encode(0)] DFUGetFileMetaDataRe
 };
 
 
+ESPrequest ListHistoryRequest
+{
+    string name;
+};
+
+ESPresponse [exceptions_inline, nil_remove] ListHistoryResponse
+{
+    binary xmlmap;
+};
+
+ESPrequest EraseHistoryRequest
+{
+    string name;
+};
+
+ESPresponse [exceptions_inline, nil_remove] EraseHistoryResponse
+{
+    binary xmlmap;
+};
+
+
+
 //  ===========================================================================
 ESPservice [
     auth_feature("DEFERRED"),
@@ -735,9 +757,13 @@ ESPservice [
     ESPmethod [resp_xsl_default("/esp/xslt/addto_superfile.xslt")] AddtoSuperfile(AddtoSuperfileRequest, AddtoSuperfileResponse);
     ESPmethod [auth_feature("DfuAccess:READ"), resp_xsl_default("/esp/xslt/dfu_superedit.xslt")] SuperfileList(SuperfileListRequest, SuperfileListResponse);
     ESPmethod [resp_xsl_default("/esp/xslt/dfu_superresult.xslt")] SuperfileAction(SuperfileActionRequest, SuperfileActionResponse);
+
     ESPmethod [auth_feature("DfuAccess:READ")] Savexml(SavexmlRequest, SavexmlResponse);
     ESPmethod [auth_feature("DfuAccess:WRITE")] Add(AddRequest, AddResponse);
     ESPmethod [auth_feature("DfuAccess:WRITE")] AddRemote(AddRemoteRequest, AddRemoteResponse);
+
+    ESPmethod ListHistory(ListHistoryRequest, ListHistoryResponse);
+    ESPmethod EraseHistory(EraseHistoryRequest, EraseHistoryResponse);
 };
 
 SCMexportdef(WSDFU);

--- a/esp/services/ws_dfu/ws_dfuService.cpp
+++ b/esp/services/ws_dfu/ws_dfuService.cpp
@@ -117,9 +117,9 @@ CThorNodeGroup* CThorNodeGroupCache::lookup(const char* groupName, unsigned time
 void CWsDfuEx::init(IPropertyTree *cfg, const char *process, const char *service)
 {
     StringBuffer xpath;
-    
+
     DBGLOG("Initializing %s service [process = %s]", service, process);
-    
+
     xpath.appendf("Software/EspProcess[@name=\"%s\"]/EspService[@name=\"%s\"]/DefaultScope", process, service);
     cfg->getProp(xpath.str(), defaultScope_);
 
@@ -213,7 +213,7 @@ bool CWsDfuEx::onDFUSearch(IEspContext &context, IEspDFUSearchRequest & req, IEs
         resp.setFileTypes(ftarray);
     }
     catch(IException* e)
-    {   
+    {
         FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
@@ -258,7 +258,7 @@ void parseTwoStringArrays(const char *input, StringArray& strarray1, StringArray
     if (name_len > 0 && value_len > 0)
     {
         char * inputText = (char *) input;
-        inputText += 2; //skip 2 chars 
+        inputText += 2; //skip 2 chars
 
         loop
         {
@@ -282,18 +282,18 @@ void parseTwoStringArrays(const char *input, StringArray& strarray1, StringArray
 
             if (!inputText || strlen(inputText) < columnNameLen + columnValueLen)
                 break;
-            
+
             char * colon = inputText + columnNameLen;
             if (!colon)
                 break;
 
-            StringAttr tmp;         
+            StringAttr tmp;
             tmp.set(inputText, columnNameLen);
             strarray1.append(tmp.get());
             tmp.set(colon, columnValueLen);
-            //tmp.toUpperCase(); 
+            //tmp.toUpperCase();
             strarray2.append(tmp.get());
-                
+
             inputText = colon + columnValueLen;
         }
     }
@@ -322,7 +322,7 @@ bool CWsDfuEx::onDFUQuery(IEspContext &context, IEspDFUQueryRequest & req, IEspD
         doLogicalFileSearch(context, userdesc.get(), req, resp);
     }
     catch(IException* e)
-    {   
+    {
         FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
 
@@ -357,7 +357,7 @@ bool CWsDfuEx::onDFUInfo(IEspContext &context, IEspDFUInfoRequest &req, IEspDFUI
         }
     }
     catch(IException* e)
-    {   
+    {
         FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
 
@@ -435,7 +435,7 @@ bool CWsDfuEx::onDFUSpace(IEspContext &context, IEspDFUSpaceRequest & req, IEspD
             wuTime.getDate(yearTo, monthTo, dayTo, true);
             wuTime.getTime(hour, minute, second, nano, true);
             wuTo.appendf("%4d-%02d-%02d %02d:%02d:%02d",yearTo,monthTo,dayTo,hour,minute,second);
-        
+
             StringBuffer endDate;
             endDate.appendf("%02d/%02d/%04d", monthTo, dayTo, yearTo);
             resp.setEndDate(endDate.str());
@@ -449,7 +449,7 @@ bool CWsDfuEx::onDFUSpace(IEspContext &context, IEspDFUSpaceRequest & req, IEspD
             {
                 StringBuffer wuFrom, wuTo;
                 bool bFirst = true;
-                ForEach(*fi) 
+                ForEach(*fi)
                 {
                     IPropertyTree &attr=fi->query();
                     StringBuffer modf(attr.queryProp("@modified"));
@@ -514,7 +514,7 @@ bool CWsDfuEx::onDFUSpace(IEspContext &context, IEspDFUSpaceRequest & req, IEspD
             SpaceItems64.append(*item64.getClear());
         }
 
-        ForEach(*fi) 
+        ForEach(*fi)
         {
             IPropertyTree &attr=fi->query();
 
@@ -546,7 +546,7 @@ bool CWsDfuEx::onDFUSpace(IEspContext &context, IEspDFUSpaceRequest & req, IEspD
             {
                 setSpaceItemByOwner(SpaceItems64, attr.queryProp("@owner"), attr.queryProp("@name"), attr.getPropInt64("@size",-1));
             }
-            else 
+            else
             {
                 setSpaceItemByScope(SpaceItems64, scopeName, attr.queryProp("@name"), attr.getPropInt64("@size",-1));
             }
@@ -592,7 +592,7 @@ bool CWsDfuEx::onDFUSpace(IEspContext &context, IEspDFUSpaceRequest & req, IEspD
         resp.setCountBy(req.getCountBy());
     }
     catch(IException* e)
-    {   
+    {
         FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
@@ -626,7 +626,7 @@ bool CWsDfuEx::setSpaceItemByScope(IArrayOf<IEspSpaceItem>& SpaceItems64, const 
             scope[pName - logicalName] = 0;
         }
     }
-            
+
     if (strlen(scope) > 0)
     {
         IEspSpaceItem *item0 = NULL;
@@ -807,7 +807,7 @@ bool CWsDfuEx::setSpaceItemByOwner(IArrayOf<IEspSpaceItem>& SpaceItems64, const 
     return true;
 }
 
-bool CWsDfuEx::createSpaceItemsByDate(IArrayOf<IEspSpaceItem>& SpaceItems, StringBuffer interval, unsigned& yearFrom, 
+bool CWsDfuEx::createSpaceItemsByDate(IArrayOf<IEspSpaceItem>& SpaceItems, StringBuffer interval, unsigned& yearFrom,
     unsigned& monthFrom, unsigned& dayFrom, unsigned& yearTo, unsigned& monthTo, unsigned& dayTo)
 {
     if (!stricmp(interval, COUNTBY_YEAR))
@@ -831,7 +831,7 @@ bool CWsDfuEx::createSpaceItemsByDate(IArrayOf<IEspSpaceItem>& SpaceItems, Strin
     else if (!stricmp(interval, COUNTBY_QUARTER))
     {
         for (unsigned i = yearFrom; i <= yearTo; i++)
-        {   
+        {
             int quartStart = 1;
             int quartEnd = 4;
             if (i == yearFrom)
@@ -885,7 +885,7 @@ bool CWsDfuEx::createSpaceItemsByDate(IArrayOf<IEspSpaceItem>& SpaceItems, Strin
     else if (!stricmp(interval, COUNTBY_MONTH))
     {
         for (unsigned i = yearFrom; i <= yearTo; i++)
-        {   
+        {
             int jFrom = (i != yearFrom) ? 1 : monthFrom;
             int jTo =  (i != yearTo) ? 12 : monthTo;
             for (int j = jFrom; j <= jTo; j++)
@@ -908,7 +908,7 @@ bool CWsDfuEx::createSpaceItemsByDate(IArrayOf<IEspSpaceItem>& SpaceItems, Strin
     else
     {
         for (unsigned i = yearFrom; i <= yearTo; i++)
-        {   
+        {
             int jFrom = (i != yearFrom) ? 1 : monthFrom;
             int jTo =  (i != yearTo) ? 12 : monthTo;
             for (int j = jFrom; j <= jTo; j++)
@@ -1436,7 +1436,7 @@ bool CWsDfuEx::onDFUArrayAction(IEspContext &context, IEspDFUArrayActionRequest 
 
             strncpy(curfile, file, len);
             curfile[len] = 0;
-            
+
             try
             {
                 Owned<IDistributedFile> df = queryDistributedFileDirectory().lookup(curfile, userdesc.get(), true);
@@ -1481,7 +1481,7 @@ bool CWsDfuEx::onDFUArrayAction(IEspContext &context, IEspDFUArrayActionRequest 
             resp.setRedirectTo(subfiles.str());
     }
     catch(IException* e)
-    {   
+    {
         FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
@@ -1532,7 +1532,7 @@ bool CWsDfuEx::onDFUDefFile(IEspContext &context,IEspDFUDefFileRequest &req, IEs
         resp.setDefFile_mimetype(type.str());
     }
     catch(IException* e)
-    {   
+    {
         FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
@@ -1562,7 +1562,7 @@ void CWsDfuEx::getDefFile(IUserDescriptor* udesc, const char* FileName,StringBuf
 
     StringBuffer text;
     text.append(df->queryAttributes().queryProp("ECL"));
-    
+
     MultiErrorReceiver errs;
     OwnedHqlExpr record = parseQuery(text.str(), &errs);
     if (errs.errCount())
@@ -1571,7 +1571,7 @@ void CWsDfuEx::getDefFile(IUserDescriptor* udesc, const char* FileName,StringBuf
         IError *first = errs.firstError();
         first->toString(errtext);
         throw MakeStringException(ECLWATCH_CANNOT_PARSE_ECL_QUERY, "Failed in parsing ECL query: %s @ %d:%d.", errtext.str(), first->getColumn(), first->getLine());
-    } 
+    }
 
     if(!record)
         throw MakeStringException(ECLWATCH_CANNOT_PARSE_ECL_QUERY, "Failed in parsing ECL query.");
@@ -1583,7 +1583,7 @@ void CWsDfuEx::getDefFile(IUserDescriptor* udesc, const char* FileName,StringBuf
 
     data->setProp("filename",fname ? fname+1 : FileName);
 
-    toXML(data, returnStr, 0, 0); 
+    toXML(data, returnStr, 0, 0);
 }
 
 bool CWsDfuEx::checkFileContent(IEspContext &context, IUserDescriptor* udesc, const char * logicalName, const char * cluster)
@@ -1654,7 +1654,7 @@ bool FindInStringArray(StringArray& clusters, const char *cluster)
     }
     else
     {
-#if 0 //Comment out since clusters are not set for some old files  
+#if 0 //Comment out since clusters are not set for some old files
         if (!clusters.ordinality())
             return true;
 
@@ -1768,7 +1768,7 @@ void CWsDfuEx::getFilePartsOnClusters(IEspContext &context, const char* clusterR
         {
             IPartDescriptor& part = pi->query();
             unsigned partIndex = part.queryPartIndex();
-                        
+
             StringBuffer partSizeStr;
             IPropertyTree* partPropertyTree = &part.queryProperties();
             if (!partPropertyTree)
@@ -1971,7 +1971,7 @@ void CWsDfuEx::doGetFileDetails(IEspContext &context, IUserDescriptor* udesc, co
         Owned<IDistributedSuperFileIterator> iter = df->getOwningSuperFiles();
         if(iter.get() != NULL)
         {
-            ForEach(*iter) 
+            ForEach(*iter)
             {
                 //printf("%s,%s\n",iter->query().queryLogicalName(),lname);
                 Owned<IEspDFULogicalFile> File = createDFULogicalFile("","");
@@ -1979,7 +1979,7 @@ void CWsDfuEx::doGetFileDetails(IEspContext &context, IUserDescriptor* udesc, co
                 LogicalFiles.append(*File.getClear());
             }
         }
-        
+
         if(LogicalFiles.length() > 0)
         {
             FileDetails.setSuperfiles(LogicalFiles);
@@ -2014,7 +2014,7 @@ void CWsDfuEx::doGetFileDetails(IEspContext &context, IUserDescriptor* udesc, co
     if (version >= 1.20)
         FileDetails.setCsvEscape(df->queryAttributes().queryProp("@csvEscape"));
 
-  
+
     //Time and date of the file
     tmpstr.clear();
     dt.getDateString(tmpstr);
@@ -2220,12 +2220,12 @@ void CWsDfuEx::getLogicalFileAndDirectory(IEspContext &context, IUserDescriptor*
         StringBuffer filter;
         filter.append(dirname);
         filter.append("::*");
-        
+
         Owned<IDFAttributesIterator> fi = queryDistributedFileDirectory().getDFAttributesIterator(filter.toLowerCase().str(), udesc, false,true, NULL);
         if(fi)
         {
             StringBuffer size;
-            ForEach(*fi) 
+            ForEach(*fi)
             {
                 IPropertyTree &attr=fi->query();
 
@@ -2245,7 +2245,7 @@ void CWsDfuEx::getLogicalFileAndDirectory(IEspContext &context, IUserDescriptor*
     Owned<IDFScopeIterator> iter = queryDistributedFileDirectory().getScopeIterator(udesc,dirname,false);
     if(iter)
     {
-        ForEach(*iter) 
+        ForEach(*iter)
         {
             const char *scope = iter->query();
             if (scope && *scope)
@@ -2293,7 +2293,7 @@ bool CWsDfuEx::onDFUFileView(IEspContext &context, IEspDFUFileViewRequest &req, 
         resp.setDFULogicalFiles(logicalFiles);
     }
     catch(IException* e)
-    {   
+    {
         FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
@@ -3600,11 +3600,11 @@ bool CWsDfuEx::onSuperfileList(IEspContext &context, IEspSuperfileListRequest &r
         }
         if(farray.length() > 0)
             resp.setSubfiles(farray);
-        
+
         resp.setSuperfile(req.getSuperfile());
     }
     catch(IException* e)
-    {   
+    {
         FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
@@ -3640,7 +3640,7 @@ bool CWsDfuEx::onSuperfileAction(IEspContext &context, IEspSuperfileActionReques
         resp.setSuperfile(req.getSuperfile());
     }
     catch(IException* e)
-    {   
+    {
         FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
@@ -3673,7 +3673,7 @@ bool CWsDfuEx::onSavexml(IEspContext &context, IEspSavexmlRequest &req, IEspSave
         resp.setXmlmap(xmlmap);
     }
     catch(IException* e)
-    {   
+    {
         FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
@@ -3698,11 +3698,11 @@ bool CWsDfuEx::onAdd(IEspContext &context, IEspAddRequest &req, IEspAddResponse 
         PROGLOG("addFileXML: %s", req.getDstname());
 
         Owned<IDFUhelper> dfuhelper = createIDFUhelper();
-        StringBuffer xmlstr(req.getXmlmap().length(),(const char*)req.getXmlmap().bufferBase()); 
+        StringBuffer xmlstr(req.getXmlmap().length(),(const char*)req.getXmlmap().bufferBase());
         dfuhelper->addFileXML(req.getDstname(), xmlstr, userdesc.get());
     }
     catch(IException* e)
-    {   
+    {
         FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
@@ -3748,7 +3748,7 @@ bool CWsDfuEx::onAddRemote(IEspContext &context, IEspAddRemoteRequest &req, IEsp
         dfuhelper->addFileRemote(dstname, ep, srcname, srcuserdesc.get(), userdesc.get());
     }
     catch(IException* e)
-    {   
+    {
         FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
@@ -3858,7 +3858,7 @@ bool CWsDfuEx::onDFUGetDataColumns(IEspContext &context, IEspDFUGetDataColumnsRe
                         bNaturalColumn = false;
                     }
 
-                    item->setColumnLabel(columnLabel.str()); 
+                    item->setColumnLabel(columnLabel.str());
 
                     if (version > 1.04 && filterByNames.length() > 0)
                     {
@@ -3870,7 +3870,7 @@ bool CWsDfuEx::onDFUGetDataColumns(IEspContext &context, IEspDFUGetDataColumnsRe
                                 const char* value = filterByValues.item(ii);
                                 if (value && *value)
                                 {
-                                    item->setColumnValue(value); 
+                                    item->setColumnValue(value);
                                     break;
                                 }
                             }
@@ -3893,7 +3893,7 @@ bool CWsDfuEx::onDFUGetDataColumns(IEspContext &context, IEspDFUGetDataColumnsRe
                         item->setColumnSize(strlen(columnLabel.str()));
                         columnSize = 2;
                     }
-                    else 
+                    else
                     {
                         if (columnType == TypeInteger || columnType == TypeUnsignedInteger)
                         {
@@ -3937,7 +3937,7 @@ bool CWsDfuEx::onDFUGetDataColumns(IEspContext &context, IEspDFUGetDataColumnsRe
                             item->setColumnSize(columnSize);
                             item->setMaxSize(columnSize);
                         }
-                        else 
+                        else
                         {
                             item->setColumnType("Others");
                             columnSize = STRINGSIZE;
@@ -3955,7 +3955,7 @@ bool CWsDfuEx::onDFUGetDataColumns(IEspContext &context, IEspDFUGetDataColumnsRe
                         dataKeyedColumns[lineCount].append(*item.getLink());
                         lineCount++;
                     }
-                    else 
+                    else
                     {
                         if (lineSizeCount + columnSize < STRINGSIZE)
                         {
@@ -3994,7 +3994,7 @@ bool CWsDfuEx::onDFUGetDataColumns(IEspContext &context, IEspDFUGetDataColumnsRe
                         bNaturalColumn = false;
                     }
 
-                    item->setColumnLabel(columnLabel.str()); 
+                    item->setColumnLabel(columnLabel.str());
 
                     if (version > 1.04 && filterByNames.length() > 0)
                     {
@@ -4006,7 +4006,7 @@ bool CWsDfuEx::onDFUGetDataColumns(IEspContext &context, IEspDFUGetDataColumnsRe
                                 const char* value = filterByValues.item(ii);
                                 if (value && *value)
                                 {
-                                    item->setColumnValue(value); 
+                                    item->setColumnValue(value);
                                     break;
                                 }
                             }
@@ -4027,7 +4027,7 @@ bool CWsDfuEx::onDFUGetDataColumns(IEspContext &context, IEspDFUGetDataColumnsRe
                         item->setColumnSize(strlen(columnLabel.str()));
                         columnSize = 2;
                     }
-                    else 
+                    else
                     {
                         if (columnType == TypeInteger || columnType == TypeUnsignedInteger)
                         {
@@ -4071,7 +4071,7 @@ bool CWsDfuEx::onDFUGetDataColumns(IEspContext &context, IEspDFUGetDataColumnsRe
                             item->setColumnSize(columnSize);
                             item->setMaxSize(columnSize);
                         }
-                        else 
+                        else
                         {
                             item->setColumnType("Others");
                             columnSize = STRINGSIZE;
@@ -4089,7 +4089,7 @@ bool CWsDfuEx::onDFUGetDataColumns(IEspContext &context, IEspDFUGetDataColumnsRe
                         dataNonKeyedColumns[lineCount].append(*item.getLink());
                         lineCount++;
                     }
-                    else 
+                    else
                     {
                         if (lineSizeCount + columnSize < STRINGSIZE)
                         {
@@ -4197,7 +4197,7 @@ bool CWsDfuEx::onDFUGetDataColumns(IEspContext &context, IEspDFUGetDataColumnsRe
                 //resp.setColumnCount(columnCount);
                 resp.setRowCount(total);
             }
-            
+
             resp.setLogicalName(logicalNameStr.str());
             resp.setStartIndex(startIndex);
             resp.setEndIndex(endIndex);
@@ -4221,7 +4221,7 @@ bool CWsDfuEx::onDFUGetDataColumns(IEspContext &context, IEspDFUGetDataColumnsRe
             resp.setChooseFile(0);
     }
     catch(IException* e)
-    {   
+    {
         FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
@@ -4243,7 +4243,7 @@ bool CWsDfuEx::onDFUSearchData(IEspContext &context, IEspDFUSearchDataRequest &r
 
         const char* selectedKey = req.getSelectedKey();
 
-        if (strlen(selectedKey) > 0)  
+        if (strlen(selectedKey) > 0)
         {
             resp.setSelectedKey(req.getSelectedKey());
         }
@@ -4358,7 +4358,7 @@ bool CWsDfuEx::onDFUSearchData(IEspContext &context, IEspDFUSearchDataRequest &r
             const char* parentName = req.getParentName();
             if (parentName && *parentName)
                 browseDataRequest->setParentName(parentName);
-            
+
             browseDataRequest->setFilterBy(req.getFilterBy());
             browseDataRequest->setShowColumns(req.getShowColumns());
             browseDataRequest->setStartForGoback(req.getStartForGoback());
@@ -4395,7 +4395,7 @@ bool CWsDfuEx::onDFUSearchData(IEspContext &context, IEspDFUSearchDataRequest &r
         }
     }
     catch(IException* e)
-    {   
+    {
         FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
@@ -4601,7 +4601,7 @@ bool CWsDfuEx::onDFUBrowseData(IEspContext &context, IEspDFUBrowseDataRequest &r
             throw MakeStringException(ECLWATCH_TOO_MANY_DATA_ROWS,"Browser Cannot display more than %d data rows.", MAX_VIEWKEYFILE_ROWS);
 
         bool bSchemaOnly=req.getSchemaOnly() ? req.getSchemaOnly() : false;
-        bool bDisableUppercaseTranslation = req.getDisableUppercaseTranslation() ? req.getDisableUppercaseTranslation() : false; 
+        bool bDisableUppercaseTranslation = req.getDisableUppercaseTranslation() ? req.getDisableUppercaseTranslation() : false;
 
 #define HPCCBROWSER 1
 #ifdef HPCCBROWSER
@@ -4609,7 +4609,7 @@ bool CWsDfuEx::onDFUBrowseData(IEspContext &context, IEspDFUBrowseDataRequest &r
         const char* showColumns = req.getShowColumns();
 
         __int64 read=0;
-        __int64 total = 0;  
+        __int64 total = 0;
         StringBuffer msg;
         StringArray columnLabels, columnLabelsType;
         IArrayOf<IEspDFUData> DataList;
@@ -4623,7 +4623,7 @@ bool CWsDfuEx::onDFUBrowseData(IEspContext &context, IEspDFUBrowseDataRequest &r
         unsigned int max_name_length = 3; //max length for name length
         unsigned int max_value_length = 4; //max length for value length:
         StringBuffer filterByStr, filterByStr0;
-        filterByStr0.appendf("%d%d", max_name_length, max_value_length);  
+        filterByStr0.appendf("%d%d", max_name_length, max_value_length);
 
         unsigned columnCount = columnLabels.length();
         IArrayOf<IEspDFUDataColumn> dataColumns;
@@ -4663,7 +4663,7 @@ bool CWsDfuEx::onDFUBrowseData(IEspContext &context, IEspDFUBrowseDataRequest &r
 
                 Owned<IEspDFUDataColumn> item = createDFUDataColumn("","");
 
-                item->setColumnLabel(label); 
+                item->setColumnLabel(label);
                 item->setColumnType(type);
                 item->setColumnSize(0); //not show this column
 
@@ -4730,7 +4730,7 @@ bool CWsDfuEx::onDFUBrowseData(IEspContext &context, IEspDFUBrowseDataRequest &r
                 {
                     CWUWrapper wu(wuid, context);
                     if (wu)
-                    {   
+                    {
                         SCMStringBuffer eclqueue0, cluster0;
                         eclqueue.append(wu->getQueue(eclqueue0).str());
                         cluster.append(wu->getClusterName(cluster0).str());
@@ -4792,7 +4792,7 @@ bool CWsDfuEx::onDFUBrowseData(IEspContext &context, IEspDFUBrowseDataRequest &r
 
                 SCMStringBuffer scmbuf;
                 meta.getColumnLabel(scmbuf, col);
-                item->setColumnLabel(scmbuf.str()); 
+                item->setColumnLabel(scmbuf.str());
                 if (!showColumns || !*showColumns)
                 {
                     item->setColumnSize(1); //Show this column
@@ -4830,11 +4830,11 @@ bool CWsDfuEx::onDFUBrowseData(IEspContext &context, IEspDFUBrowseDataRequest &r
         StringBuffer filterByStr, filterByStr0;
         unsigned int max_name_length = 3; //max length for name length
         unsigned int max_value_length = 4; //max length for value length:
-        filterByStr0.appendf("%d%d", max_name_length, max_value_length);  
+        filterByStr0.appendf("%d%d", max_name_length, max_value_length);
         if (columnCount > 0 && filterByNames.length() > 0)
         {
             Owned<IFilteredResultSet> filter = result->createFiltered();
-            
+
             for (int ii = 0; ii < filterByNames.length(); ii++)
             {
                 const char* columnName = filterByNames.item(ii);
@@ -4851,7 +4851,7 @@ bool CWsDfuEx::onDFUBrowseData(IEspContext &context, IEspDFUBrowseDataRequest &r
                             filter->addFilter(col, columnValue);
                             filterByStr.appendf("%s[%s]", columnName, columnValue);
                             filterByStr0.appendf("%03d%04d%s%s", strlen(columnName), strlen(columnValue), columnName, columnValue);
-                    
+
                             break;
                         }
                     }
@@ -4901,7 +4901,7 @@ bool CWsDfuEx::onDFUBrowseData(IEspContext &context, IEspDFUBrowseDataRequest &r
                 if(read>=count)
                     break;
             }
-        }   
+        }
         catch(IException* e)
         {
             if ((version < 1.08) || (e->errorCode() != FVERR_FilterTooRestrictive))
@@ -4936,13 +4936,13 @@ bool CWsDfuEx::onDFUBrowseData(IEspContext &context, IEspDFUBrowseDataRequest &r
         resp.setResult(buf.toByteArray());
 #endif
 
-        //resp.setFilterBy(filterByStr.str()); 
+        //resp.setFilterBy(filterByStr.str());
         if (filterByStr.length() > 0)
         {
             const char* oldStr = "&";
             const char* newStr = "&amp;";
             filterByStr.replaceString(oldStr, newStr);
-            resp.setFilterBy(filterByStr.str()); 
+            resp.setFilterBy(filterByStr.str());
         }
         if (version > 1.04)
         {
@@ -4952,7 +4952,7 @@ bool CWsDfuEx::onDFUBrowseData(IEspContext &context, IEspDFUBrowseDataRequest &r
                 const char* oldStr = "&";
                 const char* newStr = "&amp;";
                 filterByStr0.replaceString(oldStr, newStr);
-                resp.setFilterForGoBack(filterByStr0.str()); 
+                resp.setFilterForGoBack(filterByStr0.str());
             }
             resp.setColumnCount(columnCount);
             if (dataColumns.length() > 0)
@@ -5000,12 +5000,75 @@ bool CWsDfuEx::onDFUBrowseData(IEspContext &context, IEspDFUBrowseDataRequest &r
         }
     }
     catch(IException* e)
-    {   
+    {
         FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
 }
 
+
+bool CWsDfuEx::onListHistory(IEspContext &context, IEspListHistoryRequest &req, IEspListHistoryResponse &resp)
+{
+    try
+    {
+        StringBuffer username;
+        context.getUserID(username);
+        Owned<IUserDescriptor> userdesc;
+        if(username.length() > 0)
+        {
+            const char* passwd = context.queryPassword();
+            userdesc.setown(createUserDescriptor());
+            userdesc->set(username.str(), passwd);
+        }
+
+        if (!req.getName() || !*req.getName())
+            throw MakeStringException(ECLWATCH_MISSING_PARAMS, "Name required");
+        PROGLOG("onListHistory: %s", req.getName());
+
+        Owned<IDFUhelper> dfuhelper = createIDFUhelper();
+        MemoryBuffer xmlmap;
+        dfuhelper->getFileHistory(req.getName(), xmlmap, userdesc.get());
+        resp.setXmlmap(xmlmap);
+    }
+    catch(IException* e)
+    {
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
+    }
+    return true;
+}
+
+bool CWsDfuEx::onEraseHistory(IEspContext &context, IEspEraseHistoryRequest &req, IEspEraseHistoryResponse &resp)
+{
+    try
+    {
+        StringBuffer username;
+        context.getUserID(username);
+        Owned<IUserDescriptor> userdesc;
+        if(username.length() > 0)
+        {
+            const char* passwd = context.queryPassword();
+            userdesc.setown(createUserDescriptor());
+            userdesc->set(username.str(), passwd);
+        }
+
+        if (!req.getName() || !*req.getName())
+            throw MakeStringException(ECLWATCH_MISSING_PARAMS, "Name required");
+        PROGLOG("onEraseHistory: %s", req.getName());
+
+        Owned<IDFUhelper> dfuhelper = createIDFUhelper();
+        MemoryBuffer xmlmap;
+        dfuhelper->getFileHistory(req.getName(), xmlmap, userdesc.get());
+        resp.setXmlmap(xmlmap);
+
+        Owned<IDistributedFile> file = queryDistributedFileDirectory().lookup(req.getName(),userdesc.get());
+        file->eraseHistory();
+    }
+    catch(IException* e)
+    {
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
+    }
+    return true;
+}
 
 void CWsDfuEx::getRoxieClusterConfig(char const * clusterType, char const * clusterName, char const * processName, StringBuffer& netAddress, int& port)
 {
@@ -5060,7 +5123,7 @@ void CWsDfuEx::getRoxieClusterConfig(char const * clusterType, char const * clus
             netAddress.append(addr);
     }
 #endif
-    
+
     return;
 }
 
@@ -5146,7 +5209,7 @@ void CWsDfuEx::getMappingColumns(IRelatedBrowseFile * file, bool isPrimary, Unsi
     IViewRelation* parentRelation = file->queryParentRelation();
     for (unsigned i=0; i < parentRelation->numMappingFields(); i++)
     {
-        //find out the column numbers to remove 
+        //find out the column numbers to remove
         unsigned col = parentRelation->queryMappingField(i, isPrimary);
         cols.append(col);
     }
@@ -5186,13 +5249,13 @@ void CWsDfuEx::readColumnsForDisplay(StringBuffer& schemaText, StringArray& colu
         else if (hasChildren)
             columnsDisplayType.append("Object");
         else
-            columnsDisplayType.append("Unknown");   
+            columnsDisplayType.append("Unknown");
     }
 
     return;
 }
 
-void CWsDfuEx::mergeSchema(IRelatedBrowseFile * file, StringBuffer& schemaText, StringBuffer schemaText2, 
+void CWsDfuEx::mergeSchema(IRelatedBrowseFile * file, StringBuffer& schemaText, StringBuffer schemaText2,
                                     StringArray& columnsDisplay, StringArray& columnsDisplayType, StringArray& columnsHide)
 {
     if (schemaText.length() < 1)
@@ -5281,7 +5344,7 @@ void CWsDfuEx::mergeSchema(IRelatedBrowseFile * file, StringBuffer& schemaText, 
         bool bRename = false;
         if (cols.ordinality() != 0)
         {
-            ForEachItemIn(i1,cols) 
+            ForEachItemIn(i1,cols)
             {
                 unsigned col = cols.item(i1);
                 if (col == col0)
@@ -5375,7 +5438,7 @@ void CWsDfuEx::mergeDataRow(StringBuffer& newRow, int depth, IPropertyTreeIterat
                         const char* key = columnsHide.item(i);
                         if (!key || strcmp(key, label))
                             continue;
-                        
+
                         bHide = true;
                         break;
                     }
@@ -5389,7 +5452,7 @@ void CWsDfuEx::mergeDataRow(StringBuffer& newRow, int depth, IPropertyTreeIterat
                         const char* key = columnsUsed.item(i);
                         if (!key || strcmp(key, label))
                             continue;
-                        
+
                         StringBuffer newName(label);
                         newName.append("-2");
                         e->renameProp("/", newName.str());
@@ -5431,12 +5494,12 @@ void CWsDfuEx::mergeDataRow(StringBuffer& newRow, StringBuffer dataRow1, StringB
     if (it)
     {
         StringArray columnLabels0;
-        mergeDataRow(newRow, 0, it, columnLabels0, columnLabels);   
+        mergeDataRow(newRow, 0, it, columnLabels0, columnLabels);
     }
 
     Owned<IPropertyTreeIterator> it2 = data2->getElements("*");
     if (it2)
-    {   
+    {
         mergeDataRow(newRow, 1, it2, columnsHide, columnLabels);
     }
 
@@ -5445,7 +5508,7 @@ void CWsDfuEx::mergeDataRow(StringBuffer& newRow, StringBuffer dataRow1, StringB
     return;
 }
 
-void CWsDfuEx::browseRelatedFileSchema(IRelatedBrowseFile * file, const char* parentName, unsigned depth, StringBuffer& schemaText, 
+void CWsDfuEx::browseRelatedFileSchema(IRelatedBrowseFile * file, const char* parentName, unsigned depth, StringBuffer& schemaText,
                                                     StringArray& columnsDisplay, StringArray& columnsDisplayType, StringArray& columnsHide)
 {
     //if (file in set of files to display or iterate)
@@ -5535,7 +5598,7 @@ schemaText0.append("</xs:schema>");
     return;
 }
 
-int CWsDfuEx::browseRelatedFileDataSet(double version, IRelatedBrowseFile * file, const char* parentName, unsigned depth, __int64 start, __int64& count, __int64& read, 
+int CWsDfuEx::browseRelatedFileDataSet(double version, IRelatedBrowseFile * file, const char* parentName, unsigned depth, __int64 start, __int64& count, __int64& read,
                                         StringArray& columnsHide, StringArray& dataSetOutput)
 {
     int iRet = 0;
@@ -5674,8 +5737,8 @@ rows++;
 
 //sample filterBy: 340020001id1
 //sample data: <XmlSchema name="myschema">...</XmlSchema><Dataset xmlSchema="myschema">...</Dataset>
-int CWsDfuEx::GetIndexData(IEspContext &context, bool bSchemaOnly, const char* indexName, const char* parentName, const char* filterBy, __int64 start, 
-                                        __int64& count, __int64& read, __int64& total, StringBuffer& message, StringArray& columnLabels, 
+int CWsDfuEx::GetIndexData(IEspContext &context, bool bSchemaOnly, const char* indexName, const char* parentName, const char* filterBy, __int64 start,
+                                        __int64& count, __int64& read, __int64& total, StringBuffer& message, StringArray& columnLabels,
                                         StringArray& columnLabelsType, IArrayOf<IEspDFUData>& DataList, bool webDisableUppercaseTranslation)
 {
     if (!indexName || !*indexName)
@@ -5762,7 +5825,7 @@ int CWsDfuEx::GetIndexData(IEspContext &context, bool bSchemaOnly, const char* i
     {
         web->gatherWeb(indexName0, df, options);
         browser.setown(web->createBrowseTree(indexName0));
-    }   
+    }
     catch(IException* e)
     {
         if ((e->errorCode() != FVERR_CouldNotResolveX) || (indexName[0] != '~'))

--- a/esp/services/ws_dfu/ws_dfuService.hpp
+++ b/esp/services/ws_dfu/ws_dfuService.hpp
@@ -143,6 +143,8 @@ public:
     virtual bool onAddRemote(IEspContext &context, IEspAddRemoteRequest &req, IEspAddRemoteResponse &resp);
     virtual bool onSuperfileList(IEspContext &context, IEspSuperfileListRequest &req, IEspSuperfileListResponse &resp);
     virtual bool onSuperfileAction(IEspContext &context, IEspSuperfileActionRequest &req, IEspSuperfileActionResponse &resp);
+    virtual bool onListHistory(IEspContext &context, IEspListHistoryRequest &req, IEspListHistoryResponse &resp);
+    virtual bool onEraseHistory(IEspContext &context, IEspEraseHistoryRequest &req, IEspEraseHistoryResponse &resp);
 
 private:
     const char* getPrefixFromLogicalName(const char* logicalName, StringBuffer& prefix);
@@ -161,7 +163,7 @@ private:
     bool doLogicalFileSearch(IEspContext &context, IUserDescriptor* udesc, IEspDFUQueryRequest & req, IEspDFUQueryResponse & resp);
     void doGetFileDetails(IEspContext &context, IUserDescriptor* udesc, const char *name,const char *cluster,
         const char *description,IEspDFUFileDetail& FileDetails);
-    bool createSpaceItemsByDate(IArrayOf<IEspSpaceItem>& SpaceItems, StringBuffer interval, unsigned& yearFrom, 
+    bool createSpaceItemsByDate(IArrayOf<IEspSpaceItem>& SpaceItems, StringBuffer interval, unsigned& yearFrom,
         unsigned& monthFrom, unsigned& dayFrom, unsigned& yearTo, unsigned& monthTo, unsigned& dayTo);
     bool setSpaceItemByScope(IArrayOf<IEspSpaceItem>& SpaceItems64, const char*scopeName, const char*logicalName, __int64 size);
     bool setSpaceItemByOwner(IArrayOf<IEspSpaceItem>& SpaceItems64, const char *owner, const char *logicalName, __int64 size);
@@ -188,16 +190,16 @@ private:
     void setRootFilter(INewResultSet* result, const char* filterBy, IResultSetFilter* filter, bool disableUppercaseTranslation = true);
     void getMappingColumns(IRelatedBrowseFile * file, bool isPrimary, UnsignedArray& cols);
     void readColumnsForDisplay(StringBuffer& schemaText, StringArray& columnsDisplay, StringArray& columnsDisplayType);
-    void mergeSchema(IRelatedBrowseFile * file, StringBuffer& schemaText, StringBuffer schemaText2, 
+    void mergeSchema(IRelatedBrowseFile * file, StringBuffer& schemaText, StringBuffer schemaText2,
         StringArray& columnsDisplay, StringArray& columnsDisplayType, StringArray& columnsHide);
     void mergeDataRow(StringBuffer& newRow, int depth, IPropertyTreeIterator* it, StringArray& columnsHide, StringArray& columnsUsed);
     void mergeDataRow(StringBuffer& newRow, StringBuffer dataRow1, StringBuffer dataRow2, StringArray& columnsHide);
-    void browseRelatedFileSchema(IRelatedBrowseFile * file, const char* parentName, unsigned depth, StringBuffer& schemaText, 
+    void browseRelatedFileSchema(IRelatedBrowseFile * file, const char* parentName, unsigned depth, StringBuffer& schemaText,
         StringArray& columnsDisplay, StringArray& columnsDisplayType, StringArray& columnsHide);
-    int browseRelatedFileDataSet(double version, IRelatedBrowseFile * file, const char* parentName, unsigned depth, __int64 start, __int64& count, __int64& read, 
+    int browseRelatedFileDataSet(double version, IRelatedBrowseFile * file, const char* parentName, unsigned depth, __int64 start, __int64& count, __int64& read,
                                         StringArray& columnsHide, StringArray& dataSetOutput);
-    int GetIndexData(IEspContext &context, bool bSchemaOnly, const char* indexName, const char* parentName, const char* filterBy, __int64 start, 
-                                        __int64& count, __int64& read, __int64& total, StringBuffer& message, StringArray& columnLabels, 
+    int GetIndexData(IEspContext &context, bool bSchemaOnly, const char* indexName, const char* parentName, const char* filterBy, __int64 start,
+                                        __int64& count, __int64& read, __int64& total, StringBuffer& message, StringArray& columnLabels,
                                         StringArray& columnLabelsType, IArrayOf<IEspDFUData>& DataList, bool webDisableUppercaseTranslation);
     bool getUserFilePermission(IEspContext &context, IUserDescriptor* udesc, const char* logicalName, SecAccessFlags& permission);
     void parseStringArray(const char *input, StringArray& strarray);


### PR DESCRIPTION
Add code to retrieve, copy and create new history record for a
distributed file.

Add new actions to dfuplus
- list history records in 4 format: ascii, XML, CSV and JSON
- erase file history with/without backup it into an XML file

Signed-off-by: Attila Vamos attila.vamos@gmail.com
