### PR TITLE
HPCC-16388 Generated #line directives can be split

### DIFF
--- a/ecl/hqlcpp/hqlwcpp.cpp
+++ b/ecl/hqlcpp/hqlwcpp.cpp
@@ -2143,8 +2143,13 @@ void HqlCppWriter::generateStmtLine(IHqlStmt * stmt)
     if (filename && line)
     {
         out.append("#line ");
-        generateExprCpp(line).append(" ");
-        generateExprCpp(filename);
+        generateExprCpp(line).append(" \"");
+        IValue *value = filename->queryValue();
+        assertex(value);
+        StringBuffer fname;
+        value->getStringValue(fname);
+        appendStringAsCPP(out, fname.length(), fname.str(), false).append("\"");
+        // NOTE - don't used generateExprCpp(filename), as that wil split the string at 120 chars
         newline();
     }
     else


### PR DESCRIPTION
With long filenames, the string gets split to the next line, giving syntax
errors in generated C++.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
