### PR TITLE
HPCC-16665 Roxie core dumps when PIPE activity stopped before it was started

### DIFF
--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -2069,7 +2069,8 @@ public:
             DBGLOG("RecordPullerThread::stop");
         {
             CriticalBlock c(crit); // stop is called on our consumer's thread. We need to take care calling stop for our input to make sure it is not in mid-nextRow etc etc.
-            inputStream->stop();
+            if (inputStream)
+                inputStream->stop();
         }
         RestartableThread::join();
     }


### PR DESCRIPTION

Signed-off-by: Richard Chapman <rchapman@hpccsystems.com>