### PR TITLE
HPCC-16579 Reduce notifyClosed tracing.

### DIFF
--- a/system/mp/mpcomm.cpp
+++ b/system/mp/mpcomm.cpp
@@ -502,7 +502,7 @@ public:
     bool nextChannel(CMPChannel *&c);
     void addConnectionMonitor(IConnectionMonitor *monitor);
     void removeConnectionMonitor(IConnectionMonitor *monitor);
-    void notifyClosed(SocketEndpoint &ep);
+    void notifyClosed(SocketEndpoint &ep, bool trace);
     StringBuffer &getReceiveQueueDetails(StringBuffer &buf) 
     {
         return receiveq.getReceiveQueueDetails(buf);
@@ -1071,7 +1071,7 @@ public:
         }
         catch (IException *e) {
             FLLOG(MCoperatorWarning, unknownJob, e,"MP writepacket");
-            closeSocket();
+            closeSocket(false, true);
             throw;
         }
         return true;
@@ -1129,7 +1129,7 @@ public:
     bool send(MemoryBuffer &mb, mptag_t tag, mptag_t replytag, CTimeMon &tm, bool reply);
 
 
-    void closeSocket(bool keepsocket=false)
+    void closeSocket(bool keepsocket=false, bool trace=false)
     {
         ISocket *s;
         bool socketfailed = false;
@@ -1161,7 +1161,7 @@ public:
             }
             parent->querySelectHandler().remove(s);
         }
-        parent->notifyClosed(remoteep);
+        parent->notifyClosed(remoteep, trace);
         if (socketfailed) {
             try {
                 s->Release();
@@ -1472,7 +1472,7 @@ public:
                     }
                 }
                 if (pc) 
-                    pc->closeSocket();
+                    pc->closeSocket(false, true);
                 return false;
             }
             do {
@@ -1572,7 +1572,7 @@ public:
         // error here, so close socket (ignore error as may be closed already)
         try {
             if(parent)
-                parent->closeSocket();
+                parent->closeSocket(false, true);
         }
         catch (IException *e) {
             e->Release();
@@ -1602,7 +1602,7 @@ CMPChannel::CMPChannel(CMPServer *_parent,SocketEndpoint &_remoteep)
 void CMPChannel::reset()
 {
     reader->shutdown(); // clear as early as possible
-    closeSocket();
+    closeSocket(false, true);
     reader->Release();
     channelsock = NULL;
     multitag = TAG_NULL;
@@ -1685,7 +1685,7 @@ bool CMPChannel::attachSocket(ISocket *newsock,const SocketEndpoint &_remoteep,c
         try {
             LOG(MCdebugInfo(100), unknownJob, "Message Passing - removing stale socket to %s",ep2.str());
             CriticalUnblock unblock(connectsect);
-            closeSocket(true);
+            closeSocket(true, true);
 #ifdef REFUSE_STALE_CONNECTION
             if (!ismaster)
                 return false;
@@ -2433,12 +2433,15 @@ bool CMPServer::nextChannel(CMPChannel *&cur)
     return cur!=NULL;
 }
 
-void CMPServer::notifyClosed(SocketEndpoint &ep)
+void CMPServer::notifyClosed(SocketEndpoint &ep, bool trace)
 {
 #ifdef _TRACEMPSERVERNOTIFYCLOSED
-    StringBuffer url;
-    LOG(MCdebugInfo(100), unknownJob, "MP: CMPServer::notifyClosed %s",ep.getUrlStr(url).str());
-    PrintStackReport();
+    if (trace)
+    {
+        StringBuffer url;
+        LOG(MCdebugInfo(100), unknownJob, "MP: CMPServer::notifyClosed %s",ep.getUrlStr(url).str());
+        PrintStackReport();
+    }
 #endif
     notifyclosedthread->notify(ep);
 }


### PR DESCRIPTION
Recently added tracing was too verbose.
Supress notifyClosed tracing from explicitly closed sockets.

Signed-off-by: Jake Smith <jake.smith@lexisnexis.com>