### PR TITLE
HPCC-16995 PATTERN EscapeQuot := ''''; no longer compiles

### DIFF
--- a/ecl/hql/hqlerrors.hpp
+++ b/ecl/hql/hqlerrors.hpp
@@ -240,6 +240,7 @@
 #define ERR_STRING_UNENDED          2195  /* Unended string constant: string must end in one line */
 #define ERR_STRING_ILLDELIMITER     2196  /* " is illegal string delimiter: use ' instead */
 #define ERR_IFBLOCK_EMPTYDEF        2197  /* Empty ifblock definition */
+#define ERR_STRING_DOUBLE_QUOTE     2198  /* '' is not an escaped quote character: use \' instead */
 
 /* hash commands */
 #define ERR_TMPLT_EOFINFOR          2200 /* EOF encountered inside #FOR */

--- a/ecl/hql/hqlgram.hpp
+++ b/ecl/hql/hqlgram.hpp
@@ -1260,6 +1260,7 @@ private:
         bool inComment;
         bool inSignature;
         bool inCpp;
+        bool inMultiString;
         bool encrypted;
         StringBuffer javaDocComment;
 

--- a/ecl/hql/hqllex.l
+++ b/ecl/hql/hqllex.l
@@ -1552,10 +1552,10 @@ FUNCTIONMACRO|MACRO {
 (d|D|q|Q|v|V|u|U|u8|U8)?"'''"  { 
                         setupdatepos; 
                         BEGIN(MULTISTRING);
-                        lexer->inCpp = true;
+                        lexer->inMultiString = true;
                     }
 <MULTISTRING>[^\n]*"'''"[^\n]*  {
-                        lexer->inCpp = false;
+                        lexer->inMultiString = false;
                         int endpos = lexer->yyPosition;
                         //skip to the position of ''' on the line)
                         while (memcmp(lexer->yyBuffer+endpos, "'''", 3) != 0)
@@ -1753,6 +1753,16 @@ FUNCTIONMACRO|MACRO {
                         return (UNICODE_CONST);
                     }
                         
+
+(d|D|q|Q|v|V)?\'([^'\r\n\\]|\\[^\r\n])*\'/\' {
+                        /* error pattern - a string immediately followed by a ' usually means someone thought they could use '' to escape a quote char */
+                        /* It's usually going to hit a grammar error too, but patterns can legally be formed of two adjacent string tokens */
+                        lexer->reportWarning(CategoryMistake, returnToken, ERR_STRING_DOUBLE_QUOTE, "'' is not an escaped quote character: use \\' instead");
+                        int oldColumn = lexer->yyColumn;
+                        int oldPosition = lexer->yyPosition;
+                        setupdatepos;
+                        return lexer->processStringLiteral(returnToken, CUR_TOKEN_TEXT, CUR_TOKEN_LENGTH-1, oldColumn, oldPosition);
+                    }
 
 (d|D|q|Q|v|V)?\'([^'\r\n\\]|\\[^\r\n])*\' {
                         int oldColumn = lexer->yyColumn;

--- a/ecl/hql/hqlparse.cpp
+++ b/ecl/hql/hqlparse.cpp
@@ -178,6 +178,7 @@ void HqlLex::init(IFileContents * _text)
     inComment = false;
     inSignature = false;
     inCpp = false;
+    inMultiString = false;
     hasHashbreak = false;
     encrypted = false;
     loopTimes = 0;
@@ -2560,6 +2561,8 @@ int HqlLex::yyLex(YYSTYPE & returnToken, bool lookup, const short * activeState)
                 reportError(returnToken, ERR_COMMENT_UNENDED,"Signature is not terminated");
             else if (inCpp)
                 reportError(returnToken, ERR_COMMENT_UNENDED,"BEGINC++ or EMBED is not terminated");
+            else if (inMultiString)
+                reportError(returnToken, ERR_COMMENT_UNENDED,"Multiline string constant is not terminated");
             if (hashendKinds.ordinality())
             {
                 StringBuffer msg("Unexpected EOF: ");

--- a/ecl/regress/quququerre.ecl
+++ b/ecl/regress/quququerre.ecl
@@ -1,0 +1,3 @@
+unterminated := '''
+Oops, I forgot to terminate this multiline string;
+

--- a/ecl/regress/tpat5e.ecl
+++ b/ecl/regress/tpat5e.ecl
@@ -1,0 +1,48 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+//See pp219-> of dragon.
+
+r := record
+  string line;
+  end;
+
+d := dataset([
+{'abc * def + ghi'},
+{'(a + b) * (c + d)'},
+{''}],r);
+
+
+//Example comes from Dragon pp218->
+
+pattern ws := [' ','\t',',','yyy''']*;
+token id := PATTERN('[a-zA-Z]+');
+
+rule beforeId := pattern('');
+rule afterId := pattern('');
+rule E := beforeId id afterId;
+
+
+results := 
+    record
+        beforePos := matchposition(beforeId);
+        afterPos := matchposition(afterId);
+        x := MATCHTEXT(id)+'!';
+    end;
+
+outfile1 := PARSE(d,line,E,results,skip(ws),scan,parse);
+output(outfile1);


### PR DESCRIPTION
Improve error message for unterminated multiline string constants.

Generate a warning if a (normal) string constant is followed by a ' - it
normally means someone was trying to use '' within a string constant to
indicate an escaped quote.

Signed-off-by: Richard Chapman <rchapman@hpccsystems.com>