### PR TITLE
HPCC-16423 Ensure subclass methods signature is correct

### DIFF
--- a/esp/services/esdl_svc_engine/esdl_svc_engine.cpp
+++ b/esp/services/esdl_svc_engine/esdl_svc_engine.cpp
@@ -19,7 +19,7 @@
 #include "esdl_svc_engine.hpp"
 #include "params2xml.hpp"
 
-void CEsdlSvcEngine::init(IPropertyTree *cfg, const char *process, const char *service)
+void CEsdlSvcEngine::init(const IPropertyTree *cfg, const char *process, const char *service)
 {
     EsdlServiceImpl::init(cfg, process, service);
 

--- a/esp/services/esdl_svc_engine/esdl_svc_engine.hpp
+++ b/esp/services/esdl_svc_engine/esdl_svc_engine.hpp
@@ -35,10 +35,10 @@ public:
 
     ~CEsdlSvcEngine();
 
-    virtual void init(IPropertyTree *cfg, const char *process, const char *service);
-    void generateTransactionId(IEspContext & context, StringBuffer & trxid);
-    virtual IPropertyTree *createTargetContext(IEspContext &context, IPropertyTree *tgtcfg, IEsdlDefService &srvdef, IEsdlDefMethod &mthdef, IPropertyTree *req_pt);
-    virtual void esdl_log(IEspContext &context, IEsdlDefService &srvdef, IEsdlDefMethod &mthdef, IPropertyTree *tgtcfg, IPropertyTree *tgtctx, IPropertyTree *req_pt, const char *xmlresp, const char *logdata, unsigned int timetaken);
+    virtual void init(const IPropertyTree *cfg, const char *process, const char *service) override;
+    void generateTransactionId(IEspContext & context, StringBuffer & trxid) override;
+    virtual IPropertyTree *createTargetContext(IEspContext &context, IPropertyTree *tgtcfg, IEsdlDefService &srvdef, IEsdlDefMethod &mthdef, IPropertyTree *req_pt) override;
+    virtual void esdl_log(IEspContext &context, IEsdlDefService &srvdef, IEsdlDefMethod &mthdef, IPropertyTree *tgtcfg, IPropertyTree *tgtctx, IPropertyTree *req_pt, const char *xmlresp, const char *logdata, unsigned int timetaken) override;
 };
 
 class CEsdlSvcEngineSoapBindingEx : public EsdlBindingImpl


### PR DESCRIPTION
Fix CEsdlSvcEngine::init's signature to ensure it overrides EsdlServiceImpl init 
Declare methods which override superclass methods

Signed-off-by: Rodrigo Pastrana <rodrigo.pastrana@lexisnexis.com>