### PR TITLE
HPCC-16689 Unittests hangs up after it reports the result.

### DIFF
--- a/testing/unittests/CMakeLists.txt
+++ b/testing/unittests/CMakeLists.txt
@@ -41,6 +41,7 @@ include_directories (
          ./../../common/remote
          ./../../dali/base
          ./../../system/security/shared
+         ./../../common/deftype
     )
 
 ADD_DEFINITIONS( -D_CONSOLE )
@@ -52,6 +53,7 @@ target_link_libraries ( unittests
          jlib
          remote
          dalibase
+         deftype
          ${CPPUNIT_LIBRARIES}
     )
 

--- a/testing/unittests/unittests.cpp
+++ b/testing/unittests/unittests.cpp
@@ -20,6 +20,8 @@
 #include "jstats.h"
 #include "jregexp.hpp"
 #include "jfile.hpp"
+#include "deftype.hpp"
+#include "rmtfile.hpp"
 
 /*
  * This is the main unittest driver for HPCC. From here,
@@ -242,9 +244,12 @@ int main(int argc, char* argv[])
         }
         wasSuccessful = list || runner.run( "", false );
     }
+    releaseAtoms();
+    ClearTypeCache();   // Clear this cache before the file hooks are unloaded
+    removeFileHooks();
+
     objects.kill();
     ExitModuleObjects();
-    releaseAtoms();
     return wasSuccessful;
 }
 


### PR DESCRIPTION
Extend and re-arrange the objects destroying sequence at the end of main()

Signed-off-by: Attila Vamos <attila.vamos@gmail.com>