### PR TITLE
HPCC-16351 Convert SecAccess flags to typesafe enum

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -3951,7 +3951,7 @@ void CLocalWorkUnit::remoteCheckAccess(IUserDescriptor *user, bool writeaccess) 
     unsigned auditflags = DALI_LDAP_AUDIT_REPORT|DALI_LDAP_READ_WANTED;
     if (writeaccess)
         auditflags |= DALI_LDAP_WRITE_WANTED;
-    int perm = SecAccess_Full;
+    SecAccessFlags perm = SecAccess_Full;
     const char *scopename = p->queryProp("@scope");
     if (scopename&&*scopename) {
         if (!user)

--- a/dali/base/dasess.hpp
+++ b/dali/base/dasess.hpp
@@ -122,9 +122,9 @@ interface ISessionManager: extends IInterface
 #define DALI_LDAP_READ_WANTED               (2)
 #define DALI_LDAP_WRITE_WANTED              (4)
 
-#define HASREADPERMISSION(p)        (((p)&3)==3)        
-#define HASWRITEPERMISSION(p)       (((p)&5)==5)
-#define HASNOSECURITY(p)            ((p)==-1)           // security is disabled
+#define HASREADPERMISSION(p)        (((p) & (NewSecAccess_Access & NewSecAccess_Read)) == (NewSecAccess_Access & NewSecAccess_Read))
+#define HASWRITEPERMISSION(p)       (((p) & (NewSecAccess_Access & NewSecAccess_Write)) == (NewSecAccess_Access & NewSecAccess_Write))
+
 
 extern da_decl ISessionManager &querySessionManager();
 

--- a/esp/services/ws_access/ws_accessService.cpp
+++ b/esp/services/ws_access/ws_accessService.cpp
@@ -4184,7 +4184,7 @@ bool Cws_accessEx::onFilePermission(IEspContext &context, IEspFilePermissionRequ
         if ((!groupName || !*groupName) && (!userName || !*userName))
             throw MakeStringException(ECLWATCH_INVALID_ACCOUNT_NAME, "Either user name or group name has to be specified.");
 
-        int access = SecAccess_Unavailable;
+        SecAccessFlags access = SecAccess_Unavailable;
         if (userName && *userName) //for user
         {
             resp.setFileName(fileName);
@@ -4287,7 +4287,7 @@ bool Cws_accessEx::onFilePermission(IEspContext &context, IEspFilePermissionRequ
                     scopes.add(lastFileScope.str(), 0);
                 }
 
-                access = 0;
+                access = SecAccess_None;
                 ForEachItemIn(y, scopes)
                 {
                     StringBuffer namebuf = scopes.item(y);
@@ -4308,7 +4308,7 @@ bool Cws_accessEx::onFilePermission(IEspContext &context, IEspFilePermissionRequ
 
                             int allows = perm.getAllows();
                             int denies = perm.getDenies();
-                            access = allows & (~denies);
+                            access = (SecAccessFlags)(allows & (~denies));
                             break;
                         }
                     }
@@ -4317,7 +4317,7 @@ bool Cws_accessEx::onFilePermission(IEspContext &context, IEspFilePermissionRequ
                         e->Release();
                     }
 
-                    if (access != 0)
+                    if (access != SecAccess_None)
                         break;
                 }
             }
@@ -4331,7 +4331,7 @@ bool Cws_accessEx::onFilePermission(IEspContext &context, IEspFilePermissionRequ
                 resp.setUserPermission("Read Access Permission");
             else if((access & NewSecAccess_Access) == NewSecAccess_Access)
                 resp.setUserPermission("Access Permission");
-            else if (access == 0)
+            else if (access == (SecAccessFlags)NewSecAccess_None)
                 resp.setUserPermission("None Access Permission");
             else
                 resp.setUserPermission("Permission Unknown");

--- a/esp/services/ws_dfu/ws_dfuService.cpp
+++ b/esp/services/ws_dfu/ws_dfuService.cpp
@@ -1674,7 +1674,7 @@ bool FindInStringArray(StringArray& clusters, const char *cluster)
     return bFound;
 }
 
-static void getFilePermission(CDfsLogicalFileName &dlfn, ISecUser & user, IUserDescriptor* udesc, ISecManager* secmgr, int& permission)
+static void getFilePermission(CDfsLogicalFileName &dlfn, ISecUser & user, IUserDescriptor* udesc, ISecManager* secmgr, SecAccessFlags& permission)
 {
     if (dlfn.isMulti())
     {
@@ -1709,7 +1709,7 @@ static void getFilePermission(CDfsLogicalFileName &dlfn, ISecUser & user, IUserD
     return;
 }
 
-bool CWsDfuEx::getUserFilePermission(IEspContext &context, IUserDescriptor* udesc, const char* logicalName, int& permission)
+bool CWsDfuEx::getUserFilePermission(IEspContext &context, IUserDescriptor* udesc, const char* logicalName, SecAccessFlags& permission)
 {
     ISecManager* secmgr = context.querySecManager();
     if (!secmgr)
@@ -2164,7 +2164,7 @@ void CWsDfuEx::doGetFileDetails(IEspContext &context, IUserDescriptor* udesc, co
 
     if (version > 1.08 && udesc)
     {
-        int permission;
+        SecAccessFlags permission;
         if (getUserFilePermission(context, udesc, name, permission))
         {
             switch (permission)

--- a/esp/services/ws_dfu/ws_dfuService.hpp
+++ b/esp/services/ws_dfu/ws_dfuService.hpp
@@ -199,7 +199,7 @@ private:
     int GetIndexData(IEspContext &context, bool bSchemaOnly, const char* indexName, const char* parentName, const char* filterBy, __int64 start, 
                                         __int64& count, __int64& read, __int64& total, StringBuffer& message, StringArray& columnLabels, 
                                         StringArray& columnLabelsType, IArrayOf<IEspDFUData>& DataList, bool webDisableUppercaseTranslation);
-    bool getUserFilePermission(IEspContext &context, IUserDescriptor* udesc, const char* logicalName, int& permission);
+    bool getUserFilePermission(IEspContext &context, IUserDescriptor* udesc, const char* logicalName, SecAccessFlags& permission);
     void parseStringArray(const char *input, StringArray& strarray);
     int superfileAction(IEspContext &context, const char* action, const char* superfile, StringArray& subfiles,
         const char* beforeSubFile, bool existingSuperfile, bool autocreatesuper, bool deleteFile, bool removeSuperfile =  true);

--- a/plugins/workunitservices/workunitservices.cpp
+++ b/plugins/workunitservices/workunitservices.cpp
@@ -222,7 +222,7 @@ static bool checkScopeAuthorized(IUserDescriptor *user, const char *scopename)
     if (securityDisabled)
         return true;
     unsigned auditflags = DALI_LDAP_AUDIT_REPORT|DALI_LDAP_READ_WANTED;
-    int perm = SecAccess_Full;
+    SecAccessFlags perm = SecAccess_Full;
     if (scopename && *scopename)
     {
         perm = querySessionManager().getPermissionsLDAP("workunit",scopename,user,auditflags);

--- a/system/security/LdapSecurity/aci.cpp
+++ b/system/security/LdapSecurity/aci.cpp
@@ -588,7 +588,7 @@ public:
 };
 
 //Translates ACI permission settings to SecAccessFlags
-SecAccessFlags NewSec2Sec(int newsec)
+SecAccessFlags NewSec2Sec(NewSecAccessFlags newsec)
 {
     int sec = SecAccess_None;
     if(newsec == -1)
@@ -713,7 +713,7 @@ public:
 
             perm = allow & (~deny);
 
-            perms = NewSec2Sec(perm);
+            perms = NewSec2Sec((NewSecAccessFlags)perm);
         }
         
         resource.setAccessFlags(perms);
@@ -916,7 +916,7 @@ CSecurityDescriptor* AciProcessor::createDefaultSD(ISecUser * const user, ISecRe
     return createDefaultSD(user, resource->getName(), ptype);   
 }
 
-StringBuffer& AciProcessor::sec2aci(int secperm, StringBuffer& aciperm)
+StringBuffer& AciProcessor::sec2aci(SecAccessFlags secperm, StringBuffer& aciperm)
 {
     throw MakeStringException(-1, "You should call the implementation of the child class");
 }
@@ -1049,7 +1049,7 @@ CSecurityDescriptor* AciProcessor::changePermission(CSecurityDescriptor* initial
  *    Class CIPlanetAciProcessor 
  ****************************************************************/
 
-StringBuffer& CIPlanetAciProcessor::sec2aci(int secperm, StringBuffer& aciperm)
+StringBuffer& CIPlanetAciProcessor::sec2aci(SecAccessFlags secperm, StringBuffer& aciperm)
 {
     if(secperm == SecAccess_Unavailable || secperm == SecAccess_None)
         return aciperm;
@@ -1134,7 +1134,7 @@ CSecurityDescriptor* CIPlanetAciProcessor::createDefaultSD(ISecUser * const user
  *    Class COpenLdapAciProcessor 
  ****************************************************************/
 
-StringBuffer& COpenLdapAciProcessor::sec2aci(int secperm, StringBuffer& aciperm)
+StringBuffer& COpenLdapAciProcessor::sec2aci(SecAccessFlags secperm, StringBuffer& aciperm)
 {
     if(secperm == SecAccess_Unavailable || secperm == SecAccess_None)
         return aciperm;

--- a/system/security/LdapSecurity/aci.ipp
+++ b/system/security/LdapSecurity/aci.ipp
@@ -52,7 +52,7 @@ public:
     virtual void lookupSid(const char* act_name, MemoryBuffer& act_sid, ACT_TYPE acttype=USER_ACT);
     virtual int sdSegments(CSecurityDescriptor* sd);
 
-    virtual StringBuffer& sec2aci(int secperm, StringBuffer& aciperm);
+    virtual StringBuffer& sec2aci(SecAccessFlags secperm, StringBuffer& aciperm);
     virtual bool getPermissionsArray(CSecurityDescriptor *sd, IArrayOf<CPermission>& permissions);
     virtual CSecurityDescriptor* changePermission(CSecurityDescriptor* initialsd, CPermissionAction& action);
 };
@@ -65,7 +65,7 @@ public:
         m_servertype = IPLANET;
     }
 
-    virtual StringBuffer& sec2aci(int secperm, StringBuffer& aciperm);
+    virtual StringBuffer& sec2aci(SecAccessFlags secperm, StringBuffer& aciperm);
     virtual CSecurityDescriptor* createDefaultSD(ISecUser * const user, const char* name, SecPermissionType ptype);
     virtual CSecurityDescriptor* createDefaultSD(ISecUser * const user, ISecResource* resource, MemoryBuffer& initial_sd);
 };
@@ -78,7 +78,7 @@ public:
         m_servertype = OPEN_LDAP;
     }
     
-    virtual StringBuffer& sec2aci(int secperm, StringBuffer& aciperm);
+    virtual StringBuffer& sec2aci(SecAccessFlags secperm, StringBuffer& aciperm);
     virtual CSecurityDescriptor* createDefaultSD(ISecUser * const user, const char* name, SecPermissionType ptype);
     virtual CSecurityDescriptor* createDefaultSD(ISecUser * const user, ISecResource* resource, MemoryBuffer& initial_sd);
 };

--- a/system/security/LdapSecurity/permissions.cpp
+++ b/system/security/LdapSecurity/permissions.cpp
@@ -122,7 +122,7 @@ NewSecAccessFlags PermissionProcessor::ldap2newsec(unsigned ldapperm)
     return (NewSecAccessFlags)permission;
 }
 
-unsigned PermissionProcessor::newsec2ldap(SecAccessFlags secperm)
+unsigned PermissionProcessor::newsec2ldap(NewSecAccessFlags secperm)
 {
     if((secperm & NewSecAccess_Full) == NewSecAccess_Full)
     {
@@ -1055,7 +1055,7 @@ bool PermissionProcessor::getPermissions(ISecUser& user, IArrayOf<CSecurityDescr
             granted_access = 0;
         }
 
-        unsigned permission = ldap2sec(granted_access);
+        SecAccessFlags permission = ldap2sec(granted_access);
         resource.setAccessFlags(permission);
     }   
     CloseHandle(usertoken);
@@ -1348,7 +1348,7 @@ CSecurityDescriptor* PermissionProcessor::changePermission(CSecurityDescriptor* 
     if(stricmp(action.m_action.str(), "delete") != 0 && action.m_allows != 0)
     {
         uaccess_allows.grfAccessMode = GRANT_ACCESS;
-        uaccess_allows.grfAccessPermissions = newsec2ldap((SecAccessFlags)action.m_allows);
+        uaccess_allows.grfAccessPermissions = newsec2ldap((NewSecAccessFlags)action.m_allows);
         uaccess_allows.grfInheritance = NO_INHERITANCE;
         uaccess_allows.Trustee.MultipleTrusteeOperation = NO_MULTIPLE_TRUSTEE;
         uaccess_allows.Trustee.pMultipleTrustee = NULL;
@@ -1372,7 +1372,7 @@ CSecurityDescriptor* PermissionProcessor::changePermission(CSecurityDescriptor* 
     if(stricmp(action.m_action.str(), "delete") != 0 && action.m_denies != 0)
     {
         uaccess_denies.grfAccessMode = DENY_ACCESS;
-        uaccess_denies.grfAccessPermissions = newsec2ldap(action.m_denies);
+        uaccess_denies.grfAccessPermissions = newsec2ldap((NewSecAccessFlags)action.m_denies);
         uaccess_denies.grfInheritance = NO_INHERITANCE ;
         uaccess_denies.Trustee.MultipleTrusteeOperation = NO_MULTIPLE_TRUSTEE;
         uaccess_denies.Trustee.pMultipleTrustee = NULL;
@@ -1397,7 +1397,7 @@ CSecurityDescriptor* PermissionProcessor::changePermission(CSecurityDescriptor* 
         DWORD new_dacl_size = dacl_size + newace_size;
         dacl_size = new_dacl_size;
         pnewdacl = (PACL)alloca(new_dacl_size);
-        rc = AddAccessDeniedAce(pnewdacl, &new_dacl_size, pdacl, ACL_REVISION, newsec2ldap((SecAccessFlags)action.m_denies), act_psid);
+        rc = AddAccessDeniedAce(pnewdacl, &new_dacl_size, pdacl, ACL_REVISION, newsec2ldap((NewSecAccessFlags)action.m_denies), act_psid);
         if(rc == 0)
         {
             int error = GetLastError();
@@ -1412,7 +1412,7 @@ CSecurityDescriptor* PermissionProcessor::changePermission(CSecurityDescriptor* 
         DWORD newace_size = sizeof(ACE_HEADER) + sizeof(ACCESS_MASK) + sizeofSid(act_psid);
         DWORD new_dacl_size = dacl_size + newace_size;
         pnewdacl = (PACL)alloca(new_dacl_size);
-        rc = AddAccessAllowedAce(pnewdacl, &new_dacl_size, pdacl, ACL_REVISION, newsec2ldap((SecAccessFlags)action.m_allows), act_psid);
+        rc = AddAccessAllowedAce(pnewdacl, &new_dacl_size, pdacl, ACL_REVISION, newsec2ldap((NewSecAccessFlags)action.m_allows), act_psid);
         if(rc == 0)
         {
             int error = GetLastError();

--- a/system/security/LdapSecurity/permissions.ipp
+++ b/system/security/LdapSecurity/permissions.ipp
@@ -703,7 +703,7 @@ protected:
     unsigned sec2ldap(SecAccessFlags secperm);
 
     NewSecAccessFlags ldap2newsec(unsigned ldapperm);
-    unsigned newsec2ldap(SecAccessFlags secperm);
+    unsigned newsec2ldap(NewSecAccessFlags secperm);
 public:
     IMPLEMENT_IINTERFACE;
 


### PR DESCRIPTION
There are still many places that reference SecAccessFlags as integer.
This PR converts them to the typesafe enum

Signed-off-by: Russ Whitehead william.whitehead@lexisnexis.com
