### PR TITLE
HPCC-14493 Cross domaing scripting of ESP API

### DIFF
--- a/esp/bindings/http/platform/httpservice.hpp
+++ b/esp/bindings/http/platform/httpservice.hpp
@@ -67,6 +67,7 @@ public:
 
     virtual int onPost();
     virtual int onGet();
+    virtual int onOptions();
 
     virtual int onGetFile(CHttpRequest* request, CHttpResponse* response, const char *path);
     virtual int onGetXslt(CHttpRequest* request, CHttpResponse* response, const char *path);

--- a/esp/bindings/http/platform/httptransport.cpp
+++ b/esp/bindings/http/platform/httptransport.cpp
@@ -1235,6 +1235,10 @@ int CHttpRequest::parseFirstLine(char* oneline)
     {
         setMethod(HEAD_METHOD);
     }
+    else if(!stricmp(method.str(), OPTIONS_METHOD))
+    {
+        setMethod(OPTIONS_METHOD);
+    }
 
     StringBuffer pathbuf;
     curptr = Utils::getWord(curptr, pathbuf);

--- a/esp/bindings/http/platform/httptransport.ipp
+++ b/esp/bindings/http/platform/httptransport.ipp
@@ -35,6 +35,7 @@
 #define POST_METHOD "POST"
 #define GET_METHOD "GET"
 #define HEAD_METHOD "HEAD"
+#define OPTIONS_METHOD "OPTIONS"
 
 #define UNKNOWN_METHOD_ERROR -1;
 


### PR DESCRIPTION
Adds CORS interoperability to ESP, but only for interoperability with
cross domain browser calls.  We do not treat the browser as a trusted
entity or rely on it to make security decisions for us.

Since we implement general purpose APIs and not just scripted pages
we need to be diligent and secure for every request whether it comes
from a cross domain browser, a REST or SOAP client, or any other source.

Signed-off-by: Anthony Fishbeck anthony.fishbeck@lexisnexis.com
