### PR TITLE
HPCC-16387 Fix issue with unstarted conditionals

### DIFF
--- a/thorlcr/activities/loop/thloopslave.cpp
+++ b/thorlcr/activities/loop/thloopslave.cpp
@@ -794,6 +794,14 @@ class CConditionalActivity : public CSlaveActivity
     IThorDataLink *selectedItdl = nullptr;
     IEngineRowStream *selectedInputStream = nullptr;
 
+    void stopUnselectedInputs()
+    {
+        ForEachItemIn(i, inputs)
+        {
+            if (i != branch)
+                stopInput(i);
+        }
+    }
 protected:
     unsigned branch = (unsigned)-1;
 
@@ -805,11 +813,7 @@ public:
     virtual void start() override
     {
         ActivityTimer s(totalCycles, timeActivities);
-        ForEachItemIn(i, inputs)
-        {
-            if (i != branch)
-                stopInput(i);
-        }
+        stopUnselectedInputs();
         if (queryInput(branch))
         {
             startInput(branch);
@@ -821,7 +825,9 @@ public:
     }
     virtual void stop() override
     {
-        if ((branch>0) && queryInput(branch)) // branch 0 stopped by PARENT::stop
+        if (!hasStarted())
+            stopUnselectedInputs(); // i.e. all
+        else if ((branch>0) && queryInput(branch)) // branch 0 stopped by PARENT::stop
             stopInput(branch);
         selectedInputStream = NULL;
         abortSoon = true;


### PR DESCRIPTION
If a downstream conditional causes a upstream conditional to
never start, then that upstream conditional will not stop all
it's inputs, that can cause problems, in particular when in a
child qeury which is re-executed.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
