### PR TITLE
HPCC-16858 Detect compressed files when reattaching XREF files.

### DIFF
--- a/system/jlib/jlzw.hpp
+++ b/system/jlib/jlzw.hpp
@@ -110,6 +110,8 @@ interface ICompressedFileIO: extends IFileIO
     virtual unsigned method()=0;
 };
 
+extern jlib_decl bool isCompressedFile(const char *filename);
+extern jlib_decl bool isCompressedFile(IFile *file);
 extern jlib_decl ICompressedFileIO *createCompressedFileReader(IFile *file,IExpander *expander=NULL, bool memorymapped=false, IFEflags extraFlags=IFEnone);
 extern jlib_decl ICompressedFileIO *createCompressedFileReader(IFileIO *fileio,IExpander *expander=NULL);
 extern jlib_decl ICompressedFileIO *createCompressedFileWriter(IFile *file,size32_t recordsize,bool append=false,bool setcrc=true,ICompressor *compressor=NULL, unsigned compMethod=COMPRESS_METHOD_LZW, IFEflags extraFlags=IFEnone);


### PR DESCRIPTION
Check physical files, test to see if compressed so as to mark
the meta data correctly, also add size or compressedSize
dependent on whether compressed or not.

Signed-off-by: Jake Smith <jake.smith@lexisnexisrisk.com>