### PR TITLE
HPCC-16776 Suppress too many files warning

### DIFF
--- a/esp/src/eclwatch/DFUQueryWidget.js
+++ b/esp/src/eclwatch/DFUQueryWidget.js
@@ -372,6 +372,8 @@ define([
                 DropZoneFolders: true
             });
 
+            this.filter.setValue(this.id + "MaxNumberOfFiles", 1000);
+            this.filter.emit("apply");
             this.initWorkunitsGrid();
 
             this.filter.on("clear", function (evt) {
@@ -382,20 +384,6 @@ define([
             });
             topic.subscribe("hpcc/dfu_wu_completed", function (topic) {
                 context.refreshGrid();
-            });
-
-            WsDfu.DFUQuery({
-                request: {}
-            }).then(function (response) {
-                if (lang.exists("DFUQueryResponse.Warning", response)) {
-                    if (response.DFUQueryResponse.Warning) {
-                        dojo.publish("hpcc/brToaster", {
-                            Severity: "Error",
-                            Source: "WsDfu.DFUQuery",
-                            Exceptions: [{ Source: context.i18n.TooManyFiles, Message: context.i18n.TheReturnedResults + ": " + response.DFUQueryResponse.NumFiles + ", " + context.i18n.RepresentsASubset }]
-                        });
-                    }
-                }
             });
 
             this.createNewSuperRadio.on('change', function (value) {

--- a/esp/src/eclwatch/ESPLogicalFile.js
+++ b/esp/src/eclwatch/ESPLogicalFile.js
@@ -21,13 +21,16 @@ define([
     "dojo/store/Observable",
     "dojo/store/util/QueryResults",
     "dojo/Stateful",
+    "dojo/topic",
+    "dojo/i18n",
+    "dojo/i18n!./nls/hpcc",
 
     "hpcc/WsDfu",
     "hpcc/FileSpray",
     "hpcc/ESPRequest",
     "hpcc/ESPUtil",
     "hpcc/ESPResult"
-], function (declare, arrayUtil, lang, Deferred, Observable, QueryResults, Stateful,
+], function (declare, arrayUtil, lang, Deferred, Observable, QueryResults, Stateful, topic, i18n, nlsHPCC,
         WsDfu, FileSpray, ESPRequest, ESPUtil, ESPResult) {
 
     var _logicalFiles = {};
@@ -56,6 +59,7 @@ define([
         idProperty: "__hpcc_id",
         startProperty: "PageStartFrom",
         countProperty: "PageSize",
+        i18n: nlsHPCC,
 
         _watched: [],
         create: function (id) {
@@ -71,6 +75,17 @@ define([
                     break;
             }
         },
+        preProcessFullResponse: function (response, request) {
+            var context = this;
+            if (lang.exists("DFUQueryResponse.Warning", response) && response.DFUQueryResponse.Warning) {
+                dojo.publish("hpcc/brToaster", {
+                    Severity: "Warning",
+                    Source: "WsDfu.DFUQuery",
+                    Exceptions: [{ Source: context.i18n.TooManyFiles, Message: context.i18n.TheReturnedResults + ": " + response.DFUQueryResponse.NumFiles + ", " + context.i18n.RepresentsASubset }]
+                });
+            }
+        },
+
         update: function (id, item) {
             var storeItem = this.get(id);
             storeItem.updateData(item);

--- a/esp/src/eclwatch/nls/hpcc.js
+++ b/esp/src/eclwatch/nls/hpcc.js
@@ -332,6 +332,7 @@ define({root:
     Mask: "Mask",
     Max: "Max",
     MaxNode: "Max Node",
+    MaxNumberOfFiles: "Maximum Number Of Files",
     MaxSize: "Max Size",
     MaximumNumberOfSlaves: "Slave Number",
     MaxRecordLength: "Max Record Length",

--- a/esp/src/eclwatch/templates/DFUQueryWidget.html
+++ b/esp/src/eclwatch/templates/DFUQueryWidget.html
@@ -153,6 +153,7 @@
                         <input id="${id}ClusterTargetSelect" title="${i18n.Cluster}:" name="NodeGroup" colspan="2" style="display: inline-block; vertical-align: middle" data-dojo-type="TargetSelectWidget" />
                         <input id="${id}FromSize" title="${i18n.FromSizes}:" name="FileSizeFrom" colspan="2" data-dojo-props="trim: true, placeHolder:'4096'" data-dojo-type="dijit.form.TextBox" />
                         <input id="${id}ToSize" title="${i18n.ToSizes}:" name="FileSizeTo" colspan="2" data-dojo-props="trim: true, placeHolder:'16777216'" data-dojo-type="dijit.form.TextBox" />
+                        <input id="${id}MaxNumberOfFiles" title="${i18n.MaxNumberOfFiles}:" name="MaxNumberOfFiles" colspan="2" data-dojo-props="trim: true, placeHolder:'1000'" data-dojo-type="dijit.form.TextBox" />
                         <select id="${id}FileType" title="${i18n.FileType}:" name="FileType" colspan="2" data-dojo-type="dijit.form.Select">
                             <option value="" selected="selected">${i18n.LogicalFilesAndSuperfiles}</option>
                             <option value="Logical Files Only">${i18n.LogicalFilesOnly}</option>


### PR DESCRIPTION
Within the logical files query page we have intialized a filter that will load the first 1000 files if the 100,000 file cap is met which previous set off a toaster alert. If the user removes this filter the warning toaster message will fire.

Signed-off-by: Miguel Vazquez <miguel.vazquez@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [ ] I have read the CONTRIBUTORS document.
- [ ] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [x] Scalability
  - [x] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [x] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [x] This is a user interface / front-end modification
  - [x] I have tested my changes in multiple modern browers
  - [x] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
