### PR TITLE
HPCC-16873 Get/set dfuserver queue in FileSpray web services

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -4611,6 +4611,28 @@ IStringVal &getProcessQueueNames(IStringVal &ret, const char *process, const cha
 #define ECLSCHEDULER_QUEUE_EXT ".eclscheduler"
 #define ECLAGENT_QUEUE_EXT ".agent"
 
+extern WORKUNIT_API void getDFUServerQueueNames(StringArray &ret, const char *process)
+{
+    Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
+    Owned<IConstEnvironment> env = factory->openEnvironment();
+    if (!env)
+        return;
+
+    StringBuffer xpath = "Software/DfuServerProcess";
+    if (!isEmptyString(process))
+        xpath.appendf("[@name=\"%s\"]", process);
+
+    Owned<IPropertyTree> root = &env->getPTree();
+    Owned<IPropertyTreeIterator> targets = root->getElements(xpath.str());
+    ForEach(*targets)
+    {
+        IPropertyTree &target = targets->query();
+        if (target.hasProp("@queue"))
+            ret.appendUniq(target.queryProp("@queue"));
+    }
+    return;
+}
+
 extern WORKUNIT_API IStringVal &getEclCCServerQueueNames(IStringVal &ret, const char *process)
 {
     return getProcessQueueNames(ret, process, "EclCCServerProcess", ECLCCSERVER_QUEUE_EXT);

--- a/common/workunit/workunit.hpp
+++ b/common/workunit/workunit.hpp
@@ -1370,6 +1370,7 @@ protected:
 
 typedef IWorkUnitFactory * (* WorkUnitFactoryFactory)(const IPropertyTree *);
 
+extern WORKUNIT_API void getDFUServerQueueNames(StringArray &ret, const char *process);
 extern WORKUNIT_API IStringVal &getEclCCServerQueueNames(IStringVal &ret, const char *process);
 extern WORKUNIT_API IStringVal &getEclServerQueueNames(IStringVal &ret, const char *process);
 extern WORKUNIT_API IStringVal &getEclSchedulerQueueNames(IStringVal &ret, const char *process);

--- a/esp/scm/ws_fs.ecm
+++ b/esp/scm/ws_fs.ecm
@@ -207,6 +207,7 @@ GetDFUWorkunitResponse
 
 ESPrequest CreateDFUWorkunit
 {
+    [min_ver("1.14")] string DFUServerQueue;
 };
 
 ESPresponse [exceptions_inline]
@@ -327,6 +328,7 @@ ESPrequest [nil_remove] SprayFixed
     [min_ver("1.09")] bool recordStructurePresent(false);
 
     [min_ver("1.10")] bool quotedTerminator(true);
+    [min_ver("1.14")] string DFUServerQueue;
 };
 
 ESPresponse [exceptions_inline] 
@@ -377,6 +379,7 @@ ESPrequest [nil_remove] SprayVariable
     [min_ver("1.10")] bool quotedTerminator(true);
     [min_ver("1.11")] string sourceRowPath;
     [min_ver("1.11")] bool isJSON(false);
+    [min_ver("1.14")] string DFUServerQueue;
 };
 
 ESPresponse [exceptions_inline] 
@@ -392,6 +395,7 @@ ESPrequest [nil_remove] Replicate
     string cluster;
     bool   repeatLast(false);
     bool   onlyRepeated(false);
+    [min_ver("1.14")] string DFUServerQueue;
 };  
 
 ESPresponse [exceptions_inline] 
@@ -418,6 +422,7 @@ ESPrequest Despray
     bool   wrap(false);
     bool   multiCopy(false);
     [min_ver("1.02")] bool SingleConnection;
+    [min_ver("1.14")] string DFUServerQueue;
 
     bool   compress(false);
     string encrypt;
@@ -464,6 +469,7 @@ ESPrequest [nil_remove] Copy
     string decrypt;
 
     [min_ver("1.12")] bool preserveCompression(true);
+    [min_ver("1.14")] string DFUServerQueue;
 };
 
 ESPresponse [exceptions_inline] 
