### PR TITLE
HPCC-16727 HTTPCALL support for PROXYADDRESS option

### DIFF
--- a/common/thorhelper/thorsoapcall.cpp
+++ b/common/thorhelper/thorsoapcall.cpp
@@ -766,6 +766,15 @@ public:
         if (flags & SOAPFhttpheaders)
             httpHeaders.set(s.setown(helper->getHttpHeaders()));
 
+        StringAttr proxyAddress;
+        proxyAddress.set(s.setown(helper->getProxyAddress()));
+        if (!proxyAddress.isEmpty())
+        {
+            UrlListParser proxyUrlListParser(proxyAddress);
+            if (0 == proxyUrlListParser.getUrls(proxyUrlArray))
+                throw MakeStringException(0, "SOAPCALL PROXYADDRESS specified no URLs");
+        }
+
         if (wscType == STsoap)
         {
             soapaction.set(s.setown(helper->getSoapAction()));
@@ -779,15 +788,6 @@ public:
             httpHeaderValue.set(s.setown(helper->getHttpHeaderValue()));
             if(httpHeaderValue.get() && !isValidHttpValue(httpHeaderValue.get()))
                 throw MakeStringException(-1, "HTTPHEADER value contained illegal characters: %s", httpHeaderValue.get());
-
-            StringAttr proxyAddress;
-            proxyAddress.set(s.setown(helper->getProxyAddress()));
-            if (!proxyAddress.isEmpty())
-            {
-                UrlListParser proxyUrlListParser(proxyAddress);
-                if (0 == proxyUrlListParser.getUrls(proxyUrlArray))
-                    throw MakeStringException(0, "SOAPCALL PROXYADDRESS specified no URLs");
-            }
 
             if ((flags & SOAPFliteral) && (flags & SOAPFencoding))
                 throw MakeStringException(0, "SOAPCALL 'LITERAL' and 'ENCODING' options are mutually exclusive");

--- a/ecl/hqlcpp/hqlhtcpp.cpp
+++ b/ecl/hqlcpp/hqlhtcpp.cpp
@@ -17508,9 +17508,7 @@ ABoundActivity * HqlCppTranslator::doBuildActivitySOAP(BuildCtx & ctx, IHqlExpre
 
     IHqlExpression * proxyAddress = expr->queryAttribute(proxyAddressAtom);
     if (proxyAddress)
-    {
         doBuildVarStringFunction(instance->startctx, "getProxyAddress", proxyAddress->queryChild(0));
-    }
 
     IHqlExpression * namespaceAttr = expr->queryAttribute(namespaceAtom);
     IHqlExpression * responseAttr = expr->queryAttribute(responseAtom);
@@ -17666,6 +17664,10 @@ ABoundActivity * HqlCppTranslator::doBuildActivityHTTP(BuildCtx & ctx, IHqlExpre
     buildHTTPtoXml(instance->startctx);
 
     doBuildHttpHeaderStringFunction(instance->startctx, expr);
+
+    IHqlExpression * proxyAddress = expr->queryAttribute(proxyAddressAtom);
+    if (proxyAddress)
+        doBuildVarStringFunction(instance->startctx, "getProxyAddress", proxyAddress->queryChild(0));
 
     //virtual const char * queryOutputIteratorPath()
     IHqlExpression * separator = expr->queryAttribute(separatorAtom);

--- a/testing/regress/ecl/httpcall_multiheader.ecl
+++ b/testing/regress/ecl/httpcall_multiheader.ecl
@@ -16,5 +16,12 @@ string TargetURL := 'http://' + TargetIP + ':8010/WsSmc/HttpEcho?name=doe,joe&nu
 string constHeader := 'constHeaderValue';
 
 httpcallResult := HTTPCALL(TargetURL,'GET', 'text/xml', httpEchoServiceResponseRecord, xpath('Envelope/Body/HttpEchoResponse'),httpheader('literalHeader','literalValue'), httpheader('constHeader','constHeaderValue'), httpheader('storedHeader', storedHeader));
+output(httpcallResult, named('httpcallResult'));
 
-output(httpcallResult);
+//test proxyaddress functionality by using an invalid targetUrl, but a valid proxyaddress.  HTTP Host header will be wrong, but should still work fine as it's ignored by ESP.
+string hostURL := 'http://1.1.1.1:9999/WsSmc/HttpEcho?name=doe,joe&number=1';
+string targetProxy := 'http://' + TargetIP + ':8010';
+
+proxyResult := HTTPCALL(hostURL,'GET', 'text/xml', httpEchoServiceResponseRecord, xpath('Envelope/Body/HttpEchoResponse'), proxyaddress(targetProxy), httpheader('literalHeader','literalValue'), httpheader('constHeader','constHeaderValue'), httpheader('storedHeader', storedHeader));
+
+output(proxyResult, named('proxyResult'));

--- a/testing/regress/ecl/key/httpcall_multiheader.xml
+++ b/testing/regress/ecl/key/httpcall_multiheader.xml
@@ -1,3 +1,6 @@
-<Dataset name='Result 1'>
+<Dataset name='httpcallResult'>
+ <Row><Method>GET</Method><UrlPath>/WsSmc/HttpEcho</UrlPath><UrlParameters>name=doe,joe&amp;number=1</UrlParameters><Headers><Header>Accept-Encoding: gzip, deflate</Header><Header>Accept: text/xml</Header><Header>constHeader: constHeaderValue</Header><Header>literalHeader: literalValue</Header><Header>storedHeader: StoredHeaderDefault</Header></Headers><Content></Content></Row>
+</Dataset>
+<Dataset name='proxyResult'>
  <Row><Method>GET</Method><UrlPath>/WsSmc/HttpEcho</UrlPath><UrlParameters>name=doe,joe&amp;number=1</UrlParameters><Headers><Header>Accept-Encoding: gzip, deflate</Header><Header>Accept: text/xml</Header><Header>constHeader: constHeaderValue</Header><Header>literalHeader: literalValue</Header><Header>storedHeader: StoredHeaderDefault</Header></Headers><Content></Content></Row>
 </Dataset>

--- a/testing/regress/ecl/key/soapcall_multihttpheader.xml
+++ b/testing/regress/ecl/key/soapcall_multihttpheader.xml
@@ -1,4 +1,10 @@
-<Dataset name='Result 1'>
+<Dataset name='soapcallResult'>
+ <Row><Method>POST</Method><UrlPath>/WsSmc/HttpEcho</UrlPath><UrlParameters>name=doe,joe&amp;number=1</UrlParameters><Headers><Header>Accept-Encoding: gzip, deflate</Header><Header>StoredHeader: StoredHeaderDefault</Header><Header>constHeader: constHeaderValue</Header><Header>literalHeader: literalHeaderValue</Header></Headers><Content>&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;&lt;soap:Envelope xmlns:soap=&quot;http://schemas.xmlsoap.org/soap/envelope/&quot;&gt;&lt;soap:Body&gt;&lt;HttpEcho&gt;&lt;Name&gt;Doe, Joe&lt;/Name&gt;
+&lt;ADL&gt;999999&lt;/ADL&gt;
+&lt;score&gt;88.88&lt;/score&gt;
+&lt;/HttpEcho&gt;&lt;/soap:Body&gt;&lt;/soap:Envelope&gt;</Content></Row>
+</Dataset>
+<Dataset name='proxyResult'>
  <Row><Method>POST</Method><UrlPath>/WsSmc/HttpEcho</UrlPath><UrlParameters>name=doe,joe&amp;number=1</UrlParameters><Headers><Header>Accept-Encoding: gzip, deflate</Header><Header>StoredHeader: StoredHeaderDefault</Header><Header>constHeader: constHeaderValue</Header><Header>literalHeader: literalHeaderValue</Header></Headers><Content>&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;&lt;soap:Envelope xmlns:soap=&quot;http://schemas.xmlsoap.org/soap/envelope/&quot;&gt;&lt;soap:Body&gt;&lt;HttpEcho&gt;&lt;Name&gt;Doe, Joe&lt;/Name&gt;
 &lt;ADL&gt;999999&lt;/ADL&gt;
 &lt;score&gt;88.88&lt;/score&gt;

--- a/testing/regress/ecl/soapcall_multihttpheader.ecl
+++ b/testing/regress/ecl/soapcall_multihttpheader.ecl
@@ -24,4 +24,13 @@ string constHeader := 'constHeaderValue';
 
 soapcallResult := SOAPCALL(TargetURL, 'HttpEcho', httpEchoServiceRequestRecord, DATASET(httpEchoServiceResponseRecord), LITERAL, xpath('HttpEchoResponse'), httpheader('StoredHeader', storedHeader), httpheader('literalHeader', 'literalHeaderValue'), httpheader('constHeader', constHeader));
 
-output(soapcallResult);
+output(soapcallResult, named('soapcallResult'));
+
+
+//test proxyaddress functionality by using an invalid targetUrl, but a valid proxyaddress.  HTTP Host header will be wrong, but should still work fine as it's ignored by ESP.
+string HostURL := 'http://1.1.1.1:9999/WsSmc/HttpEcho?name=doe,joe&number=1';
+string TargetProxy := 'http://' + TargetIP + ':8010';
+
+proxyResult := SOAPCALL(HostURL, 'HttpEcho', httpEchoServiceRequestRecord, DATASET(httpEchoServiceResponseRecord), LITERAL, xpath('HttpEchoResponse'), proxyAddress(TargetProxy), httpheader('StoredHeader', storedHeader), httpheader('literalHeader', 'literalHeaderValue'), httpheader('constHeader', constHeader));
+
+output(proxyResult, named('proxyResult'));


### PR DESCRIPTION
HTTPCALL should support the option to set a proxy address the same
way SOAPCALL does.

Signed-off-by: Anthony Fishbeck <anthony.fishbeck@lexisnexis.com>