### PR TITLE
HPCC-14549 RowTag required for XML Spray

### DIFF
--- a/docs/ECLStandardLibraryReference/SLR-Mods/SprayXML.xml
+++ b/docs/ECLStandardLibraryReference/SLR-Mods/SprayXML.xml
@@ -85,7 +85,7 @@
           <entry><emphasis>srcRowTag</emphasis></entry>
 
           <entry>A null-terminated string containing the row delimiting XML
-          tag.</entry>
+          tag. Required. </entry>
         </row>
 
         <row>

--- a/docs/HPCCClientTools/CT_Mods/CT_Comm_Line_DFU.xml
+++ b/docs/HPCCClientTools/CT_Mods/CT_Comm_Line_DFU.xml
@@ -478,7 +478,8 @@ replicate=1</programlisting>
                   <row>
                     <entry><programlisting role="tab">    rowtag</programlisting></entry>
 
-                    <entry>The XML tag identifying each record.</entry>
+                    <entry>The XML tag identifying each record.
+                    Required.</entry>
                   </row>
 
                   <row>
@@ -888,7 +889,7 @@ dfuplus action=dspray srcname=le::imagedb
           <title>Add Operations:</title>
 
           <para>The <emphasis role="bold">add</emphasis> operation adds a new
-          logical file to the system data store. </para>
+          logical file to the system data store.</para>
 
           <para>This also allows you to restore a superfile <indexterm>
               <primary>restore a superfile</primary>
@@ -1222,7 +1223,7 @@ dfuplus action=add srcxml=exportedMysuper.xml dstname=Mysuper
           <title>Savexml Operations:</title>
 
           <para>The <emphasis role="bold">savexml</emphasis> operation saves
-          the logical file map to an XML file. </para>
+          the logical file map to an XML file.</para>
 
           <para>This feature also allows you to export the metadata from a
           superfile and then use it later to restore a superfile. This is

--- a/docs/HPCCDataHandling/DH-Mods/DH-Mod1.xml
+++ b/docs/HPCCDataHandling/DH-Mods/DH-Mod1.xml
@@ -697,7 +697,8 @@
                   <row>
                     <entry><emphasis role="bold">Row Tag </emphasis></entry>
 
-                    <entry>The tag name of the row delimiter.</entry>
+                    <entry>The tag name of the row delimiter. Required.
+                    </entry>
                   </row>
 
                   <row>


### PR DESCRIPTION
Fix HPCC-14549 RowTag required for XML Spray
XML Spray module included in multiple books
This change will update all books referencing the XML Spray module.

Signed-off-by: G-Pan <greg.panagiotatos@lexisnexis.com>
@JamesDeFabia please review.