### PR TITLE
HPCC-16559 Include descending sort orders when checking if sorted all fields

### DIFF
--- a/ecl/hql/hqlmeta.cpp
+++ b/ecl/hql/hqlmeta.cpp
@@ -3503,6 +3503,8 @@ void markValidSelectors(IHqlExpression * expr, IHqlExpression * dsSelector)
                 expr->setTransformExtra(expr);
             return;
         }
+    case no_negate:
+        break;
     default:
         return;
     }


### PR DESCRIPTION
Signed-off-by: Gavin Halliday <gavin.halliday@lexisnexis.com>