### PR TITLE
HPCC-16983 Ecl bundle installation errors

### DIFF
--- a/ecl/ecl-bundle/ecl-bundle.cpp
+++ b/ecl/ecl-bundle/ecl-bundle.cpp
@@ -1120,7 +1120,7 @@ protected:
     StringBuffer bundlePath;
     StringBuffer hooksPath;
     bool bundleCompulsory;
-    bool optRemote;
+    bool optRemote = false;
 };
 
 //-------------------------------------------------------------------------------------------------
@@ -1259,7 +1259,7 @@ private:
         return ok;
     }
 
-    bool optRecurse;
+    bool optRecurse = false;
 };
 
 //-------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Uninitialized variables causing some issues.

Signed-off-by: Richard Chapman <rchapman@hpccsystems.com>