@@ -487,6 +493,7 @@ ESPrequest Rename
     string srcname;
     string dstname;
     bool   overwrite;
+    [min_ver("1.14")] string DFUServerQueue;
 };
 
 ESPresponse [exceptions_inline] 
@@ -650,9 +657,19 @@ ESPresponse [exceptions_inline, nil_remove] GetSprayTargetsResponse
     ESParray<ESPstruct GroupNode, GroupNode> GroupNodes; 
 };
 
+ESPrequest GetDFUServerQueuesRequest
+{
+    string DFUServerName;
+};
+
+ESPresponse [exceptions_inline, nil_remove] GetDFUServerQueuesResponse
+{
+    ESParray<string> Names;
+};
+
 ESPservice [
     auth_feature("DEFERRED"),
-    version("1.13"),
+    version("1.14"),
     exceptions_inline("./smc_xslt/exceptions.xslt")] FileSpray
 {
     ESPuses ESPstruct DFUWorkunit;
@@ -687,6 +704,7 @@ ESPservice [
     ESPmethod [resp_xsl_default("/esp/xslt/dfuwuaction_results.xslt")] DeleteDropZoneFiles(DeleteDropZoneFilesRequest, DFUWorkunitsActionResponse);
     ESPmethod [min_ver("1.13")] DropZoneFileSearch(DropZoneFileSearchRequest, DropZoneFileSearchResponse);
     ESPmethod GetSprayTargets(GetSprayTargetsRequest, GetSprayTargetsResponse);
+    ESPmethod [min_ver("1.14")] GetDFUServerQueues(GetDFUServerQueuesRequest, GetDFUServerQueuesResponse);
 };
 
 SCMexportdef(FileSpray);

--- a/esp/services/ws_fs/ws_fsService.hpp
+++ b/esp/services/ws_fs/ws_fsService.hpp
@@ -97,6 +97,7 @@ public:
     virtual bool onDropZoneFiles(IEspContext &context, IEspDropZoneFilesRequest &req, IEspDropZoneFilesResponse &resp);
     virtual bool onDeleteDropZoneFiles(IEspContext &context, IEspDeleteDropZoneFilesRequest &req, IEspDFUWorkunitsActionResponse &resp);
     virtual bool onGetSprayTargets(IEspContext &context, IEspGetSprayTargetsRequest &req, IEspGetSprayTargetsResponse &resp);
+    virtual bool onGetDFUServerQueues(IEspContext &context, IEspGetDFUServerQueuesRequest &req, IEspGetDFUServerQueuesResponse &resp);
 
 protected:
     StringBuffer m_QueueLabel;
@@ -122,6 +123,8 @@ protected:
         const char pathSep, IArrayOf<IEspPhysicalFileStruct>& filesInFolder, IArrayOf<IEspPhysicalFileStruct>&files);
     bool searchDropZoneFileInFolder(IEspContext& context, IFile* f, const char* nameFilter, bool returnAll,
         const char* dropZonePath, StringBuffer& relativePath, const char pathSep, IArrayOf<IEspPhysicalFileStruct>& files);
+    void setDFUServerQueueReq(const char* dfuServerQueue, IDFUWorkUnit* wu);
+    void setUserAuth(IEspContext &context, IDFUWorkUnit* wu);
 };
 
 #endif //_ESPWIZ_FileSpray_HPP__


### PR DESCRIPTION
1. When FileSpray service is started, check whether default
dfuserver queue label is a valid dfuserver queue; 2. A new
service method is added to query dfuserver queue list; 3. A
caller may specify dfuserver queue in a FileSpray service
request. If not specified, the default dfuserver queue will
be used.

Signed-off-by: wangkx <kevin.wang@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x ] My code follows the code style of this project.
  - [x ] My code does not create any new warnings from compiler, build system, or lint.
- [x ] The commit message is properly formatted and free of typos.
  - [x ] The commit message title makes sense in a changelog, by itself.
  - [x ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x ] I have read the CONTRIBUTORS document.
- [x ] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [x ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [x ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [x ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [x ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
