### PR TITLE
HPCC-14841 Return more WU graph information in WUQueryDetails

### DIFF
--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -1472,9 +1472,11 @@ ESPresponse [exceptions_inline] WUQueryDetailsResponse
     [min_ver("1.46")] string CompileTime;
     [min_ver("1.46")] ESParray<string> LibrariesUsed;
     [min_ver("1.46")] int CountGraphs;
-    [min_ver("1.46")] ESParray<string> GraphIds;
+    [min_ver("1.46"), depr_ver("1.64")] ESParray<string> GraphIds;
     [min_ver("1.50")] int ResourceURLCount;
     [min_ver("1.51")] ESParray<string, Address> WsEclAddresses;
+    [min_ver("1.64")] ESParray<ESPstruct ECLGraph> WUGraphs;
+    [min_ver("1.64")] ESParray<ESPstruct ECLTimer> WUTimers;
 };
 
 ESPrequest WUMultiQuerySetDetailsRequest
@@ -1792,7 +1794,7 @@ ESPresponse [exceptions_inline, nil_remove] WUGetNumFileToCopyResponse
 
 ESPservice [
     auth_feature("DEFERRED"), //This declares that the method logic handles feature level authorization
-    version("1.63"), default_client_version("1.63"),
+    version("1.64"), default_client_version("1.64"),
     noforms,exceptions_inline("./smc_xslt/exceptions.xslt"),use_method_name] WsWorkunits
 {
     ESPmethod [resp_xsl_default("/esp/xslt/workunits.xslt")]     WUQuery(WUQueryRequest, WUQueryResponse);

--- a/esp/services/ws_workunits/ws_workunitsHelpers.hpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.hpp
@@ -166,8 +166,10 @@ public:
     void getSourceFiles(IEspECLWorkunit &info, unsigned flags);
     unsigned getTimerCount();
     void getTimers(IEspECLWorkunit &info, unsigned flags);
+    void doGetTimers(IArrayOf<IEspECLTimer>& timers);
     void getHelpers(IEspECLWorkunit &info, unsigned flags);
     void getGraphInfo(IEspECLWorkunit &info, unsigned flags);
+    void doGetGraphs(IArrayOf<IEspECLGraph>& graphs);
     void getWUGraphNameAndTypes(WUGraphType graphType, IArrayOf<IEspNameAndType>& graphNameAndTypes);
     void getGraphTimingData(IArrayOf<IConstECLTimingData> &timingData, unsigned flags);
     bool getFileSize(const char* fileName, const char* IPAddress, offset_t& fileSize);

--- a/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
+++ b/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
@@ -1642,10 +1642,13 @@ bool CWsWorkunitsEx::onWUQueryDetails(IEspContext &context, IEspWUQueryDetailsRe
             libUsed.append(libs->query().getName(s).str());
         if (libUsed.length())
             resp.setLibrariesUsed(libUsed);
-        unsigned numGraphIds = getGraphIdsByQueryId(querySet, queryId, graphIds);
-        resp.setCountGraphs(numGraphIds);
-        if (numGraphIds > 0)
-            resp.setGraphIds(graphIds);
+        if (version < 1.64)
+        {
+            unsigned numGraphIds = getGraphIdsByQueryId(querySet, queryId, graphIds);
+            resp.setCountGraphs(numGraphIds);
+            if (numGraphIds > 0)
+                resp.setGraphIds(graphIds);
+        }
     }
 
     StringArray logicalFiles;
@@ -1679,6 +1682,20 @@ bool CWsWorkunitsEx::onWUQueryDetails(IEspContext &context, IEspWUQueryDetailsRe
     {
         WsWuInfo winfo(context, wuid);
         resp.setResourceURLCount(winfo.getResourceURLCount());
+        if (version >= 1.64)
+        {
+            IArrayOf<IEspECLTimer> timers;
+            winfo.doGetTimers(timers); //Graph Duration
+            if (timers.length())
+                resp.setWUTimers(timers);
+
+            IArrayOf<IEspECLGraph> graphs;
+            winfo.doGetGraphs(graphs); //Graph Name, Label, Started, Finished, Type
+            unsigned numGraphIds = graphs.length();
+            resp.setCountGraphs(numGraphIds);
+            if (numGraphIds > 0)
+                resp.setWUGraphs(graphs);
+        }
     }
     if (req.getIncludeWsEclAddresses())
     {


### PR DESCRIPTION
The existing WsWorkunits.WUQueryDetails only returns graph ID.
The WsWorkunits.WUInfo returns gragh type, label, and timing.
In this fix, the functions of retrieving graph information in
WsWorkunits.WUInfo are collected into 2 methods which are used
in WUQueryDetails also.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
