### PR TITLE
HPCC-16554 Fix WsEcl seg fault when alias references missing query id

### DIFF
--- a/esp/services/ws_ecl/ws_ecl_service.cpp
+++ b/esp/services/ws_ecl/ws_ecl_service.cpp
@@ -373,7 +373,7 @@ void CWsEclBinding::getQueryNames(IPropertyTree* settree, const char *id, const 
 
     VStringBuffer xpath("Query[@id='%s']", id);
     IPropertyTree *query = settree->queryPropTree(xpath.str());
-    if (query->getPropBool("@isLibrary") || query->getPropBool("@suspended"))
+    if (!query || query->getPropBool("@isLibrary") || query->getPropBool("@suspended"))
         return;
 
     if (!qname || !*qname)


### PR DESCRIPTION
Signed-off-by: Anthony Fishbeck <anthony.fishbeck@lexisnexis.com>