### PR TITLE
HPCC-16671 Fix potential stall in lookupjoin in multichannel child query

### DIFF
--- a/thorlcr/activities/lookupjoin/thlookupjoinslave.cpp
+++ b/thorlcr/activities/lookupjoin/thlookupjoinslave.cpp
@@ -1455,7 +1455,6 @@ public:
         outputMeta.set(leftITDL->queryFromActivity()->queryContainer().queryHelper()->queryOutputMeta());
 
         eos = eog = someSinceEog = false;
-        atomic_set(&interChannelToNotifyCount, 0);
         currentHashEntry.index = 0;
         currentHashEntry.count = 0;
 
@@ -2671,6 +2670,7 @@ public:
                 if (gotRHS)
                 {
                     // Other channels sharing HT. So do not reset until all here
+                    // NB: See handleGlobalRHS, if any channel failed over to local, all will have been marked failed over to local.
                     if (!hasFailedOverToLocal() && queryJob().queryJobChannels()>1)
                         InterChannelBarrier();
                 }


### PR DESCRIPTION
A local lookup join activity in a child query could restart and
reset an atomic used for channel synchronization after the others
had started using it.
This would cause the synchronization mechanism to go out of a
sync and cause a stall.

Signed-off-by: Jake Smith <jake.smith@lexisnexis.com>