### PR TITLE
HPCC-16345 Optimize MAX(unsigned, 0) and IF(unsigned < 0, 0, unsigned)

### DIFF
--- a/common/deftype/deftype.hpp
+++ b/common/deftype/deftype.hpp
@@ -206,6 +206,7 @@ public:
     virtual IHqlScope * castToScope() = 0;
 
     inline bool isBoolean() const { return getTypeCode() == type_boolean; }
+    inline bool isUnsignedNumeric() { return (isInteger() || getTypeCode()==type_decimal) && !isSigned(); }
 
 private:
     inline IValue * castFrom(__int64 value) { return NULL; }

--- a/ecl/regress/fold6.ecl
+++ b/ecl/regress/fold6.ecl
@@ -1,0 +1,35 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2016 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+// Test folding of comparisons of unsigned values against zero
+
+unsigned4 a := nofold(3); // : STORED('a');
+ASSERT(MAX(a, (unsigned4) 0) = a);
+ASSERT(a >= 0);
+ASSERT(0 <= a);
+
+BIG_ENDIAN unsigned4 ba := nofold(3); // : STORED('ba');
+
+ASSERT(MAX(ba, (BIG_ENDIAN unsigned4) 0) = ba);
+ASSERT(ba >= 0);
+ASSERT(0 <= ba);
+
+unsigned decimal4 da := nofold(3); // : STORED('da');
+
+ASSERT(MAX(da, (unsigned decimal4) 0) = da);
+ASSERT(da >= 0);
+ASSERT(0 <= da);


### PR DESCRIPTION
Helps avoid C++ compiler warnings.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
