### PR TITLE
HPCC-16315: Fix roxie json response missing "Results" object

### DIFF
--- a/roxie/ccd/ccdprotocol.cpp
+++ b/roxie/ccd/ccdprotocol.cpp
@@ -1143,8 +1143,8 @@ public:
                 name.append("Response");
             appendJSONName(responseHead, name.str()).append(" {");
             appendJSONValue(responseHead, "sequence", seqNo);
-            if (contentsMap.length() || results)
-                delimitJSON(responseHead);
+            appendJSONName(responseHead, "Results").append(" {");
+
             unsigned len = responseHead.length();
             client->write(responseHead.detach(), len, true);
         }
@@ -1154,7 +1154,7 @@ public:
             results->finalize(seqNo, ",", resultFilter.ordinality() ? resultFilter.item(0) : NULL);
         if (!resultFilter.ordinality() && !(protocolFlags & HPCC_PROTOCOL_CONTROL))
         {
-            responseTail.append("}");
+            responseTail.append("}}");
             unsigned len = responseTail.length();
             client->write(responseTail.detach(), len, true);
         }


### PR DESCRIPTION
This was a regression in 6.0.

Signed-off-by: Anthony Fishbeck anthony.fishbeck@lexisnexis.com
