### PR TITLE
HPCC-16369 Fix missing child query progress issue

### DIFF
--- a/thorlcr/graph/thgraph.cpp
+++ b/thorlcr/graph/thgraph.cpp
@@ -1030,7 +1030,7 @@ bool isLoopActivity(CGraphElementBase &container)
 }
 /////
 
-CGraphBase::CGraphBase(CJobChannel &_jobChannel) : jobChannel(_jobChannel), job(_jobChannel.queryJob())
+CGraphBase::CGraphBase(CJobChannel &_jobChannel) : jobChannel(_jobChannel), job(_jobChannel.queryJob()), progressUpdated(false)
 {
     xgmml = NULL;
     parent = owner = NULL;
@@ -1099,6 +1099,7 @@ void CGraphBase::deserializeCreateContexts(MemoryBuffer &mb)
 void CGraphBase::reset()
 {
     setCompleteEx(false);
+    clearProgressUpdated();
     graphCancelHandler.reset();
     if (0 == containers.count())
     {

--- a/thorlcr/graph/thgraph.hpp
+++ b/thorlcr/graph/thgraph.hpp
@@ -434,7 +434,6 @@ class graph_decl CGraphBase : public CInterface, implements IEclGraphResults, im
     CGraphTable childGraphsTable;
     CGraphArrayCopy childGraphs;
     Owned<IGraphTempHandler> tmpHandler;
-    bool initialized = false;
 
     void clean();
 
@@ -549,6 +548,8 @@ protected:
     IBarrier *startBarrier, *waitBarrier, *doneBarrier;
     mptag_t mpTag, startBarrierTag, waitBarrierTag, doneBarrierTag;
     bool connected, started, aborted, graphDone, sequential;
+    bool initialized = false;
+    std::atomic_bool progressUpdated;
     CJobBase &job;
     CJobChannel &jobChannel;
     graph_id graphId;
@@ -583,9 +584,11 @@ public:
     CGraphBase *queryOwner() { return owner; }
     CGraphBase *queryParent() { return parent?parent:this; }
     IMPServer &queryMPServer() const;
+    void clearProgressUpdated() { progressUpdated.store(false); }
+    void setProgressUpdated() { progressUpdated.store(true); }
+    bool hasProgress() const { return progressUpdated; }
+    bool checkProgressUpdatedAndClear() { return progressUpdated.exchange(false); }
     bool syncInitData();
-    inline void setInitialized() { initialized = true; }
-    inline bool isInitialized() const { return initialized; }
     bool isComplete() const { return complete; }
     bool isGlobal() const { return global; }
     bool isStarted() const { return started; }

--- a/thorlcr/graph/thgraphmaster.cpp
+++ b/thorlcr/graph/thgraphmaster.cpp
@@ -249,7 +249,6 @@ void CSlaveMessageHandler::main()
                             element->sentActInitData->set(slave, 0); // clear to permit serializeActivityInitData to resend
                         toSerialize.append(*LINK(element));
                     }
-                    graph->setInitialized();
                     msg.clear();
                     mptag_t replyTag = job.queryJobChannel(0).queryMPServer().createReplyTag();
                     msg.append(replyTag); // second reply
@@ -2661,6 +2660,8 @@ bool CMasterGraph::deserializeStats(unsigned node, MemoryBuffer &mb)
     CriticalBlock b(createdCrit);
     unsigned count, _count;
     mb.read(count);
+    if (count)
+        setProgressUpdated();
     _count = count;
     while (count--)
     {

--- a/thorlcr/graph/thgraphslave.hpp
+++ b/thorlcr/graph/thgraphslave.hpp
@@ -359,10 +359,9 @@ class graphslave_decl CSlaveGraph : public CGraphBase
 {
     CJobSlave *jobS;
     Semaphore getDoneSem;
-    bool initialized, progressActive, progressToCollect;
     CriticalSection progressCrit;
-    SpinLock progressActiveLock; // MORE use atomic variables (and progressToCollect.exchange()) to remove this spin lock
     bool doneInit = false;
+    std::atomic_bool progressActive;
 
 public:
 
@@ -383,6 +382,7 @@ public:
     virtual bool preStart(size32_t parentExtractSz, const byte *parentExtract) override;
     virtual void start() override;
     virtual void abort(IException *e) override;
+    virtual void reset() override;
     virtual void done() override;
     virtual IThorGraphResults *createThorGraphResults(unsigned num);
 

--- a/thorlcr/master/thdemonserver.cpp
+++ b/thorlcr/master/thdemonserver.cpp
@@ -72,7 +72,7 @@ private:
         try
         {
             StatsSubgraphScope subgraph(stats, graph->queryGraphId());
-            if (graph->isInitialized())
+            if (graph->hasProgress()) // if there have ever been any progress, ensure they are republished
                 doReportGraph(stats, graph, finished);
             Owned<IThorGraphIterator> graphIter = graph->getChildGraphs();
             ForEach (*graphIter)


### PR DESCRIPTION
Child queries which did not require meta data initialization,
did not flag master that they were initialized and as a
consequence their progress data was not updated, so missing from
the graph control.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
