### PR TITLE
HPCC-16188 Physical Tabs in DESDL not changing

### DIFF
--- a/esp/src/eclwatch/DynamicESDLDetailsWidget.js
+++ b/esp/src/eclwatch/DynamicESDLDetailsWidget.js
@@ -249,6 +249,13 @@ define([
                     context.addBindingButton.set("disabled", false);
                     context.deleteBindingButton.set("disabled", true);
                 }
+            }  else {
+                domConstruct.destroy(this.id + "serviceInformation");
+                domConstruct.create("p", {});
+                context.details.setContent(context.i18n.PleaseSelectADynamicESDLService);
+                context.widget._Binding.set("disabled", true);
+                context.deleteBindingButton.set("disabled", true);
+                context.addBindingButton.set("disabled", true);
             }
 
             this.inherited(arguments);
@@ -260,7 +267,7 @@ define([
             var currSel = this.getSelectedChild();
             if (currSel.id == this.widget._Summary.id && !this.widget._Summary.__hpcc_initalized) {
                 this.widget._Summary.__hpcc_initalized = true;
-                var table = domConstruct.create("table", {});
+                var table = domConstruct.create("table", {id: this.id + "serviceInformation"});
                 if (this.params.__hpcc_parentName) {
                     for (var key in this.params) {
                         if (this.params.hasOwnProperty(key) && !(this.params[key] instanceof Object)) {

--- a/esp/src/eclwatch/DynamicESDLQueryWidget.js
+++ b/esp/src/eclwatch/DynamicESDLQueryWidget.js
@@ -93,11 +93,13 @@ define([
 
             retVal.on("dgrid-select", function (event) {
                 var selection = context.grid.getSelected();
-                if (selection.length) {
+                if (selection[0].__hpcc_parentName) {
                     lang.mixin(selection[0],{
                         Owner: context
                     });
                     context.detailsWidget.init(selection[0]);
+                } else {
+                    context.detailsWidget.init({0: context.i18n.PleaseSelectADynamicESDLService});
                 }
             });
             return retVal;


### PR DESCRIPTION
The user was having issues when selecting a parent tree element and while in the bindings tab it would not reset the display. We have overcome this by resetting selection and disabling tabs if not in anything but a child tree element.

Fixes: HPCC-16188
Fixes: HPCC-16189

Signed-off by: Miguel Vazquez <miguel.vazquez@lexisnexis.com>