### PR TITLE
HPCC-16688 Add CBlas library to lib2 for APPLE

### DIFF
--- a/lib2/CMakeLists.txt
+++ b/lib2/CMakeLists.txt
@@ -26,6 +26,7 @@ if (APPLE)
     list(APPEND DYLIBS ${OPENSSL_LIBRARIES})
     list(APPEND DYLIBS ${ZLIB_LIBRARIES})
     list(APPEND DYLIBS ${LIBXML2_LIBRARIES})
+    list(APPEND DYLIBS ${CBLAS_LIBRARIES})
 elseif (WIN32)
     #TODO:  Should find these dlls not assume them.
     if (NOT USE_NATIVE_LIBRARIES)
@@ -105,6 +106,12 @@ foreach(dylib ${DYLIBS})
         string(REPLACE ".1.2.8.dylib" ".1.dylib" dylib_1_path "${dylib_path}")
         if (NOT "${dylib_1_path}" STREQUAL "${dylib_path}")
             set(fixupCommand "${fixupCommand}\r\nexecute_process(COMMAND install_name_tool -change \"${dylib_1_path}\" \"@loader_path/../lib2/${dylib_name_ext}\" \${file})")
+        endif ()
+
+        if ("${dylib_path}" MATCHES "^/usr/local/Cellar/.*$")
+            get_filename_component(dylib_dir ${dylib} DIRECTORY)
+            set(dylib_link_path "${dylib_dir}/${dylib_name_ext}")
+            set(fixupCommand "${fixupCommand}\r\nexecute_process(COMMAND install_name_tool -change \"${dylib_link_path}\" \"@loader_path/../lib2/${dylib_name_ext}\" \${file})")
         endif ()
 
         install(CODE "


### PR DESCRIPTION
Also work-around Homebrew library symbolic link and multiple library copies:
1) cmake configuration finds openblas library under /usr/local/opt/openblas/lib with generic name which is symbolic link
2) libeclblas.dylib links real openblas library under /usr/local/opt/openblas/lib/
3) cmake get_filename_component finds real openblas library under /usr/local/Cellar/openblas/

Signed-off-by: Xiaoming Wang <xiaoming.wang@lexisnexi.com> 
@Michael-Gardner please help to review
