### PR TITLE
HPCC-16697 Fix problem commoning conditional and unconditional expressions

### DIFF
--- a/ecl/hqlcpp/hqlttcpp.ipp
+++ b/ecl/hqlcpp/hqlttcpp.ipp
@@ -744,6 +744,7 @@ protected:
     IHqlExpression * hoist(IHqlExpression * expr, IHqlExpression * hoisted);
     IHqlExpression * transformCond(IHqlExpression * expr);
     void doAnalyseExpr(IHqlExpression * expr);
+    void doAnalyseConditionalExpr(IHqlExpression * expr, unsigned firstConditional);
 
     inline AutoScopeMigrateInfo * queryBodyExtra(IHqlExpression * expr)     { return static_cast<AutoScopeMigrateInfo *>(queryTransformExtra(expr->queryBody())); }
 
@@ -755,6 +756,7 @@ private:
     bool hasCandidate;
     bool isSequential;
     unsigned curGraph;
+    unsigned graphDepth = 0;
     HqlExprArray graphActions;
     unsigned activityDepth;
     HqlExprArray * globalTarget;


### PR DESCRIPTION
If the first use of an expression is conditional, but subsequent uses
are unconditional, then the common expression must be evaluated
unconditionally.  This includes if the graph is inside a scalar
conditional context.

Signed-off-by: Gavin Halliday <gavin.halliday@lexisnexis.com>