### PR TITLE
HPCC-16351 Convert SecAccess flags to typesafe enum

### DIFF
--- a/dali/base/dasess.hpp
+++ b/dali/base/dasess.hpp
@@ -123,8 +123,8 @@ interface ISessionManager: extends IInterface
 #define DALI_LDAP_READ_WANTED               (2)
 #define DALI_LDAP_WRITE_WANTED              (4)
 
-#define HASREADPERMISSION(p)        (((p) & (NewSecAccess_Access & NewSecAccess_Read)) == (NewSecAccess_Access & NewSecAccess_Read))
-#define HASWRITEPERMISSION(p)       (((p) & (NewSecAccess_Access & NewSecAccess_Write)) == (NewSecAccess_Access & NewSecAccess_Write))
+#define HASREADPERMISSION(p)        (((p) & (NewSecAccess_Access | NewSecAccess_Read)) == (NewSecAccess_Access | NewSecAccess_Read))
+#define HASWRITEPERMISSION(p)       (((p) & (NewSecAccess_Access | NewSecAccess_Write)) == (NewSecAccess_Access | NewSecAccess_Write))
 
 
 extern da_decl ISessionManager &querySessionManager();


### PR DESCRIPTION
Typo in refactoring meant security checks were failing!

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
