### PR TITLE
HPCC-16646 Eclagent does not record new log files on date rollover

### DIFF
--- a/ecl/eclagent/eclagent.cpp
+++ b/ecl/eclagent/eclagent.cpp
@@ -1910,6 +1910,8 @@ void EclAgent::doProcess()
     bool deleteJobTemps = true;
     try
     {
+        updateWULogfile();//Update workunit logfile name in case of date rollover
+
         WorkunitUpdate w = updateWorkUnit();
 
         addTimeStamp(w, SSTglobal, NULL, StWhenQueryFinished);


### PR DESCRIPTION
There are certain code paths where an ECLAgent workunit that spans execution
to the next day does not record the newer logfile in the workunit helpers
section. This PR ensures it does

Signed-off-by: Russ Whitehead <william.whitehead@lexisnexis.com>