### PR TITLE
HPCC-16488 Thor cleaner abort/signal shutdown

### DIFF
--- a/initfiles/bin/init_thor.in
+++ b/initfiles/bin/init_thor.in
@@ -24,6 +24,7 @@ source  ${INSTALL_DIR}/etc/init.d/hpcc_common
 component=$(basename $PWD)
 
 PID_NAME="${PID_DIR}/${component}.pid"
+INIT_PID_NAME="${PID_DIR}/init_${component}.pid"
 
 timestamp="$(date +%Y_%m_%d_%H_%M_%S)"
 export logfile="${LOG_DIR}/${component}/init_${component}_${timestamp}.log"

--- a/thorlcr/slave/thslavemain.cpp
+++ b/thorlcr/slave/thslavemain.cpp
@@ -219,16 +219,21 @@ bool ControlHandler(ahType type)
 {
     if (ahInterrupt == type)
         LOG(MCdebugProgress, thorJob, "CTRL-C detected");
-    else if (!jobListenerStopped)
-        LOG(MCdebugProgress, thorJob, "SIGTERM detected");
-    bool unregOK = false;
+    else
+    {
+        if (jobListenerStopped)
+            return false;
+        else
+            LOG(MCdebugProgress, thorJob, "SIGTERM detected");
+    }
+
     if (!jobListenerStopped)
     {
         if (masterNode)
-            unregOK = UnregisterSelf(NULL);
+            UnregisterSelf(NULL);
         abortSlave();
     }
-    return !unregOK;
+    return true;
 }
 
 void usage()


### PR DESCRIPTION
This update allows Thor slaves to end more robustly and cleanly when there is either a problem with a slave or a user requested shutdown.

@Michael-Gardner please review (specifically the init_thor change to add back in the missing INIT_PID_NAME env var).

@jakesmith please review the other changes.

Signed-off-by: Mark Kelly mark.kelly@lexisnexis.com
