### PR TITLE
HPCC-16898 WuidRead inside child query provided wrong meta info.

### DIFF
--- a/thorlcr/activities/wuidread/thwuidreadslave.cpp
+++ b/thorlcr/activities/wuidread/thwuidreadslave.cpp
@@ -101,7 +101,7 @@ public:
     {
         initMetaInfo(info);
         info.isSource = true;
-        if (firstNode())
+        if (container.queryLocal() || firstNode())
             info.unknownRowsOutput = true;
         else
         {


### PR DESCRIPTION
If a wuidread activity was used inside a child query, it
incorrectly returned the wrong meta count on slaves > 1.
In a global wuid read activity, all rows are output on slave 1
only. When a wuid read activity is used in a child query, all
slaves see the result.
The incorrect meta row count was seen and checked by a lookup/all
join inside a childquery and therefore hit an assert when it
mismatched the actual count.

Signed-off-by: Jake Smith <jake.smith@lexisnexisrisk.com>