### PR TITLE
HPCC-16487 Can't import tensorflow in embedded python

### DIFF
--- a/plugins/pyembed/pyembed.cpp
+++ b/plugins/pyembed/pyembed.cpp
@@ -274,6 +274,8 @@ public:
 #endif
         // Initialize the Python Interpreter
         Py_Initialize();
+        const char *argv[] = { nullptr };
+        PySys_SetArgvEx(0, (char **) argv, 0);
         PyEval_InitThreads();
         tstate = PyEval_SaveThread();
         initialized = true;


### PR DESCRIPTION
Set up fake argc/argv in case any python code (such as tensorflow) assumes it
is present.

Signed-off-by: Richard Chapman rchapman@hpccsystems.com
