### PR TITLE
HPCC-15792 Re-enable restriction on despraying only to dropzones

### DIFF
--- a/dali/ft/filecopy.cpp
+++ b/dali/ft/filecopy.cpp
@@ -2703,7 +2703,10 @@ void FileSprayer::checkFilePath(RemoteFilename & filename)
 
             Owned<IConstDropZoneInfo> dropZone = env->getDropZoneByAddressPath(netaddress.str(), pfilePath);
             if (!dropZone)
-                LOG(MCdebugInfo, unknownJob, "No matching drop zone path to file path: '%s'", filePath.str());
+            {
+                LOG(MCdebugInfo, unknownJob, "No matching drop zone path to file path: '%s'", pfilePath);
+                throwError1(DFTERR_NoMatchingDropzonePath, pfilePath);
+            }
             else
             {
                 SCMStringBuffer dropZoneName;

--- a/dali/ft/fterror.hpp
+++ b/dali/ft/fterror.hpp
@@ -153,7 +153,7 @@
 #define DFTERR_WrongSplitRecordSize_Text        "Invalid Record Size (%d, 0x%08x)!"
 #define DFTERR_InvalidXmlPartSize_Text          "Invalid XML part size:%" I64F "d! Size is less than XML Header (%" I64F "d) + Footer (%" I64F "d)) size!"
 #define DFTERR_InvalidFilePath_Text             "Invalid file path: '%s'. For security reason it is forbidden to use '%s' or '%s' to build a path!"
-#define DFTERR_NoMatchingDropzonePath_Text      "No matching drop zone path to target path: '%s'."
+#define DFTERR_NoMatchingDropzonePath_Text      "No matching drop zone path to file path: '%s'."
 #define DFTERR_LocalhostAddressUsed_Text        "Localhost address used in remote file name: '%s'"
 
 

--- a/testing/regress/ecl/despray.ecl
+++ b/testing/regress/ecl/despray.ecl
@@ -143,7 +143,7 @@ c5 := CATCH(NOFOLD(p5), ONFAIL(TRANSFORM(rec,
 #end
 
 
-// This should pass based on HPCC-15787 write log entry instead of thow an exception if
+// This should fail based on
 // not an existing dropzone path used in target file path
 DestFile6 := '/var/lib/HPCCSystems/mydropzona/' + File;
 dst6 := NOFOLD(DATASET([{SourceFile, DestFile6, SrcAddrIp, True, '', ''}], rec));
@@ -163,7 +163,7 @@ c6 := CATCH(NOFOLD(p6), ONFAIL(TRANSFORM(rec,
 #end
 
 
-// This should pass based on HPCC15787 write log entry instead of thow an exception if
+// This should fail based on
 // try to despray out of a drop zone
 DestFile7 := '/var/lib/HPCCSystems/' + File;
 dst7 := NOFOLD(DATASET([{SourceFile, DestFile7, SrcAddrIp, True, '', ''}], rec));
@@ -183,7 +183,7 @@ c7 := CATCH(NOFOLD(p7), ONFAIL(TRANSFORM(rec,
 #end
 
 
-// This should passbased on HPCC15787 write log entry instead of thow an exception if
+// This should fail based on
 // not an existing dropzone path used in target file path
 DestFile8 := '/var/lib/HPCCSystems/mydropzone../' + File;
 dst8 := NOFOLD(DATASET([{SourceFile, DestFile8, SrcAddrIp, True, '', ''}], rec));

--- a/testing/regress/ecl/key/despray.xml
+++ b/testing/regress/ecl/key/despray.xml
@@ -13,13 +13,13 @@
  <Row><result>Fail</result></Row>
 </Dataset>
 <Dataset name='Result 6'>
- <Row><result>Pass</result></Row>
+ <Row><result>Fail</result></Row>
 </Dataset>
 <Dataset name='Result 7'>
- <Row><result>Pass</result></Row>
+ <Row><result>Fail</result></Row>
 </Dataset>
 <Dataset name='Result 8'>
- <Row><result>Pass</result></Row>
+ <Row><result>Fail</result></Row>
 </Dataset>
 <Dataset name='Result 9'>
  <Row><result>Pass</result></Row>


### PR DESCRIPTION
Restore exception if file path doesn't match to any dropzone.

Update despray regression test case/

Signed-off-by: Attila Vamos attila.vamos@gmail.com
