### PR TITLE
HPCC-17102 The redissynctest fails if parallel queries used in regression suite.

### DIFF
--- a/testing/regress/ecl/rediserrortests.ecl
+++ b/testing/regress/ecl/rediserrortests.ecl
@@ -25,55 +25,60 @@ IMPORT Std;
 
 STRING server := '--SERVER=127.0.0.1:6379';
 STRING password := 'foobared';
-redis.FlushDB(server, /*database*/, password);
+
+// The database is need to avoid crossover manipulation when multiple redis tests
+// executed in parallel
+INTEGER4 database := 0;
+INTEGER4 invalidDatabase := 16;
+redis.FlushDB(server, database, password);
 myRedis := redisServer(server, password);
 
 myFuncStr(STRING key) := FUNCTION
- value := myRedis.GetString(key);
+ value := myRedis.GetString(key, database);
  return value;
 END;
 myFuncUtf8(STRING key) := FUNCTION
- value := myRedis.GetUtf8(key);
+ value := myRedis.GetUtf8(key, database);
  return value;
 END;
 myFuncUni(STRING key) := FUNCTION
- value := myRedis.GetUnicode(key);
+ value := myRedis.GetUnicode(key, database);
  return value;
 END;
 
 getString(STRING key, STRING key2, myFuncStr func) := FUNCTION
-    value := myRedis.GetOrLockString(key);
-    RETURN IF (LENGTH(value) = 0, myRedis.SetAndPublishString(key, func(key2)), value);
+    value := myRedis.GetOrLockString(key, database);
+    RETURN IF (LENGTH(value) = 0, myRedis.SetAndPublishString(key, func(key2), database), value);
 END;
 getUtf8(STRING key, STRING key2, myFuncUtf8 func) := FUNCTION
-    value := myRedis.GetOrLockUtf8(key);
-    RETURN IF (LENGTH(value) = 0, myRedis.SetAndPublishUtf8(key, func(key2)), value);
+    value := myRedis.GetOrLockUtf8(key, database);
+    RETURN IF (LENGTH(value) = 0, myRedis.SetAndPublishUtf8(key, func(key2), database), value);
 END;
 getUnicode(STRING key, STRING key2, myFuncUni func) := FUNCTION
-    value := myRedis.GetOrLockUnicode(key);
-    RETURN IF (LENGTH(value) = 0, myRedis.SetAndPublishUnicode(key, func(key2)), value);
+    value := myRedis.GetOrLockUnicode(key, database);
+    RETURN IF (LENGTH(value) = 0, myRedis.SetAndPublishUnicode(key, func(key2), database), value);
 END;
 
 //Test some exceptions
 myRedis4 := RedisServer(server);
 STRING noauth := 'Redis Plugin: ERROR - authentication for 127.0.0.1:6379 failed : NOAUTH Authentication required.';
 STRING opNotPerm :=  'Redis Plugin: ERROR - authentication for 127.0.0.1:6379 failed : ERR operation not permitted';
-ds1 := DATASET(NOFOLD(1), TRANSFORM({STRING value}, SELF.value := myRedis4.GetString('authTest' + (STRING)COUNTER)));
+ds1 := DATASET(NOFOLD(1), TRANSFORM({STRING value}, SELF.value := myRedis4.GetString('authTest' + (STRING)COUNTER, database)));
 SEQUENTIAL(
-    myRedis.FlushDB();
+    myRedis.FlushDB(database);
     OUTPUT(CATCH(ds1, ONFAIL(TRANSFORM({ STRING value }, SELF.value := IF(FAILMESSAGE = noauth OR FAILMESSAGE = opNotPerm, 'Auth Failed', 'Unexpected Error - ' + FAILMESSAGE)))));
     );
 
-ds2 := DATASET(NOFOLD(1), TRANSFORM({STRING value}, SELF.value := myRedis.GetString('authTest' + (STRING)COUNTER)));
+ds2 := DATASET(NOFOLD(1), TRANSFORM({STRING value}, SELF.value := myRedis.GetString('authTest' + (STRING)COUNTER, database)));
 SEQUENTIAL(
-    myRedis.FlushDB();
+    myRedis.FlushDB(database);
     OUTPUT(CATCH(ds2, ONFAIL(TRANSFORM({ STRING value }, SELF.value := FAILMESSAGE))));
     );
 
 myRedis5 := RedisServer('--SERVER=127.0.0.1:9999');
-ds3 := DATASET(NOFOLD(1), TRANSFORM({STRING value}, SELF.value := myRedis5.GetString('connectTest' + (STRING)COUNTER)));
+ds3 := DATASET(NOFOLD(1), TRANSFORM({STRING value}, SELF.value := myRedis5.GetString('connectTest' + (STRING)COUNTER, database)));
 SEQUENTIAL(
-    myRedis.FlushDB();
+    myRedis.FlushDB(database);
     OUTPUT(CATCH(ds3, ONFAIL(TRANSFORM({ STRING value }, SELF.value := FAILMESSAGE))));
     );
 
