### PR TITLE
HPCC-16644 Improve reporting of segfaults

### DIFF
--- a/system/jlib/jexcept.cpp
+++ b/system/jlib/jexcept.cpp
@@ -1013,7 +1013,6 @@ void excsighandler(int signum, siginfo_t *info, void *extra)
     __int64 ip = uc->uc_mcontext.gregs[REG_RIP];
     __int64 sp = uc->uc_mcontext.gregs[REG_RSP];
 #endif
-    
     excsignal = signum;
     s.appendf("SIG: %s(%d), accessing " I64X ", IP=" I64X, strsignal(signum),signum, (__int64)info->si_addr, ip);
     
@@ -1021,6 +1020,10 @@ void excsighandler(int signum, siginfo_t *info, void *extra)
     PROGLOG("Signal:    %d %s",signum,strsignal(signum));
     PROGLOG("Fault IP:  " I64X "", ip);
     PROGLOG("Accessing: " I64X "", (unsigned __int64) info->si_addr);
+#ifdef _EXECINFO_H
+    printStackReport(ip);
+#endif
+
     PROGLOG("Registers:" );
     PROGLOG("EAX:" I64X "  EBX:" I64X "  ECX:" I64X "  EDX:" I64X "  ESI:" I64X "  EDI:" I64X "",
 #ifdef __APPLE__
@@ -1060,6 +1063,10 @@ void excsighandler(int signum, siginfo_t *info, void *extra)
     PROGLOG("Signal:    %d %s",signum,strsignal(signum));
     PROGLOG("Fault IP:  %08X", ip);
     PROGLOG("Accessing: %08X", (unsigned) info->si_addr);
+#ifdef _EXECINFO_H
+    printStackReport(ip);
+#endif
+
     PROGLOG("Registers:" );
     PROGLOG("EAX:%08X  EBX:%08X  ECX:%08X  EDX:%08X  ESI:%08X  EDI:%08X",
         uc->uc_mcontext.gregs[REG_EAX], uc->uc_mcontext.gregs[REG_EBX], 
@@ -1190,9 +1197,6 @@ void excsighandler(int signum, siginfo_t *info, void *extra)
 
 #endif
 
-#ifdef _EXECINFO_H
-    printStackReport();
-#endif  
     StringBuffer threadlist;
     PROGLOG( "ThreadList:\n%s",getThreadList(threadlist).str());
     queryLogMsgManager()->flushQueue(10*1000);
@@ -1376,7 +1380,7 @@ void jlib_decl serializeException(IException * e, MemoryBuffer & out)
 }
 
 
-void printStackReport()
+void printStackReport(__int64 startIP)
 {
     if (!queryLogMsgManager())
         return;
@@ -1388,7 +1392,21 @@ void printStackReport()
     void *btarray[100];
     unsigned btn = backtrace (btarray, 100);
     char **strings = backtrace_symbols (btarray, btn);
-    for (unsigned i=0; i<btn; i++)
+    unsigned i;
+    unsigned firstReal = 0;
+    if (startIP)
+    {
+        VStringBuffer iptext("[%p]", (void *) startIP);
+        for (i=0; i<btn; i++)
+        {
+            if (strstr(strings[i], iptext) != nullptr)
+            {
+                firstReal = i;
+                break;
+            }
+        }
+    }
+    for (i=firstReal; i<btn; i++)
         DBGLOG("  %s", strings[i]);
     free (strings);
 #endif

--- a/system/jlib/jexcept.hpp
+++ b/system/jlib/jexcept.hpp
@@ -142,7 +142,7 @@ __declspec(noreturn) void jlib_decl throwUnexpectedException(const char * where,
 IException jlib_decl * deserializeException(MemoryBuffer & in); 
 void jlib_decl serializeException(IException * e, MemoryBuffer & out); 
 
-void  jlib_decl printStackReport();
+void  jlib_decl printStackReport(__int64 startIP = 0);
 // Macro for legacy name of above function
 #define PrintStackReport printStackReport
 


### PR DESCRIPTION
Skip leading lines of backtrace that serve only to confuse...

Move the backtrace higher so it's more likely that we get it (the registers
and hex dump of stack frame tend to be less interesting).

Signed-off-by: Richard Chapman <rchapman@hpccsystems.com>