### PR TITLE
HPCC-16636 Superfile locks held too long if read from child query

### DIFF
--- a/thorlcr/graph/thgraphmaster.cpp
+++ b/thorlcr/graph/thgraphmaster.cpp
@@ -235,6 +235,8 @@ void CSlaveMessageHandler::main()
                         {
                             element->reset();
                             element->doCreateActivity(parentExtractSz, parentExtract);
+                            if (element->queryActivity())
+                                element->preStart(parentExtractSz, parentExtract);
                         }
                         catch (IException *e)
                         {


### PR DESCRIPTION
If a child query reads a super file, it bypassed the mechanism
that released the super file lock and kept only the sub file
locks.

Signed-off-by: Jake Smith <jake.smith@lexisnexis.com>