### PR TITLE
HPCC-16618 XmlSchema xs:fractionalDigits should be xs:fractionDigits

### DIFF
--- a/common/deftype/deftype.cpp
+++ b/common/deftype/deftype.cpp
@@ -3679,7 +3679,7 @@ void XmlSchemaBuilder::getXmlTypeName(StringBuffer & xmlType, ITypeInfo & type)
             type.getECLType(typesXml);
             typesXml.append("\"><xs:restriction base=\"xs:decimal\">");
             typesXml.appendf("<xs:totalDigits value=\"%d\"/>", type.getDigits());
-            typesXml.appendf("<xs:fractionalDigits value=\"%d\" fixed=\"true\"/>", type.getPrecision());
+            typesXml.appendf("<xs:fractionDigits value=\"%d\" fixed=\"true\"/>", type.getPrecision());
             typesXml.append("</xs:restriction></xs:simpleType>").newline();
         }
         break;


### PR DESCRIPTION
Signed-off-by: Richard Chapman <rchapman@hpccsystems.com>