### PR TITLE
HPCC-17112 Regression suite to check warnings

### DIFF
--- a/testing/regress/ecl-test
+++ b/testing/regress/ecl-test
@@ -165,6 +165,8 @@ class RegressMain:
                                 nargs=1,  default = ['all'],   metavar="class[,class,...]")
         executionParser.add_argument('--excludeclass', '-e', help="exclude subclass(es) of the suite. Default value is 'none'",
                                 nargs=1,  default = ['none'],   metavar="class[,class,...]")
+        executionParser.add_argument('--handleEclccWarningFile', '-w', help="Create/overwrite/delete ECLCC warning file.",
+                                action='store_true')
 
         parser = argparse.ArgumentParser(prog=prog, description=description,  parents=[helperParser, commonParser,  executionParser])
 

--- a/testing/regress/ecl/key/loopif.eclccwarn
+++ b/testing/regress/ecl/key/loopif.eclccwarn
@@ -1,0 +1,2 @@
+loopif.ecl(27,68): warning C2168: Field 'i' in TABLE does not appear to be properly defined by grouping conditions
+0 error, 1 warning

--- a/testing/regress/ecl/key/xmlout2.eclccwarn
+++ b/testing/regress/ecl/key/xmlout2.eclccwarn
@@ -1,0 +1,2 @@
+xmlout2.ecl(66,38): warning C1023: Condition is always false
+0 error, 1 warning

--- a/testing/regress/hpcc/common/shell.py
+++ b/testing/regress/hpcc/common/shell.py
@@ -58,4 +58,4 @@ class Shell:
             exception.output = err_msg
             logging.debug("exception.output:'%s'",  err_msg)
             raise Error('1001', err=str(err_msg))
-        return stdout
+        return stdout, stderr

--- a/testing/regress/hpcc/regression/regress.py
+++ b/testing/regress/hpcc/regression/regress.py
@@ -504,35 +504,43 @@ class Regression:
         res = 0
         wuid = None
         if ECLCC().makeArchive(query):
-            eclCmd = ECLcmd()
-            try:
-                if publish:
-                    res = eclCmd.runCmd("publish", cluster, query, report[0],
-                                      server=self.config.espIp,
-                                      username=self.config.username,
-                                      password=self.config.password, 
-                                      retryCount=self.config.maxAttemptCount)
-                else:
-                    res = eclCmd.runCmd("run", cluster, query, report[0],
-                                      server=self.config.espIp,
-                                      username=self.config.username,
-                                      password=self.config.password, 
-                                      retryCount=self.config.maxAttemptCount)
-            except Error as e:
-                logging.debug("Exception raised:'%s'"  % ( str(e)),  extra={'taskId':cnt})
+            if query.isEclccWarningChanged():
+                logging.debug("Should check Eclcc Warning:'%s'"  % (query.getEclccWarning()),  extra={'taskId':cnt})
                 res = False
                 wuid = 'Not found'
                 query.setWuid(wuid)
-                query.diff = query.getBaseEcl()+"\n\t"+str(e)
+                query.diff = query.getEclccWarningChanges()
                 report[0].addResult(query)
-                pass
-            except:
-                logging.error("Unexpected error:'%s'" %( sys.exc_info()[0]) ,  extra={'taskId':cnt})
+            else:
+                eclCmd = ECLcmd()
+                try:
+                    if publish:
+                        res = eclCmd.runCmd("publish", cluster, query, report[0],
+                                          server=self.config.espIp,
+                                          username=self.config.username,
+                                          password=self.config.password,
+                                          retryCount=self.config.maxAttemptCount)
+                    else:
+                        res = eclCmd.runCmd("run", cluster, query, report[0],
+                                          server=self.config.espIp,
+                                          username=self.config.username,
+                                          password=self.config.password,
+                                          retryCount=self.config.maxAttemptCount)
+                except Error as e:
+                    logging.debug("Exception raised:'%s'"  % ( str(e)),  extra={'taskId':cnt})
+                    res = False
+                    wuid = 'Not found'
+                    query.setWuid(wuid)
+                    query.diff = query.getBaseEcl()+"\n\t"+str(e)
+                    report[0].addResult(query)
+                    pass
+                except:
+                    logging.error("Unexpected error:'%s'" %( sys.exc_info()[0]) ,  extra={'taskId':cnt})
 
