### PR TITLE
HPCC-17092 Report correct RAM values in CentOS 7

### DIFF
--- a/common/monitoring/preflight
+++ b/common/monitoring/preflight
@@ -63,7 +63,12 @@ if [ "${1:0:1}" == '-' ]; then
 
     #find machineInfo and output:
 
-    mem=`free | head -n 3 | tail -n 1 | awk '{print $3,$4}'`
+    checkSwapLine=`free | head -n 3 | tail -n 1 | awk '{print $1}'`
+    if ! [ "$checkSwapLine" = "Swap:" ]; then
+        mem=`free | head -n 3 | tail -n 1 | awk '{print $3,$4}'`
+    else
+        mem=`free | head -n 2 | tail -n 1 | awk '{print $2-$7,$7}'`
+    fi
     cpu=`vmstat 1 2 | tail -n 1 | awk '{print $15}'`
     echo CPU-Idle: $cpu%
     cuptime=`uptime | cut -f 1,2 -d ','`


### PR DESCRIPTION
The preflight script uses 'free' command to retrieve system memory
values. The response format of the command is changed in CentOS 7.
This fix checks the format before retrieving the values from the
response.

Example of free on CentOS 7:
free
total used free shared buff/cache available
Mem: 24679696 745408 15354024 484056 8580264 23115424
Swap: 4194296 2342044 1852252

Example of free on other OS systems:
free
total used free shared buffers cached
Mem: 132186424 85905932 46280492 1269732 1246032 48452744
-/+ buffers/cache: 36207156 95979268
Swap: 8388600 1371044 7017556

Signed-off-by: wangkx <kevin.wang@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [x] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [x] Scalability
  - [x] Performance
  - [x] Security
  - [x] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [x] This change fixes the problem, not just the symptom
  - [x] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->
In ECLWatch, check the preflight result page on both CentOS 7 and other OS systems.

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
