### PR TITLE
HPCC-16179 Redundant LDAP server not used

### DIFF
--- a/system/security/LdapSecurity/ldapconnection.cpp
+++ b/system/security/LdapSecurity/ldapconnection.cpp
@@ -134,16 +134,21 @@ private:
     StringArray m_hostArray;
     Mutex       m_HMMutex;
     unsigned    m_curHostIdx;
+    bool        m_populated;
 
 public:
+    CHostManager()
+    {
+        m_populated = false;
+    }
+
     void populateHosts(const char* addrlist)
     {
-        static bool populated = false;
-        if (populated)
+        if (m_populated)
             return;
 
         synchronized block(m_HMMutex);
-        if (!populated)
+        if (!m_populated)
         {
             char *copyFullText = strdup(addrlist);
             char *saveptr;
@@ -187,7 +192,7 @@ public:
             }
 
             m_curHostIdx = 0;
-            populated = true;
+            m_populated = true;
         }
     }
 

--- a/system/security/LdapSecurity/ldapconnection.hpp
+++ b/system/security/LdapSecurity/ldapconnection.hpp
@@ -85,7 +85,11 @@ ldap_compare_ext_s LDAP_P((
     typedef struct timeval TIMEVAL;
 #endif
 
-#define LDAPTIMEOUT 60 //20 second connection/search timeout
+#ifdef _DEBUG
+	#define LDAPTIMEOUT 5
+#else
+	#define LDAPTIMEOUT 20
+#endif
 #define DEFAULT_LDAP_POOL_SIZE 10
 
 // 1 for ActiveDirectory, 2 for iPlanet, 3 for openLdap
@@ -165,6 +169,8 @@ interface ILdapConfig : extends IInterface
     virtual LdapServerType getServerType() = 0;
     virtual const char * getCfgServerType() const = 0;
     virtual StringBuffer& getLdapHost(StringBuffer& hostbuf) = 0;
+    virtual int getHostCount() = 0;
+    virtual void blacklistHost(const char * host) = 0;
     virtual void markDown(const char* ldaphost) = 0;
     virtual int getLdapPort() = 0;
     virtual int getLdapSecurePort() = 0;


### PR DESCRIPTION
The LDAP connection pool incorrectly creates connections to all LDAP servers
listed in the configuration. This is bad because a resource could be created
on one LDAP, followed by attempts to reference it on another LDAP.
The correct behavior is to use the same one, and
if it fails move on to the next one. This PR replaces the old CLoadBalancer
class with a CHostManager, which implements the correct behavior

Signed-off-by: Russ Whitehead <william.whitehead@lexisnexis.com>