-            wuid = query.getWuid()
-            logging.debug("CMD result: '%s', wuid:'%s'"  % ( res,  wuid),  extra={'taskId':cnt})
-            if wuid == 'Not found':
-                res = False
+                wuid = query.getWuid()
+                logging.debug("CMD result: '%s', wuid:'%s'"  % ( res,  wuid),  extra={'taskId':cnt})
+                if wuid == 'Not found':
+                    res = False
         else:
             res = False
             report[0].addResult(query)

--- a/testing/regress/hpcc/util/ecl/cc.py
+++ b/testing/regress/hpcc/util/ecl/cc.py
@@ -40,7 +40,7 @@ class ECLCC(Shell):
         except Error as err:
             logging.debug("getArchive exception:'%s'",  repr(err))
             self.makeArchiveError = str(err)
-            return repr(err)
+            return (repr(err), repr( err))
 
     def makeArchive(self, ecl):
         self.addIncludePath(ecl.dir_inc)
@@ -51,7 +51,7 @@ class ECLCC(Shell):
             os.mkdir(dirname)
         if os.path.isfile(filename):
             os.unlink(filename)
-        result = self.getArchive(ecl)
+        result, stderr = self.getArchive(ecl)
 
         if result.startswith( 'Error()'):
             retVal = False
@@ -73,6 +73,9 @@ class ECLCC(Shell):
                 ecl.diff += repr(self.makeArchiveError)
             self.makeArchiveError=''
         else:
+            logging.debug("%3d. makeArchive (stderr:'%s')", ecl.getTaskId(), stderr )
+            if 'arning' in stderr:
+                ecl.setEclccWarning(stderr)
             logging.debug("%3d. makeArchive (filename:'%s')", ecl.getTaskId(), filename )
             FILE = open(filename, "w")
             FILE.write(result)

--- a/testing/regress/hpcc/util/ecl/command.py
+++ b/testing/regress/hpcc/util/ecl/command.py
@@ -88,8 +88,9 @@ class ECLcmd(Shell):
         results=''
         try:
             #print "runCmd:", args
-            results = self.__ECLcmd()(*args)
+            results, stderr = self.__ECLcmd()(*args)
             logging.debug("%3d. results:'%s'", eclfile.getTaskId(),  results)
+            logging.debug("%3d. stderr :'%s'", eclfile.getTaskId(),  stderr)
             data = '\n'.join(line for line in
                              results.split('\n') if line) + "\n"
             ret = data.split('\n')

--- a/testing/regress/hpcc/util/util.py
+++ b/testing/regress/hpcc/util/util.py
@@ -106,7 +106,7 @@ def queryWuid(jobname,  taskId):
     args.append('--server=' + gConfig.espIp)
     args.append('--username=' + gConfig.username)
     args.append('--password=' + gConfig.password)
-    res = shell.command(cmd, *defaults)(*args)
+    res, stderr = shell.command(cmd, *defaults)(*args)
     logging.debug("%3d. queryWuid(%s, cmd :'%s') result is: '%s'",  taskId,  jobname, cmd,  res)
     wuid = "Not found"
     state = 'N/A'


### PR DESCRIPTION
Add code to collect, check and report eclcc generated warnings.

Add elcccwarn file to loopif.ecl and xmlout2.ecl files as known issues.

Update README.rst file to explain how warning check works and
how to prepare .eclccwarn file.

Signed-off-by: HPCCSmoketest <hpccsmoketest@gmail.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [x] I have added tests to cover my changes.
  - [x] All new and existing tests passed.
  - [x] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [x] Scalability
  - [x] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [x] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [x] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [x] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->
It is tested with locally executed full OBT with --PQ enabled.
<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
