### PR TITLE
HPCC-16387 Ensure stop is not called until after all rows returned

### DIFF
--- a/thorlcr/activities/aggregate/thaggregateslave.cpp
+++ b/thorlcr/activities/aggregate/thaggregateslave.cpp
@@ -40,7 +40,7 @@ protected:
         if (inputStopped)
             return;
         inputStopped = true;
-        PARENT::stop();
+        stopInput(0);
     }
     virtual void start() override
     {
@@ -157,6 +157,7 @@ public:
     virtual void stop() override
     {
         doStopInput();
+        PARENT::stop();
     }
     CATCH_NEXTROW()
     {

--- a/thorlcr/activities/firstn/thfirstnslave.cpp
+++ b/thorlcr/activities/firstn/thfirstnslave.cpp
@@ -53,8 +53,8 @@ public:
         {
             abortSoon = true;
             stopped = true;
-            PARENT::stop();
         }
+        PARENT::stop();
     }
     virtual void getMetaInfo(ThorDataLinkMetaInfo &info)
     {

--- a/thorlcr/activities/keyedjoin/thkeyedjoinslave.cpp
+++ b/thorlcr/activities/keyedjoin/thkeyedjoinslave.cpp
@@ -1749,7 +1749,7 @@ public:
         if (!inputStopped)
         {
             inputStopped = true;
-            PARENT::stop();
+            PARENT::stopInput(0);
         }
     }
     void doAbortLimit(CJoinGroup *jg)
@@ -2071,6 +2071,7 @@ public:
             }
         }
         stopInput();
+        PARENT::stop();
 #ifdef TRACE_JOINGROUPS
         ActPrintLog("groupsPendsNoted = %d", groupsPendsNoted);
         ActPrintLog("fetchReadBack = %d", fetchReadBack);
@@ -2079,7 +2080,6 @@ public:
         ActPrintLog("wroteToFetchPipe = %d", wroteToFetchPipe);
         ActPrintLog("groupsComplete = %d", groupsComplete);
 #endif
-        dataLinkStop();
     }
     const void *doDenormTransform(RtlDynamicRowBuilder &target, CJoinGroup &group)
     {

--- a/thorlcr/activities/limit/thlimitslave.cpp
+++ b/thorlcr/activities/limit/thlimitslave.cpp
@@ -38,7 +38,7 @@ protected:
         {
             stopped = true;
             sendResult(c);
-            PARENT::stop();
+            PARENT::stopInput(0);
         }
     }
 
@@ -75,6 +75,7 @@ public:
     virtual void stop() override
     {
         stopInput(getDataLinkCount());
+        PARENT::stop();
     }
     virtual bool isGrouped() const override { return queryInput(0)->isGrouped(); }
     virtual void getMetaInfo(ThorDataLinkMetaInfo &info) override

--- a/thorlcr/activities/loop/thloopslave.cpp
+++ b/thorlcr/activities/loop/thloopslave.cpp
@@ -105,7 +105,7 @@ public:
     void doStop()
     {
         sendEndLooping();
-        PARENT::stop();
+        stopInput(0);
     }
 // IThorDataLink
     virtual bool isGrouped() const override { return false; }
@@ -427,6 +427,7 @@ public:
     {
         if (nextRowFeeder)
             nextRowFeeder->stop(); // NB: This will block if this slave's loop hasn't hit eof, it will continue looping until 'finishedLooping'
+        PARENT::stop();
     }
 };
 
@@ -500,7 +501,8 @@ public:
     {
         finalResultStream.clear();
         loopResults.clear();
-        CLoopSlaveActivityBase::doStop();
+        doStop();
+        PARENT::stop();
     }
 };
 

--- a/thorlcr/activities/msort/thgroupsortslave.cpp
+++ b/thorlcr/activities/msort/thgroupsortslave.cpp
@@ -82,13 +82,13 @@ public:
     virtual void stop()
     {
         out.clear();
-        PARENT::stop();
         if (hasStarted())
         {
             CriticalBlock block(statsCs);
             mergeStats(spillStats, iLoader);
             iLoader.clear();
         }
+        PARENT::stop();
     }
     CATCH_NEXTROW()
     {

--- a/thorlcr/activities/msort/thmsortslave.cpp
+++ b/thorlcr/activities/msort/thmsortslave.cpp
@@ -119,7 +119,7 @@ public:
                 abortSoon,
                 auxrowif);
 
