### PR TITLE
HPCC-16771 Unable to add user to LDAP group

### DIFF
--- a/esp/src/eclwatch/ws_access.js
+++ b/esp/src/eclwatch/ws_access.js
@@ -106,7 +106,7 @@ define([
             var retVal = this.inherited(arguments);
             self.UserGroupEdit({
                 request: {
-                    username: object.__hpcc_username,
+                    username: this.username,
                     action: object.isMember ? "add" : "delete",
                     groupnames_i1: object.name
                 }


### PR DESCRIPTION
When an admin tries to add a user to a group, i get the error "username can't be empty". Confirmed username is empty in the request

Signed-off by: Miguel Vazquez <miguel.vazquez@lexisnexis.com>