### PR TITLE
HPCC-16619 Ensure no_select in out of line functions are normalized

### DIFF
--- a/ecl/hqlcpp/hqlttcpp.ipp
+++ b/ecl/hqlcpp/hqlttcpp.ipp
@@ -1065,6 +1065,7 @@ protected:
 
     IHqlExpression * transformAmbiguous(IHqlExpression * expr, bool isActiveOk);
     IHqlExpression * transformAmbiguousChildren(IHqlExpression * expr);
+    IHqlExpression * transformCall(IHqlExpression * expr);
     IHqlExpression * transformNewDataset(IHqlExpression * expr, bool isActiveOk);
     IHqlExpression * transformRelated(IHqlExpression * expr);
     IHqlExpression * transformSelectorsAttr(IHqlExpression * expr);


### PR DESCRIPTION
Signed-off-by: Gavin Halliday <gavin.halliday@lexisnexis.com>