### PR TITLE
HPCC-16534 Multi part disk aggregates failed to merge stats.

### DIFF
--- a/thorlcr/activities/thactivityutil.cpp
+++ b/thorlcr/activities/thactivityutil.cpp
@@ -890,10 +890,10 @@ IRowStream *createSequentialPartHandler(CPartHandler *partHandler, IArrayOf<IPar
                     someInGroup = false;
                     return NULL;
                 }
-                partHandler->stop();
                 ++part;
                 if (part >= parts)
                 {
+                    partHandler->stop();
                     partHandler.clear();
                     eof = true;
                     return NULL;

--- a/thorlcr/activities/thdiskbaseslave.cpp
+++ b/thorlcr/activities/thdiskbaseslave.cpp
@@ -76,6 +76,7 @@ CDiskPartHandlerBase::CDiskPartHandlerBase(CDiskReadSlaveActivityBase &_activity
 
 void CDiskPartHandlerBase::setPart(IPartDescriptor *_partDesc)
 {
+    stop(); // close previous if open
     partDesc.set(_partDesc);
     compressed = partDesc->queryOwner().isCompressed(&blockCompressed);
     if (NULL != activity.eexp.get())
@@ -165,6 +166,8 @@ void CDiskPartHandlerBase::open()
 
 void CDiskPartHandlerBase::stop()
 {
+    if (!iFile)
+        return;
     if (!eoi)
         checkFileCrc = false; // cannot perform file CRC if diskread has not read whole file.
     CRC32 fileCRC;
@@ -176,6 +179,7 @@ void CDiskPartHandlerBase::stop()
             throw MakeThorOperatorException(TE_FileCrc, "CRC Failure having read file: %s", filename.get());
         checkFileCrc = false;
     }
+    iFile.clear();
 }
 
 

--- a/thorlcr/activities/xmlread/thxmlreadslave.cpp
+++ b/thorlcr/activities/xmlread/thxmlreadslave.cpp
@@ -100,7 +100,10 @@ class CXmlReadSlaveActivity : public CDiskReadSlaveActivityBase
             xmlParser.clear();
             inputIOstream.clear();
             if (checkFileCrc)
+            {
                 fileCRC.reset(~crcStream->queryCrc()); // MORE should prob. change stream to use CRC32
+                crcStream.clear();
+            }
             mergeStats(fileStats, iFileIO);
             iFileIO.clear();
         }


### PR DESCRIPTION
If a disk count/aggregate activity was reading multiple physical
file parts, it was not calling the normal part close methods.
Consequently it was not merging the stats from each part read.
The net result, was that the stats. captured only represented
the last part read.

Signed-off-by: Jake Smith jake.smith@lexisnexis.com
