### PR TITLE
HPCC-16590 UDP stats reporting config option

### DIFF
--- a/initfiles/etc/DIR_NAME/environment.conf.in
+++ b/initfiles/etc/DIR_NAME/environment.conf.in
@@ -22,6 +22,8 @@ interface=*
 use_epoll=true
 # allow kernel pagecache flushing where enabled (true/false)
 allow_pgcache_flush=true
+# report UDP network stats
+udp_stats=true
 mpStart=7101
 mpEnd=7500
 mpSoMaxConn=128

--- a/initfiles/etc/DIR_NAME/environment.xml.in
+++ b/initfiles/etc/DIR_NAME/environment.xml.in
@@ -771,6 +771,7 @@
   <log>${LOG_PATH}</log>
   <logfields>TIM+DAT+MLT+MID+PID+TID+COD+QUO+PFX</logfields>
   <use_epoll>true</use_epoll>
+  <udp_stats>true</udp_stats>
   <runtime>${RUNTIME_PATH}</runtime>
   <lock>${LOCK_PATH}</lock>
   <configs>${CONFIG_DIR}</configs>

--- a/system/jlib/jdebug.cpp
+++ b/system/jlib/jdebug.cpp
@@ -57,6 +57,7 @@
  #include <mach/mach_host.h>
  #include <mach/vm_statistics.h>
 #endif
+#include "build-config.h"
 
 //===========================================================================
 #ifdef _DEBUG
@@ -2339,6 +2340,10 @@ public:
         hook.set(_hook);
         term = false;
         latestCPU = 0;
+        // UDP stats reported unless explicitly disabled
+        Owned<IProperties> conf = createProperties(CONFIG_DIR PATHSEPSTR "environment.conf", true);
+        if (conf->getPropBool("udp_stats", true))
+            traceMode |= PerfMonUDP;
 #ifdef _WIN32
         memset(&liOldIdleTime,0,sizeof(liOldIdleTime));
         memset(&liOldSystemTime,0,sizeof(liOldSystemTime));

--- a/system/jlib/jdebug.hpp
+++ b/system/jlib/jdebug.hpp
@@ -304,7 +304,7 @@ enum
 #ifdef _WIN32
     PerfMonStandard  = PerfMonProcMem
 #else
-    PerfMonStandard  = PerfMonProcMem|PerfMonExtended|PerfMonUDP
+    PerfMonStandard  = PerfMonProcMem|PerfMonExtended
 #endif
 
 };

--- a/testing/regress/environment.xml.in
+++ b/testing/regress/environment.xml.in
@@ -761,6 +761,7 @@
   <log>${LOG_PATH}</log>
   <logfields>TIM+DAT+MLT+MID+PID+TID+COD+QUO+PFX</logfields>
   <use_epoll>true</use_epoll>
+  <udp_stats>true</udp_stats>
   <runtime>${RUNTIME_PATH}</runtime>
   <lock>${LOCK_PATH}</lock>
   <configs>${CONFIG_DIR}</configs>


### PR DESCRIPTION
@jakesmith please review.  This update makes UDP stat collection and reporting a config option.  It is enabled [on] by default but can be disabled.

Signed-off-by: Mark Kelly <mark.kelly@lexisnexis.com>