### PR TITLE
HPCC-16429 Coverity: out-of-bounds-access

### DIFF
--- a/tools/esdlcomp/esdlcomp.h
+++ b/tools/esdlcomp/esdlcomp.h
@@ -892,12 +892,16 @@ public:
     {
         if (!xsdgrouptype)
         {
-            xsdgrouptype = strdup(getMetaString("xsd_group_type", "\"all\""));
-            if (*xsdgrouptype == '\"')
-                xsdgrouptype++;
-            char *finger = strchr(xsdgrouptype, '\"');
-            if (finger)
-                *finger=0;
+            const char* s = getMetaString("xsd_group_type", "\"all\"");
+            if (*s == '\"')
+            {
+                xsdgrouptype = strdup(s+1);
+                char *finger = strchr(xsdgrouptype, '\"');
+                if (finger)
+                    *finger=0;
+            }
+            else
+                xsdgrouptype = strdup(s);
         }
         return xsdgrouptype;
     }

--- a/tools/hidl/hidlcomp.h
+++ b/tools/hidl/hidlcomp.h
@@ -853,10 +853,10 @@ public:
             const char* s = getMetaString("xsd_group_type", "\"all\"");
             if (*s == '\"')
             {
-                s++;
+                s++;  // Skip leading " and (assumed) trailing "
                 size_t len = strlen(s);
-                xsdgrouptype = (char*)malloc(len);
-                strncpy(xsdgrouptype,s,len-1);
+                xsdgrouptype = (char*) malloc(len);
+                memcpy(xsdgrouptype,s,len-1);
                 xsdgrouptype[len-1]=0;
             }
             else


### PR DESCRIPTION
The one it was reporting was a false positive, but the copy in esdlcomp.h that
had been reworked (perhaps to avoid that warning?) was dangerous.

Signed-off-by: Richard Chapman <rchapman@hpccsystems.com>