### PR TITLE
HPCC-16309 Security Manager to improve handling access code

### DIFF
--- a/common/dllserver/CMakeLists.txt
+++ b/common/dllserver/CMakeLists.txt
@@ -39,7 +39,8 @@ include_directories (
          ./../../system/include 
          ./../../dali/base 
          ./../../system/jlib 
-         ./../../common/environment 
+         ./../../common/environment
+         ./../../system/security/shared
     )
 
 IF (NOT WIN32)

--- a/common/environment/CMakeLists.txt
+++ b/common/environment/CMakeLists.txt
@@ -39,7 +39,8 @@ include_directories (
          ./../../system/mp 
          ./../../system/include 
          ./../../dali/base 
-         ./../../system/jlib 
+         ./../../system/jlib
+         ./../../system/security/shared
     )
 
 ADD_DEFINITIONS( -D_USRDLL -DENVIRONMENT_EXPORTS )

--- a/common/thorhelper/CMakeLists.txt
+++ b/common/thorhelper/CMakeLists.txt
@@ -94,6 +94,7 @@ include_directories (
          ./../../roxie/roxiemem
          ./../../testing/unittests
          ${TBB_INCLUDE_DIR}
+         ./../../system/security/shared
     )
 
 ADD_DEFINITIONS( -DTHORHELPER_EXPORTS -D_USRDLL )

--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -2209,14 +2209,14 @@ private:
     bool checkScope(const char *scopeName)
     {
         int *perms = scopePermissions.getValue(scopeName);
-        int perm;
+        SecAccessFlags perm;
         if (!perms)
         {
-            perm = secuser.get() ? secmgr->authorizeWorkunitScope(*secuser, scopeName):-1;
+            perm = secuser.get() ? secmgr->authorizeWorkunitScope(*secuser, scopeName) : SecAccess_Unavailable;
             scopePermissions.setValue(scopeName, perm);
         }
         else
-            perm = *perms;
+            perm = (SecAccessFlags)*perms;
         return perm >= SecAccess_Read;
     }
 };

--- a/dali/base/dadfs.hpp
+++ b/dali/base/dadfs.hpp
@@ -37,7 +37,7 @@
 #include "jptree.hpp"
 #include "mpbase.hpp"
 #include "dafdesc.hpp"
-
+#include "seclib.hpp"
 
 typedef __int64 DistributedLockID;
 #define FOREIGN_DALI_TIMEOUT (1000*60*5)
@@ -590,11 +590,11 @@ interface IDistributedFileDirectory: extends IInterface
                                                     unsigned timeout=INFINITE) = 0;  // NB lookup will also return superfiles
     virtual void removeSuperFile(const char *_logicalname, bool delSubs=false, IUserDescriptor *user=NULL, IDistributedFileTransaction *transaction=NULL)=0;
 
-    virtual int getFilePermissions(const char *lname,IUserDescriptor *user,unsigned auditflags=0)=0; // see dasess for auditflags values
+    virtual SecAccessFlags getFilePermissions(const char *lname,IUserDescriptor *user,unsigned auditflags=0)=0; // see dasess for auditflags values
     virtual void setDefaultUser(IUserDescriptor *user)=0;
     virtual IUserDescriptor* queryDefaultUser()=0;
-    virtual int getNodePermissions(const IpAddress &ip,IUserDescriptor *user,unsigned auditflags=0)=0;
-    virtual int getFDescPermissions(IFileDescriptor *,IUserDescriptor *user,unsigned auditflags=0)=0;
+    virtual SecAccessFlags getNodePermissions(const IpAddress &ip,IUserDescriptor *user,unsigned auditflags=0)=0;
+    virtual SecAccessFlags getFDescPermissions(IFileDescriptor *,IUserDescriptor *user,unsigned auditflags=0)=0;
 
     virtual DistributedFileCompareResult fileCompare(const char *lfn1,const char *lfn2,DistributedFileCompareMode mode,StringBuffer &errstr,IUserDescriptor *user)=0;
     virtual bool filePhysicalVerify(const char *lfn1,IUserDescriptor *user,bool includecrc,StringBuffer &errstr)=0;

--- a/dali/base/dasess.hpp
+++ b/dali/base/dasess.hpp
@@ -27,6 +27,7 @@
 #endif
 
 #include "dacoven.hpp"
+#include "seclib.hpp"
 
 typedef DALI_UID SessionId;
 typedef DALI_UID SubscriptionId;
@@ -107,7 +108,7 @@ interface ISessionManager: extends IInterface
     virtual StringBuffer &getClientProcessEndpoint(SessionId id,StringBuffer &buf)=0; // for diagnostics
     virtual unsigned queryClientCount() = 0; // for SNMP
 
-    virtual int getPermissionsLDAP(const char *key,const char *obj,IUserDescriptor *udesc,unsigned auditflags, int *err=NULL)=0;
+    virtual SecAccessFlags getPermissionsLDAP(const char *key,const char *obj,IUserDescriptor *udesc,unsigned auditflags, int *err=NULL)=0;
     virtual bool checkScopeScansLDAP()=0;
     virtual unsigned getLDAPflags()=0;
     virtual void setLDAPflags(unsigned flags)=0;

--- a/dali/dafilesrv/dafilesrv.cmake
+++ b/dali/dafilesrv/dafilesrv.cmake
@@ -34,6 +34,7 @@ include_directories (
          ./../../system/jlib 
          ${CMAKE_BINARY_DIR}
          ${CMAKE_BINARY_DIR}/oss
+         ./../../system/security/shared
     )
 
 if (WIN32)

