### PR TITLE
HPCC-16956 Add an optional warning when global datasets are hoisted from child queries

### DIFF
--- a/ecl/hqlcpp/hqlcerrors.hpp
+++ b/ecl/hqlcpp/hqlcerrors.hpp
@@ -272,6 +272,7 @@
 #define HQLWRN_OnlyLocalMergeJoin               4545
 #define HQLWRN_WorkflowDependParameter          4546
 #define HQLWRN_OutputScalarInsideChildQuery     4547
+#define HQLWRN_GlobalDatasetFromChildQuery      4548
 
 //Temporary errors
 #define HQLERR_OrderOnVarlengthStrings          4601
@@ -562,6 +563,7 @@
 #define HQLWRN_OnlyLocalMergeJoin_Text          "Only LOCAL versions of %s are currently supported on THOR"
 #define HQLWRN_WorkflowDependParameter_Text     "Workflow action %s appears to be dependent upon a parameter"
 #define HQLWRN_OutputScalarInsideChildQuery_Text "Output(%s) of single value inside a child query has undefined behaviour"
+#define HQLWRN_GlobalDatasetFromChildQuery_Text "Global dataset expression (%s) is used in a child query"
 
 #define HQLERR_DistributionVariableLengthX_Text "DISTRIBUTION does not support variable length field '%s'"
 #define HQLERR_DistributionUnsupportedTypeXX_Text "DISTRIBUTION does not support field '%s' with type %s"

--- a/ecl/hqlcpp/hqlttcpp.cpp
+++ b/ecl/hqlcpp/hqlttcpp.cpp
@@ -8506,6 +8506,15 @@ IHqlExpression * AutoScopeMigrateTransformer::createTransformed(IHqlExpression *
             s.append("[").append(expr->queryName()).append("] ");
         s.append("as an item to hoist");
         DBGLOG("%s", s.str());
+        if (extra->globalInsideChild)
+        {
+            StringBuffer nameText;
+            if (expr->queryName())
+                nameText.append(expr->queryName());
+            else
+                getExprECL(expr, nameText);
+            translator.reportWarning(CategoryEfficiency, SeverityIgnore, queryActiveLocation(expr), HQLWRN_GlobalDatasetFromChildQuery, HQLWRN_GlobalDatasetFromChildQuery_Text, nameText.str());
+        }
 
         GlobalAttributeInfo info("jobtemp::auto","auto", transformed);
         info.extractGlobal(NULL, translator.getTargetClusterType());


### PR DESCRIPTION
Signed-off-by: Gavin Halliday <gavin.halliday@lexisnexis.com>