### PR TITLE
HPCC-17010 DOCS:Prog.Guide. Add ID Attribute

### DIFF
--- a/docs/ECLProgrammersGuide/PrGd-Includer.xml
+++ b/docs/ECLProgrammersGuide/PrGd-Includer.xml
@@ -178,13 +178,11 @@
                 xmlns:xi="http://www.w3.org/2001/XInclude" />
   </chapter>
 
-  <chapter>
+  <chapter id="EmbeddedLanguages_DataStores">
     <title>Embedded Languages and Data stores</title>
 
     <xi:include href="ECLProgrammersGuide/PRG_Mods/CodeSign.xml"
                 xpointer="element(/1)"
                 xmlns:xi="http://www.w3.org/2001/XInclude" />
-
-   
   </chapter>
 </book>


### PR DESCRIPTION
Fix HPCC-17010 DOCS:Prog.Guide. Add ID Attribute
Add unique (non-printing, undisplayed) ID Attribute to the
Chapter (5) in the Programmers Guide book that does not have one.
The purpose of this unique code is merely to identify the chapter,
allow inclusion by reference, and ultimately to give the resulting
HTML file a useable name, rather than that semi-random string of
letters and numbers that it will bear without the proper attribute.

Signed-off-by: G-Pan <greg.panagiotatos@lexisnexis.com>

@RichardTaylorHPCC please review. 
@JamesDeFabia OPTIONALLY Review 