### PR TITLE
HPCC-16705 Returning nested dataset from embedded Python is not assuming LINKCOUNTED

### DIFF
--- a/ecl/hqlcpp/hqlttcpp.cpp
+++ b/ecl/hqlcpp/hqlttcpp.cpp
@@ -9382,9 +9382,12 @@ IHqlExpression * HqlLinkedChildRowTransformer::createTransformedBody(IHqlExpress
             }
         }
         break;
-    case no_attr:
     case no_embedbody:
-        //Don't change the type of an embed body - otherwise result it will become link counted when not expected.
+        if (expr->queryAttribute(languageAtom))
+            break;
+        //Don't change the type of an embedded C++ body - otherwise result it will become link counted when not expected.
+        // Fall into...
+    case no_attr:
         return LINK(expr);
     }
     return QuickHqlTransformer::createTransformedBody(expr);

--- a/ecl/regress/implicitlink.ecl
+++ b/ecl/regress/implicitlink.ecl
@@ -1,0 +1,33 @@
+IMPORT Python;
+
+nested := RECORD
+  integer value;
+END;
+
+parent := RECORD
+  DATASET(nested) nest;
+END;
+
+DATASET(parent) getP() := EMBED(Python)
+  return [
+          [
+           1,2,3,4
+          ],
+          [
+           5,6,7,8
+          ]
+         ]
+ENDEMBED;
+
+pcode(DATASET(parent) p) := EMBED(Python)
+  for child in p:
+   for c2 in child.nest:
+    print c2.value,
+ENDEMBED;
+
+ds := getp(); 
+//ds := DATASET([{[{1},{3}]}], parent);
+//ds;
+pcode(ds);
+
+


### PR DESCRIPTION
Child datasets within the result should preferably be LINKCOUNTED by default.
The exception for calls to embedded code is really only required for embedded
C++.

Signed-off-by: Richard Chapman <rchapman@hpccsystems.com>