### PR TITLE
HPCC-16535 INIT_PID_NAME missing from init_thor

### DIFF
--- a/initfiles/bin/init_thor.in
+++ b/initfiles/bin/init_thor.in
@@ -24,6 +24,7 @@ source  ${INSTALL_DIR}/etc/init.d/hpcc_common
 component=$(basename $PWD)
 
 PID_NAME="${PID_DIR}/${component}.pid"
+INIT_PID_NAME="${PID_DIR}/init_${component}.pid"
 
 timestamp="$(date +%Y_%m_%d_%H_%M_%S)"
 export logfile="${LOG_DIR}/${component}/init_${component}_${timestamp}.log"


### PR DESCRIPTION
INIT_PID_NAME is an env var of a file referenced in several places within the init_thor script and was accidentally removed some time ago.
Without this fix, the init_thor script cannot remove this file and then during thor shutdown from hpcc-init -c mythor stop, a warning message occurs which is incorrect and misleading stating something to the effect of "pid file found but no pid running"

@Michael-Gardner I pulled this into its own issue, separate from the signal handling, please review.

Signed-off-by: Mark Kelly mark.kelly@lexisnexis.com
