### PR TITLE
HPCC-16610 Ensure lookup join with const RHS still stops RHS.

### DIFF
--- a/thorlcr/activities/lookupjoin/thlookupjoinslave.cpp
+++ b/thorlcr/activities/lookupjoin/thlookupjoinslave.cpp
@@ -1536,9 +1536,9 @@ public:
         {
             clearRHS();
             clearHT();
-            if (right)
-                stopInput(1, "(R)");
         }
+        if (right)
+            stopInput(1, "(R)");
         if (broadcaster)
             broadcaster->reset();
         stopInput(0, "(L)");


### PR DESCRIPTION
Signed-off-by: Jake Smith <jake.smith@lexisnexis.com>