### PR TITLE
HPCC-16731 Set MALLOC_ARENA_MAX for better glibc malloc performance

### DIFF
--- a/version.cmake
+++ b/version.cmake
@@ -4,7 +4,7 @@
 set ( HPCC_PROJECT "community" )
 set ( HPCC_MAJOR 6 )
 set ( HPCC_MINOR 0 )
-set ( HPCC_POINT 10 )
-set ( HPCC_MATURITY "release" )
-set ( HPCC_SEQUENCE 1 )
+set ( HPCC_POINT 11 )
+set ( HPCC_MATURITY "closedown" )
+set ( HPCC_SEQUENCE 0 )
 ###


### PR DESCRIPTION
@jakesmith please review.

NOTE: We could look into adding a setting to the environment.conf for this, if you wanted to make this more configurable.

Signed-off-by: Mark Kelly <mark.kelly@lexisnexis.com>