### PR TITLE
HPCC-16611 Ignore SIGPIPE after ldap_bind() calls

### DIFF
--- a/system/jlib/jthread.cpp
+++ b/system/jlib/jthread.cpp
@@ -1640,20 +1640,24 @@ class CIgnoreSIGPIPE
 public:
     CIgnoreSIGPIPE()
     {
+        oact.sa_handler = SIG_IGN;
         struct sigaction act;
         sigset_t blockset;
         sigemptyset(&blockset);
         act.sa_mask = blockset;
         act.sa_handler = SIG_IGN;
         act.sa_flags = 0;
-        sigaction(SIGPIPE, &act, NULL);
+        sigaction(SIGPIPE, &act, &oact);
     }
 
     ~CIgnoreSIGPIPE()
     {
-        signal(SIGPIPE, SIG_DFL);
+        if (oact.sa_handler != SIG_IGN)
+            sigaction(SIGPIPE, &oact, NULL);
     }
 
+private:
+    struct sigaction oact;
 };
 
 #define WHITESPACE " \t\n\r"

--- a/system/security/LdapSecurity/ldaputils.hpp
+++ b/system/security/LdapSecurity/ldaputils.hpp
@@ -40,7 +40,6 @@ public:
     static LDAP* LdapInit(const char* protocol, const char* host, int port, int secure_port);
     static int LdapSimpleBind(LDAP* ld, char* userdn, char* password);
     // userdn is required for ldap_simple_bind_s, not really necessary for ldap_bind_s.
-    static int LdapBindInternal(LDAP* ld, const char* domain, const char* username, const char* password, const char* userdn, LdapServerType server_type, const char* method="kerberos");
     static int LdapBind(LDAP* ld, const char* domain, const char* username, const char* password, const char* userdn, LdapServerType server_type, const char* method="kerberos");
     static void bin2str(MemoryBuffer& from, StringBuffer& to);
     static int getServerInfo(const char* ldapserver, int ldapport, StringBuffer& domainDN, LdapServerType& stype, const char* domainname);


### PR DESCRIPTION
Updated PR with a more complete and better fix.

Signed-off-by: Mark Kelly <mark.kelly@lexisnexis.com>