### PR TITLE
HPCC-16180 addscopes should offer the option to clear ldap cache

### DIFF
--- a/tools/addScopes/CMakeLists.txt
+++ b/tools/addScopes/CMakeLists.txt
@@ -34,7 +34,9 @@ include_directories (
          ./../../system/security/LdapSecurity
          ./../../system/security/shared 
          ./../../system/jlib 
-         ./../../system/include 
+         ./../../system/include
+         ./../../dali/base
+         ./../../system/mp
     )
 
 ADD_DEFINITIONS( -D_CONSOLE )

--- a/tools/addScopes/addScopes.cpp
+++ b/tools/addScopes/addScopes.cpp
@@ -80,13 +80,9 @@ int main(int argc, char* argv[])
                 releaseAtoms();
                 return -1;
             }
-            Owned<ISecUser> user = secmgr->createUser(sysuser.str());
-            ISecCredentials& cred = user->credentials();
+
             StringBuffer decPwd;
             decrypt(decPwd, passbuf.str());
-            cred.setPassword(decPwd.str());
-            ok = secmgr->clearPermissionsCache(*user);
-            printf(ok ? "ESP Cache cleared\n" : "Error clearing ESP Cache\n");
 
             //Clear Dali cache
             Owned<IUserDescriptor> userdesc(createUserDescriptor());


### PR DESCRIPTION
Currently when addScopes is run to add private LDAP file scopes, the changes
are not visible until the Dali cache recycles.  This PR adds a new command line
option ( -c ) which, when specified, will clear the permission cache
making the changes immediately visible.

Signed-off-by: Russ Whitehead william.whitehead@lexisnexis.com
