### PR TITLE
HPCC-16829 Valgrind reporting invalid memory access in roxie

### DIFF
--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -2703,7 +2703,7 @@ public:
 
     virtual void stopSink(unsigned outputIdx)
     {
-        if (!stopped[outputIdx])
+        if (outputIdx < numOutputs && !stopped[outputIdx])  // Implicit dependencies on DiskWrite activities do not count as outputs
         {
             stopped[outputIdx] = true;
             for (unsigned s = 0; s < numOutputs; s++)


### PR DESCRIPTION
Signed-off-by: Richard Chapman <rchapman@hpccsystems.com>