### PR TITLE
HPCC-16339 Both summary01last.ecl and summary02all.ecl are segfaulted in performance test.

### DIFF
--- a/system/jlib/jstats.cpp
+++ b/system/jlib/jstats.cpp
@@ -1569,7 +1569,7 @@ public:
     virtual void beginActivityScope(unsigned id) { throwUnexpected(); }
     virtual void beginEdgeScope(unsigned id, unsigned oid) { throwUnexpected(); }
     virtual void endScope()
-    { 
+    {
         node = &stack.popGet();
     }
     virtual void addStatistic(StatisticKind kind, unsigned __int64 value)
@@ -2323,9 +2323,15 @@ void StatisticsFilter::addFilter(const char * filter)
 
 void StatisticsFilter::setFilter(const char * filter)
 {
+    if (isEmptyString(filter))
+        return;
+
     loop
     {
         const char * closeBra = strchr(filter, ']');
+        if (!closeBra)
+            throw MakeStringException(1, "Missing close bracket ']' in '%s' ", filter);
+
         const char * comma = strchr(closeBra, ',');
         if (comma)
         {


### PR DESCRIPTION
Add code to check settings of StatisticsFilter object:
- avoid to process empty filter string
- check the filter string contains close bracket ']' char.

Tested with a subset of Performance Suite

Signed-off-by: Attila Vamos attila.vamos@gmail.com
