### PR TITLE
HPCC-16564 EmployeeID not showing up

### DIFF
--- a/esp/src/eclwatch/UserDetailsWidget.js
+++ b/esp/src/eclwatch/UserDetailsWidget.js
@@ -129,6 +129,9 @@ define([
                     if (lang.exists("UserInfoEditInputResponse.lastname", response)) {
                         context.updateInput("LastName", null, response.UserInfoEditInputResponse.lastname);
                     }
+                    if (lang.exists("UserInfoEditInputResponse.employeeID", response)) {
+                        context.updateInput("EmployeeID", null, response.UserInfoEditInputResponse.employeeID);
+                    }
                 });
             }
         },


### PR DESCRIPTION
Whenever an admin adds an employee ID to a user details area and then comes back to that user the ID from the U/I has disappeared.

Signed-off by: Miguel Vazquez <miguel.vazquez@lexisnexis.com>