### PR TITLE
HPCC-16441 Fix super getAccessedTime method

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -6455,7 +6455,7 @@ public:
         CriticalBlock block (sect);
         ForEachItemIn(i,subfiles) {
             IDistributedFile &f=subfiles.item(i);
-            if (set)
+            if (!set)
                 set = f.getAccessedTime(dt);
             else {
                 CDateTime cmp;
@@ -6465,7 +6465,7 @@ public:
                 }
             }
         }
-        return false;
+        return set;
     }
 
     void setAccessedTime(const CDateTime &dt)


### PR DESCRIPTION
Was comparing with passed in param, instead of (as intended)
getting 1st of subs then comparing to most recent.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
