### PR TITLE
HPCC-16419 Fix compiler warning

### DIFF
--- a/common/thorhelper/roxiedebug.cpp
+++ b/common/thorhelper/roxiedebug.cpp
@@ -1440,8 +1440,8 @@ void CBaseServerDebugContext::waitForDebugger(DebugState state, IActivityDebugCo
     sequence++;
 }
 
-CBaseServerDebugContext::CBaseServerDebugContext(const IContextLogger &_logctx, IPropertyTree *_queryXGMML, SafeSocket &_client) 
-    : CBaseDebugContext(_logctx), queryXGMML(_queryXGMML), client(_client)
+CBaseServerDebugContext::CBaseServerDebugContext(const IContextLogger &_logctx, IPropertyTree *_queryXGMML)
+    : CBaseDebugContext(_logctx), queryXGMML(_queryXGMML)
 {
     sequence = 0;
     previousSequence = 0;

--- a/common/thorhelper/roxiedebug.hpp
+++ b/common/thorhelper/roxiedebug.hpp
@@ -302,7 +302,6 @@ class THORHELPER_API CBaseServerDebugContext : public CBaseDebugContext, impleme
 
 protected:
     StringAttr debugId;
-    SafeSocket &client;
 
     Owned<IPropertyTree> queryXGMML;
     Semaphore debugeeSem;
@@ -321,7 +320,7 @@ protected:
     virtual void waitForDebugger(DebugState state, IActivityDebugContext *probe);
 public:
     IMPLEMENT_IINTERFACE;
-    CBaseServerDebugContext(const IContextLogger &_logctx, IPropertyTree *_queryXGMML, SafeSocket &_client) ;
+    CBaseServerDebugContext(const IContextLogger &_logctx, IPropertyTree *_queryXGMML) ;
     void serializeBreakpoints(MemoryBuffer &to);
     virtual void debugInitialize(const char *id, const char *_queryName, bool _breakAtStart);
     virtual void debugTerminate();

--- a/ecl/eclagent/eclagent.cpp
+++ b/ecl/eclagent/eclagent.cpp
@@ -432,7 +432,7 @@ IPooledThread *CHThorDebugSocketListener::createNew()
 //=======================================================================================
 
 CHThorDebugContext::CHThorDebugContext(const IContextLogger &_logctx, IPropertyTree *_queryXGMML, EclAgent *_eclAgent) 
-    : CBaseServerDebugContext(_logctx, _queryXGMML, client), eclAgent(_eclAgent)
+    : CBaseServerDebugContext(_logctx, _queryXGMML), eclAgent(_eclAgent)
 {
 }
 

--- a/roxie/ccd/ccdcontext.cpp
+++ b/roxie/ccd/ccdcontext.cpp
@@ -2476,8 +2476,8 @@ class CRoxieServerDebugContext : extends CBaseServerDebugContext
 public:
     IRoxieSlaveContext *ctx;
 
-    CRoxieServerDebugContext(IRoxieSlaveContext *_ctx, const IContextLogger &_logctx, IPropertyTree *_queryXGMML, SafeSocket &_client)
-        : CBaseServerDebugContext(_logctx, _queryXGMML, _client), ctx(_ctx)
+    CRoxieServerDebugContext(IRoxieSlaveContext *_ctx, const IContextLogger &_logctx, IPropertyTree *_queryXGMML)
+        : CBaseServerDebugContext(_logctx, _queryXGMML), ctx(_ctx)
     {
     }
 
@@ -2715,7 +2715,7 @@ protected:
     {
         if (!debugPermitted || !ownEP.port || !nativeProtocol)
             throw MakeStringException(ROXIE_ACCESS_ERROR, "Debug queries are not permitted on this system");
-        debugContext.setown(new CRoxieServerDebugContext(this, logctx, factory->cloneQueryXGMML(), *nativeProtocol->querySafeSocket()));
+        debugContext.setown(new CRoxieServerDebugContext(this, logctx, factory->cloneQueryXGMML()));
         debugContext->debugInitialize(debugUID, factory->queryQueryName(), breakAtStart);
         if (workUnit)
         {


### PR DESCRIPTION
Compiler warned that client was uninitialized at the point that it was passed
to base class constructor.

As far as I can tell it is never used, so refactored to remove it.

Signed-off-by: Richard Chapman <rchapman@hpccsystems.com>