-            PARENT::stop();
+            PARENT::stopInput(0);
             if (abortSoon)
             {
                 ActPrintLogEx(&queryContainer(), thorlog_null, MCwarning, "MSortSlaveActivity::start aborting");
@@ -161,13 +161,12 @@ public:
             barrier->wait(false);
             ActPrintLog("SORT barrier.2 raised");
         }
-        PARENT::stop();
         if (queryInputStarted(0))
         {
             ActPrintLog("SORT waiting for merge");
             sorter->stopMerge();
         }
-        dataLinkStop();
+        PARENT::stop();
     }
     virtual void reset() override
     {

--- a/thorlcr/activities/rollup/throllupslave.cpp
+++ b/thorlcr/activities/rollup/throllupslave.cpp
@@ -156,7 +156,6 @@ class CDedupRollupBaseActivity : public CSlaveActivity, implements IStopInput
     typedef CSlaveActivity PARENT;
 
     bool rollup;
-    CriticalSection stopsect;
     Linked<IThorRowInterfaces> rowif;
 
 protected:
@@ -177,11 +176,6 @@ public:
         global = _global;
         groupOp = _groupOp;
     }
-    virtual void stopInput()
-    {
-        CriticalBlock block(stopsect);  // can be called async by distribute
-        PARENT::stop();
-    }
     virtual void setInputStream(unsigned index, CThorInput &_input, bool consumerOrdered) override
     {
         PARENT::setInputStream(index, _input, consumerOrdered);
@@ -195,10 +189,6 @@ public:
         rowif.set(queryRowInterfaces(input));
         eogNext = eos = false;
         numKept = 0;
-    }
-    virtual void stop()
-    {
-        stopInput();
     }
     virtual void getMetaInfo(ThorDataLinkMetaInfo &info)
     {
@@ -280,6 +270,11 @@ public:
     {
         if (global)
             cancelReceiveMsg(queryJobChannel().queryMyRank(), mpTag);
+    }
+// IStopInput
+    virtual void stopInput() override
+    {
+        PARENT::stopInput(0);
     }
 };
 

--- a/thorlcr/activities/topn/thtopnslave.cpp
+++ b/thorlcr/activities/topn/thtopnslave.cpp
@@ -174,14 +174,14 @@ public:
         }
         if (global || 0 == topNLimit || 0 == sortedCount)
         {
-            PARENT::stop();
+            PARENT::stopInput(0);
             if (!global || 0 == topNLimit)
                 eos = true;
         }
         return retStream.getClear();
     }
 // IThorDataLink
-    virtual void start()
+    virtual void start() override
     {
         ActivityTimer s(totalCycles, timeActivities);
         PARENT::start();
@@ -192,7 +192,7 @@ public:
         if (0 == topNLimit)
         {
             eos = true;
-            PARENT::stop();
+            PARENT::stopInput(0);
         }
         else
         {
@@ -202,7 +202,7 @@ public:
         eog = false;
     }
     virtual bool isGrouped() const override { return grouped; }
-    virtual void stop()
+    virtual void stop() override
     {
         if (out)
             out->stop();

--- a/thorlcr/graph/thgraphslave.hpp
+++ b/thorlcr/graph/thgraphslave.hpp
@@ -37,9 +37,6 @@
 #include "traceslave.hpp"
 #include "thorstrand.hpp"
 
-// #define OUTPUT_RECORDSIZE // causes the record size to be logged for each activity on the 1st call to dataLinkIncrement
-
-
 interface IStartableEngineRowStream : extends IEngineRowStream
 {
     virtual void start() = 0;
@@ -89,12 +86,15 @@ public:
     inline void dataLinkIncrement() { dataLinkIncrement(1); }
     inline void dataLinkIncrement(rowcount_t v)
     {
+#ifdef _TESTING
+        assertex(hasStarted());
 #ifdef OUTPUT_RECORDSIZE
         if (count==THORDATALINK_STARTED)
         {
             size32_t rsz = parent.queryRowMetaData(this)->getMinRecordSize();
             parent.ActPrintLog("Record size %s= %d", parent.queryRowMetaData(this)->isVariableSize()?"(min) ":"",rsz);
         }
+#endif
 #endif
         icount += v;
         count += v;


### PR DESCRIPTION
Change to hasStarted() caused selfjoin stall.
It's okay to stop input early, but stop() should not be called before all rows are returned.
    
Signed-off-by: Jake Smith <jake.smith@lexisnexis.com>
