### PR TITLE
HPCC-16585 Esp shouldn't output empty CustomBindingParameters entry

### DIFF
--- a/initfiles/componentfiles/configxml/esp.xsl
+++ b/initfiles/componentfiles/configxml/esp.xsl
@@ -511,11 +511,13 @@
                   </xsl:if>              
                </xsl:if>
 
-               <CustomBindingParameters>
-                  <xsl:for-each select="$envBindNode/CustomBindingParameter">
-                     <xsl:copy-of select="."/>
-                  </xsl:for-each>
-               </CustomBindingParameters>
+	       <xsl:if test="$envBindNode/CustomBindingParameter">
+                 <CustomBindingParameters>
+                    <xsl:for-each select="$envBindNode/CustomBindingParameter">
+                       <xsl:copy-of select="."/>
+                    </xsl:for-each>
+                 </CustomBindingParameters>
+	       </xsl:if>
 
                <!-- if the generated EspBinding/Authenticate is missing @workunitsBasedn then add it there -->
                <xsl:variable name="defaultWorkunitsBasedn">


### PR DESCRIPTION
- Esp binding with no custom binding parameters will not generate
  a custom binding parameters tag

Signed-off-by: Gleb Aronsky <gleb.aronsky@lexisnexis.com>