### PR TITLE
HPCC-16952 Loading eclblas plugin on OSX causes fork() to core

### DIFF
--- a/plugins/eclblas/CMakeLists.txt
+++ b/plugins/eclblas/CMakeLists.txt
@@ -51,7 +51,7 @@ if(USE_CBLAS)
     ADD_DEFINITIONS(-D_USRDLL -DECLBLAS_EXPORTS)
 
     HPCC_ADD_LIBRARY(eclblas SHARED ${SRCS})
-    install(TARGETS eclblas DESTINATION plugins )
+    install ( TARGETS eclblas RUNTIME DESTINATION ${EXEC_DIR} LIBRARY DESTINATION ${LIB_DIR} )  # No need to put in plugins dir
     target_link_libraries(eclblas
         eclrtl
         ${CBLAS_LIBRARIES})


### PR DESCRIPTION
This appears to be a known issue with openBlas, fixed in more recent versions.

As a quick workaround, and since it's a desirable change anyway, move the
eclblas dll out of plugins and into libs - we can and should do this for any
plugin for which there is a .ecllib proxy.

Signed-off-by: Richard Chapman <rchapman@hpccsystems.com>