### PR TITLE
HPCC-16667 Despray setFilePerms to older dafilesrv compatibility

### DIFF
--- a/common/remote/sockfile.cpp
+++ b/common/remote/sockfile.cpp
@@ -1756,7 +1756,18 @@ public:
         initSendBuffer(sendBuffer);
         MemoryBuffer replyBuffer;
         sendBuffer.append((RemoteFileCommandType)RFCsetfileperms).append(filename).append(fPerms);
-        sendRemoteCommand(sendBuffer, replyBuffer);
+        try
+        {
+            sendRemoteCommand(sendBuffer, replyBuffer);
+        }
+        catch (IDAFS_Exception *e)
+        {
+            if (e->errorCode() == RFSERR_InvalidCommand)
+                WARNLOG("umask setFilePermissions (0%o) not supported on remote server", fPerms);
+            else
+                throw e;
+        }
+
     }
 
     offset_t size()


### PR DESCRIPTION
@jakesmith please review.  This update allows for a despray to not fail when despraying to an older version dafilesrv that does not have the setFilePermission cmd.  Without this update the despray fails with an RFSERR_InvalidCommand:39 exception.

Signed-off-by: Mark Kelly <mark.kelly@lexisnexis.com>