### PR TITLE
HPCC-16094 Directly check workunit aborting in abort handler

### DIFF
--- a/thorlcr/graph/thgraphmaster.cpp
+++ b/thorlcr/graph/thgraphmaster.cpp
@@ -1668,12 +1668,15 @@ bool CJobMaster::go()
                 return;
             if (flags & SubscribeOptionAbort)
             {
-                if (wu.aborting())
+                Owned<IWorkUnitFactory> factory = getWorkUnitFactory();
+                if (factory->isAborting(wu.queryWuid()))
                 {
                     LOG(MCwarning, thorJob, "ABORT detected from user");
                     Owned <IException> e = MakeThorException(TE_WorkUnitAborting, "User signalled abort");
                     job.fireException(e);
                 }
+                else
+                    PROGLOG("CWorkunitPauseHandler [SubscribeOptionAbort] notifier called, workunit was not aborting");
             }
             if (flags & SubscribeOptionAction)
             {


### PR DESCRIPTION
It is not safe to check workunit aborting() as abortDirty may be
stale. Instead directly check factory isAborting()

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
