### PR TITLE
HPCC-16491 Work-around CMake productbuild packaging issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,6 +189,10 @@ if(APPLE OR WIN32)
     HPCC_ADD_SUBDIRECTORY(lib2)
 endif(APPLE OR WIN32)
 
+if(APPLE)
+    HPCC_ADD_SUBDIRECTORY(package)
+endif(APPLE)
+
 ###
 ## CPack install and packaging setup.
 ###

--- a/package/CMakeLists.txt
+++ b/package/CMakeLists.txt
@@ -1,0 +1,2 @@
+configure_file("packaging_osx.sh" ${CMAKE_CURRENT_BINARY_DIR} COPYONLY)
+configure_file("distribution_template.xml" ${CMAKE_CURRENT_BINARY_DIR} COPYONLY)

--- a/package/distribution_template.xml
+++ b/package/distribution_template.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<installer-gui-script minSpecVersion="2">
+    <title>${TITLE}</title>
+    <welcome file="Welcome.txt"/>
+    <license file="License.txt"/>
+    <readme file="ReadMe.txt"/>
+    <options allow-external-scripts="no" customize="allow" rootVolumeOnly="false"/>
+    <pkg-ref id="hpccsystems.product"/>
+    <options customize="never" require-scripts="false"/>
+    <choices-outline>
+        <line choice="default">
+            <line choice="hpccsystems.product"/>
+        </line>
+    </choices-outline>
+    <choice id="default"/>
+    <choice id="hpccsystems.product" visible="false">
+        <pkg-ref id="hpccsystems.product"/>
+    </choice>
+    <pkg-ref id="hpccsystems.product" version="0" onConclusion="none">${PACKAGE_NAME}.pkg</pkg-ref>
+    <product version="${FULL_VERSION}"/>
+</installer-gui-script>

--- a/package/packaging_osx.sh
+++ b/package/packaging_osx.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+WORK_ROOT=$(dirname $0)
+cd $WORK_ROOT
+WORK_ROOT=$(pwd)
+
+ARCH=$(uname -m)
+BUILD_ROOT=${WORK_ROOT}/..
+cd ${BUILD_ROOT}/_CPack_Packages/Darwin-x86_64/productbuild/hpccsystems-clienttools-community*${ARCH}
+PACKAGE_SRC=$(pwd)
+cd $WORK_ROOT
+
+#-----------------------------------------------
+#
+# Get variables
+#
+#-----------------------------------------------
+#get os "Darwin"
+OSTYPE=Darwin
+
+#ID=$(grep "^SET\(CPACK_PACKAGE_NAME \"hpccsystems-clienttools-6.2\"" ${BUILD_ROOT}/CPackConfig.cmake)
+ID=$(grep "CPACK_PACKAGE_NAME " ${BUILD_ROOT}/CPackConfig.cmake | \
+     cut -d' ' -f2 | cut -d'"' -f2)
+echo "Title: $ID"
+
+PACKAGE_NAME=$(grep "CPACK_SOURCE_PACKAGE_FILE_NAME " \
+       ${BUILD_ROOT}/CPackConfig.cmake | cut -d' ' -f2 | cut -d'"' -f2)
+PACKAGE_NAME="${PACKAGE_NAME}${OSTYPE}-${ARCH}"
+echo "CPACK_PACKAGE_NAME: $PACKAGE_NAME"
+
+FULL_VERSION=$(grep "CPACK_PACKAGE_VERSION " ${BUILD_ROOT}/CPackConfig.cmake | \
+     cut -d' ' -f2 | cut -d'"' -f2)
+echo "FULL_VERSION: $FULL_VERSION"
+
+#-----------------------------------------------
+#
+# Create package with pkgbuilds
+#
+#-----------------------------------------------
+echo ""
+echo "Create ${PACKAGE_NAME}.pkg with pkgbuild"
+[ -d "${PACKAGE_NAME}" ] && rm -rf ${PACKAGE_NAME}
+mkdir -p ${PACKAGE_NAME}
+cd ${PACKAGE_NAME}
+echo "pkgbuild --root ${PACKAGE_SRC}/opt --install-location "/opt" --identifier $ID ${PACKAGE_NAME}.pkg"
+pkgbuild --root ${PACKAGE_SRC}/opt --install-location "/opt" --identifier $ID ${PACKAGE_NAME}.pkg
+if [ $? -ne 0 ]
+then
+  echo "Error to run pkgbuild"
+  exit 1
+fi
+if [ ! -e ${PACKAGE_NAME}.pkg ]
+then
+  echo "Failed to generate ${PACKAGE_NAME}.pkg"
+  exit 1
+fi
+cd ..
+
+#-----------------------------------------------
+#
+# Creaate distribution.xml from template
+#
+#-----------------------------------------------
+echo ""
+echo "Create Distribution.xml"
+
+sed "s/\${TITLE}/${ID}/g; \
+     s/\${PACKAGE_NAME}/${PACKAGE_NAME}/g; \
+     s/\${FULL_VERSION}/${FULL_VERSION}/g" \
+     ${WORK_ROOT}/distribution_template.xml > distribution.xml
+
+#-----------------------------------------------
+#
+# Add Welcome/License/ReadMe with productbuild
+#
+#-----------------------------------------------
+echo ""
+echo "Add Welcome/License/ReadMe to ${PACKAGE_NAME}.pkg with productbuild"
+[ -d resources ] && rm -rf resources
+mkdir -p resources
+cp ${PACKAGE_SRC}/Contents/*.txt resources/
+echo "productbuild --distribution ./distribution.xml --package-path ./${PACKAGE_NAME} --resources ./resources  ${PACKAGE_NAME}.pkg"
+productbuild --distribution ./distribution.xml --package-path ./${PACKAGE_NAME} --resources ./resources  ${PACKAGE_NAME}.pkg
+
+#-----------------------------------------------
+#
+# Create DMG file
+#
+#-----------------------------------------------
+echo ""
+mv ${PACKAGE_NAME}.pkg ./${PACKAGE_NAME}/
+echo "hdiutil create -volname ${PACKAGE_NAME} -srcfolder ./${PACKAGE_NAME} -ov ${PACKAGE_NAME}.dmg"
+hdiutil create -volname ${PACKAGE_NAME} -srcfolder ./${PACKAGE_NAME} -ov ${PACKAGE_NAME}.dmg
+
+echo ""
+echo "DONE"

--- a/system/jlib/CMakeLists.txt
+++ b/system/jlib/CMakeLists.txt
@@ -40,7 +40,7 @@ endif(NOT TARGET lz4)
 
 
 if (CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_CLANG)
-  SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-switch -Wno-unused-parameter -Werror")
+  SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-switch -Wno-unused-parameter -Werror -Wno-error=delete-non-virtual-dtor")
 endif()
 
 set (    SRCS 


### PR DESCRIPTION
CMake productbuild generator doesn't work correct in CMake 3.7 rc1
Also add CXX flag to non-virtual destructor compiler error for CLANG 8.0.0
For OS X 10.9 may need to add -DOPENLDAP_INCLUDE_DIR=/usr/include" otherwise
ldap.h may referenced incorrectly.

For more detail reference https://track.hpccsystems.com/browse/HPCC-16491

Xiaoming Wang xiaoming.wang@lexisnexi.com 

@Michael-Gardner please review