@@ -82,32 +87,32 @@ SEQUENTIAL(
     OUTPUT(CATCH(ds4, ONFAIL(TRANSFORM({ STRING value }, SELF.value := FAILMESSAGE))));
     );
 
-ds5 := DATASET(NOFOLD(1), TRANSFORM({STRING value}, SELF.value := myRedis.GetString('maxDB' + (STRING)COUNTER, 16)));
+ds5 := DATASET(NOFOLD(1), TRANSFORM({STRING value}, SELF.value := myRedis.GetString('maxDB' + (STRING)COUNTER, invalidDatabase)));
 SEQUENTIAL(
     OUTPUT(CATCH(ds5, ONFAIL(TRANSFORM({ STRING value }, SELF.value := FAILMESSAGE))));
     );
 
 //Test exception for checking expected channels
-ds6 := DATASET(NOFOLD(1), TRANSFORM({string value}, SELF.value := myRedis.GetOrLockString('channelTest' + (string)COUNTER)));
+ds6 := DATASET(NOFOLD(1), TRANSFORM({string value}, SELF.value := myRedis.GetOrLockString('channelTest' + (string)COUNTER, database)));
 SEQUENTIAL(
-    myRedis.FlushDB();
-    myRedis.SetString('channelTest1', 'redis_ecl_lock_blah_blah_blah');
+    myRedis.FlushDB(database);
+    myRedis.SetString('channelTest1', 'redis_ecl_lock_blah_blah_blah', database);
     OUTPUT(CATCH(ds6, ONFAIL(TRANSFORM({ STRING value }, SELF.value := FAILMESSAGE))));
     );
 
-ds7 := DATASET(NOFOLD(1), TRANSFORM({string value}, SELF.value := myRedis.GetOrLockString('channelTest' + (string)(1+COUNTER))));
+ds7 := DATASET(NOFOLD(1), TRANSFORM({string value}, SELF.value := myRedis.GetOrLockString('channelTest' + (string)(1+COUNTER), database)));
 SEQUENTIAL(
-    myRedis.FlushDB();
-    myRedis.SetString('channelTest2', 'redis_ecl_lock_channelTest2_0');
+    myRedis.FlushDB(database);
+    myRedis.SetString('channelTest2', 'redis_ecl_lock_channelTest2_0', database);
     OUTPUT(CATCH(ds7, ONFAIL(TRANSFORM({ STRING value }, SELF.value := FAILMESSAGE))));
     );
 
 //Test timeout
 myRedisNoTO := redisServerWithoutTimeout(server, password);
-dsTO := DATASET(NOFOLD(1), TRANSFORM({string value}, SELF.value := myRedisNoTO.GetOrLockString('timeoutTest' + (string)COUNTER,,,1000)));
+dsTO := DATASET(NOFOLD(1), TRANSFORM({string value}, SELF.value := myRedisNoTO.GetOrLockString('timeoutTest' + (string)COUNTER, database,,1000)));
 SEQUENTIAL(
-    myRedis.FlushDB();
-    myRedis.GetOrLockString('timeoutTest1');
+    myRedis.FlushDB(database);
+    myRedis.GetOrLockString('timeoutTest1', database);
     OUTPUT(CATCH(dsTO, ONFAIL(TRANSFORM({ STRING value }, SELF.value := FAILMESSAGE))));
     );
 
@@ -116,10 +121,10 @@ STRING redisTO := 'Redis Plugin: ERROR - GetOrLock<type> \'timeoutTest2\' on dat
 STRING authTO := 'Redis Plugin: ERROR - server authentication for 127.0.0.1:6379 failed : Resource temporarily unavailable';
 STRING getSetTO := 'Redis Plugin: ERROR - SET %b %b NX PX 1000 \'timeoutTest2\' on database 0 for 127.0.0.1:6379 failed : Resource temporarily unavailable';
 STRING subscribeTO := 'Redis Plugin: ERROR - SUBSCRIBE &apos;redis_ecl_lock_timeoutTest2_0&apos; on database 0 for 127.0.0.1:6379 failed : Resource temporarily unavailable';
