### PR TITLE
HPCC-9578 ASSERT code is poor

### DIFF
--- a/ecl/hqlcpp/hqlttcpp.cpp
+++ b/ecl/hqlcpp/hqlttcpp.cpp
@@ -7547,6 +7547,7 @@ void ScalarGlobalTransformer::doAnalyseExpr(IHqlExpression * expr)
     case no_null:
     case no_all:
     case no_funcdef:
+    case no_assert:
         return;
     case no_persist_check:
         //No point spotting global within this since it will not create a subquery..


### PR DESCRIPTION
Avoid executing the code for the ASSERT message unless the condition fails.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
