### PR TITLE
HPCC-16800 Add "extern 'C'" to fix couchbaseembed load fails

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -40,7 +40,7 @@
 [submodule "plugins/couchbase/libcouchbase-cxx"]
 	path = plugins/couchbase/libcouchbase-cxx
 	url = https://github.com/hpcc-systems/libcouchbase-cxx.git
-[submodule "libcouchbase"]
+[submodule "plugins/couchbase/libcouchbase"]
 	path = plugins/couchbase/libcouchbase
 	url = https://github.com/hpcc-systems/libcouchbase.git
 [submodule "plugins/redis/hiredis"]

--- a/plugins/couchbase/couchbaseembed.cpp
+++ b/plugins/couchbase/couchbaseembed.cpp
@@ -39,7 +39,7 @@ static const char *g_version = "Couchbase Embed Helper 1.0.0";
 static const char *g_compatibleVersions[] = { g_version, nullptr };
 static const NullFieldProcessor NULLFIELD(NULL);
 
-COUCHBASEEMBED_PLUGIN_API bool getECLPluginDefinition(ECLPluginDefinitionBlock *pb)
+extern "C" COUCHBASEEMBED_PLUGIN_API bool getECLPluginDefinition(ECLPluginDefinitionBlock *pb)
 {
     if (pb->size == sizeof(ECLPluginDefinitionBlockEx))
     {


### PR DESCRIPTION
1. update module libcouchbase entry to plugins/couchbase/libcouchbase. Without above git fetch submodule libcouchbase will fail on latest Jenkins 2.8
1. Add extern "C" to keep getECLPluginDefinition function name unmangled so dlsym can find it in Unix

Signed-off-by: Xiaoming Wang <xiaoming.wang@lexisnexi.com> 

@Michael-Gardner please review