### PR TITLE
HPCC-16665 Roxie core dumps when PIPE activity stopped before it was started

### DIFF
--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -9292,7 +9292,8 @@ public:
         puller.stop();
         CRoxieServerActivity::stop();
         pipe.clear();
-        readTransformer->setStream(NULL);
+        if (readTransformer)
+            readTransformer->setStream(NULL);
     }
 
     virtual void reset()


### PR DESCRIPTION
Additional fix

Signed-off-by: Richard Chapman <rchapman@hpccsystems.com>