### PR TITLE
HPCC-16755 Release log queue lock after a queue item is read

### DIFF
--- a/esp/logging/logginglib/logthread.cpp
+++ b/esp/logging/logginglib/logthread.cpp
@@ -403,26 +403,22 @@ IEspUpdateLogRequestWrap* CLogThread::unserializeLogRequestContent(const char* l
 
 void CLogThread::writeJobQueue(IEspUpdateLogRequestWrap* jobToWrite)
 {
-	if (jobToWrite)
-	{
-		CriticalBlock b(logQueueCrit);
-		int QueueSize = logQueue.ordinality();
-		if(QueueSize > maxLogQueueLength)
-			ERRLOG("LOGGING QUEUE SIZE %d EXECEEDED MaxLogQueueLength %d, check the logging server.",QueueSize, maxLogQueueLength);
+    if (jobToWrite)
+    {
+        CriticalBlock b(logQueueCrit);
+        int QueueSize = logQueue.ordinality();
+        if(QueueSize > maxLogQueueLength)
+            ERRLOG("LOGGING QUEUE SIZE %d EXECEEDED MaxLogQueueLength %d, check the logging server.",QueueSize, maxLogQueueLength);
 
-		if(QueueSize!=0 && QueueSize % signalGrowingQueueAt == 0)
-			ERRLOG("Logging Queue at %d records. Check the logging server.",QueueSize);
+        if(QueueSize!=0 && QueueSize % signalGrowingQueueAt == 0)
+            ERRLOG("Logging Queue at %d records. Check the logging server.",QueueSize);
 
-		logQueue.enqueue(LINK(jobToWrite));
-	}
+        logQueue.enqueue(LINK(jobToWrite));
+    }
 }
 
 IEspUpdateLogRequestWrap* CLogThread::readJobQueue()
 {
-	CriticalBlock b(logQueueCrit);
-	if (logQueue.ordinality() > 0)
-	{
-		return (IEspUpdateLogRequestWrap*)logQueue.dequeue();
-	}
-	return NULL;
+    CriticalBlock b(logQueueCrit);
+    return (IEspUpdateLogRequestWrap*)logQueue.dequeue();
 }

--- a/esp/logging/logginglib/logthread.hpp
+++ b/esp/logging/logginglib/logthread.hpp
@@ -58,6 +58,8 @@ class CLogThread : public Thread , implements IUpdateLogThread
     unsigned serializeLogRequestContent(IEspUpdateLogRequestWrap* request, StringBuffer& logData);
     IEspUpdateLogRequestWrap* unserializeLogRequestContent(const char* logData);
     bool enqueue(IEspUpdateLogRequestWrap* logRequest);
+    void writeJobQueue(IEspUpdateLogRequestWrap* jobToWrite);
+    IEspUpdateLogRequestWrap* readJobQueue();
 
 public:
     IMPLEMENT_IINTERFACE;


### PR DESCRIPTION
In the existing code, after a log thread gets log queue lock, it
does not release the lock before finishing all of queued log items.
ESP logging manager may wait for a long time to add a log request
into the queue if the log thread is working on the queued items.
In this fix, the log thread releases the queue lock as soon as it
reads a queue item from the queue.

Signed-off-by: wangkx <kevin.wang@lexisnexis.com>