### PR TITLE
HPCC-16761 Remove extra critset for ESP Logging queue

### DIFF
--- a/esp/logging/logginglib/logthread.hpp
+++ b/esp/logging/logginglib/logthread.hpp
@@ -47,7 +47,7 @@ class CLogThread : public Thread , implements IUpdateLogThread
 
     Owned<IEspLogAgent> logAgent;
     LOGServiceType services[MAXLOGSERVICES];
-    SafeQueueOf<IInterface, false> logQueue;
+    QueueOf<IInterface, false> logQueue;
     CriticalSection logQueueCrit;
     Semaphore       m_sem;
 


### PR DESCRIPTION
Multi-thread guards are implemented at the log thread level tp
protect job queue from enqueue, dequeue, and backup logSafe file.
So, we do not need to the extra critset from SafeQueueOf. This
will improve performance.

Signed-off-by: wangkx <kevin.wang@lexisnexis.com>