### PR TITLE
HPCC-16413 - TestDate.ecl failures on OSX

### DIFF
--- a/plugins/timelib/timelib.cpp
+++ b/plugins/timelib/timelib.cpp
@@ -667,6 +667,9 @@ TIMELIB_API unsigned int TIMELIB_CALL tlAdjustTime(unsigned int time, short hour
     unsigned int    result = 0;
 
     memset(&timeInfo, 0, sizeof(timeInfo));
+#ifdef __APPLE__
+    timeInfo.tm_year = 2;
+#endif
 
     tlInsertTimeIntoTimeStruct(&timeInfo, time);
 
@@ -689,6 +692,9 @@ TIMELIB_API unsigned int TIMELIB_CALL tlAdjustTimeBySeconds(unsigned int time, i
     unsigned int    result = 0;
 
     memset(&timeInfo, 0, sizeof(timeInfo));
+#ifdef __APPLE__
+    timeInfo.tm_year = 2;
+#endif
 
     tlInsertTimeIntoTimeStruct(&timeInfo, time);
     timeInfo.tm_sec += seconds_delta;


### PR DESCRIPTION
There are some peculiarities in the implementation of mktime on OSX meaning it
returns -1 (and does not change input) if year is <= 1901.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
