### PR TITLE
HPCC-16963 Failures from wutool -selftest

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -2694,13 +2694,23 @@ void CWorkUnitFactory::reportAbnormalTermination(const char *wuid, WUState &stat
 }
 
 static CriticalSection deleteDllLock;
-static Owned<IWorkQueueThread> deleteDllWorkQ;
-
+static IWorkQueueThread *deleteDllWorkQ = nullptr;
+MODULE_INIT(INIT_PRIORITY_STANDARD)
+{
+    return true;
+}
+MODULE_EXIT()
+{
+    CriticalBlock b(deleteDllLock);
+    if (deleteDllWorkQ)
+        ::Release(deleteDllWorkQ);
+    deleteDllWorkQ = nullptr;
+}
 static void asyncRemoveDll(const char * name)
 {
     CriticalBlock b(deleteDllLock);
     if (!deleteDllWorkQ)
-        deleteDllWorkQ.setown(createWorkQueueThread());
+        deleteDllWorkQ = createWorkQueueThread();
     deleteDllWorkQ->post(new asyncRemoveDllWorkItem(name));
 }
 
@@ -2708,7 +2718,7 @@ static void asyncRemoveFile(const char * ip, const char * name)
 {
     CriticalBlock b(deleteDllLock);
     if (!deleteDllWorkQ)
-        deleteDllWorkQ.setown(createWorkQueueThread());
+        deleteDllWorkQ = createWorkQueueThread();
     deleteDllWorkQ->post(new asyncRemoveRemoteFileWorkItem(ip, name));
 }
 

--- a/plugins/cassandra/cassandrawu.cpp
+++ b/plugins/cassandra/cassandrawu.cpp
@@ -2701,6 +2701,10 @@ public:
         CriticalBlock b(crit);
         for (const ChildTableInfo * const * table = childTables; *table != NULL; table++)
             checkChildLoaded(**table);
+        // And a hack for the fact that Dali stores state in both @state and <state>
+        const char *stateStr = p->queryProp("@state");
+        if (stateStr)
+            p->setProp("State", stateStr);
         return p;
     }
 


### PR DESCRIPTION
Fix some false positives in the test code - not sure how they could ever have
worked...

Also fixed an issue where workunit helper file deletion thread  thread could
core if it was still running (and tried to report an issue) at program
termination.

Changed the test code to make this scenario less likely to avoid lengthy delay
at end of wutool execution (by using an invalid hostname rather than a valid
but unresponsive IP).

Signed-off-by: Richard Chapman <rchapman@hpccsystems.com>