### PR TITLE
HPCC-16997 Users filter not functioning

### DIFF
--- a/esp/src/eclwatch/templates/UserQueryWidget.html
+++ b/esp/src/eclwatch/templates/UserQueryWidget.html
@@ -52,7 +52,7 @@
                     <span data-dojo-type="dijit.ToolbarSeparator"></span>
                     <div id="${id}Filter" data-dojo-type="FilterDropDownWidget">
                         <p id="${id}LDAPWarning" style="display:none">${i18n.LDAPWarning}</p>
-                        <input id="${id}SearchInput" title="${i18n.User}:" name="searchinput" colspan="2" data-dojo-props="trim: true" data-dojo-type="dijit.form.TextBox" />
+                        <input id="${id}SearchInput" title="${i18n.User}:" name="Name" colspan="2" data-dojo-props="trim: true" data-dojo-type="dijit.form.TextBox" />
                     </div>
                     <span data-dojo-type="dijit.ToolbarSeparator"></span>
                     <div class="right" data-dojo-attach-event="onClick:_onNewPage" data-dojo-props="iconClass:'iconNewPage', showLabel:false" data-dojo-type="dijit.form.Button">${i18n.OpenInNewPage}</div>


### PR DESCRIPTION
During an ESP change "searchinput" parameter was changed to "Name" which caused the request to fail and not return updated list.

Signed-off by: Miguel Vazquez <miguel.vazquez@lexisnexis.com>