### PR TITLE
HPCC-16589 Add SIGPIPE handler to jexcept

### DIFF
--- a/system/jlib/jexcept.cpp
+++ b/system/jlib/jexcept.cpp
@@ -1448,7 +1448,7 @@ IError *createError(WarnErrorCategory category, ErrorSeverity severity, int errN
 
 //Generic handler to log SIGPIPE error. LDAP generates this signal on stale connections
 #ifndef _WIN32
-void logSigPipe(int sig)
+static void logSigPipe(int sig)
 {
     WARNLOG("Broken Pipe Signal %d - remote side closed the socket", sig);
 }

--- a/system/jlib/jexcept.cpp
+++ b/system/jlib/jexcept.cpp
@@ -1444,3 +1444,23 @@ IError *createError(WarnErrorCategory category, ErrorSeverity severity, int errN
     return new CError(category,severity,errNo,msg,filename,lineno,column,pos);
 }
 
+//---------------------------------------------------------------------------------------------------------------------
+
+//Generic handler to log SIGPIPE error. LDAP generates this signal on stale connections
+#ifndef _WIN32
+void logSigPipe(int sig)
+{
+    WARNLOG("Broken Pipe Signal %d - remote side closed the socket", sig);
+}
+
+int jlib_decl handleSigPipe()
+{
+    struct sigaction act;
+    sigset_t blockset;
+    sigemptyset(&blockset);
+    act.sa_mask = blockset;
+    act.sa_handler = logSigPipe;
+    act.sa_flags = 0;
+    return sigaction(SIGPIPE, &act, NULL);//0 on success, -1 on failure. Check errno on failure
+}
+#endif

--- a/system/jlib/jexcept.hpp
+++ b/system/jlib/jexcept.hpp
@@ -223,5 +223,9 @@ inline bool isFatal(IError * error) { return isFatal(error->getSeverity()); }
 
 extern jlib_decl IError *createError(WarnErrorCategory category, ErrorSeverity severity, int errNo, const char *msg, const char *filename, int lineno=0, int column=0, int pos=0);
 
+#ifndef _WIN32
+int jlib_decl handleSigPipe();
+#endif
+
 #endif
 


### PR DESCRIPTION
There are several places in the HPCC platform and LN branch that could benefit
from a shared SIGPIPE handler which simply logs the broken pipe status and
resumes with the program.  This PR introduces that new feature

Signed-off-by: Russ Whitehead <william.whitehead@lexisnexis.com>