### PR TITLE
HPCC-16222 Grid always opens last file in the list

### DIFF
--- a/esp/src/eclwatch/QuerySetLogicalFilesWidget.js
+++ b/esp/src/eclwatch/QuerySetLogicalFilesWidget.js
@@ -34,7 +34,7 @@ define([
         i18n: nlsHPCC,
 
         gridTitle: nlsHPCC.title_QuerySetLogicalFiles,
-        idProperty: "Name",
+        idProperty: "File",
 
         queryId: null,
         querySet: null,


### PR DESCRIPTION
Whenever a user is clicking on any row within QuerySetLogicalFiles the last row always opens due to an undefined id in the createDetail call.

Signed-off by: Miguel Vazquez miguel.vazquez@lexisnexis.com
