### PR TITLE
HPCC-16808 PluggableSecMgr should handle null ISecManager

### DIFF
--- a/esp/bindings/http/platform/httpbinding.cpp
+++ b/esp/bindings/http/platform/httpbinding.cpp
@@ -197,6 +197,10 @@ EspHttpBinding::EspHttpBinding(IPropertyTree* tree, const char *bindname, const 
                 {
                     //This is a Pluggable Security Manager
                     m_secmgr.setown(SecLoader::loadPluggableSecManager(bindname, bnd_cfg, secMgrCfg));
+                    if (!m_secmgr.get())
+                    {
+                        throw MakeStringException(-1, "Error loading Pluggable Security Manager : '%s'", m_authmethod.str());
+                    }
                     m_authmap.setown(m_secmgr->createAuthMap(authcfg));
                 }
                 else


### PR DESCRIPTION
…r return values

Normally a pluggable security manager that fails to initialize should throw an
exception with context to help the admin.  But if it happens to return NULL instead,
we dereference that pointer and a segfault occurs. This PR checks for NULL
and throws a more meaningful messagein that case

Signed-off-by: Russ Whitehead <william.whitehead@lexisnexis.com>