### PR TITLE
HPCC-16432 Initialise members of struct tm to avoid warning

### DIFF
--- a/system/jlib/jtime.cpp
+++ b/system/jlib/jtime.cpp
@@ -156,6 +156,8 @@ void CDateTime::getToUtcTm(struct tm & ts) const
     ts.tm_min = utc_min;
     ts.tm_sec = utc_sec;
     ts.tm_isdst = 0;
+    ts.tm_wday = 0;
+    ts.tm_yday = 0;
 }
 
 void CDateTime::deserialize(MemoryBuffer &src)


### PR DESCRIPTION
Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
