### PR TITLE
HPCC-16814 move icui18n ahead of cuuc and icudata

### DIFF
--- a/cmake_modules/FindICU.cmake
+++ b/cmake_modules/FindICU.cmake
@@ -63,7 +63,9 @@ IF (NOT ICU_FOUND)
     ELSE()
       STRING(REPLACE "icuuc" "icuin" ICU_EXTRA1 "${ICU_LIBRARIES}")
     ENDIF()
-    set (ICU_LIBRARIES ${ICU_LIBRARIES} ${ICU_EXTRA1} ${ICU_EXTRA2} )
+    # The order is important for lib2 processing:
+    # depender, such as icuil8n, should be placed before the dependee
+    set (ICU_LIBRARIES ${ICU_EXTRA1} ${ICU_LIBRARIES} ${ICU_EXTRA2} )
   ENDIF()
 
 


### PR DESCRIPTION
This is probably a legacy issue which relates to libraries install order and dependent library name change order, i.e when scanning which libraries depend on cuuc the icui18n should be installed already, otherwise icui18n will have incorrect cuuc lib path.
For lib2/CMakeLists.txt to process correctly ICU_LIBRARIES should have following order: icui18n, cuuc and icudata defined in FindICU.cmake


Signed-off-by: Xiaoming Wang <xiaoming.wang@lexisnexi.com> 

@Michael-Gardner please help to review
