### PR TITLE
HPCC-16787 Add ESP Logging timing to TxSummary, etc

### DIFF
--- a/esp/logging/loggingagent/espserverloggingagent/loggingagent.cpp
+++ b/esp/logging/loggingagent/espserverloggingagent/loggingagent.cpp
@@ -495,7 +495,7 @@ void CESPServerLoggingAgent::filterLogContent(IEspUpdateLogRequestWrap* req)
 
     StringBuffer updateLogRequestXML;
     toXML(updateLogRequestTree, updateLogRequestXML);
-    DBGLOG("filtered content and option: <%s>", updateLogRequestXML.str());
+    ESPLOG(LogMax, "filtered content and option: <%s>", updateLogRequestXML.str());
     req->clearOriginalContent();
     req->setUpdateLogRequest(updateLogRequestXML.str());
 }

--- a/esp/logging/logginglib/loggingagentbase.cpp
+++ b/esp/logging/logginglib/loggingagentbase.cpp
@@ -91,6 +91,7 @@ bool CDBLogAgentBase::getTransactionSeed(IEspGetTransactionSeedRequest& req, IEs
 
 bool CDBLogAgentBase::updateLog(IEspUpdateLogRequestWrap& req, IEspUpdateLogResponse& resp)
 {
+    unsigned startTime = (getEspLogLevel()>=LogNormal) ? msTick() : 0;
     bool ret = false;
     try
     {
@@ -119,11 +120,15 @@ bool CDBLogAgentBase::updateLog(IEspUpdateLogRequestWrap& req, IEspUpdateLogResp
             StringBuffer updateDBStatement;
             if(!buildUpdateLogStatement(logRequestTree, logDB.str(), table, logID, updateDBStatement))
                 throw MakeStringException(EspLoggingErrors::UpdateLogFailed, "Failed in creating SQL statement.");
+            if (getEspLogLevel()>=LogNormal)
+                DBGLOG("LAgent UpdateLog BuildStat %d done: %dms\n", i, msTick() -  startTime);
 
             if (getEspLogLevel() >= LogMax)
                 DBGLOG("UpdateLog: %s\n", updateDBStatement.str());
 
             executeUpdateLogStatement(updateDBStatement);
+            if (getEspLogLevel()>=LogNormal)
+                DBGLOG("LAgent UpdateLog ExecStat %d done: %dms\n", i, msTick() -  startTime);
         }
         resp.setStatusCode(0);
         ret = true;
@@ -137,6 +142,8 @@ bool CDBLogAgentBase::updateLog(IEspUpdateLogRequestWrap& req, IEspUpdateLogResp
         resp.setStatusCode(-1);
         resp.setStatusMessage(errorMessage.str());
     }
+    if (getEspLogLevel()>=LogNormal)
+        DBGLOG("LAgent UpdateLog total=%dms\n", msTick() -  startTime);
     return ret;
 }
 

--- a/esp/logging/logginglib/loggingagentbase.cpp
+++ b/esp/logging/logginglib/loggingagentbase.cpp
@@ -120,15 +120,12 @@ bool CDBLogAgentBase::updateLog(IEspUpdateLogRequestWrap& req, IEspUpdateLogResp
             StringBuffer updateDBStatement;
             if(!buildUpdateLogStatement(logRequestTree, logDB.str(), table, logID, updateDBStatement))
                 throw MakeStringException(EspLoggingErrors::UpdateLogFailed, "Failed in creating SQL statement.");
-            if (getEspLogLevel()>=LogNormal)
-                DBGLOG("LAgent UpdateLog BuildStat %d done: %dms\n", i, msTick() -  startTime);
 
-            if (getEspLogLevel() >= LogMax)
-                DBGLOG("UpdateLog: %s\n", updateDBStatement.str());
+            ESPLOG(LogNormal, "LAgent UpdateLog BuildStat %d done: %dms\n", i, msTick() -  startTime);
+            ESPLOG(LogMax, "UpdateLog: %s\n", updateDBStatement.str());
 
             executeUpdateLogStatement(updateDBStatement);
-            if (getEspLogLevel()>=LogNormal)
-                DBGLOG("LAgent UpdateLog ExecStat %d done: %dms\n", i, msTick() -  startTime);
+            ESPLOG(LogNormal, "LAgent UpdateLog ExecStat %d done: %dms\n", i, msTick() -  startTime);
         }
         resp.setStatusCode(0);
         ret = true;
@@ -142,8 +139,7 @@ bool CDBLogAgentBase::updateLog(IEspUpdateLogRequestWrap& req, IEspUpdateLogResp
         resp.setStatusCode(-1);
         resp.setStatusMessage(errorMessage.str());
     }
-    if (getEspLogLevel()>=LogNormal)
-        DBGLOG("LAgent UpdateLog total=%dms\n", msTick() -  startTime);
+    ESPLOG(LogNormal, "LAgent UpdateLog total=%dms\n", msTick() -  startTime);
     return ret;
 }
 

--- a/esp/logging/logginglib/logthread.hpp
+++ b/esp/logging/logginglib/logthread.hpp
@@ -51,7 +51,7 @@ class CLogThread : public Thread , implements IUpdateLogThread
     CriticalSection logQueueCrit;
     Semaphore       m_sem;
 
-    bool failSafeLogging;
+    bool ensureFailSafe;
     Owned<ILogFailSafe> logFailSafe;
     struct tm         m_startTime;
 

--- a/esp/logging/loggingmanager/loggingmanager.h
+++ b/esp/logging/loggingmanager/loggingmanager.h
@@ -28,10 +28,10 @@
 interface ILoggingManager : implements IInterface
 {
     virtual bool init(IPropertyTree* loggingConfig, const char* service) = 0;
-    virtual bool updateLog(const char* option, const char* logContent, StringBuffer& status) = 0;
+    virtual bool updateLog(IEspContext& espContext, const char* option, const char* logContent, StringBuffer& status) = 0;
     virtual bool updateLog(const char* option, IEspContext& espContext, IPropertyTree* userContext, IPropertyTree* userRequest,
         const char* backEndResp, const char* userResp, const char* logDatasets, StringBuffer& status) = 0;
-    virtual bool updateLog(IEspUpdateLogRequestWrap& req, IEspUpdateLogResponse& resp) = 0;
+    virtual bool updateLog(IEspContext& espContext, IEspUpdateLogRequestWrap& req, IEspUpdateLogResponse& resp) = 0;
     virtual bool getTransactionSeed(StringBuffer& transactionSeed, StringBuffer& status) = 0;
     virtual bool getTransactionSeed(IEspGetTransactionSeedRequest& req, IEspGetTransactionSeedResponse& resp) = 0;
     virtual bool getTransactionID(StringAttrMapping* transFields, StringBuffer& transactionID, StringBuffer& status) = 0;

--- a/esp/logging/loggingmanager/loggingmanager.hpp
+++ b/esp/logging/loggingmanager/loggingmanager.hpp
@@ -43,7 +43,7 @@ class CLoggingManager : implements ILoggingManager, public CInterface
     bool initialized;
 
     IEspLogAgent* loadLoggingAgent(const char* name, const char* dll, const char* type, IPropertyTree* cfg);
-    bool updateLog(IEspUpdateLogRequestWrap& req, IEspUpdateLogResponse& resp, StringBuffer& status);
+    bool updateLog(IEspContext& espContext, IEspUpdateLogRequestWrap& req, IEspUpdateLogResponse& resp, StringBuffer& status);
 
 public:
     IMPLEMENT_IINTERFACE;
@@ -55,8 +55,8 @@ public:
 
     virtual bool updateLog(const char* option, IEspContext& espContext, IPropertyTree* userContext, IPropertyTree* userRequest,
         const char* backEndResp, const char* userResp, const char* logDatasets, StringBuffer& status);
-    virtual bool updateLog(const char* option, const char* logContent, StringBuffer& status);
-    virtual bool updateLog(IEspUpdateLogRequestWrap& req, IEspUpdateLogResponse& resp);
+    virtual bool updateLog(IEspContext& espContext, const char* option, const char* logContent, StringBuffer& status);
+    virtual bool updateLog(IEspContext& espContext, IEspUpdateLogRequestWrap& req, IEspUpdateLogResponse& resp);
     virtual bool getTransactionSeed(StringBuffer& transactionSeed, StringBuffer& status);
     virtual bool getTransactionSeed(IEspGetTransactionSeedRequest& req, IEspGetTransactionSeedResponse& resp);
     virtual bool getTransactionID(StringAttrMapping* transFields, StringBuffer& transactionID, StringBuffer& status);

--- a/esp/logging/test/logging_test.cpp
+++ b/esp/logging/test/logging_test.cpp
@@ -151,7 +151,13 @@ void sendRequest()
         toXML(logContentTree, logContentXML);
         printf("log content: <%s>.\n", logContentXML.str());
         //Sleep(5000); //Waiting for loggingManager to start
-        loggingManager->updateLog(option.str(), logContentXML.str(), status);
+        Owned<IEspContext> espContext =  createEspContext();
+        const char* userName = logContentTree->queryProp("ESPContext/UserName");
+        const char* sourceIP = logContentTree->queryProp("ESPContext/SourceIP");
+        short servPort = logContentTree->getPropInt("ESPContext/Port");
+        espContext->setUserID(userName);
+        espContext->setServAddress(sourceIP, servPort);
+        loggingManager->updateLog(*espContext, option.str(), logContentXML.str(), status);
     }
     else
         printf("Invalid action.\n");

--- a/esp/logging/test/logging_test.cpp
+++ b/esp/logging/test/logging_test.cpp
@@ -136,7 +136,7 @@ void sendRequest()
         printf("userRespXML: <%s>.\n", userRespXML.str());
         printf("backEndResp: <%s>.\n", backEndResp);
 
-        //Sleep(5000); //Waiting for loggingManager to start
+        Sleep(5000); //Waiting for loggingManager to start
         loggingManager->updateLog(option.str(), *espContext, userContextTree, userRequestTree, backEndResp, userRespXML.str(), logDatasetsXML.str(), status);
     }
     else if (action.length() && strieq(action.str(), "UpdateLog1"))

