### PR TITLE
HPCC-13605 Remember user input in ws_ecl form

### DIFF
--- a/esp/xslt/wsecl3_boxform.xsl
+++ b/esp/xslt/wsecl3_boxform.xsl
@@ -31,6 +31,8 @@
               <link rel="stylesheet" type="text/css" href="/esp/files/yui/build/fonts/fonts-min.css"/>
               <link rel="stylesheet" type="text/css" href="/esp/files/css/espdefault.css"/>
               <link rel="stylesheet" type="text/css" href="/esp/files/gen_form.css"/>
+              <script type="text/javascript" src="/esp/files/hashtable.js"/>
+              <script type="text/javascript" src="/esp/files/gen_form_wsecl.js"/>
               <script type="text/javascript">
 
       <xsl:text disable-output-escaping="yes">
@@ -55,6 +57,7 @@ function setESPFormAction()
     }
 
     form.action = actionpath;
+    saveInputValues(form);
     return true;
 }
 
@@ -71,7 +74,9 @@ function switchInputForm()
 </script>
 </head>
       <body class="yui-skin-sam" onload="onPageLoad()">
-               <p align="center"/>
+                <input type="hidden" id="esp_html_"/>
+                <input type="hidden" id="esp_vals_"/>
+                <p align="center"/>
                 <table cellSpacing="0" cellPadding="1" width="100%" bgColor="#4775FF" border="0">
                     <tr align="left" class="service">
                         <td height="23">

--- a/esp/xslt/wsecl3_form.xsl
+++ b/esp/xslt/wsecl3_form.xsl
@@ -308,7 +308,7 @@ function switchInputForm()
 
                 <tr class='commands'>
                   <td align='left'>
-                    <select id="submit_type">
+                    <select id="submit_type" name="submit_type">
                         <xsl:for-each select="/FormInfo/CustomViews/Result">
                             <option><xsl:attribute name="value"><xsl:value-of select="."/></xsl:attribute><xsl:value-of select="."/></option>
                         </xsl:for-each>


### PR DESCRIPTION
1. The existing ws_ecl Dynamic Form loses the 'submit_type' select when a
   user hits the Back button on a browser. This is because the
   saveInputValues() requires a name to save the value of an input. But, the
   name is missing for the 'submit_type' select.
2. The existing ws_ecl Input Box form does not have the code to remember
   user input. Similar code for Dynamic Form is added in this fix.

Signed-off-by: wangkx kevin.wang@lexisnexis.com
