### PR TITLE
HPCC-16927 Global sort timeout not causing job to abort

### DIFF
--- a/thorlcr/msort/tsorts.cpp
+++ b/thorlcr/msort/tsorts.cpp
@@ -997,7 +997,15 @@ public:
         assertex(transferserver.get()!=NULL);
         if (intercept)
             rowArray.kill(); // don't need samples any more. All merged from disk.
-        transferserver->merge(mapsize,map,mapupper,num,endpoints,partno);
+        try
+        {
+            transferserver->merge(mapsize,map,mapupper,num,endpoints,partno);
+        }
+        catch (IException *e)
+        {
+            startmergesem.interrupt(e);
+            stop();
+        }
     }
     virtual void SingleMerge()
     {


### PR DESCRIPTION
Signed-off-by: Mark Kelly <mark.kelly@lexisnexisrisk.com>