### PR TITLE
HPCC-16481 Disable UDP reporting for Thor

### DIFF
--- a/thorlcr/graph/thgraph.cpp
+++ b/thorlcr/graph/thgraph.cpp
@@ -1340,7 +1340,7 @@ void CGraphBase::executeSubGraph(size32_t parentExtractSz, const byte *parentExt
     {
         GraphPrintLog("Graph Done");
         StringBuffer memStr;
-        getSystemTraceInfo(memStr, PerfMonStandard | PerfMonExtended);
+        getSystemTraceInfo(memStr, ((PerfMonStandard & ~PerfMonUDP) | PerfMonExtended));
         GraphPrintLog("%s", memStr.str());
     }
     if (exception)
@@ -2678,7 +2678,7 @@ void CJobBase::startJob()
     if (pinterval)
     {
         perfmonhook.setown(createThorMemStatsPerfMonHook(*this, getOptInt(THOROPT_MAX_KERNLOG, 3)));
-        startPerformanceMonitor(pinterval,PerfMonStandard,perfmonhook);
+        startPerformanceMonitor(pinterval,(PerfMonStandard & ~PerfMonUDP), perfmonhook);
     }
     PrintMemoryStatusLog();
     logDiskSpace();


### PR DESCRIPTION
This update disabled UDP stats for Thor because the performance monitor in Thor is started and stopped per job/graph and the delta between initial and current UDP errors is then not calculated which can often report misleading UDP error countts.

@jakesmith please review.

Signed-off-by: Mark Kelly mark.kelly@lexisnexis.com