-dsTO2 := DATASET(NOFOLD(1), TRANSFORM({string value}, SELF.value := redis.GetOrLockString('timeoutTest' + (string)(1+COUNTER), server, /*database*/, password, 1/*ms*/)));
+dsTO2 := DATASET(NOFOLD(1), TRANSFORM({string value}, SELF.value := redis.GetOrLockString('timeoutTest' + (string)(1+COUNTER), server, database, password, 100/*timeout ms*/)));
 SEQUENTIAL(
-    myRedis.FlushDB();
-    myRedis.GetOrLockString('timeoutTest2');
+    myRedis.FlushDB(database);
+    myRedis.GetOrLockString('timeoutTest2', database);
     OUTPUT(CATCH(dsTO2, ONFAIL(TRANSFORM({ STRING value }, SELF.value := IF(FAILMESSAGE = pluginTO
                                                                          OR FAILMESSAGE = redisTO
                                                                          OR FAILMESSAGE = authTO
@@ -129,19 +134,19 @@ SEQUENTIAL(
     );
 
 STRING pluginIntExpected := 'Redis Plugin: ERROR - INCRBY \'testINCRBY1\' on database 0 for 127.0.0.1:6379 failed : ERR value is not an integer or out of range';
-dsINCRBY := DATASET(NOFOLD(1), TRANSFORM({INTEGER value}, SELF.value := myRedis.INCRBY('testINCRBY' + (string)COUNTER, 11)));
+dsINCRBY := DATASET(NOFOLD(1), TRANSFORM({INTEGER value}, SELF.value := myRedis.INCRBY('testINCRBY' + (string)COUNTER, 11, database)));
 SEQUENTIAL(
-    myRedis.FlushDB();
-    myRedis.setString('testINCRBY1', 'this is a string and not an integer'),
+    myRedis.FlushDB(database);
+    myRedis.setString('testINCRBY1', 'this is a string and not an integer', database),
     OUTPUT(CATCH(dsINCRBY, ONFAIL(TRANSFORM({ INTEGER value }, SELF.value := IF(FAILMESSAGE = pluginIntExpected, 1, 0) ))));
     );
 
 STRING erange := 'Redis Plugin: ERROR - INCRBY \'testINCRBY11\' on database 0 for 127.0.0.1:6379 failed : ERR value is not an integer or out of range';
-dsINCRBY2 := DATASET(NOFOLD(1), TRANSFORM({INTEGER value}, SELF.value := myRedis.INCRBY('testINCRBY1' + (string)COUNTER, -11)));
+dsINCRBY2 := DATASET(NOFOLD(1), TRANSFORM({INTEGER value}, SELF.value := myRedis.INCRBY('testINCRBY1' + (string)COUNTER, -11, database)));
 SEQUENTIAL(
-    myRedis.FlushDB();
-    myRedis.setUnsigned('testINCRBY11', -1),
+    myRedis.FlushDB(database);
+    myRedis.setUnsigned('testINCRBY11', -1, database),
     OUTPUT(CATCH(dsINCRBY2, ONFAIL(TRANSFORM({ INTEGER value }, SELF.value := IF(FAILMESSAGE = erange, 1, 0) ))));
     );
 
-myRedis.FlushDB();
+myRedis.FlushDB(database);

--- a/testing/regress/ecl/redislockingtest.ecl
+++ b/testing/regress/ecl/redislockingtest.ecl
@@ -25,147 +25,153 @@ IMPORT Std;
 
 STRING server := '--SERVER=127.0.0.1:6379';
 STRING password := 'foobared';
+// The database is need to avoid crossover manipulation when multiple redis tests
+// executed in parallel
+INTEGER4 database := 10;
 myRedis := redisServer(server, password);
 
 myFuncStr(STRING key) := FUNCTION
- value := myRedis.GetString(key);
+ value := myRedis.GetString(key, database);
  return value;
 END;
 myFuncUtf8(STRING key) := FUNCTION
- value := myRedis.GetUtf8(key);
+ value := myRedis.GetUtf8(key, database);
  return value;
 END;
 myFuncUni(STRING key) := FUNCTION
- value := myRedis.GetUnicode(key);
+ value := myRedis.GetUnicode(key, database);
  return value;
 END;
 
 getString(STRING key, STRING key2, myFuncStr func) := FUNCTION
-    value := myRedis.GetOrLockString(key);
-    RETURN IF (LENGTH(value) = 0, myRedis.SetAndPublishString(key, func(key2)), value);
+    value := myRedis.GetOrLockString(key, database);
+    RETURN IF (LENGTH(value) = 0, myRedis.SetAndPublishString(key, func(key2), database), value);
 END;
 getUtf8(STRING key, STRING key2, myFuncUtf8 func) := FUNCTION
-    value := myRedis.GetOrLockUtf8(key);
-    RETURN IF (LENGTH(value) = 0, myRedis.SetAndPublishUtf8(key, func(key2)), value);
+    value := myRedis.GetOrLockUtf8(key, database);
+    RETURN IF (LENGTH(value) = 0, myRedis.SetAndPublishUtf8(key, func(key2), database), value);
 END;
 getUnicode(STRING key, STRING key2, myFuncUni func) := FUNCTION
-    value := myRedis.GetOrLockUnicode(key);
-    RETURN IF (LENGTH(value) = 0, myRedis.SetAndPublishUnicode(key, func(key2)), value);
+    value := myRedis.GetOrLockUnicode(key, database);
+    RETURN IF (LENGTH(value) = 0, myRedis.SetAndPublishUnicode(key, func(key2), database), value);
 END;
 
 //Test compatibiltiy between locking and normal functions.
 SEQUENTIAL(
-    myRedis.FlushDB(),
-    myRedis.SetUtf8('utf8', U'אבגדהוזחטיךכלםמןנסעףפץצקרשת'),
-    myRedis.GetUtf8('utf8'),
-    myRedis.GetOrLockUtf8('utf8'),
-    myRedis.FlushDB(),
-    myRedis.SetAndPublishUtf8('utf8-2', U'אבגדהוזחטיךכלםמןנסעףפץצקרשת'),
-    myRedis.GetUtf8('utf8-2'),
-    myRedis.GetOrLockUtf8('utf8-2'),
-    myRedis.FlushDB(),
+    myRedis.FlushDB( database),
+    myRedis.SetUtf8('utf8', U'אבגדהוזחטיךכלםמןנסעףפץצקרשת', database),
+    myRedis.GetUtf8('utf8', database),
+    myRedis.GetOrLockUtf8('utf8', database),
+    myRedis.FlushDB(database),
+    myRedis.SetAndPublishUtf8('utf8-2', U'אבגדהוזחטיךכלםמןנסעףפץצקרשת', database),
+    myRedis.GetUtf8('utf8-2', database),
+    myRedis.GetOrLockUtf8('utf8-2', database),
+    myRedis.FlushDB(database),
 
-    myRedis.SetUnicode('unicode', U'אבגדהוזחטיךכלםמןנסעףפץצקרשת'),
-    myRedis.GetUnicode('unicode'),
-    myRedis.GetOrLockUnicode('unicode'),
-    myRedis.FlushDB(),
-    myRedis.SetAndPublishUnicode('unicode-2', U'אבגדהוזחטיךכלםמןנסעףפץצקרשת'),
-    myRedis.GetUnicode('unicode-2'),
-    myRedis.GetOrLockUnicode('unicode-2'),
-    myRedis.FlushDB()
+    myRedis.SetUnicode('unicode', U'אבגדהוזחטיךכלםמןנסעףפץצקרשת', database),
+    myRedis.GetUnicode('unicode', database),
+    myRedis.GetOrLockUnicode('unicode', database),
+    myRedis.FlushDB(database),
+    myRedis.SetAndPublishUnicode('unicode-2', U'אבגדהוזחטיךכלםמןנסעףפץצקרשת', database),
+    myRedis.GetUnicode('unicode-2', database),
+    myRedis.GetOrLockUnicode('unicode-2', database),
+    myRedis.FlushDB(database)
     );
 
 SEQUENTIAL(
-    myRedis.FlushDB(),
-    myRedis.SetUtf8('utf8-4', U'אבגדהוזחטיךכלםמןנסעףפץצקרשת'),
-    myRedis.GetUtf8('utf8-4'),
-    myRedis.GetOrLockUtf8('utf8-4'),
-    myRedis.FlushDB()
+    myRedis.FlushDB(database),
+    myRedis.SetUtf8('utf8-4', U'אבגדהוזחטיךכלםמןנסעףפץצקרשת', database),
+    myRedis.GetUtf8('utf8-4', database),
+    myRedis.GetOrLockUtf8('utf8-4', database),
+    myRedis.FlushDB(database)
     );
 
 SEQUENTIAL(
-    myRedis.FlushDB(),
-    myRedis.SetAndPublishUtf8('utf8-5', U'אבגדהוזחטיךכלםמןנסעףפץצקרשת'),
-    myRedis.GetUtf8('utf8-5'),
-    myRedis.GetOrLockUtf8('utf8-5'),
-    myRedis.FlushDB()
+    myRedis.FlushDB(database),
+    myRedis.SetAndPublishUtf8('utf8-5', U'אבגדהוזחטיךכלםמןנסעףפץצקרשת', database),
+    myRedis.GetUtf8('utf8-5', database),
+    myRedis.GetOrLockUtf8('utf8-5', database),
+    myRedis.FlushDB(database)
     );
 
 SEQUENTIAL(
-    myRedis.FlushDB(),
-    myRedis.setUtf8('utf8-6', U'אבגדהוזחטיךכלםמןנסעףפץצקרשת'),
+    myRedis.FlushDB(database),
+    myRedis.setUtf8('utf8-6', U'אבגדהוזחטיךכלםמןנסעףפץצקרשת', database),
     getUtf8('utf8', 'utf8-6', myFuncUtf8),
 );
 SEQUENTIAL(
-    myRedis.FlushDB(),
-    myRedis.setUnicode('utf8-7', U'אבגדהוזחטיךכלםמןנסעףפץצקרשת'),
+    myRedis.FlushDB(database),
+    myRedis.setUnicode('utf8-7', U'אבגדהוזחטיךכלםמןנסעףפץצקרשת', database),
     getUnicode('utf8', 'utf8-7', myFuncUni),
 );
 
 SEQUENTIAL(
-    myRedis.FlushDB(),
-    myRedis.setString('Einnie sit', 'Good boy Einnie!'),
+    myRedis.FlushDB(database),
+    myRedis.setString('Einnie sit', 'Good boy Einnie!', database),
     getString('Einstein', 'Einnie sit', myFuncStr),
 
-    myRedis.setString('Einstein', 'This way kido'),
+    myRedis.setString('Einstein', 'This way kido', database),
     getString('Einstein', 'Einnie sit', myFuncStr),
 );
 
 //Test unlock
 SEQUENTIAL(
-    myRedis.FlushDB(),
-    myRedis.GetOrLockString('testlock',, 1000),
-    myRedis.Exists('testlock'),
+    myRedis.FlushDB(database),
+    myRedis.GetOrLockString('testlock', database, 1000),
+    myRedis.Exists('testlock', database),
     Std.System.Debug.Sleep(2000),
-    myRedis.Exists('testlock'),
+    myRedis.Exists('testlock', database),
 
-    myRedis.SetString('testlock', 'redis_ecl_lock_blah_blah_blah'),
-    myRedis.Exists('testlock'),
-    myRedis.Unlock('testlock'),
-    myRedis.Exists('testlock'),
-    myRedis.FlushDB(),
+    myRedis.SetString('testlock', 'redis_ecl_lock_blah_blah_blah', database),
+    myRedis.Exists('testlock', database),
+    myRedis.Unlock('testlock', database),
+    myRedis.Exists('testlock', database),
+    myRedis.FlushDB(database),
     );
 
 SEQUENTIAL(
-    myRedis.FlushDB(1);
-    myRedis.SetAndPublishString('testDatabaseExpire1', 'databaseThenExpire', 1, 10000);
-    myRedis.GetString('testDatabaseExpire1', 1);
-    myRedis.GetOrLockString('testDatabaseExpire1', 1);
-    myRedis.FlushDB(1);
+    myRedis.FlushDB(database + 1);
+    myRedis.SetAndPublishString('testDatabaseExpire1', 'databaseThenExpire', database + 1, 10000);
+    myRedis.GetString('testDatabaseExpire1', database + 1);
+    myRedis.GetOrLockString('testDatabaseExpire1', database + 1);
+    myRedis.FlushDB(database + 1);
     );
 
 SEQUENTIAL(
-    myRedis.FlushDB(2);
-    myRedis.SetAndPublishUnicode('testDatabaseExpire2', 'databaseThenExpire', 2, 10000);
-    myRedis.GetUnicode('testDatabaseExpire2', 2);
-    myRedis.GetOrLockUnicode('testDatabaseExpire2', 2);
-    myRedis.FlushDB(2);
+    myRedis.FlushDB(database + 2);
+    myRedis.SetAndPublishUnicode('testDatabaseExpire2', 'databaseThenExpire', database + 2, 10000);
+    myRedis.GetUnicode('testDatabaseExpire2', database + 2);
+    myRedis.GetOrLockUnicode('testDatabaseExpire2', database + 2);
+    myRedis.FlushDB(database + 2);
     );
 
 SEQUENTIAL(
-    myRedis.FlushDB(3);
-    myRedis.SetAndPublishUtf8('testDatabaseExpire3', 'databaseThenExpire', 3, 10000);
-    myRedis.GetUtf8('testDatabaseExpire3', 3);
-    myRedis.GetOrLockUtf8('testDatabaseExpire3', 3);
-    myRedis.FlushDB(3);
+    myRedis.FlushDB(database + 3);
+    myRedis.SetAndPublishUtf8('testDatabaseExpire3', 'databaseThenExpire', database + 3, 10000);
+    myRedis.GetUtf8('testDatabaseExpire3', database + 3);
+    myRedis.GetOrLockUtf8('testDatabaseExpire3', database + 3);
+    myRedis.FlushDB(database + 3);
     );
 
 SEQUENTIAL(
-    myRedis.FlushDB(),
-    myRedis.SetAndPublishString('t1', 'Good boy Einnie!');
-    myRedis.GetString('t1');
+    myRedis.FlushDB(database),
+    myRedis.SetAndPublishString('t1', 'Good boy Einnie!', database);
+    myRedis.GetString('t1', database);
 
-    myRedis.SetAndPublishString('t2', 'Good boy Einnie!', 1, 10000);
-    myRedis.GetString('t2', 1);
+    myRedis.SetAndPublishString('t2', 'Good boy Einnie!', database + 1, 10000);
+    myRedis.GetString('t2', database + 1);
 
-    myRedis.SetAndPublishString('t3', 'supercalifragilisticexpialidocious');
-    myRedis.GetString('t3');
+    myRedis.SetAndPublishString('t3', 'supercalifragilisticexpialidocious', database);
+    myRedis.GetString('t3', database);
 
-    myRedis.SetAndPublishString('t4', 'supercalifragilisticexpialidocious', 1, 10000);
-    myRedis.GetString('t4', 1);
+    myRedis.SetAndPublishString('t4', 'supercalifragilisticexpialidocious', database + 1, 10000);
+    myRedis.GetString('t4', database + 1);
 
-    myRedis.FlushDB();
-    myRedis.FlushDB(1);
+    myRedis.FlushDB(database);
+    myRedis.FlushDB(database + 1);
     );
 
-myRedis.FlushDB();
+myRedis.FlushDB(database);
+myRedis.FlushDB(database + 1);
+myRedis.FlushDB(database + 2);
+myRedis.FlushDB(database + 3);

--- a/testing/regress/ecl/redissynctest.ecl
+++ b/testing/regress/ecl/redissynctest.ecl
@@ -25,11 +25,15 @@ IMPORT Std;
 
 STRING server := '--SERVER=127.0.0.1:6379';
 STRING password := 'foobared';
-redis.FlushDB(server, /*database*/, password);
+// The database is need to avoid crossover manipulation when multiple redis tests
+// executed in parallel
+INTEGER4 database := 5;
+redis.FlushDB(server, database, password);
+
 
 SEQUENTIAL(
-    redis.SetBoolean('b', TRUE, server, /*database*/, /*expire*/, password);
-    redis.GetBoolean('b', server, /*database*/, password);
+    redis.SetBoolean('b', TRUE, server, database, /*expire*/, password);
+    redis.GetBoolean('b', server, database, password);
     );
 
 IMPORT redisServer FROM lib_redis;
@@ -37,137 +41,137 @@ myRedis := redisServer(server, password);
 
 REAL pi := 3.14159265359;
 SEQUENTIAL(
-    myRedis.SetReal('pi', pi);
-    myRedis.GetReal('pi');
-    myRedis.GetInteger('pi');
+    myRedis.SetReal('pi', pi, database);
+    myRedis.GetReal('pi', database);
+    myRedis.GetInteger('pi', database);
     );
 
 REAL pi2 := pi*pi;
 SEQUENTIAL(
-    myRedis.SetReal('pi', pi2, 1);
-    myRedis.GetReal('pi', 1);
+    myRedis.SetReal('pi', pi2, database + 1);
+    myRedis.GetReal('pi', database + 1);
     );
 
 INTEGER i := 123456789;
 SEQUENTIAL(
-    myRedis.SetInteger('i', i);
-    myRedis.GetInteger('i');
+    myRedis.SetInteger('i', i, database);
+    myRedis.GetInteger('i', database);
     );
 
 myRedis2 := redisServer('--SERVER=127.0.0.1:6380', 'youarefoobared');
 SEQUENTIAL(
-    myRedis2.SetReal('pi', pi2, 1);
-    myRedis2.GetReal('pi', 1);
+    myRedis2.SetReal('pi', pi2, database + 1);
+    myRedis2.GetReal('pi', database + 1);
     );
 
 SEQUENTIAL(
-    myRedis2.SetInteger('i', i);
-    myRedis2.GetInteger('i');
+    myRedis2.SetInteger('i', i, database);
+    myRedis2.GetInteger('i', database);
     );
 
 UNSIGNED u := 7;
 SEQUENTIAL(
-    myRedis.SetUnsigned('u', u);
-    myRedis.GetUnsigned('u');
+    myRedis.SetUnsigned('u', u, database);
+    myRedis.GetUnsigned('u', database);
     );
 
 myRedis3 := RedisServer('--SERVER=127.0.0.1:6381', password);
 SEQUENTIAL(
-    myRedis3.SetUnsigned('u3', u);
-    myRedis3.GetUnsigned('u3');
+    myRedis3.SetUnsigned('u3', u, database);
+    myRedis3.GetUnsigned('u3', database);
     );
 
 STRING str  := 'supercalifragilisticexpialidocious';
 SEQUENTIAL(
-    myRedis.SetString('str', str);
-    myRedis.GetString('str');
-    myRedis.FlushDB();
-    myRedis.Exists('str');
+    myRedis.SetString('str', str, database);
+    myRedis.GetString('str', database);
+    myRedis.FlushDB(database);
+    myRedis.Exists('str', database);
     );
 
 UNICODE uni := U'אבגדהוזחטיךכלםמןנסעףפץצקרשת';
 SEQUENTIAL(
-    myRedis.setUnicode('uni', uni);
-    myRedis.getUnicode('uni');
+    myRedis.setUnicode('uni', uni, database);
+    myRedis.getUnicode('uni', database);
     );
 
 UTF8 utf := U'אבגדהוזחטיךכלםמןנסעףפץצקרשת';
 SEQUENTIAL(
-    myRedis.SetUtf8('utf8', utf);
-    myRedis.GetUtf8('utf8');
-    myRedis.Exists('utf8');
-    myRedis.Delete('utf8');
-    myRedis.Exists('uft8');
+    myRedis.SetUtf8('utf8', utf, database);
+    myRedis.GetUtf8('utf8', database);
+    myRedis.Exists('utf8', database);
+    myRedis.Delete('utf8', database);
+    myRedis.Exists('uft8', database);
     );
 
 DATA mydata := x'd790d791d792d793d794d795d796d798d799d79ad79bd79cd79dd79dd79ed79fd7a0d7a1d7a2d7a3d7a4d7a5d7a6d7a7d7a8d7a9d7aa';
 SEQUENTIAL(
-    myRedis.SetData('data', mydata);
-    myRedis.GetData('data');
+    myRedis.SetData('data', mydata, database);
+    myRedis.GetData('data', database);
     );
 
 SEQUENTIAL(
-    myRedis.SetString('str2int', 'abcdefgh');//Heterogeneous calls will only result in an exception when the retrieved value does not fit into memory of the requested type.
-    myRedis.GetInteger('str2int');
+    myRedis.SetString('str2int', 'abcdefgh', database);//Heterogeneous calls will only result in an exception when the retrieved value does not fit into memory of the requested type.
+    myRedis.GetInteger('str2int', database);
     );
 
 sleep(INTEGER duration) := Std.System.Debug.Sleep(duration * 1000);
 
 SEQUENTIAL(
-    myRedis.Exists('str2'),
-    myRedis.Expire('str2', , 900),/*\ms*/
+    myRedis.Exists('str2', database),
+    myRedis.Expire('str2', database, 900),//\ms
     sleep(2),
-    myRedis.Exists('str2'),
+    myRedis.Exists('str2', database),
 
-    myRedis.SetString('str3', str),
-    myRedis.Exists('str3'),
-    myRedis.Expire('str3', , 900),/*\ms*/
-    myRedis.Persist('str3'),
+    myRedis.SetString('str3', str, database),
+    myRedis.Exists('str3', database),
+    myRedis.Expire('str3', database, 900),//\ms
+    myRedis.Persist('str3', database),
     sleep(2),
-    myRedis.Exists('str3')
+    myRedis.Exists('str3', database)
     );
 
 SEQUENTIAL(
-    myRedis.SetString('Einnie', 'Woof', 0, 1000),
-    myRedis.Exists('Einnie');
+    myRedis.SetString('Einnie', 'Woof', database, 1000),
+    myRedis.Exists('Einnie', database);
     sleep(2);
-    myRedis.Exists('Einnie');
+    myRedis.Exists('Einnie', database);
 
-    myRedis.SetString('Einnie', 'Woof', 0),
-    myRedis.SetString('Einnie', 'Grrrr', 1),
-    myRedis.GetString('Einnie', 0),
-    myRedis.GetString('Einnie', 1),
-    myRedis.SetString('Einnie', 'Woof-Woof'),
-    myRedis.GetString('Einnie'),
+    myRedis.SetString('Einnie', 'Woof', database),
+    myRedis.SetString('Einnie', 'Grrrr', database + 1),
+    myRedis.GetString('Einnie', database),
+    myRedis.GetString('Einnie', database + 1),
+    myRedis.SetString('Einnie', 'Woof-Woof', database),
+    myRedis.GetString('Einnie', database),
     );
 
-myRedis.DBSize();
-myRedis.DBSize(1);
-myRedis.DBSize(2);
+myRedis.DBSize(database);
+myRedis.DBSize(database + 1);
+myRedis.DBSize(database + 2);
 
 //The follwoing tests the multithreaded caching of the redis connections
 //SUM(NOFOLD(s1 + s2), a) uses two threads
 INTEGER x := 2;
 INTEGER N := 100;
-myRedis.FlushDB();
-s1 := DATASET(N, TRANSFORM({ integer a }, SELF.a := myRedis.GetInteger('transformTest' +  'x'[1..NOFOLD(0)*COUNTER]   )));
-s2 := DATASET(N, TRANSFORM({ integer a }, SELF.a := myRedis.GetInteger('transformTest' +  'x'[1..NOFOLD(0)*COUNTER]   )/2));
+myRedis.FlushDB(database);
+s1 := DATASET(N, TRANSFORM({ integer a }, SELF.a := myRedis.GetInteger('transformTest' +  'x'[1..NOFOLD(0)*COUNTER]   , database)));
+s2 := DATASET(N, TRANSFORM({ integer a }, SELF.a := myRedis.GetInteger('transformTest' +  'x'[1..NOFOLD(0)*COUNTER]   , database)/2));
 //'x'[1..NOFOLD(0)*COUNTER] prevents the compiler from obeying the 'once' keyword associated with the GetString service definition and
-//therefore calls GetString('transformTest') 2N times as could be intended.  Without this, it is only called once/thread (in this case twice).
+//therefore calls GetString('transformTest', database) 2N times as could be intended.  Without this, it is only called once/thread (in this case twice).
 //In either case the resultant aggregrate below will return 1.5xN (1.5*2*100 = 300).
 SEQUENTIAL(
-    myRedis.SetInteger('transformTest', x),
+    myRedis.SetInteger('transformTest', x, database),
     OUTPUT(SUM(NOFOLD(s1 + s2), a))//answer = (x+x/2)*N, in this case 300.
     );
 
 //Test Publish and Subscribe
 //SUM(NOFOLD(s1 + s2), a) uses two threads - this test relies on this fact to work!
 INTEGER N2 := 1000;
-subDS := DATASET(N2, TRANSFORM({ integer a }, SELF.a := (INTEGER)myRedis.Subscribe('PubSubTest' + (STRING)COUNTER)));
+subDS := DATASET(N2, TRANSFORM({ integer a }, SELF.a := (INTEGER)myRedis.Subscribe('PubSubTest' + (STRING)COUNTER, database)));
 
 INTEGER pub(STRING channel) := FUNCTION
         sl := Std.System.Debug.Sleep(10);
-        value :=  myRedis.Publish(channel, '1');
+        value :=  myRedis.Publish(channel, '1', database);
      RETURN WHEN(value, sl, BEFORE);
 END;
 pubDS := DATASET(N2, TRANSFORM({ integer a }, SELF.a := pub('PubSubTest' + (STRING)COUNTER)));
@@ -175,9 +179,9 @@ pubDS := DATASET(N2, TRANSFORM({ integer a }, SELF.a := pub('PubSubTest' + (STRI
 INTEGER pub2(STRING channel) := FUNCTION
         sl := SEQUENTIAL(
             Std.System.Debug.Sleep(10),
-            myRedis.Publish(channel, '3')//This pub is the one read by the sub.
+            myRedis.Publish(channel, '3', database)//This pub is the one read by the sub.
             );
-        value :=  myRedis.Publish(channel, '10000');//This pub isn't read by the sub, however the returned subscription count is present in the sum
+        value :=  myRedis.Publish(channel, '10000', database);//This pub isn't read by the sub, however the returned subscription count is present in the sum
      RETURN WHEN(value, sl, BEFORE);
 END;
 pubDS2 := DATASET(N2, TRANSFORM({ integer a }, SELF.a := pub2('PubSubTest' + (STRING)COUNTER)));
@@ -190,25 +194,29 @@ SEQUENTIAL(
     // N*3 > result < N*4 => all subs received a pub, however, there were result-N*3 subs still open for the second pub. result > N*4 => gremlins.
 
 SEQUENTIAL(
-    myRedis.FlushDB(),
-    myRedis.SetInteger('testINCRBY', 10),
-    myRedis.INCRBY('testINCRBY', 11),
-    myRedis.GetInteger('testINCRBY')
+    myRedis.FlushDB(database),
+    myRedis.SetInteger('testINCRBY', 10, database),
+    myRedis.INCRBY('testINCRBY', 11, database),
+    myRedis.GetInteger('testINCRBY', database)
 );
 
 SEQUENTIAL(
-    myRedis.FlushDB(),
-    myRedis.SetString('testINCRBY2', '500'),
-    myRedis.INCRBY('testINCRBY2', -11),
-    myRedis.GetInteger('testINCRBY2')
+    myRedis.FlushDB(database),
+    myRedis.SetString('testINCRBY2', '500', database),
+    myRedis.INCRBY('testINCRBY2', -11, database),
+    myRedis.GetInteger('testINCRBY2', database)
 );
 
 SEQUENTIAL(
-    myRedis.FlushDB(),
-    myRedis.SetUnsigned('testINCRBY3', 600),
-    myRedis.INCRBY('testINCRBY3', 11),
-    myRedis.GetUnsigned('testINCRBY3')
+    myRedis.FlushDB(database),
+    myRedis.SetUnsigned('testINCRBY3', 600, database),
+    myRedis.INCRBY('testINCRBY3', 11, database),
+    myRedis.GetUnsigned('testINCRBY3', database)
 );
 
-myRedis.FlushDB();
-myRedis2.FlushDB();
+// Clean up
+myRedis.FlushDB(database);
+myRedis.FlushDB(database + 1);
+myRedis2.FlushDB(database);
+myRedis2.FlushDB(database + 1);
+myRedis3.FlushDB(database);


### PR DESCRIPTION

Fix the bug where multiple Redis test cases use same database. This caused
failure when those test cases were executing parallel and modify/remove
data with same name used by other test(s).

Signed-off-by: HPCCSmoketest <hpccsmoketest@gmail.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [x] All new and existing tests passed.
  - [x] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [x] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [x] Existing deployed queries will not be broken
  - [x] This change fixes the problem, not just the symptom
  - [ x The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [x] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->
Tested manually with PQ enabled and it will be part of next OBT.
<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
