### PR TITLE
HPCC-15921 Support Linux /tmp hardening

### DIFF
--- a/initfiles/sbin/deploy-java-files.sh.in
+++ b/initfiles/sbin/deploy-java-files.sh.in
@@ -470,7 +470,7 @@ then
    [ "$target" != "/" ] && target=$(echo $target | sed 's/[\/]*$//')
 fi
 
-SCRIPT_FILE=/tmp/deploy-java-files_$$
+SCRIPT_FILE=~/deploy-java-files_$$
 createScriptFileHead
 
 EXPECT_SCRIPT_FILE=

--- a/initfiles/sbin/hpcc-push.sh.in
+++ b/initfiles/sbin/hpcc-push.sh.in
@@ -123,7 +123,7 @@ if [ -z "$source"  ] || [ -z "$target" ]; then
 fi
 
 
-SCRIPT_FILE=/tmp/hpcc-push_$$
+SCRIPT_FILE=~/hpcc-push_$$
 createScriptFile
 
 python_expected_version=2.6

--- a/initfiles/sbin/hpcc-run.sh.in
+++ b/initfiles/sbin/hpcc-run.sh.in
@@ -159,7 +159,7 @@ runScript() {
 
 doSetup() {
     init setup
-    scriptFile=/tmp/${action}_setup_$$
+    scriptFile=~/${action}_setup_$$
     createScript $scriptFile $action $args setup
     runScript
     report "${action} setup"
@@ -167,7 +167,7 @@ doSetup() {
 
 doStatus() {
     init status
-    scriptFile=/tmp/${action}_status_$$
+    scriptFile=~/${action}_status_$$
     createScript $scriptFile $action $args status
     runScript
     report "${action} status"
@@ -176,7 +176,7 @@ doStatus() {
 doStop() {
     echo "$action stop in the cluster ..."
     init stop
-    scriptFile=/tmp/${action}_stop_$$
+    scriptFile=~/${action}_stop_$$
     if [[ -n "${comp}" ]]; then
         createScript $scriptFile $action $args stop
         OPTIONS="${DEFAULT_OPTIONS} -h $IPsFile"
@@ -220,7 +220,7 @@ doStart() {
         local numIPs=$(wc -l $startFile | awk '{ print $1 }')
         if [[ $numIPs -gt 0 ]]; then
             echo "$action start in the cluster ..."
-            scriptFile=/tmp/${action}_start_$$
+            scriptFile=~/${action}_start_$$
             createScript $scriptFile $action $args start
             OPTIONS="${DEFAULT_OPTIONS} -h $startFile"
             runScript $startFile

--- a/initfiles/sbin/install-hpcc.exp
+++ b/initfiles/sbin/install-hpcc.exp
@@ -122,10 +122,10 @@ proc copyPayload {} {
 }
 
 proc expandPayload {} {
-   global ip user password prompt
+   global ip user password prompt remote_install
 
    set timeout 180
-   eval "spawn [sshcmd ssh "${user}@${ip} \"cd /; tar -zxf ~/remote_install.tgz\""]"
+   eval "spawn [sshcmd ssh "${user}@${ip} \"cd /; tar -zxf ~/remote_install.tgz; cp ${remote_install}/remote-install-engine.sh ~/ \""]"
    expect {
       *?assword:* {
          send "${password}\r"
@@ -174,7 +174,7 @@ proc runPayload {} {
    }
 
    expect -re $
-   send "${cmd_prefix} ${remote_install}/remote-install-engine.sh ${remote_install}/${basepkg}\r"
+   send "${cmd_prefix} ~/remote-install-engine.sh ${remote_install}/${basepkg}\r"
    expect {
       "*password for*" {
          send "${password}\r"

--- a/initfiles/sbin/remote-install-engine.sh.in
+++ b/initfiles/sbin/remote-install-engine.sh.in
@@ -208,5 +208,4 @@ if [ ${_USER} -eq 1 ]; then
     fi
 fi
 rm -rf ${REMOTE_INSTALL}
-rm -rf ~/remote_install.tgz
 exit 0


### PR DESCRIPTION
The Linux /tmp hardening does not allow script file directly run from /tmp.
The fix is to move the scripts to user home if possible.  If not the file
will be removed to other place to execute.

Signed-off-by: Xiaoming Wang xiaoming.wang@lexisnexi.com

@Michael-Gardner please reviewing it.