--- a/esp/platform/espcontext.cpp
+++ b/esp/platform/espcontext.cpp
@@ -466,9 +466,6 @@ public:
     {
         if (m_txSummary)
         {
-            if (!m_hasException && (getEspLogLevel() <= LogNormal))
-                m_txSummary->clear();
-
             updateTraceSummaryHeader();
             m_txSummary->append("total", m_processingTime, "ms");
         }

--- a/esp/services/ws_loggingservice/loggingservice.cpp
+++ b/esp/services/ws_loggingservice/loggingservice.cpp
@@ -85,6 +85,7 @@ bool CWsLoggingServiceEx::onUpdateLog(IEspContext& context, IEspUpdateLogRequest
         if (!context.validateFeatureAccess(WSLOGGING_ACCESS, SecAccess_Write, false))
             throw MakeStringException(EspLoggingErrors::WSLoggingAccessDenied, "Failed to update log. Permission denied.");
 
+        context.addTraceSummaryTimeStamp("startQLog");
         for (unsigned int x = 0; x < loggingAgentThreads.size(); x++)
         {
             IUpdateLogThread* loggingThread = loggingAgentThreads[x];
@@ -92,6 +93,7 @@ bool CWsLoggingServiceEx::onUpdateLog(IEspContext& context, IEspUpdateLogRequest
                 continue;
             loggingThread->queueLog(&req);
         }
+        context.addTraceSummaryTimeStamp("endQLog");
         resp.setStatusCode(0);
         resp.setStatusMessage("Log will be updated.");
     }


### PR DESCRIPTION
Add ESP Logging timing to TxSummary. And:
1. In ESP Logging, log more details when loglevel >= 5.
2. The existing code does not log several TxSummary items when loglevel
<= 5. The code is changed to always log those TxSummary items.
3. Only log filtered log content when loglevel >= LogMax.

Signed-off-by: wangkx <kevin.wang@lexisnexis.com>