--- a/dali/daliadmin/daliadmin.cpp
+++ b/dali/daliadmin/daliadmin.cpp
@@ -1522,7 +1522,7 @@ static void listrelationships(const char *primary,const char *secondary)
 
 int dfsperm(const char *obj,IUserDescriptor *user)
 {
-    int perm = SecAccess_None;
+    SecAccessFlags perm = SecAccess_None;
     if (strchr(obj,'\\')||strchr(obj,'/')) {
         Owned<IFileDescriptor> fd = createFileDescriptor();
         RemoteFilename rfn;

--- a/dali/dalidiag/CMakeLists.txt
+++ b/dali/dalidiag/CMakeLists.txt
@@ -34,7 +34,8 @@ include_directories (
          ./../base 
          ./../../system/mp 
          ./../../system/include 
-         ./../../system/jlib 
+         ./../../system/jlib
+         ./../../system/security/shared
     )
 
 ADD_DEFINITIONS( -D_CONSOLE )

--- a/dali/dalidiag/dalidiag.cpp
+++ b/dali/dalidiag/dalidiag.cpp
@@ -380,7 +380,7 @@ void filePermissions(const char *lname,const char *username,const char *password
 {
     Owned<IUserDescriptor> user = createUserDescriptor();
     user->set(username,password);
-    int perm=queryDistributedFileDirectory().getFilePermissions(lname,user);
+    SecAccessFlags perm=queryDistributedFileDirectory().getFilePermissions(lname,user);
     printf("Permissions for %s = %d\n",lname,perm);
 }
 

--- a/dali/dalistop/CMakeLists.txt
+++ b/dali/dalistop/CMakeLists.txt
@@ -34,7 +34,8 @@ include_directories (
          ./../base 
          ./../../system/mp 
          ./../../system/include 
-         ./../../system/jlib 
+         ./../../system/jlib
+         ./../../system/security/shared
     )
 
 ADD_DEFINITIONS( -D_CONSOLE )

--- a/dali/datest/datest.cmake
+++ b/dali/datest/datest.cmake
@@ -33,7 +33,8 @@ include_directories (
          ./../../system/mp 
          . 
          ./../../system/include 
-         ./../../system/jlib 
+         ./../../system/jlib
+         ./../../system/security/shared
     )
 
 HPCC_ADD_EXECUTABLE ( datest ${SRCS} )

--- a/dali/daunittest/CMakeLists.txt
+++ b/dali/daunittest/CMakeLists.txt
@@ -36,7 +36,8 @@ include_directories (
          ./../../system/mp 
          . 
          ./../../system/include 
-         ./../../system/jlib 
+         ./../../system/jlib
+         ./../../system/security/shared
     )
 
 ADD_DEFINITIONS( -D_CONSOLE )

--- a/dali/dfu/dfurun.cpp
+++ b/dali/dfu/dfurun.cpp
@@ -498,7 +498,7 @@ public:
         unsigned auditflags = (DALI_LDAP_AUDIT_REPORT|DALI_LDAP_READ_WANTED);
         if (write)
             auditflags |= DALI_LDAP_WRITE_WANTED;
-        int perm = queryDistributedFileDirectory().getFDescPermissions(fd,user,auditflags);
+        SecAccessFlags perm = queryDistributedFileDirectory().getFDescPermissions(fd,user,auditflags);
         IDFS_Exception *e = NULL;
         if (!HASREADPERMISSION(perm)) 
             throw MakeStringException(DFSERR_LookupAccessDenied,"Lookup permission denied for physical file(s)");

--- a/dali/dfu/dfuserver.cmake
+++ b/dali/dfu/dfuserver.cmake
@@ -44,7 +44,8 @@ include_directories (
          ./../../system/jlib 
          ./../ft 
          ./../../common/environment 
-         ./../../common/workunit 
+         ./../../common/workunit
+         ./../../system/security/shared
     )
 
 HPCC_ADD_EXECUTABLE ( dfuserver ${SRCS} )

--- a/dali/dfuXRefLib/CMakeLists.txt
+++ b/dali/dfuXRefLib/CMakeLists.txt
@@ -44,7 +44,8 @@ include_directories (
          ./../../system/include 
          ./../../system/jlib 
          ./../../common/environment 
-         ./../../common/workunit 
+         ./../../common/workunit
+         ./../../system/security/shared
     )
 
 ADD_DEFINITIONS( -D_USRDLL -DDFUXREFLIB_EXPORTS )

--- a/dali/dfuxref/CMakeLists.txt
+++ b/dali/dfuxref/CMakeLists.txt
@@ -39,6 +39,7 @@ include_directories (
          ./../../common/environment 
          ./../dfuXRefLib
          ./../base
+         ./../../system/security/shared
     )
 
 ADD_DEFINITIONS ( -D_CONSOLE -DMAIN_DFUXREF )

--- a/dali/ft/ftslave.cmake
+++ b/dali/ft/ftslave.cmake
@@ -33,7 +33,8 @@ include_directories (
          ./../../system/mp 
          ./../base 
          ./../../system/include 
-         ./../../system/jlib 
+         ./../../system/jlib
+         ./../../system/security/shared
     )
 
 HPCC_ADD_EXECUTABLE ( ftslave ${SRCS} )

--- a/dali/sasha/CMakeLists.txt
+++ b/dali/sasha/CMakeLists.txt
@@ -55,6 +55,7 @@ include_directories (
          ${HPCC_SOURCE_DIR}/plugins/workunitservices 
          ${CMAKE_BINARY_DIR}
          ${CMAKE_BINARY_DIR}/oss
+         ${HPCC_SOURCE_DIR}/system/security/shared
     )
 
 ADD_DEFINITIONS( -D_CONSOLE )

--- a/dali/server/daldap.cpp
+++ b/dali/server/daldap.cpp
@@ -117,7 +117,7 @@ public:
     }
 
 
-    int getPermissions(const char *key,const char *obj,IUserDescriptor *udesc,unsigned auditflags)
+    SecAccessFlags getPermissions(const char *key,const char *obj,IUserDescriptor *udesc,unsigned auditflags)
     {
         if (!ldapsecurity||((getLDAPflags()&DLF_ENABLED)==0)) 
             return SecAccess_Full;
@@ -151,7 +151,7 @@ public:
         bool wuscope = stricmp(key,"workunit")==0;
 
         if (checkScopeScans() && (filescope || wuscope)) {
-            int perm = SecAccess_None;
+            SecAccessFlags perm = SecAccess_None;
             unsigned start = msTick();
             if (filescope)
                 perm=ldapsecurity->authorizeFileScope(*user, obj);

--- a/dali/server/daldap.hpp
+++ b/dali/server/daldap.hpp
@@ -26,7 +26,7 @@ interface IUserDescriptor;
 
 interface IDaliLdapConnection: extends IInterface
 {
-    virtual int getPermissions(const char *key,const char *obj,IUserDescriptor *udesc,unsigned auditflags)=0;
+    virtual SecAccessFlags getPermissions(const char *key,const char *obj,IUserDescriptor *udesc,unsigned auditflags)=0;
     virtual bool checkScopeScans() = 0;
     virtual unsigned getLDAPflags() = 0;
     virtual void setLDAPflags(unsigned flags) = 0;

--- a/dali/updtdalienv/CMakeLists.txt
+++ b/dali/updtdalienv/CMakeLists.txt
@@ -36,7 +36,8 @@ include_directories (
          . 
          ./../../system/include 
          ./../../system/jlib 
-         ./../ft 
+         ./../ft
+         ./../../system/security/shared
     )
 
 ADD_DEFINITIONS( -D_CONSOLE )

--- a/deployment/configgen/CMakeLists.txt
+++ b/deployment/configgen/CMakeLists.txt
@@ -35,6 +35,7 @@ include_directories (
          ./../../dali/base 
          ${CMAKE_BINARY_DIR}
          ${CMAKE_BINARY_DIR}/oss
+         ./../../system/security/shared
     )
 
 ADD_DEFINITIONS ( -D_CONSOLE )

--- a/deployment/configutils/CMakeLists.txt
+++ b/deployment/configutils/CMakeLists.txt
@@ -37,6 +37,7 @@ include_directories (
          ${HPCC_SOURCE_DIR}/deployment/deploy
          ${CMAKE_BINARY_DIR}/oss
          ${CMAKE_BINARY_DIR}
+         ${HPCC_SOURCE_DIR}/system/security/shared
     )
 
 ADD_DEFINITIONS ( -D_USRDLL -DCONFIGUTILS_EXPORTS )

--- a/deployment/deploy/CMakeLists.txt
+++ b/deployment/deploy/CMakeLists.txt
@@ -52,6 +52,7 @@ include_directories (
          ${CMAKE_BINARY_DIR}
          ${CMAKE_BINARY_DIR}/oss
          ${HPCC_SOURCE_DIR}/deployment/configutils
+         ${HPCC_SOURCE_DIR}/system/security/shared
     )
 
 ADD_DEFINITIONS ( -D_USRDLL -DDEPLOY_EXPORTS )

--- a/deployment/deployutils/CMakeLists.txt
+++ b/deployment/deployutils/CMakeLists.txt
@@ -45,6 +45,7 @@ include_directories (
          ${HPCC_SOURCE_DIR}/deployment/configutils
          ${CMAKE_BINARY_DIR}
          ${CMAKE_BINARY_DIR}/oss
+         ${HPCC_SOURCE_DIR}/system/security/shared
     )
 
 ADD_DEFINITIONS ( -D_USRDLL -DDEPLOYUTILS_EXPORTS )

--- a/deployment/envgen/CMakeLists.txt
+++ b/deployment/envgen/CMakeLists.txt
@@ -37,6 +37,7 @@ include_directories (
          ./../../dali/base 
          ${CMAKE_BINARY_DIR}
          ${CMAKE_BINARY_DIR}/oss
+         ./../../system/security/shared
     )
 
 ADD_DEFINITIONS ( -D_CONSOLE )

--- a/ecl/agentexec/CMakeLists.txt
+++ b/ecl/agentexec/CMakeLists.txt
@@ -36,7 +36,8 @@ include_directories (
          ./../../dali/remote 
          ./../../common/workunit 
          ./../../system/mp 
-         ./../../dali/base 
+         ./../../dali/base
+         ./../../system/security/shared
     )
 
 ADD_DEFINITIONS( -D_CONSOLE )

--- a/ecl/eclccserver/CMakeLists.txt
+++ b/ecl/eclccserver/CMakeLists.txt
@@ -41,7 +41,8 @@ include_directories (
          ./../../system/mp 
          ./../../dali/base 
          ./../../common/dllserver 
-         ./../../system/jlib 
+         ./../../system/jlib
+         ./../../system/security/shared
     )
 
 HPCC_ADD_EXECUTABLE ( eclccserver ${SRCS} ${INCLUDES} )

--- a/ecl/eclscheduler/CMakeLists.txt
+++ b/ecl/eclscheduler/CMakeLists.txt
@@ -41,6 +41,7 @@ include_directories (
          ./../../dali/base 
          ./../../system/jlib 
          ./../../ecl/schedulectrl
+         ./../../system/security/shared
     )
 
 HPCC_ADD_EXECUTABLE ( eclscheduler ${SRCS} ${INCLUDES} )

--- a/ecl/hthor/CMakeLists.txt
+++ b/ecl/hthor/CMakeLists.txt
@@ -67,6 +67,7 @@ include_directories (
          ${CMAKE_BINARY_DIR}
          ${CMAKE_BINARY_DIR}/oss
          ${HPCC_SOURCE_DIR}/dali/ft
+         ${HPCC_SOURCE_DIR}/system/security/shared
     )
 
 ADD_DEFINITIONS( -D_USRDLL -DHTHOR_EXPORTS -DSTARTQUERY_EXPORTS )

--- a/ecl/scheduleadmin/CMakeLists.txt
+++ b/ecl/scheduleadmin/CMakeLists.txt
@@ -35,7 +35,8 @@ include_directories (
          ./../../dali/base 
          ./../../system/jlib 
          ./../schedulectrl 
-         ./../../common/workunit 
+         ./../../common/workunit
+         ./../../system/security/shared
     )
 
 ADD_DEFINITIONS( -DNO_SYBASE -D_CONSOLE )

--- a/ecl/schedulectrl/CMakeLists.txt
+++ b/ecl/schedulectrl/CMakeLists.txt
@@ -38,7 +38,8 @@ include_directories (
          ./../../dali/base 
          ./../../system/jlib 
          ./../schedulectrl 
-         ./../../common/workunit 
+         ./../../common/workunit
+         ./../../system/security/shared
     )
 
 ADD_DEFINITIONS( -D_USRDLL -DSCHEDULECTRL_EXPORTS )

--- a/esp/services/ws_dfu/ws_dfuService.cpp
+++ b/esp/services/ws_dfu/ws_dfuService.cpp
@@ -1688,7 +1688,7 @@ static void getFilePermission(CDfsLogicalFileName &dlfn, ISecUser & user, IUserD
     }
     else
     {
-        int permissionTemp;
+        SecAccessFlags permissionTemp;
         if (dlfn.isForeign())
         {
             permissionTemp = queryDistributedFileDirectory().getFilePermissions(dlfn.get(), udesc);

--- a/plugins/fileservices/fileservices.cpp
+++ b/plugins/fileservices/fileservices.cpp
@@ -2153,7 +2153,7 @@ static void checkExternalFileRights(ICodeContext *ctx, CDfsLogicalFileName &lfn,
         auditflags |= (DALI_LDAP_AUDIT_REPORT|DALI_LDAP_READ_WANTED);
     if (wr)
         auditflags |= (DALI_LDAP_AUDIT_REPORT|DALI_LDAP_WRITE_WANTED);
-    int perm = queryDistributedFileDirectory().getFilePermissions(lfn.get(),udesc,auditflags);
+    SecAccessFlags perm = queryDistributedFileDirectory().getFilePermissions(lfn.get(),udesc,auditflags);
     if (wr) {
         if (!HASWRITEPERMISSION(perm)) {
             throw MakeStringException(-1,"Write permission denied for %s", lfn.get());

--- a/roxie/ccd/CMakeLists.txt
+++ b/roxie/ccd/CMakeLists.txt
@@ -63,30 +63,31 @@ set (   SRCS
 
 include_directories ( 
          .
-         ./../../common/remote
-         ./../../system/jhtree 
-         ./../../system/mp 
-         ./../../common/workunit 
-         ./../../roxie/udplib 
-         ./../../roxie/roxie 
-         ./../../common/environment 
-         ./../../ecl/hthor 
-         ./../../ecl/schedulectrl
-         ./../../rtl/nbcd 
-         ./../../common/deftype 
-         ./../../system/include 
-         ./../../dali/base 
-         ./../../dali/dfu 
-         ./../../roxie/roxiemem 
-         ./../../common/dllserver 
-         ./../../system/jlib 
-         ./../../common/thorhelper 
-         ./../../rtl/eclrtl 
-         ./../../rtl/include
-         ./../../testing/unittests
+         ${HPCC_SOURCE_DIR}/common/remote
+         ${HPCC_SOURCE_DIR}/system/jhtree
+         ${HPCC_SOURCE_DIR}/system/mp
+         ${HPCC_SOURCE_DIR}/common/workunit
+         ${HPCC_SOURCE_DIR}/roxie/udplib
+         ${HPCC_SOURCE_DIR}/roxie/roxie
+         ${HPCC_SOURCE_DIR}/common/environment
+         ${HPCC_SOURCE_DIR}/ecl/hthor
+         ${HPCC_SOURCE_DIR}/ecl/schedulectrl
+         ${HPCC_SOURCE_DIR}/rtl/nbcd
+         ${HPCC_SOURCE_DIR}/common/deftype
+         ${HPCC_SOURCE_DIR}/system/include
+         ${HPCC_SOURCE_DIR}/dali/base
+         ${HPCC_SOURCE_DIR}/dali/dfu
+         ${HPCC_SOURCE_DIR}/roxie/roxiemem
+         ${HPCC_SOURCE_DIR}/common/dllserver
+         ${HPCC_SOURCE_DIR}/system/jlib
+         ${HPCC_SOURCE_DIR}/common/thorhelper
+         ${HPCC_SOURCE_DIR}/rtl/eclrtl
+         ${HPCC_SOURCE_DIR}/rtl/include
+         ${HPCC_SOURCE_DIR}/testing/unittests
          ${CMAKE_BINARY_DIR}
          ${CMAKE_BINARY_DIR}/oss
          ${HPCC_SOURCE_DIR}/dali/ft
+         ${HPCC_SOURCE_DIR}/system/security/shared
     )
 
 ADD_DEFINITIONS( -D_USRDLL -DCCD_EXPORTS -DSTARTQUERY_EXPORTS )

--- a/system/security/LdapSecurity/aci.cpp
+++ b/system/security/LdapSecurity/aci.cpp
@@ -588,9 +588,9 @@ public:
 };
 
 //Translates ACI permission settings to SecAccessFlags
-int NewSec2Sec(int newsec)
+SecAccessFlags NewSec2Sec(int newsec)
 {
-    int sec = 0;
+    int sec = SecAccess_None;
     if(newsec == -1)
         return SecAccess_Unavailable;
     if(newsec == NewSecAccess_Full)
@@ -603,7 +603,7 @@ int NewSec2Sec(int newsec)
     if((newsec & NewSecAccess_Access) == NewSecAccess_Access)
         sec |= SecAccess_Access;
 
-    return sec;
+    return (SecAccessFlags)sec;
 }
 
 /****************************************************************
@@ -654,6 +654,7 @@ public:
         }
 
         int perm = 0;
+        SecAccessFlags perms = SecAccess_None;
         if(m_acilist.length() == 0)
         {
             perm = SecAccess_Unavailable;
@@ -712,10 +713,10 @@ public:
 
             perm = allow & (~deny);
 
-            perm = NewSec2Sec(perm);
+            perms = NewSec2Sec(perm);
         }
         
-        resource.setAccessFlags(perm);
+        resource.setAccessFlags(perms);
         return true;
     }
 

--- a/system/security/LdapSecurity/ldapconnection.hpp
+++ b/system/security/LdapSecurity/ldapconnection.hpp
@@ -284,7 +284,7 @@ interface ILdapClient : extends IInterface
     virtual const char* getPasswordStorageScheme() = 0;
     virtual bool createUserScope(ISecUser& user) = 0;
     virtual aindex_t getManagedFileScopes(IArrayOf<ISecResource>& scopes) = 0;
-    virtual int queryDefaultPermission(ISecUser& user) = 0;
+    virtual SecAccessFlags queryDefaultPermission(ISecUser& user) = 0;
 
     //Data View related interfaces
     virtual void createView(const char * viewName, const char * viewDescription) = 0;

--- a/system/security/LdapSecurity/ldapsecurity.cpp
+++ b/system/security/LdapSecurity/ldapsecurity.cpp
@@ -213,27 +213,27 @@ ISecUser * CLdapSecUser::clone()
  *     CLdapSecResource                                   *
  **********************************************************/
 
-CLdapSecResource::CLdapSecResource(const char *name) : m_name(name), m_access(0), m_required_access(0)
+CLdapSecResource::CLdapSecResource(const char *name) : m_name(name), m_access(SecAccess_None), m_required_access(SecAccess_None)
 {
     m_resourcetype = RT_DEFAULT;
 }
 
-void CLdapSecResource::addAccess(int flags)
+void CLdapSecResource::addAccess(SecAccessFlags flags)
 {
-    m_access |= flags;
+    m_access = (SecAccessFlags)((int)m_access | (int)flags);
 }
 
-void CLdapSecResource::setAccessFlags(int flags)
+void CLdapSecResource::setAccessFlags(SecAccessFlags flags)
 {
     m_access = flags;
 }
 
-void CLdapSecResource::setRequiredAccessFlags(int flags)
+void CLdapSecResource::setRequiredAccessFlags(SecAccessFlags flags)
 {
     m_required_access = flags;
 }
 
-int CLdapSecResource::getRequiredAccessFlags()
+SecAccessFlags CLdapSecResource::getRequiredAccessFlags()
 {
     return m_required_access;
 }
@@ -244,7 +244,7 @@ const char * CLdapSecResource::getName()
     return m_name.get();
 }
 
-int CLdapSecResource::getAccessFlags()
+SecAccessFlags CLdapSecResource::getAccessFlags()
 {
     return m_access;
 }
@@ -668,7 +668,7 @@ bool CLdapSecManager::authorizeEx(SecResourceType rtype, ISecUser& sec_user, ISe
     return rc;
 }
 
-int CLdapSecManager::authorizeEx(SecResourceType rtype, ISecUser & user, const char * resourcename, IEspSecureContext* secureContext)
+SecAccessFlags CLdapSecManager::authorizeEx(SecResourceType rtype, ISecUser & user, const char * resourcename, IEspSecureContext* secureContext)
 {
     if(!resourcename || !*resourcename)
         return SecAccess_Full;
@@ -681,7 +681,7 @@ int CLdapSecManager::authorizeEx(SecResourceType rtype, ISecUser & user, const c
     if(ok)
         return rlist->queryResource(0)->getAccessFlags();
     else
-        return -1;
+        return SecAccess_Unavailable;
 }
 
 bool CLdapSecManager::authorizeEx(SecResourceType rtype, ISecUser& sec_user, ISecResourceList * Resources, bool doAuthentication)
@@ -743,7 +743,7 @@ bool CLdapSecManager::authorizeEx(SecResourceType rtype, ISecUser& sec_user, ISe
     return rc;
 }
 
-int CLdapSecManager::authorizeEx(SecResourceType rtype, ISecUser & user, const char * resourcename, bool doAuthentication)
+SecAccessFlags CLdapSecManager::authorizeEx(SecResourceType rtype, ISecUser & user, const char * resourcename, bool doAuthentication)
 {
     if(!resourcename || !*resourcename)
         return SecAccess_Full;
@@ -756,13 +756,13 @@ int CLdapSecManager::authorizeEx(SecResourceType rtype, ISecUser & user, const c
     if(ok)
         return rlist->queryResource(0)->getAccessFlags();
     else
-        return -1;
+        return SecAccess_Unavailable;
 }
 
-int CLdapSecManager::getAccessFlagsEx(SecResourceType rtype, ISecUser & user, const char * resourcename)
+SecAccessFlags CLdapSecManager::getAccessFlagsEx(SecResourceType rtype, ISecUser & user, const char * resourcename)
 {
     if(!resourcename || !*resourcename)
-        return -1;
+        return SecAccess_Unavailable;
 
     Owned<ISecResourceList> rlist0;
     rlist0.setown(createResourceList("resources"));
@@ -770,7 +770,7 @@ int CLdapSecManager::getAccessFlagsEx(SecResourceType rtype, ISecUser & user, co
     
     CLdapSecResourceList * reslist = (CLdapSecResourceList*)rlist0.get();
     if(!reslist)
-        return -1;
+        return SecAccess_Unavailable;
     IArrayOf<ISecResource>& rlist = reslist->getResourceList();
     int nResources = rlist.length();
     int ri;
@@ -782,7 +782,7 @@ int CLdapSecManager::getAccessFlagsEx(SecResourceType rtype, ISecUser & user, co
     }
 
     if (nResources <= 0)
-        return -1;
+        return SecAccess_Unavailable;
 
     bool ok = false;
 
@@ -822,7 +822,7 @@ int CLdapSecManager::getAccessFlagsEx(SecResourceType rtype, ISecUser & user, co
     if(ok)
         return rlist0->queryResource(0)->getAccessFlags();
     else
-        return -1;
+        return SecAccess_Unavailable;
 }
 
 bool CLdapSecManager::authorize(ISecUser& sec_user, ISecResourceList * Resources, IEspSecureContext* secureContext)
@@ -831,7 +831,7 @@ bool CLdapSecManager::authorize(ISecUser& sec_user, ISecResourceList * Resources
 }
 
 
-int CLdapSecManager::authorizeFileScope(ISecUser & user, const char * filescope)
+SecAccessFlags CLdapSecManager::authorizeFileScope(ISecUser & user, const char * filescope)
 {
     if(filescope == 0 || filescope[0] == '\0')
         return SecAccess_Full;
@@ -839,7 +839,7 @@ int CLdapSecManager::authorizeFileScope(ISecUser & user, const char * filescope)
     StringBuffer managedFilescope;
     if(m_permissionsCache->isCacheEnabled() && !m_usercache_off)
     {
-        int accessFlags;
+        SecAccessFlags accessFlags;
         //See if file scope in question is managed by LDAP permissions.
         //  If not, return default file permission (dont call out to LDAP)
         //  If is, look in cache for permission of longest matching managed scope strings. If found return that permission (no call to LDAP),
@@ -857,7 +857,7 @@ int CLdapSecManager::authorizeFileScope(ISecUser & user, const char * filescope)
     if(ok)
         return rlist->queryResource(0)->getAccessFlags();
     else
-        return -1;
+        return SecAccess_Unavailable;
 }
 
 bool CLdapSecManager::authorizeFileScope(ISecUser & user, ISecResourceList * resources)
@@ -870,7 +870,7 @@ bool CLdapSecManager::authorizeViewScope(ISecUser & user, ISecResourceList * res
     return authorizeEx(RT_VIEW_SCOPE, user, resources);
 }
 
-int CLdapSecManager::authorizeWorkunitScope(ISecUser & user, const char * wuscope)
+SecAccessFlags CLdapSecManager::authorizeWorkunitScope(ISecUser & user, const char * wuscope)
 {
     if(wuscope == 0 || wuscope[0] == '\0')
         return SecAccess_Full;
@@ -883,7 +883,7 @@ int CLdapSecManager::authorizeWorkunitScope(ISecUser & user, const char * wuscop
     if(ok)
         return rlist->queryResource(0)->getAccessFlags();
     else
-        return -1;
+        return SecAccess_Unavailable;
 }
     
 bool CLdapSecManager::authorizeWorkunitScope(ISecUser & user, ISecResourceList * resources)
@@ -1058,7 +1058,7 @@ IAuthMap * CLdapSecManager::createAuthMap(IPropertyTree * authconfig)
                     authmap->add(pathstr.str(), rlist);
                 }
                 ISecResource* rs = rlist->addResource(rstr.str());
-                unsigned requiredaccess = str2perm(required.str());
+                SecAccessFlags requiredaccess = str2perm(required.str());
                 rs->setRequiredAccessFlags(requiredaccess);
                 rs->setDescription(description.str());
             }
@@ -1101,7 +1101,7 @@ IAuthMap * CLdapSecManager::createFeatureMap(IPropertyTree * authconfig)
                     feature_authmap->add(pathstr.str(), rlist);
                 }
                 ISecResource* rs = rlist->addResource(rstr.str());
-                unsigned requiredaccess = str2perm(required.str());
+                SecAccessFlags requiredaccess = str2perm(required.str());
                 rs->setRequiredAccessFlags(requiredaccess);
                 rs->setDescription(description.str());
             }
@@ -1290,7 +1290,7 @@ aindex_t CLdapSecManager::getManagedFileScopes(IArrayOf<ISecResource>& scopes)
     return m_ldap_client->getManagedFileScopes(scopes);
 }
 
-int CLdapSecManager::queryDefaultPermission(ISecUser& user)
+SecAccessFlags CLdapSecManager::queryDefaultPermission(ISecUser& user)
 {
     return m_ldap_client->queryDefaultPermission(user);
 }

--- a/system/security/LdapSecurity/ldapsecurity.ipp
+++ b/system/security/LdapSecurity/ldapsecurity.ipp
@@ -233,8 +233,8 @@ class CLdapSecResource : implements ISecResource, public CInterface
 {
 private:
     StringAttr         m_name;
-    int                m_access;
-    int                m_required_access;
+    SecAccessFlags     m_access;
+    SecAccessFlags     m_required_access;
     Owned<IProperties> m_parameters;
     StringBuffer       m_description;
     StringBuffer       m_value;
@@ -244,13 +244,13 @@ public:
     IMPLEMENT_IINTERFACE
 
     CLdapSecResource(const char *name);
-    void addAccess(int flags);
-    void setAccessFlags(int flags);
-    virtual void setRequiredAccessFlags(int flags);
-    virtual int getRequiredAccessFlags();
+    void addAccess(SecAccessFlags flags);
+    void setAccessFlags(SecAccessFlags flags);
+    virtual void setRequiredAccessFlags(SecAccessFlags flags);
+    virtual SecAccessFlags getRequiredAccessFlags();
 //interface ISecResource : extends IInterface
     virtual const char * getName();
-    virtual int  getAccessFlags();
+    virtual SecAccessFlags getAccessFlags();
     virtual int addParameter(const char* name, const char* value);
     virtual const char * getParameter(const char * name);
     virtual void setDescription(const char* description);
@@ -351,14 +351,14 @@ public:
     bool unsubscribe(ISecAuthenticEvents & events);
     bool authorize(ISecUser& sec_user, ISecResourceList * Resources, IEspSecureContext* secureContext);
     bool authorizeEx(SecResourceType rtype, ISecUser& sec_user, ISecResourceList * Resources, IEspSecureContext* secureContext = NULL);
-    int authorizeEx(SecResourceType rtype, ISecUser& sec_user, const char* resourcename, IEspSecureContext* secureContext = NULL);
-    virtual int authorizeFileScope(ISecUser & user, const char * filescope);
+    SecAccessFlags authorizeEx(SecResourceType rtype, ISecUser& sec_user, const char* resourcename, IEspSecureContext* secureContext = NULL);
+    virtual SecAccessFlags authorizeFileScope(ISecUser & user, const char * filescope);
     virtual bool authorizeFileScope(ISecUser & user, ISecResourceList * resources);
     virtual bool authorizeViewScope(ISecUser & user, ISecResourceList * resources);
-    virtual int authorizeWorkunitScope(ISecUser & user, const char * wuscope);
+    virtual SecAccessFlags authorizeWorkunitScope(ISecUser & user, const char * wuscope);
     virtual bool authorizeWorkunitScope(ISecUser & user, ISecResourceList * resources);
     virtual bool addResources(ISecUser& sec_user, ISecResourceList * resources);
-    virtual int getAccessFlagsEx(SecResourceType rtype, ISecUser & user, const char * resourcename);
+    virtual SecAccessFlags getAccessFlagsEx(SecResourceType rtype, ISecUser & user, const char * resourcename);
     virtual bool addResourcesEx(SecResourceType rtype, ISecUser &user, ISecResourceList* resources, SecPermissionType ptype = PT_ADMINISTRATORS_ONLY, const char* basedn = NULL);
     virtual bool addResourceEx(SecResourceType rtype, ISecUser& user, const char* resourcename, SecPermissionType ptype = PT_ADMINISTRATORS_ONLY, const char* basedn = NULL);
     virtual bool updateResources(ISecUser& sec_user, ISecResourceList * resources){return false;}
@@ -401,7 +401,7 @@ public:
     virtual void copyResource(SecResourceType rtype, const char * oldname, const char * newname, const char * basedn);
 
     virtual bool authorizeEx(SecResourceType rtype, ISecUser& sec_user, ISecResourceList * Resources, bool doAuthentication);
-    virtual int authorizeEx(SecResourceType rtype, ISecUser& sec_user, const char* resourcename, bool doAuthentication);
+    virtual SecAccessFlags authorizeEx(SecResourceType rtype, ISecUser& sec_user, const char* resourcename, bool doAuthentication);
 
     virtual void normalizeDn(const char* dn, StringBuffer& ndn);
     virtual bool isSuperUser(ISecUser* user);
@@ -440,7 +440,7 @@ public:
     }
     virtual bool createUserScopes();
     virtual aindex_t getManagedFileScopes(IArrayOf<ISecResource>& scopes);
-    virtual int queryDefaultPermission(ISecUser& user);
+    virtual SecAccessFlags queryDefaultPermission(ISecUser& user);
     virtual bool clearPermissionsCache(ISecUser &user);
     virtual bool authenticateUser(ISecUser & user, bool * superUser);
     virtual secManagerType querySecMgrType() { return SMT_LDAP; }

--- a/system/security/LdapSecurity/permissions.cpp
+++ b/system/security/LdapSecurity/permissions.cpp
@@ -60,16 +60,14 @@ PermissionProcessor::PermissionProcessor(IPropertyTree* config)
     m_cfg->getProp(".//@ldapAddress", m_server);
 }
 
-unsigned PermissionProcessor::ldap2sec(unsigned ldapperm)
+SecAccessFlags PermissionProcessor::ldap2sec(unsigned ldapperm)
 {
-    unsigned permission = 0;
-
     if((ldapperm & 0xFF) == 0xFF)
     {
-        permission |= SecAccess_Full;
-        return permission;
+        return SecAccess_Full;
     }
 
+    unsigned permission = SecAccess_None;
     if(ldapperm & ADS_RIGHT_DS_LIST_OBJECT)
         permission |= SecAccess_Access;
     if(ldapperm & 0x14)
@@ -77,19 +75,17 @@ unsigned PermissionProcessor::ldap2sec(unsigned ldapperm)
     if(ldapperm & 0x28)
         permission |= SecAccess_Write;
 
-    return permission;
+    return (SecAccessFlags)permission;
 }
 
-unsigned PermissionProcessor::sec2ldap(unsigned secperm)
+unsigned PermissionProcessor::sec2ldap(SecAccessFlags secperm)
 {
-    unsigned permission = 0;
-
     if((secperm & SecAccess_Full) == SecAccess_Full)
     {
-        permission |= 0xF01FF;
-        return permission;
+        return 0xF01FF;
     }
 
+    unsigned permission = SecAccess_None;
     if((secperm & SecAccess_Access) == SecAccess_Access)
     {
         permission |=  ADS_RIGHT_DS_LIST_OBJECT;
@@ -108,36 +104,32 @@ unsigned PermissionProcessor::sec2ldap(unsigned secperm)
     return permission;
 }
 
-unsigned PermissionProcessor::ldap2newsec(unsigned ldapperm)
+NewSecAccessFlags PermissionProcessor::ldap2newsec(unsigned ldapperm)
 {
-    unsigned permission = 0;
-
     if((ldapperm & 0xFF) == 0xFF)
     {
-        permission |= NewSecAccess_Full;
-        return permission;
+        return NewSecAccess_Full;
     }
 
+    unsigned permission = NewSecAccess_None;
     if(ldapperm & ADS_RIGHT_DS_LIST_OBJECT)
-        permission |= SecAccess_Access;
+        permission |= NewSecAccess_Access;
     if(ldapperm & 0x14)
         permission |= NewSecAccess_Read;
     if(ldapperm & 0x28)
         permission |= NewSecAccess_Write;
 
-    return permission;
+    return (NewSecAccessFlags)permission;
 }
 
-unsigned PermissionProcessor::newsec2ldap(unsigned secperm)
+unsigned PermissionProcessor::newsec2ldap(SecAccessFlags secperm)
 {
-    unsigned permission = 0;
-
     if((secperm & NewSecAccess_Full) == NewSecAccess_Full)
     {
-        permission |= 0xF01FF;
-        return permission;
+        return 0xF01FF;
     }
 
+    unsigned permission = SecAccess_None;
     if((secperm & SecAccess_Access) == SecAccess_Access)
     {
         permission |=  ADS_RIGHT_DS_LIST_OBJECT;
@@ -1086,7 +1078,7 @@ bool PermissionProcessor::getPermissions(ISecUser& user, IArrayOf<CSecurityDescr
         MemoryBuffer& sdbuf = csd.getDescriptor();
         if(sdbuf.length() == 0)
         {
-            resource.setAccessFlags((unsigned)-1);
+            resource.setAccessFlags(SecAccess_Unavailable);
             continue;
         }
         PSECURITY_DESCRIPTOR psd = (PSECURITY_DESCRIPTOR)(sdbuf.toByteArray());
@@ -1150,7 +1142,7 @@ bool PermissionProcessor::getPermissions(ISecUser& user, IArrayOf<CSecurityDescr
         }
 
         unsigned ldapperm = allows & (~denies);
-        unsigned permission = ldap2sec(ldapperm);
+        SecAccessFlags permission = ldap2sec(ldapperm);
         resource.setAccessFlags(permission);
     }
 #endif
@@ -1356,7 +1348,7 @@ CSecurityDescriptor* PermissionProcessor::changePermission(CSecurityDescriptor* 
     if(stricmp(action.m_action.str(), "delete") != 0 && action.m_allows != 0)
     {
         uaccess_allows.grfAccessMode = GRANT_ACCESS;
-        uaccess_allows.grfAccessPermissions = newsec2ldap(action.m_allows);
+        uaccess_allows.grfAccessPermissions = newsec2ldap((SecAccessFlags)action.m_allows);
         uaccess_allows.grfInheritance = NO_INHERITANCE;
         uaccess_allows.Trustee.MultipleTrusteeOperation = NO_MULTIPLE_TRUSTEE;
         uaccess_allows.Trustee.pMultipleTrustee = NULL;
@@ -1405,7 +1397,7 @@ CSecurityDescriptor* PermissionProcessor::changePermission(CSecurityDescriptor* 
         DWORD new_dacl_size = dacl_size + newace_size;
         dacl_size = new_dacl_size;
         pnewdacl = (PACL)alloca(new_dacl_size);
-        rc = AddAccessDeniedAce(pnewdacl, &new_dacl_size, pdacl, ACL_REVISION, newsec2ldap(action.m_denies), act_psid);
+        rc = AddAccessDeniedAce(pnewdacl, &new_dacl_size, pdacl, ACL_REVISION, newsec2ldap((SecAccessFlags)action.m_denies), act_psid);
         if(rc == 0)
         {
             int error = GetLastError();
@@ -1420,7 +1412,7 @@ CSecurityDescriptor* PermissionProcessor::changePermission(CSecurityDescriptor* 
         DWORD newace_size = sizeof(ACE_HEADER) + sizeof(ACCESS_MASK) + sizeofSid(act_psid);
         DWORD new_dacl_size = dacl_size + newace_size;
         pnewdacl = (PACL)alloca(new_dacl_size);
-        rc = AddAccessAllowedAce(pnewdacl, &new_dacl_size, pdacl, ACL_REVISION, newsec2ldap(action.m_allows), act_psid);
+        rc = AddAccessAllowedAce(pnewdacl, &new_dacl_size, pdacl, ACL_REVISION, newsec2ldap((SecAccessFlags)action.m_allows), act_psid);
         if(rc == 0)
         {
             int error = GetLastError();

--- a/system/security/LdapSecurity/permissions.ipp
+++ b/system/security/LdapSecurity/permissions.ipp
@@ -699,11 +699,11 @@ private:
     ILdapClient*         m_ldap_client;
 
 protected:
-    unsigned ldap2sec(unsigned ldapperm);
-    unsigned sec2ldap(unsigned secperm);
+    SecAccessFlags ldap2sec(unsigned ldapperm);
+    unsigned sec2ldap(SecAccessFlags secperm);
 
-    unsigned ldap2newsec(unsigned ldapperm);
-    unsigned newsec2ldap(unsigned secperm);
+    NewSecAccessFlags ldap2newsec(unsigned ldapperm);
+    unsigned newsec2ldap(SecAccessFlags secperm);
 public:
     IMPLEMENT_IINTERFACE;
 

--- a/system/security/plugins/htpasswdSecurity/htpasswdSecurity.cpp
+++ b/system/security/plugins/htpasswdSecurity/htpasswdSecurity.cpp
@@ -100,7 +100,7 @@ public:
 						authmap->add(pathstr.str(), rlist);
 					}
 					ISecResource* rs = rlist->addResource(rstr.str());
-					unsigned requiredaccess = str2perm(required.str());
+                    SecAccessFlags requiredaccess = str2perm(required.str());
 					rs->setRequiredAccessFlags(requiredaccess);
 					rs->setDescription(description.str());
                     rs->setAccessFlags(SecAccess_Full);//grant full access to authenticated users
@@ -153,17 +153,17 @@ protected:
         return -2;//never expires
     }
 
-    int authorizeEx(SecResourceType rtype, ISecUser & user, const char * resourcename, IEspSecureContext* secureContext) override
+    SecAccessFlags authorizeEx(SecResourceType rtype, ISecUser & user, const char * resourcename, IEspSecureContext* secureContext) override
     {
         return SecAccess_Full;//grant full access to authenticated users
     }
 
-    int getAccessFlagsEx(SecResourceType rtype, ISecUser& sec_user, const char* resourcename) override
+    SecAccessFlags getAccessFlagsEx(SecResourceType rtype, ISecUser& sec_user, const char* resourcename) override
     {
         return SecAccess_Full;//grant full access to authenticated users
     }
 
-    int authorizeFileScope(ISecUser & user, const char * filescope) override
+    SecAccessFlags authorizeFileScope(ISecUser & user, const char * filescope) override
     {
         return SecAccess_Full;//grant full access to authenticated users
     }
@@ -183,7 +183,7 @@ protected:
         return true;//success
     }
 
-    int authorizeWorkunitScope(ISecUser & user, const char * filescope) override
+    SecAccessFlags authorizeWorkunitScope(ISecUser & user, const char * filescope) override
     {
         return SecAccess_Full;//grant full access to authenticated users
     }

--- a/system/security/shared/SecurityResource.hpp
+++ b/system/security/shared/SecurityResource.hpp
@@ -24,8 +24,8 @@ class CSecurityResource : implements ISecResource, public CInterface
 private:
     StringAttr m_name;
     StringBuffer m_value;
-    int        m_access;
-    int        m_required_access;
+    SecAccessFlags    m_access;
+    SecAccessFlags    m_required_access;
     Owned<IProperties> m_parameters;
 
     StringBuffer m_description;
@@ -41,7 +41,7 @@ public:
 
     void addAccess(int flags)
     {
-        m_access |= flags;
+        m_access =  SecAccessFlags((int)m_access | flags);
     }
     
 //interface ISecResource : extends IInterface
@@ -50,12 +50,12 @@ public:
         return m_name.get();
     }
 
-    void setAccessFlags(int flags)
+    void setAccessFlags(SecAccessFlags flags)
     {
         m_access = flags;
     }
         
-    int getAccessFlags()
+    SecAccessFlags getAccessFlags()
     {
         return m_access;
     }
@@ -79,12 +79,12 @@ public:
         return NULL;
 
     }
-    virtual void setRequiredAccessFlags(int flags)
+    virtual void setRequiredAccessFlags(SecAccessFlags flags)
     {
         m_required_access = flags;
     }
 
-    virtual int getRequiredAccessFlags()
+    virtual SecAccessFlags getRequiredAccessFlags()
     {
         return m_required_access;
     }

--- a/system/security/shared/authmap.cpp
+++ b/system/security/shared/authmap.cpp
@@ -131,9 +131,9 @@ bool CAuthMap::addToBackend()
     return ok;
 }
 
-unsigned str2perm(const char* permstr)
+SecAccessFlags str2perm(const char* permstr)
 {
-    unsigned perm;
+    SecAccessFlags perm;
     if(permstr == NULL)
     {
         PROGLOG("permission string is NULL, using default");

--- a/system/security/shared/authmap.ipp
+++ b/system/security/shared/authmap.ipp
@@ -21,7 +21,7 @@
 #include "jliball.hpp"
 #include "seclib.hpp"
 
-unsigned str2perm(const char* permstr);
+SecAccessFlags str2perm(const char* permstr);
 
 class CSecResourceListHolder : public CInterface, implements IInterface
 {

--- a/system/security/shared/basesecurity.hpp
+++ b/system/security/shared/basesecurity.hpp
@@ -81,22 +81,22 @@ public:
         return false;
     }
 
-    int authorizeEx(SecResourceType rtype, ISecUser & user, const char * resourcename, IEspSecureContext* secureContext)
+    SecAccessFlags authorizeEx(SecResourceType rtype, ISecUser & user, const char * resourcename, IEspSecureContext* secureContext)
     {
         UNIMPLEMENTED;
-        return 0;
+        return SecAccess_None;
     }
 
-    int getAccessFlagsEx(SecResourceType rtype, ISecUser & user, const char * resourcename)
+    SecAccessFlags getAccessFlagsEx(SecResourceType rtype, ISecUser & user, const char * resourcename)
     {
         UNIMPLEMENTED;
-        return 0;
+        return SecAccess_None;
     }
 
-    int authorizeFileScope(ISecUser & user, const char * filescope)
+    SecAccessFlags authorizeFileScope(ISecUser & user, const char * filescope)
     {
         UNIMPLEMENTED;
-        return 0;
+        return SecAccess_None;
     }
 
     bool authorizeFileScope(ISecUser & user, ISecResourceList * resources)
@@ -237,10 +237,10 @@ public:
         return false;
     }
 
-    int authorizeWorkunitScope(ISecUser & user, const char * filescope)
+    SecAccessFlags authorizeWorkunitScope(ISecUser & user, const char * filescope)
     {
         UNIMPLEMENTED;
-        return 0;
+        return SecAccess_None;
     }
 
     bool authorizeWorkunitScope(ISecUser & user, ISecResourceList * resources)
@@ -273,10 +273,10 @@ public:
         return 0;
     }
 
-    int queryDefaultPermission(ISecUser& user)
+    SecAccessFlags queryDefaultPermission(ISecUser& user)
     {
         UNIMPLEMENTED;
-        return 0;
+        return SecAccess_None;
     }
 
     bool clearPermissionsCache(ISecUser & user)

--- a/system/security/shared/caching.cpp
+++ b/system/security/shared/caching.cpp
@@ -527,7 +527,7 @@ inline void CPermissionsCache::removeAllManagedFileScopes()
 
     etc. Until full scope path checked, or no read permissions hit on ancestor scope.
 */
-bool CPermissionsCache::queryPermsManagedFileScope(ISecUser& sec_user, const char * fullScope, StringBuffer& managedScope, int * accessFlags)
+bool CPermissionsCache::queryPermsManagedFileScope(ISecUser& sec_user, const char * fullScope, StringBuffer& managedScope, SecAccessFlags * accessFlags)
 {
     if (!fullScope || !*fullScope)
     {
@@ -639,7 +639,7 @@ bool CPermissionsCache::queryPermsManagedFileScope(ISecUser& sec_user, const cha
     return rc;
 }
 
-int CPermissionsCache::queryDefaultPermission(ISecUser& user)
+SecAccessFlags CPermissionsCache::queryDefaultPermission(ISecUser& user)
 {
     if (m_defaultPermission == SecAccess_Unknown)
     {

--- a/system/security/shared/caching.hpp
+++ b/system/security/shared/caching.hpp
@@ -205,9 +205,9 @@ public:
     bool addManagedFileScopes(IArrayOf<ISecResource>& scopes);
     void removeManagedFileScopes(IArrayOf<ISecResource>& scopes);
     void removeAllManagedFileScopes();
-    bool queryPermsManagedFileScope(ISecUser& sec_user, const char * fullScope, StringBuffer& managedScope, int * accessFlags);
+    bool queryPermsManagedFileScope(ISecUser& sec_user, const char * fullScope, StringBuffer& managedScope, SecAccessFlags * accessFlags);
     void setSecManager(ISecManager * secMgr) { m_secMgr = secMgr; }
-    int  queryDefaultPermission(ISecUser& user);
+    SecAccessFlags  queryDefaultPermission(ISecUser& user);
 private:
 
     typedef std::map<string, CResPermissionsCache*> MapResPermissionsCache;
@@ -226,7 +226,7 @@ private:
     StringAttr                  m_secMgrClass;
 
     //Managed File Scope support
-    int                         m_defaultPermission;
+    SecAccessFlags              m_defaultPermission;
     map<string, ISecResource*>  m_managedFileScopesMap;
     mutable ReadWriteLock       m_scopesRWLock;//guards m_managedFileScopesMap
     ISecManager *               m_secMgr;

--- a/system/security/shared/seclib.hpp
+++ b/system/security/shared/seclib.hpp
@@ -200,10 +200,10 @@ interface ISecProperty : extends IInterface
 
 interface ISecResource : extends ISecProperty
 {
-    virtual void setAccessFlags(int flags) = 0;
-    virtual int getAccessFlags() = 0;
-    virtual void setRequiredAccessFlags(int flags) = 0;
-    virtual int getRequiredAccessFlags() = 0;
+    virtual void setAccessFlags(SecAccessFlags flags) = 0;
+    virtual SecAccessFlags getAccessFlags() = 0;
+    virtual void setRequiredAccessFlags(SecAccessFlags flags) = 0;
+    virtual SecAccessFlags getRequiredAccessFlags() = 0;
     virtual int addParameter(const char * name, const char * value) = 0;
     virtual const char * getParameter(const char * name) = 0;
     virtual void setDescription(const char * description) = 0;
@@ -278,9 +278,9 @@ interface ISecManager : extends IInterface
     virtual bool unsubscribe(ISecAuthenticEvents & events) = 0;
     virtual bool authorize(ISecUser & user, ISecResourceList * resources, IEspSecureContext* secureContext) = 0;
     virtual bool authorizeEx(SecResourceType rtype, ISecUser & user, ISecResourceList * resources, IEspSecureContext* secureContext = NULL) = 0;
-    virtual int authorizeEx(SecResourceType rtype, ISecUser & user, const char * resourcename, IEspSecureContext* secureContext = NULL) = 0;
-    virtual int getAccessFlagsEx(SecResourceType rtype, ISecUser & user, const char * resourcename) = 0;
-    virtual int authorizeFileScope(ISecUser & user, const char * filescope) = 0;
+    virtual SecAccessFlags authorizeEx(SecResourceType rtype, ISecUser & user, const char * resourcename, IEspSecureContext* secureContext = NULL) = 0;
+    virtual SecAccessFlags getAccessFlagsEx(SecResourceType rtype, ISecUser & user, const char * resourcename) = 0;
+    virtual SecAccessFlags authorizeFileScope(ISecUser & user, const char * filescope) = 0;
     virtual bool authorizeFileScope(ISecUser & user, ISecResourceList * resources) = 0;
     virtual bool authorizeViewScope(ISecUser & user, ISecResourceList * resources) = 0;
     virtual bool addResources(ISecUser & user, ISecResourceList * resources) = 0;
@@ -305,13 +305,13 @@ interface ISecManager : extends IInterface
     virtual void copyResource(SecResourceType rtype, const char * oldname, const char * newname, const char * basedn) = 0;
     virtual void cacheSwitch(SecResourceType rtype, bool on) = 0;
     virtual bool authTypeRequired(SecResourceType rtype) = 0;
-    virtual int authorizeWorkunitScope(ISecUser & user, const char * filescope) = 0;
+    virtual SecAccessFlags authorizeWorkunitScope(ISecUser & user, const char * filescope) = 0;
     virtual bool authorizeWorkunitScope(ISecUser & user, ISecResourceList * resources) = 0;
     virtual const char * getDescription() = 0;
     virtual unsigned getPasswordExpirationWarningDays() = 0;
     virtual bool createUserScopes() = 0;
     virtual aindex_t getManagedFileScopes(IArrayOf<ISecResource>& scopes) = 0;
-    virtual int queryDefaultPermission(ISecUser& user) = 0;
+    virtual SecAccessFlags queryDefaultPermission(ISecUser& user) = 0;
     virtual bool clearPermissionsCache(ISecUser & user) = 0;
     virtual bool authenticateUser(ISecUser & user, bool * superUser) = 0;
     virtual secManagerType querySecMgrType() = 0;

--- a/system/security/test/author/authorDlg.cpp
+++ b/system/security/test/author/authorDlg.cpp
@@ -238,7 +238,7 @@ void CAuthorDlg::AddResPermissions(const char *name)
     
     if (res)
     {
-        unsigned flags = res->getAccessFlags();
+        SecAccessFlags flags = res->getAccessFlags();
 
         if ((flags & allperms))
         {

--- a/testing/unittests/CMakeLists.txt
+++ b/testing/unittests/CMakeLists.txt
@@ -40,6 +40,7 @@ include_directories (
          ./../../system/mp
          ./../../common/remote
          ./../../dali/base
+         ./../../system/security/shared
     )
 
 ADD_DEFINITIONS( -D_CONSOLE )

--- a/thorlcr/activities/activitymasters_lcr.cmake
+++ b/thorlcr/activities/activitymasters_lcr.cmake
@@ -91,6 +91,7 @@ include_directories (
          ./../activities 
          ./../../rtl/eclrtl
          ${HPCC_SOURCE_DIR}/dali/ft
+         ./../../system/security/shared
     )
 
 HPCC_ADD_LIBRARY( activitymasters_lcr SHARED ${SRCS} )

--- a/thorlcr/graph/graph_lcr.cmake
+++ b/thorlcr/graph/graph_lcr.cmake
@@ -53,6 +53,7 @@ include_directories (
          ./../../rtl/eclrtl 
          ./../../common/thorhelper 
          ./../../roxie/roxiemem
+         ./../../system/security/shared
     )
 
 HPCC_ADD_LIBRARY( graph_lcr SHARED ${SRCS} )

--- a/thorlcr/master/CMakeLists.txt
+++ b/thorlcr/master/CMakeLists.txt
@@ -55,6 +55,7 @@ include_directories (
          ./../../roxie/roxiemem
          ${CMAKE_BINARY_DIR}
          ${CMAKE_BINARY_DIR}/oss
+         ./../../system/security/shared
     )
 
 ADD_DEFINITIONS( -D_CONSOLE )

--- a/thorlcr/mfilemanager/CMakeLists.txt
+++ b/thorlcr/mfilemanager/CMakeLists.txt
@@ -49,6 +49,7 @@ include_directories (
          ./../mfilemanager 
          ./../../common/thorhelper 
          ./../../roxie/roxiemem
+         ./../../system/security/shared
     )
 
 ADD_DEFINITIONS( -D_USRDLL -DMFILEMANAGER_EXPORTS )

--- a/thorlcr/slave/CMakeLists.txt
+++ b/thorlcr/slave/CMakeLists.txt
@@ -53,6 +53,7 @@ include_directories (
          ./../../roxie/roxiemem
          ${CMAKE_BINARY_DIR}
          ${CMAKE_BINARY_DIR}/oss
+         ./../../system/security/shared
     )
 
 ADD_DEFINITIONS( -D_CONSOLE )

--- a/thorlcr/thorcodectx/CMakeLists.txt
+++ b/thorlcr/thorcodectx/CMakeLists.txt
@@ -44,6 +44,7 @@ include_directories (
          ./../../rtl/eclrtl 
          ./../../thorlcr/shared 
          ./../../roxie/roxiemem
+         ./../../system/security/shared
     )
 
 ADD_DEFINITIONS( -DTHORCODECTX_EXPORTS -D_USRDLL )

--- a/tools/backupnode/CMakeLists.txt
+++ b/tools/backupnode/CMakeLists.txt
@@ -36,6 +36,7 @@ include_directories (
          ./../../dali/base
          ./../../system/jhtree
          ./../../rtl/eclrtl
+         ./../../system/security/shared
     )
 
 ADD_DEFINITIONS( -D_CONSOLE )

--- a/tools/swapnode/swapnode.cmake
+++ b/tools/swapnode/swapnode.cmake
@@ -35,6 +35,7 @@ include_directories (
          ./../../system/jlib
          ./../../common/environment
          ./../../common/workunit
+         ./../../system/security/shared
     )
 
 ADD_DEFINITIONS( -D_CONSOLE -DENABLE_AUTOSWAP )

--- a/tools/wutool/CMakeLists.txt
+++ b/tools/wutool/CMakeLists.txt
@@ -36,7 +36,8 @@ include_directories (
          ./../../system/jlib 
          ./../../common/environment 
          ./../../common/workunit 
-         ./../../testing/unittests 
+         ./../../testing/unittests
+         ./../../system/security/shared
     )
 
 if ( USE_CPPUNIT )


### PR DESCRIPTION
Currently, security access codes sometime use the SecAccessFlags enumeration,
other times use hardcoded values such as 0, -1, -255. This PR makes all
references to these flags typesafe, as well as the methods that process them

Signed-off-by: Russ Whitehead william.whitehead@lexisnexis.com
