### PR TITLE
HPCC-16422 Fix clang warning about use of uninitialized variable

### DIFF
--- a/common/environment/environment.cpp
+++ b/common/environment/environment.cpp
@@ -1556,7 +1556,7 @@ void CLocalEnvironment::clearCache()
     if (conn)
     {
         p.clear();
-        unsigned mode;
+        unsigned mode = 0;
         try
         {
             conn->reload();


### PR DESCRIPTION
Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
