### PR TITLE
HPCC-16940 CPermissionsCache is corrupting password

### DIFF
--- a/system/security/shared/caching.cpp
+++ b/system/security/shared/caching.cpp
@@ -359,17 +359,12 @@ bool CPermissionsCache::lookup(ISecUser& sec_user)
 
             if(cachedpw && pw && *pw != '\0')
             {
-                StringBuffer md5pbuf;
-                md5_string2(pw, md5pbuf);
-                if(strcmp(cachedpw, md5pbuf.str()) == 0)
+                if(strcmp(cachedpw, pw) == 0)
                 {
 #ifdef _DEBUG
                     DBGLOG("CACHE: CPermissionsCache Found validated user %s", username);
 #endif
-                    // Copy cached user to the sec_user structure, but still keep the original clear text password.
-                    StringAttr originalPW(pw);
                     user->queryUser()->copyTo(sec_user);
-                    sec_user.credentials().setPassword(originalPW.get());
                     return true;
                 }
                 else

--- a/system/security/shared/caching.hpp
+++ b/system/security/shared/caching.hpp
@@ -108,16 +108,7 @@ public:
     {
         if(!user)
             throw MakeStringException(-1, "can't create CachedUser, NULL user pointer");
-
         m_user.setown(user);
-        const char* pw = user->credentials().getPassword();
-        if(pw && *pw)
-        {
-            StringBuffer md5pbuf;
-            md5_string2(pw, md5pbuf);
-            user->credentials().setPassword(md5pbuf.str());
-        }
-
         time(&m_timestamp);
     }
 


### PR DESCRIPTION
When the permission cache saves the cached user object, it converts the password
attribute from plain text to MD5 encrypted.  This is incorrect as everywhere
else in the code expects it to be plain text. This PR leaves it in plain text

Signed-off-by: Russ Whitehead <william.whitehead@lexisnexis.com>