### PR TITLE
HPCC-16604 Remove TODO from topology page

### DIFF
--- a/esp/src/eclwatch/nls/hpcc.js
+++ b/esp/src/eclwatch/nls/hpcc.js
@@ -439,6 +439,7 @@ define({root:
     PleasePickADefinition: "Please pick a definition",
     PleaseSelectAUserOrGroup: "Please select a user or a group along with a file name",
     PleaseSelectADynamicESDLService: "Please select a dynamic ESDL service",
+    PleaseSelectATopologyItem: "Please select a target, service or machine.",
     Plugins: "Plugins",
     PleaseEnterANumber: "Please enter a number 1 - ",
     Port: "Port",

--- a/esp/src/eclwatch/templates/TopologyDetailsWidget.html
+++ b/esp/src/eclwatch/templates/TopologyDetailsWidget.html
@@ -8,7 +8,7 @@
                     <div id="${id}NewPage" class="right" data-dojo-attach-event="onClick:_onNewPage" data-dojo-props="iconClass:'iconNewPage', showLabel:false" data-dojo-type="dijit.form.Button">${i18n.OpenInNewPage}</div>
                 </div>
                 <div id="${id}_Details" data-dojo-props="region: 'center'" data-dojo-type="dijit.layout.ContentPane">
-                    TODO
+                    ${i18n.PleaseSelectATopologyItem}
                 </div>
             </div>
             <div id="${id}_Configuration" title="${i18n.Configuration}" data-dojo-type="ECLSourceWidget">


### PR DESCRIPTION
By default topology page displays TODO. Adding a placeholder text until user selects one of the topology services, targets, systems.

Signed-off by: Miguel Vazquez <miguel.vazquez@lexisnexis.com>