### PR TITLE
HPCC-15728 foldExternalCall C++ mangling issues

### DIFF
--- a/ecl/hql/hqlutil.cpp
+++ b/ecl/hql/hqlutil.cpp
@@ -7557,23 +7557,23 @@ protected:
         case type_utf8:
             if (type->getSize() == UNKNOWN_LENGTH)
                 result.append("j");
-            result.append(hasConst ? "PKc" : "Pc");
+            result.append(lookupRepeat(hasConst ? "PKc" : "Pc"));
             return true;
         case type_varstring:
-            result.append(hasConst ? "PKc" : "Pc");
+            result.append(lookupRepeat(hasConst ? "PKc" : "Pc"));
             return true;
         case type_data:
             if (type->getSize() == UNKNOWN_LENGTH)
                 result.append("j");
-            result.append(hasConst ? "PKv" : "Pv");
+            result.append(lookupRepeat(hasConst ? "PKv" : "Pv"));
             return true;
         case type_unicode:
             if (type->getSize() == UNKNOWN_LENGTH)
                 result.append("j");
-            result.append(hasConst ? "PKt" : "Pt");
+            result.append(lookupRepeat(hasConst ? "PKt" : "Pt"));
             return true;
         case type_varunicode:
-            result.append(hasConst ? "PKt" : "Pt");
+            result.append(lookupRepeat(hasConst ? "PKt" : "Pt"));
             return true;
         case type_char:
             result.append("c");
@@ -7589,15 +7589,15 @@ protected:
         case type_table:
         case type_groupedtable:
             result.append("j"); // size32_t
-            result.append(hasConst ? "PKv" : "Pv"); // [const] void *
+            result.append(lookupRepeat(hasConst ? "PKv" : "Pv")); // [const] void *
             return true;
         case type_set:
             result.append("b"); // bool
             result.append("j"); // unsigned
-            result.append(hasConst ? "PKv" : "Pv"); // *
+            result.append(lookupRepeat(hasConst ? "PKv" : "Pv")); // *
             return true;
         case type_row:
-            result.append("Ph");
+            result.append(lookupRepeat("Ph"));
             return true;
         case type_void:
             result.append("v");
@@ -7616,6 +7616,18 @@ protected:
         throwUnexpected();
     }
 
+    StringArray repeatsSeen;
+    StringBuffer thisRepeat;
+    const char *lookupRepeat(const char *typeStr)
+    {
+        ForEachItemIn(idx, repeatsSeen)
+        {
+            if (streq(repeatsSeen.item(idx), typeStr))
+                return thisRepeat.appendf("S%d_", idx).str();
+        }
+        repeatsSeen.append(typeStr);
+        return typeStr;
+    }
 
     bool mangleFunctionReturnType(StringBuffer & returnType, StringBuffer & params, ITypeInfo * retType)
     {

--- a/testing/regress/ecl/key/testfold.xml
+++ b/testing/regress/ecl/key/testfold.xml
@@ -1,0 +1,3 @@
+<Dataset name='Result 1'>
+ <Row><Result_1>ok</Result_1></Row>
+</Dataset>

--- a/testing/regress/ecl/testfold.ecl
+++ b/testing/regress/ecl/testfold.ecl
@@ -1,0 +1,8 @@
+s := service : fold,library('eclrtl')
+  integer4 rtlCompareVStrVStr(const varstring a, const varstring b) : pure,CPP;
+END;
+
+ASSERT(s.rtlCompareVStrVStr('1','1')=0, CONST);
+ASSERT(s.rtlCompareVStrVStr('1','0')>0, CONST);
+ASSERT(s.rtlCompareVStrVStr('1','2')<0, CONST);
+OUTPUT('ok');


### PR DESCRIPTION
Clang and gcc 3.2 and later uses this scheme - I don't think we support any
earlier versions of gcc.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
