### PR TITLE
HPCC-16379 Allow typesdefs for SERVICE function return types

### DIFF
--- a/ecl/hql/hqlgram.y
+++ b/ecl/hql/hqlgram.y
@@ -4093,6 +4093,7 @@ funcRetType
                             $$.setType(makeRowType(expr->getType()));
                             $$.setPosition($1);
                         }
+    | typeDef
     ;
 
 payloadPart


### PR DESCRIPTION
Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
