### PR TITLE
HPCC-16833 Regression suite mode to fail on row leaks and missing stops

### DIFF
--- a/common/thorhelper/roxiehelper.cpp
+++ b/common/thorhelper/roxiehelper.cpp
@@ -81,11 +81,9 @@ void CRHRollingCacheElem::set(const void *_row)
 //CRHRollingCache copied/modified from THOR CRollingCache
 CRHRollingCache::~CRHRollingCache()
 {
-    loop 
+    while (cache.ordinality())
     {  
         CRHRollingCacheElem *e = cache.dequeue();  
-        if (!e)  
-            break;  
         delete e;  
     }  
 }

--- a/roxie/ccd/ccdcontext.cpp
+++ b/roxie/ccd/ccdcontext.cpp
@@ -2979,6 +2979,8 @@ public:
                 graph.clear();
                 childGraphs.kill();
                 probeManager.clear();
+                ::Release(deserializedResultStore);
+                deserializedResultStore = nullptr;
                 if (rowManager && rowManager->allocated())
                 {
                     rowManager->reportLeaks();

--- a/roxie/ccd/ccdquery.cpp
+++ b/roxie/ccd/ccdquery.cpp
@@ -302,6 +302,7 @@ QueryOptions::QueryOptions()
     traceEnabled = defaultTraceEnabled;
     traceLimit = defaultTraceLimit;
     allSortsMaySpill = false; // No global default for this
+    failOnLeaks = false;
 }
 
 QueryOptions::QueryOptions(const QueryOptions &other)
@@ -332,6 +333,7 @@ QueryOptions::QueryOptions(const QueryOptions &other)
     traceEnabled = other.traceEnabled;
     traceLimit = other.traceLimit;
     allSortsMaySpill = other.allSortsMaySpill;
+    failOnLeaks = other.failOnLeaks;
 }
 
 void QueryOptions::setFromWorkUnit(IConstWorkUnit &wu, const IPropertyTree *stateInfo)
@@ -372,6 +374,7 @@ void QueryOptions::setFromWorkUnit(IConstWorkUnit &wu, const IPropertyTree *stat
     updateFromWorkUnit(traceEnabled, wu, "traceEnabled");
     updateFromWorkUnit(traceLimit, wu, "traceLimit");
     updateFromWorkUnit(allSortsMaySpill, wu, "allSortsMaySpill");
+    updateFromWorkUnit(failOnLeaks, wu, "failOnLeaks");
 }
 
 void QueryOptions::updateFromWorkUnitM(memsize_t &value, IConstWorkUnit &wu, const char *name)
@@ -422,6 +425,7 @@ void QueryOptions::setFromContext(const IPropertyTree *ctx)
         updateFromContext(traceEnabled, ctx, "@traceEnabled", "_TraceEnabled");
         updateFromContext(traceLimit, ctx, "@traceLimit", "_TraceLimit");
         // Note: allSortsMaySpill is not permitted at context level (too late anyway, unless I refactored)
+        updateFromContext(failOnLeaks, ctx, "@failOnLeaks", "_FailOnLeaks");
     }
 }
 

--- a/roxie/ccd/ccdquery.hpp
+++ b/roxie/ccd/ccdquery.hpp
@@ -123,6 +123,7 @@ public:
     bool timeActivities;
     bool allSortsMaySpill;
     bool traceEnabled;
+    bool failOnLeaks;
 
 private:
     static const char *findProp(const IPropertyTree *ctx, const char *name1, const char *name2);

--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -1365,6 +1365,8 @@ public:
             {
                 if (state==STATEstarted || state==STATEstarting)
                 {
+                    if (ctx->queryOptions().failOnLeaks)
+                        throw makeStringExceptionV(ROXIE_INTERNAL_ERROR, "STATE: activity %d reset without stop", activityId);
                     if (traceStartStop || traceLevel > 2)
                         CTXLOG("STATE: activity %d reset without stop", activityId);
                     stop();

--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -8297,6 +8297,7 @@ public:
         calculated = false;
         processedAny = false;
         anyThisGroup = false;
+        ReleaseRoxieRows(sorted);
         CRoxieServerActivity::reset();
     }
 
@@ -8427,7 +8428,7 @@ public:
             curQuantile++;
             if (curQuantile > numDivisions)
             {
-                sorted.kill();
+                ReleaseRoxieRows(sorted);
                 sorter->reset();
                 calculated = false; // ready for next group
             }

--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -16164,14 +16164,6 @@ public:
     {
     }
 
-    virtual void stop()
-    {
-        ForEachItemIn(i2, selectedStreams)
-            selectedStreams.item(i2)->stop();
-
-        CRoxieServerMultiInputBaseActivity::stop();
-    }
-
     virtual unsigned __int64 queryLocalCycles() const
     {
         __int64 localCycles = totalCycles.totalCycles;
@@ -16285,14 +16277,11 @@ public:
                 selectedJunctions.append(junctionArray[nextIndex-1]);
             }
         }
-
         // NB: Whatever pulls this nwayinput activity, starts and stops the selectedInputs and selectedJunctions
+        // But the N-Way input itself is now done with processing, and can stop itself/dependencies.
+        stop();
     }
 
-    virtual void stop()
-    {
-        // NB: Whatever pulls this nwayinput activity, starts and stops the selectedInputs
-    }
 };
 
 class CRoxieServerNWayInputActivityFactory : public CRoxieServerMultiInputFactory
@@ -16364,6 +16353,8 @@ public:
                 selectedJunctions.append(resultJunctions[i]);
             }
         }
+        // I have done with my processing - note that this won't stop my inputs
+        stop();
     }
 
     virtual void reset()    


### PR DESCRIPTION
Designed for use from regression suite, option to treat row leaks as fatal, to
try to make sure they are not accidentally introduced.

Signed-off-by: Richard Chapman <rchapman@hpccsystems.com>