### PR TITLE
HPCC-16998 Hidl generated warning message needs terminating \n

### DIFF
--- a/tools/hidl/hidlcomp.cpp
+++ b/tools/hidl/hidlcomp.cpp
@@ -5442,7 +5442,7 @@ void writeAccessMap(const char * rawServiceAccessList, const char * methodname, 
                 {
                     if (strieq(currAccessName, "NONE") || strieq(currAccessName, "DEFERRED"))
                     {
-                        outf("\n//WARNING: Developer has suppressed automatic feature level authorization, ensure this behavior is correct!");
+                        outf("\n//WARNING: Developer has suppressed automatic feature level authorization, ensure this behavior is correct!\n");
                         continue;
                     }
                     else


### PR DESCRIPTION

- Warning message now contains terminating \n which prevents uninteded logic changes

Signed-off-by: Rodrigo Pastrana <rodrigo.pastrana@lexisnexis.com>