### PR TITLE
HPCC-16753 Modified gpg call and version check for 16.10

### DIFF
--- a/cmake_modules/commonSetup.cmake
+++ b/cmake_modules/commonSetup.cmake
@@ -172,10 +172,20 @@ IF ("${COMMONSETUP_DONE}" STREQUAL "")
       if(DEFINED SIGN_MODULES_KEYID)
         set(GPG_DEFAULT_KEY_OPTION --default-key)
       endif()
+      execute_process(COMMAND bash "-c" "gpg --version | awk 'NR==1{print $3}'"
+        OUTPUT_VARIABLE GPG_VERSION
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET)
+    if(${GPG_VERSION} VERSION_GREATER "2.1")
+          set(GPG_PINENTRY_MODE --pinentry-mode loopback --batch --no-tty)
+      else()
+          set(GPG_PINENTRY_MODE --batch --no-tty)
+      endif()
       execute_process(
           COMMAND rm -f sm_keycheck.tmp sm_keycheck.asc
           COMMAND touch sm_keycheck.tmp
-          COMMAND gpg --output sm_keycheck.asc ${GPG_DEFAULT_KEY_OPTION} ${SIGN_MODULES_KEYID}  --clearsign ${GPG_PASSPHRASE_OPTION} ${SIGN_MODULES_PASSPHRASE} --batch --no-tty sm_keycheck.tmp
+          COMMAND gpg --clearsign ${GPG_PINENTRY_MODE} ${GPG_DEFAULT_KEY_OPTION} ${SIGN_MODULES_KEYID} ${GPG_PASSPHRASE_OPTION} ${SIGN_MODULES_PASSPHRASE} --output sm_keycheck.asc sm_keycheck.tmp
+          TIMOUT 120
           WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
           RESULT_VARIABLE rc_var
           ERROR_VARIABLE err_var


### PR DESCRIPTION
@xwang2713 Please check this against 16.10 and another random distro we support.  I had to restart the gpg-agent on our 16.10 openstack build machine in order to properly load the secret portion of the key.  

Signed-off-by: Michael Gardner <michael.gardner@lexisnexis.com>