### PR TITLE
HPCC-16808 SecLoader to better handle pluggable secmgr errors

### DIFF
--- a/system/security/shared/secloader.hpp
+++ b/system/security/shared/secloader.hpp
@@ -67,7 +67,10 @@ public:
 
         //Call ISecManager instance factory and return the new instance
         DBGLOG("Calling '%s' in pluggable security manager '%s'", instFactory.str(), libName.str());
-        return xproc(bindingName, *secMgrCfg, *bindingCfg);
+        ISecManager* pPSM = xproc(bindingName, *secMgrCfg, *bindingCfg);
+        if (pPSM == nullptr)
+            throw MakeStringException(-1, "%s Security Manager %s failed to instantiate in call to %s", lsm, libName.str(), instFactory.str());
+        return pPSM;
     }
 
     static ISecManager* loadSecManager(const char* model_name, const char* servicename, IPropertyTree* cfg)


### PR DESCRIPTION
If a pluggable security manager factory method fails to instantiate, the current
security loader dereferences the NULL pointer and segfaults. Although its not
normal for a ctor to fail, we should handle this case more elegantly by throwing
a meaningful exception.

Signed-off-by: Russ Whitehead <william.whitehead@lexisnexis.com>