### PR TITLE
HPCC-16518 Fix potentially hitting asserts in UDP/SNMP reports

### DIFF
--- a/system/jlib/jdebug.cpp
+++ b/system/jlib/jdebug.cpp
@@ -2170,8 +2170,8 @@ public:
             {
                 unsigned queue = strtoul(cols.item(queueCol), NULL, 16);
                 unsigned drops = 0;
-                if (dropsCol)
-                    drops =  strtoul(cols.item(dropsCol), NULL, 10);
+                if (dropsCol >= 0)
+                    drops = strtoul(cols.item(dropsCol), NULL, 10);
                 if (queue || drops)
                 {
                     unsigned port = strtoul(cols.item(portCol), NULL, 16);
@@ -2243,6 +2243,8 @@ public:
                         if (streq(columnNames.item(idx), "InErrors"))
                             inErrorsCol = idx;
                     }
+                    if (inErrorsCol == -1)
+                        break;
                 }
                 if (fgets(ln, sizeof(ln), netfp))
                 {


### PR DESCRIPTION
1) An assert could have been hit in the UDP stats reporter if the
"drops" column heading was not found.
2) In the SNMP stats reporter, if the "InErrors" column heading
was not found, it could in theory hit an assert when trying to
find the data entry.

In reality, I don't think either case could actually be hit.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
