### PR TITLE
HPCC-16897 FIX OSX client tools "libsecuresocket.so missing"

### DIFF
--- a/esp/bindings/http/client/httpclient.cpp
+++ b/esp/bindings/http/client/httpclient.cpp
@@ -61,15 +61,15 @@ IHttpClient* CHttpClientContext::createHttpClient(const char* proxy, const char*
         CriticalBlock b(m_sscrit);
         if(m_ssctx.get() == NULL)
         {
+            StringBuffer libName;
+            IEspPlugin *pplg = loadPlugin(libName.append(SharedObjectPrefix).append(SSLIB).append(SharedObjectExtension));
+            if (!pplg)
+                throw MakeStringException(-1, "dll/shared-object %s can't be loaded", libName.str());
+
             if(m_config.get() == NULL)
             {
                 createSecureSocketContext_t xproc = NULL;
-                IEspPlugin *pplg = loadPlugin(SSLIB);
-                if (pplg)
-                    xproc = (createSecureSocketContext_t) pplg->getProcAddress("createSecureSocketContext");
-                else
-                    throw MakeStringException(-1, "dll/shared-object %s can't be loaded", SSLIB);
-
+                xproc = (createSecureSocketContext_t) pplg->getProcAddress("createSecureSocketContext");
                 if (xproc)
                     m_ssctx.setown(xproc(ClientSocket));
                 else
@@ -78,12 +78,7 @@ IHttpClient* CHttpClientContext::createHttpClient(const char* proxy, const char*
             else
             {
                 createSecureSocketContextEx2_t xproc = NULL;
-                IEspPlugin *pplg = loadPlugin(SSLIB);
-                if (pplg)
-                    xproc = (createSecureSocketContextEx2_t) pplg->getProcAddress("createSecureSocketContextEx2");
-                else
-                    throw MakeStringException(-1, "dll/shared-object %s can't be loaded", SSLIB);
-
+                xproc = (createSecureSocketContextEx2_t) pplg->getProcAddress("createSecureSocketContextEx2");
                 if (xproc)
                     m_ssctx.setown(xproc(m_config.get(),ClientSocket));
                 else

--- a/esp/platform/espplugin.ipp
+++ b/esp/platform/espplugin.ipp
@@ -51,7 +51,7 @@ public:
         SharedObject::load(m_plugin.str(), true);       // I'm not really sure what this should be - if global (as default) there will be clashes between multiple dloads
         if (!loaded())
         {
-            ERRLOG("ESP Failed to load shared object (%s)", m_plugin.str());    
+            ERRLOG("Failed to load shared object (%s)", m_plugin.str());
             return false;
         }
         return true;

--- a/system/security/securesocket/securesocket.hpp
+++ b/system/security/securesocket/securesocket.hpp
@@ -35,11 +35,7 @@
 #include "jsocket.hpp"
 #include "jptree.hpp"
 
-#ifdef _WIN32
-#define SSLIB "securesocket.dll"
-#else
-#define SSLIB "libsecuresocket.so"
-#endif
+#define SSLIB "securesocket"
 
 enum SecureSocketType
 {


### PR DESCRIPTION
OSX version of client tools should be looking for libsecuresocket.dylib.

Signed-off-by: Anthony Fishbeck <anthony.fishbeck@lexisnexis.com>