### PR TITLE
HPCC-16271 Dafilesrv copyfile exception crash

### DIFF
--- a/common/remote/sockfile.cpp
+++ b/common/remote/sockfile.cpp
@@ -363,7 +363,7 @@ const char *RFCStrings[] =
     RFCText(RFCsetfileperms),
     RFCText(RFCunknown),
 };
-static const char *getRFCText(unsigned cmd)
+static const char *getRFCText(RemoteFileCommandType cmd)
 {
     if (cmd > RFCmax)
         cmd = RFCmax;
@@ -2984,15 +2984,16 @@ inline void appendErr3(MemoryBuffer &reply, unsigned e, int code, const char *er
     reply.append(e);
     reply.append(msg.str());
 }
-inline void appendCmdErr(MemoryBuffer &reply, unsigned e, int code, const char *errMsg)
+inline void appendCmdErr(MemoryBuffer &reply, RemoteFileCommandType e, int code, const char *errMsg)
 {
     StringBuffer msg;
     msg.appendf("ERROR: %s(%d) '%s'", getRFCText(e), code, errMsg?errMsg:"");
     // RFCOpenIO needs remapping to non-zero for client to know its an error
     // perhaps we should use code here instead of e ?
-    if ((RemoteFileCommandType)e == RFCopenIO)
-        e = RFSERR_OpenFailed;
-    reply.append(e);
+    unsigned err = e;
+    if ((RemoteFileCommandType)err == RFCopenIO)
+        err = RFSERR_OpenFailed;
+    reply.append(err);
     reply.append(msg.str());
 }
 

--- a/common/remote/sockfile.cpp
+++ b/common/remote/sockfile.cpp
@@ -2991,7 +2991,7 @@ inline void appendCmdErr(MemoryBuffer &reply, RemoteFileCommandType e, int code,
     // RFCOpenIO needs remapping to non-zero for client to know its an error
     // perhaps we should use code here instead of e ?
     unsigned err = e;
-    if ((RemoteFileCommandType)err == RFCopenIO)
+    if (e == RFCopenIO)
         err = RFSERR_OpenFailed;
     reply.append(err);
     reply.append(msg.str());

--- a/dali/datest/datest.cpp
+++ b/dali/datest/datest.cpp
@@ -710,19 +710,16 @@ struct RecordStruct
 // #define NRECS ((__int64)1024*1024*500/sizeof(RecordStruct)) // i.e. ~500MB
 // #define NRECS ((__int64)1024*500/sizeof(RecordStruct)) // i.e. ~500KB
 
-void TestCopyFile(char *srcfname, char *dstfname)
+void TestCopyFile(char *srcfname, char *dstfname) // TEST_COPYFILE
 {
     // example cmdline: datest srcfile //1.2.3.4:7100/home/username/dstfile
-    IFile *srcfile = createIFile(srcfname);
-    IFileIO *srcio = srcfile->open(IFOcreate);
+    Owned<IFile> srcfile = createIFile(srcfname);
+    Owned<IFileIO> srcio = srcfile->open(IFOcreate);
     char buf[100] = { "TestCopyFile" };
     srcio->write(0, 18, buf);
     srcio->close();
-    srcio->Release();
-    IFile *dstfile = createIFile(dstfname);
+    Owned<IFile> dstfile = createIFile(dstfname);
     srcfile->copyTo(dstfile,0x100000,NULL,false);
-    srcfile->Release();
-    dstfile->Release();
 }
 
 void TestRemoteFile3(int nfiles, int fsizemb)

--- a/dali/datest/datest.cpp
+++ b/dali/datest/datest.cpp
@@ -46,6 +46,7 @@ static unsigned nIter = 1;
 //#define TEST_REMOTEFILE
 //#define TEST_REMOTEFILE2
 //#define TEST_REMOTEFILE3
+//#define TEST_COPYFILE
 //#define TEST_DEADLOCK
 //#define TEST_THREADS
 #define MDELAY 100
@@ -708,6 +709,21 @@ struct RecordStruct
 // #define NRECS ((__int64)1024*1024*1024*2/sizeof(RecordStruct)) // i.e. ~2GB
 // #define NRECS ((__int64)1024*1024*500/sizeof(RecordStruct)) // i.e. ~500MB
 // #define NRECS ((__int64)1024*500/sizeof(RecordStruct)) // i.e. ~500KB
+
+void TestCopyFile(char *srcfname, char *dstfname)
+{
+    // example cmdline: datest srcfile //1.2.3.4:7100/home/username/dstfile
+    IFile *srcfile = createIFile(srcfname);
+    IFileIO *srcio = srcfile->open(IFOcreate);
+    char buf[100] = { "TestCopyFile" };
+    srcio->write(0, 18, buf);
+    srcio->close();
+    srcio->Release();
+    IFile *dstfile = createIFile(dstfname);
+    srcfile->copyTo(dstfile,0x100000,NULL,false);
+    srcfile->Release();
+    dstfile->Release();
+}
 
 void TestRemoteFile3(int nfiles, int fsizemb)
 {
@@ -3079,6 +3095,13 @@ int main(int argc, char* argv[])
         if(argc >= 3)
             fsizemb = atoi(argv[2]);
         TestRemoteFile3(nfiles, fsizemb);
+        return 0;
+#endif
+#if defined(TEST_COPYFILE)
+        if(argc >= 3)
+            TestCopyFile(argv[1], argv[2]);
+        else
+            DBGLOG("TestCopyFile(src-file, dst-file) missing arguments");
         return 0;
 #endif
         if (argc<2) {


### PR DESCRIPTION
Note this problem only occurs with version 5.4.10 because issue is solved with https://track.hpccsystems.com/browse/HPCC-14888 (https://github.com/hpcc-systems/HPCC-Platform/pull/8192) that went into version 5.6.0

This update extends the solution to return a more correct error string that matches the error value passed in.

Signed-off-by: Mark Kelly mark.kelly@lexisnexis.com
