### PR TITLE
HPCC-16871 Despray BLOBs with DFUPLus info

### DIFF
--- a/docs/ECLProgrammersGuide/PRG_Mods/PrG_Workwith_Blobs.xml
+++ b/docs/ECLProgrammersGuide/PRG_Mods/PrG_Workwith_Blobs.xml
@@ -23,8 +23,9 @@
     <para>In the HPCCClientTools.PDF there is a chapter devoted to the
     DFUplus.exe program. This is a command line tool with specific options
     that allow you to spray and despray files into BLOBs in the HPCC. In all
-    the examples below, we'll assume you have a DFUPLUS.INI file in the same folder as the executable containing
-    the standard content described in that section of the PDF.</para>
+    the examples below, we'll assume you have a DFUPLUS.INI file in the same
+    folder as the executable containing the standard content described in that
+    section of the PDF.</para>
 
     <para>The key to making a spray operation write to BLOBs is the use of the
     <emphasis>prefix=Filename,Filesize</emphasis> option. For example, the
@@ -35,6 +36,14 @@
     <programlisting>C:\&gt;dfuplus action=spray srcip=10.150.51.26 srcfile=c:\import\*.jpg,c:\import\*.bmp 
             dstcluster=le_thor dstname=LE::imagedb overwrite=1 
             PREFIX=FILENAME,FILESIZE nosplit=1</programlisting>
+
+    <para>When using the wildcard characters (* and ?) to spray multiple
+    source files (<emphasis>srcfile</emphasis>) to a single
+    <emphasis>dstname</emphasis>, you MUST use both the
+    <emphasis>filename</emphasis> and <emphasis>filesize</emphasis>
+    (FILENAME,FILESIZE) options if you need to be able to despray the contents
+    of each record in the <emphasis>dstname</emphasis> back to the multiple
+    source files they originally came from. </para>
   </sect2>
 
   <sect2 id="Working_with_BLOB_Data">

--- a/docs/HPCCClientTools/CT_Mods/CT_Comm_Line_DFU.xml
+++ b/docs/HPCCClientTools/CT_Mods/CT_Comm_Line_DFU.xml
@@ -25,8 +25,7 @@
       <title>Command Line Interface</title>
 
       <sect2 id="DFUPlusexe">
-        <title><emphasis
-        role="bold">dfuplus</emphasis><emphasis></emphasis><emphasis
+        <title><emphasis role="bold">dfuplus </emphasis><emphasis
         role="bold">[--version] action=</emphasis><emphasis>operation
         </emphasis><emphasis
         role="bold">[</emphasis><emphasis>@filename</emphasis><emphasis
@@ -408,7 +407,10 @@ replicate=1</programlisting>
                     endian) and the size of integer to contain it (<emphasis
                     role="bold">1</emphasis> to <emphasis
                     role="bold">8</emphasis> bytes). If format and size are
-                    omitted, the default is L4.</entry>
+                    omitted, the default is L4. <para>Use in conjunction with
+                    the <emphasis>filename</emphasis> option to retain the
+                    appropriate file structure and to allow for despray into
+                    same. </para></entry>
                   </row>
 
                   <row>
@@ -648,7 +650,10 @@ END;</programlisting>
                   <entry>Uses the prepended size of the file (see the
                   <emphasis>prefix</emphasis> option to the spray
                   <emphasis>operation</emphasis>) to split out the data into
-                  separate files.</entry>
+                  separate files.<para>Use in conjunction with the
+                  <emphasis>filename</emphasis> option to retain the
+                  appropriate file structure and to allow for despray into
+                  same. </para></entry>
                 </row>
               </tbody>
             </tgroup>

--- a/docs/HPCCClientTools/CT_Mods/CT_Comm_Line_DFU.xml
+++ b/docs/HPCCClientTools/CT_Mods/CT_Comm_Line_DFU.xml
@@ -407,10 +407,14 @@ replicate=1</programlisting>
                     endian) and the size of integer to contain it (<emphasis
                     role="bold">1</emphasis> to <emphasis
                     role="bold">8</emphasis> bytes). If format and size are
-                    omitted, the default is L4. <para>Use in conjunction with
-                    the <emphasis>filename</emphasis> option to retain the
-                    appropriate file structure and to allow for despray into
-                    same. </para></entry>
+                    omitted, the default is L4. <para>When using wildcard
+                    characters (* and ?) to spray multiple source files
+                    (srcfile) to a single dstname, you MUST use both the
+                    filename and filesize options if you need to be able to
+                    despray the contents of each record in the dstname back to
+                    the multiple source files they originally came from. If
+                    you never need to do that, then the filesize option may be
+                    omitted. </para></entry>
                   </row>
 
                   <row>
@@ -650,10 +654,13 @@ END;</programlisting>
                   <entry>Uses the prepended size of the file (see the
                   <emphasis>prefix</emphasis> option to the spray
                   <emphasis>operation</emphasis>) to split out the data into
-                  separate files.<para>Use in conjunction with the
-                  <emphasis>filename</emphasis> option to retain the
-                  appropriate file structure and to allow for despray into
-                  same. </para></entry>
+                  separate files.<para>When using wildcard characters (* and
+                  ?) to spray multiple source files (srcfile) to a single
+                  dstname, you MUST use both the filename and filesize options
+                  if you need to be able to despray the contents of each
+                  record in the dstname back to the multiple source files they
+                  originally came from. If you never need to do that, then the
+                  filesize option may be omitted. </para></entry>
                 </row>
               </tbody>
             </tgroup>


### PR DESCRIPTION
Fix HPCC-16871 Despray BLOBs with DFUPLus info
Added language pertaining to a Forum post which a user was trying to despray image files. 
Added to Client Tools and Programmers Guide docs. 
Seemingly only needed to add the filename/format options.

Not squashing at this time, as I anticipate comments and additional changes, 
I can squash when approved. 

@RichardTaylorHPCC please review
@JamesDeFabia FYI - review optional
