### PR TITLE
HPCC-17039 Switch StringAttr to use size_t

### DIFF
--- a/cmake_modules/commonSetup.cmake
+++ b/cmake_modules/commonSetup.cmake
@@ -365,7 +365,7 @@ IF ("${COMMONSETUP_DONE}" STREQUAL "")
 
     if (CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANGXX)
       message ("Using compiler: ${CMAKE_CXX_COMPILER_ID} :: ${CMAKE_CXX_COMPILER_VERSION} :: ${CLANG_VERSION} :: ${APPLE_CLANG_VERSION}")
-      SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -frtti -fPIC -fmessage-length=0 -Wformat -Wformat-security -Wformat-nonliteral -pthread -Wuninitialized")
+      SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -frtti -fPIC -fmessage-length=0 -Werror=format -Wformat-security -Wformat-nonliteral -pthread -Wuninitialized")
       SET (CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -rdynamic")
       SET (CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -g -fno-inline-functions")
       if (CMAKE_COMPILER_IS_GNUCXX)

--- a/common/remote/rmtsmtp.cpp
+++ b/common/remote/rmtsmtp.cpp
@@ -484,7 +484,7 @@ public:
         warnings = _warnings;
         CSMTPValidator validator;
         if(strlen(senderHeader) + sender.length() > 998)
-            throw MakeStringException(0, "email sender address too long: %u characters", sender.length());
+            throw MakeStringException(0, "email sender address too long: %" I64F "u characters",  static_cast<__uint64>(sender.length()));
         validator.validateAddress(sender.get(), "email sender address");
 
         getRecipients(validator, _to);
@@ -492,7 +492,7 @@ public:
             throw MakeStringException(0, "Email recipient address list too long: %u characters", to.length());
 
         if(strlen(subjectHeader) + subject.length() > 998)
-            throw MakeStringException(0, "Email subject too long: %u characters", subject.length());
+            throw MakeStringException(0, "Email subject too long: %" I64F "u characters",  static_cast<__uint64>(subject.length()));
         validator.validateValue(subject.get(), "email subject");
     }
 

--- a/common/thorhelper/roxiehelper.cpp
+++ b/common/thorhelper/roxiehelper.cpp
@@ -1768,7 +1768,7 @@ void CSafeSocket::flush()
         if (!adaptiveRoot || mlResponseFmt != MarkupFmt_JSON)
         {
             if (traceLevel > 5)
-                DBGLOG("Writing content head length %d to HTTP socket", contentHead.length());
+                DBGLOG("Writing content head length %" I64F "u to HTTP socket", static_cast<__uint64>(contentHead.length()));
             sock->write(contentHead.str(), contentHead.length());
             sent += contentHead.length();
         }
@@ -1783,7 +1783,7 @@ void CSafeSocket::flush()
         if (!adaptiveRoot || mlResponseFmt != MarkupFmt_JSON)
         {
             if (traceLevel > 5)
-                DBGLOG("Writing content tail length %d to HTTP socket", contentTail.length());
+                DBGLOG("Writing content tail length %" I64F "u to HTTP socket", static_cast<__uint64>(contentTail.length()));
             sock->write(contentTail.str(), contentTail.length());
             sent += contentTail.length();
         }

--- a/system/jlib/jptree.cpp
+++ b/system/jlib/jptree.cpp
@@ -1834,7 +1834,7 @@ IPropertyTree *PTree::addPropTree(const char *xpath, IPropertyTree *val)
         else
         {
             aindex_t pos = (aindex_t)-1;
-            if (qualifier.length())
+            if (!qualifier.isEmpty())
             {
                 pos = ((PTree *)child)->getChildMatchPos(qualifier);
                 if ((aindex_t) -1 == pos)
@@ -2625,7 +2625,7 @@ void PTree::deserialize(MemoryBuffer &src)
     {
         size32_t pos = src.getPos();
         src.read(eName);
-        if (!eName.length())
+        if (eName.isEmpty())
             break;
         src.reset(pos); // reset to re-read tree name
         IPropertyTree *child = create(src);
@@ -2648,7 +2648,7 @@ void PTree::deserializeSelf(MemoryBuffer &src)
     loop
     {
         src.read(attrName);
-        if (!attrName.length())
+        if (attrName.isEmpty())
             break;
         src.read(attrValue);
         setProp(attrName, attrValue);
@@ -3650,7 +3650,7 @@ void _synchronizePTree(IPropertyTree *target, IPropertyTree *source)
         }
         else
         {
-            if (!firstOfType.length() || 0 != strcmp(firstOfType, e.queryName()))
+            if (firstOfType.isEmpty() || 0 != strcmp(firstOfType, e.queryName()))
             {
                 if (firstOfType.length() && srcTypeIter)
                 {

--- a/system/jlib/jstring.cpp
+++ b/system/jlib/jstring.cpp
@@ -1290,7 +1290,7 @@ StringAttr::StringAttr(const char * _text)
   text = _text ? strdup(_text) : NULL;
 }
 
-StringAttr::StringAttr(const char * _text, unsigned _len)
+StringAttr::StringAttr(const char * _text, size_t _len)
 {
     text = NULL;
     set(_text, _len);
@@ -1323,7 +1323,7 @@ void StringAttr::set(const char * _text)
     free(oldtext);
 }
 
-void StringAttr::set(const char * _text, unsigned _len)
+void StringAttr::set(const char * _text, size_t _len)
 {
     char * oldtext = text;
     text = (char *)malloc(_len+1);

--- a/system/jlib/jstring.hpp
+++ b/system/jlib/jstring.hpp
@@ -250,7 +250,7 @@ class jlib_decl StringAttr
 {
 public:
     inline StringAttr(void)                     { text = NULL; }
-    StringAttr(const char * _text, unsigned _len);
+    StringAttr(const char * _text, size_t _len);
     StringAttr(const char * _text);
     StringAttr(const StringAttr & src);
     StringAttr(StringAttr && src);
@@ -261,13 +261,13 @@ public:
     inline void clear()                         { setown(NULL); }
     inline char * detach()                      { char * ret = text; text = NULL; return ret; }
     inline const char * get() const             { return text; }
-    inline size32_t     length() const          { return text ? (size32_t)strlen(text) : 0; }
+    inline size_t length() const                { return text ? strlen(text) : 0; }
     inline bool isEmpty() const                 { return !text||!*text; } // faster than (length==0)
     inline const char * str() const             { return text ? text : ""; } // safe form (doesn't return NULL)
 
     void         set(const char * _text);
     void         setown(const char * _text);
-    void         set(const char * _text, unsigned _len);
+    void         set(const char * _text, size_t _len);
     void         set(const StringBuffer & source);
     void         setown(StringBuffer & source);
     void         toLowerCase();


### PR DESCRIPTION
This addresses some coverity warnings about potential truncations, and is
liable to be marginally more efficient.

Also changed format mismatch warnings to be fatal, because it made testing
this change easier and seems like a good thing to do anyway.

Signed-off-by: Richard Chapman <rchapman@hpccsystems.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [x] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [x] Scalability
  - [x] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [x] Premature optimization
  - [x] Existing deployed queries will not be broken
  - [x] This change fixes the problem, not just the symptom
  - [x] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately

## Testing:
Compiled full system including plugins on linux and OSX.
Checked that no format errors were introduced.
Full regression suite run in progress (will update when complete)
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
