### PR TITLE
HPCC-16582 Ensure logical filename issued on index read error

### DIFF
--- a/thorlcr/activities/fetch/thfetchslave.ipp
+++ b/thorlcr/activities/fetch/thfetchslave.ipp
@@ -39,7 +39,7 @@ interface IFetchStream : extends IInterface
     virtual void abort() = 0;
 };
 
-IFetchStream *createFetchStream(CSlaveActivity &owner, IThorRowInterfaces *keyRowIf, IThorRowInterfaces *fetchRowIf, bool &abortSoon, CPartDescriptorArray &parts, unsigned offsetCount, size32_t offsetMapSz, const void *offsetMap, IFetchHandler *iFetchHandler, mptag_t tag, IExpander *eexp=NULL);
+IFetchStream *createFetchStream(CSlaveActivity &owner, IThorRowInterfaces *keyRowIf, IThorRowInterfaces *fetchRowIf, bool &abortSoon, const char *logicalFilename, CPartDescriptorArray &parts, unsigned offsetCount, size32_t offsetMapSz, const void *offsetMap, IFetchHandler *iFetchHandler, mptag_t tag, IExpander *eexp=NULL);
 
 activityslaves_decl CActivityBase *createFetchSlave(CGraphElementBase *container);
 activityslaves_decl CActivityBase *createCsvFetchSlave(CGraphElementBase *container);

--- a/thorlcr/activities/indexread/thindexreadslave.cpp
+++ b/thorlcr/activities/indexread/thindexreadslave.cpp
@@ -138,7 +138,7 @@ protected:
         rfn.getPath(filePath);
         unsigned crc=0;
         partDesc.getCrc(crc);
-        Owned<IDelayedFile> lfile = queryThor().queryFileCache().lookup(*this, partDesc);
+        Owned<IDelayedFile> lfile = queryThor().queryFileCache().lookup(*this, logicalFilename, partDesc);
         return createKeyIndex(filePath.str(), crc, *lfile, false, false);
     }
     const void *nextKey()

--- a/thorlcr/activities/keyedjoin/thkeyedjoinslave.cpp
+++ b/thorlcr/activities/keyedjoin/thkeyedjoinslave.cpp
@@ -1882,7 +1882,7 @@ public:
                 filePart.getFilename(0, rfn);
                 StringBuffer filename;
                 rfn.getPath(filename);
-                Owned<IDelayedFile> lfile = queryThor().queryFileCache().lookup(*this, filePart);
+                Owned<IDelayedFile> lfile = queryThor().queryFileCache().lookup(*this, indexName, filePart);
                 partKeySet->addIndex(createKeyIndex(filename.str(), crc, *lfile, false, false));
             }
             while (ip<numIndexParts);
@@ -1982,7 +1982,7 @@ public:
                 unsigned i=0;
                 for(; i<dataParts.ordinality(); i++)
                 {
-                    Owned<IDelayedFile> dFile = queryThor().queryFileCache().lookup(*this, dataParts.item(i), eexp);
+                    Owned<IDelayedFile> dFile = queryThor().queryFileCache().lookup(*this, indexName, dataParts.item(i), eexp);
                     fetchFiles.append(*dFile.getClear());
                 }
             }

--- a/thorlcr/graph/thgraph.hpp
+++ b/thorlcr/graph/thgraph.hpp
@@ -1137,7 +1137,7 @@ interface IExpander;
 interface IThorFileCache : extends IInterface
 {
     virtual bool remove(IDelayedFile &dFile) = 0;
-    virtual IDelayedFile *lookup(CActivityBase &activity, IPartDescriptor &partDesc, IExpander *expander=NULL) = 0;
+    virtual IDelayedFile *lookup(CActivityBase &activity, const char *logicalFilenae, IPartDescriptor &partDesc, IExpander *expander=NULL) = 0;
 };
 
 class graph_decl CThorResourceBase : implements IThorResource, public CInterface

--- a/thorlcr/graph/thgraphslave.cpp
+++ b/thorlcr/graph/thgraphslave.cpp
@@ -1933,7 +1933,7 @@ public:
         CriticalBlock b(crit);
         return _remove(*lFile);
     }
-    virtual IDelayedFile *lookup(CActivityBase &activity, IPartDescriptor &partDesc, IExpander *expander)
+    virtual IDelayedFile *lookup(CActivityBase &activity, const char *logicalFilename, IPartDescriptor &partDesc, IExpander *expander)
     {
         StringBuffer filename;
         RemoteFilename rfn;
@@ -1943,7 +1943,7 @@ public:
         Linked<CLazyFileIO> file = files.find(filename.str());
         if (!file)
         {
-            Owned<IReplicatedFile> repFile = createEnsurePrimaryPartFile(activity, filename.str(), &partDesc);
+            Owned<IReplicatedFile> repFile = createEnsurePrimaryPartFile(activity, logicalFilename, &partDesc);
             bool compressed = partDesc.queryOwner().isCompressed();
             file.setown(new CLazyFileIO(*this, filename.str(), repFile.getClear(), compressed, expander));
         }


### PR DESCRIPTION
When failing to find a physical whilst processing a logical index
file, the error would report the primary physical part as the
logical name.

Fix by corectly reporting the logical name in the error.

Signed-off-by: Jake Smith <jake.smith@lexisnexis.com>