### PR TITLE
HPCC-14681 Fix "double free" memory in ESP esdl logging

### DIFF
--- a/esp/logging/loggingmanager/loggingmanager.h
+++ b/esp/logging/loggingmanager/loggingmanager.h
@@ -27,11 +27,11 @@
 
 interface IEspLogEntry  : implements IInterface
 {
-    virtual void setEspContext(IEspContext* ctx)  = 0;
-    virtual void setUserContextTree(IPropertyTree* tree) = 0;
-    virtual void setUserRequestTree(IPropertyTree* tree) = 0;
-    virtual void setLogInfoTree(IPropertyTree* tree) = 0;
-    virtual void setExtraLog(IInterface* extra) = 0;
+    virtual void setOwnEspContext(IEspContext* ctx)  = 0;
+    virtual void setOwnUserContextTree(IPropertyTree* tree) = 0;
+    virtual void setOwnUserRequestTree(IPropertyTree* tree) = 0;
+    virtual void setOwnLogInfoTree(IPropertyTree* tree) = 0;
+    virtual void setOwnExtraLog(IInterface* extra) = 0;
     virtual void setOption(const char* ptr) = 0;
     virtual void setLogContent(const char* ptr) = 0;
     virtual void setBackEndResp(const char* ptr) = 0;

--- a/esp/logging/loggingmanager/loggingmanager.hpp
+++ b/esp/logging/loggingmanager/loggingmanager.hpp
@@ -45,11 +45,11 @@ public:
 
     CEspLogEntry(void) { };
 
-    void setEspContext(IEspContext* ctx) { espContext.setown(ctx); };
-    void setUserContextTree(IPropertyTree* tree) { userContextTree.setown(tree); };
-    void setUserRequestTree(IPropertyTree* tree) { userRequestTree.setown(tree); };
-    void setLogInfoTree(IPropertyTree* tree) { logInfoTree.setown(tree); };
-    void setExtraLog(IInterface* extra) { extraLog.setown(extra); };
+    void setOwnEspContext(IEspContext* ctx) { espContext.setown(ctx); };
+    void setOwnUserContextTree(IPropertyTree* tree) { userContextTree.setown(tree); };
+    void setOwnUserRequestTree(IPropertyTree* tree) { userRequestTree.setown(tree); };
+    void setOwnLogInfoTree(IPropertyTree* tree) { logInfoTree.setown(tree); };
+    void setOwnExtraLog(IInterface* extra) { extraLog.setown(extra); };
     void setOption(const char* ptr) { option.set(ptr); };
     void setLogContent(const char* ptr) { logContent.set(ptr); };
     void setBackEndResp(const char* ptr) { backEndResp.set(ptr); };

--- a/esp/logging/test/logging_test.cpp
+++ b/esp/logging/test/logging_test.cpp
@@ -139,9 +139,9 @@ void sendRequest()
         Sleep(5000); //Waiting for loggingManager to start
         Owned<IEspLogEntry> entry = loggingManager->createLogEntry();
         entry->setOption(option.str());
-        entry->setEspContext(espContext);
-        entry->setUserContextTree(userContextTree);
-        entry->setUserRequestTree(userRequestTree);
+        entry->setOwnEspContext(LINK(espContext));
+        entry->setOwnUserContextTree(LINK(userContextTree));
+        entry->setOwnUserRequestTree(LINK(userRequestTree));
         entry->setUserResp(userRespXML.str());
         entry->setBackEndResp(backEndResp);
         entry->setLogDatasets(logDatasetsXML.str());
@@ -169,7 +169,7 @@ void sendRequest()
 
         Owned<IEspLogEntry> entry = loggingManager->createLogEntry();
         entry->setOption(option.str());
-        entry->setEspContext(espContext);
+        entry->setOwnEspContext(LINK(espContext));
         entry->setLogContent(logContentXML.str());
         loggingManager->updateLog(entry, status);
     }

--- a/esp/services/esdl_svc_engine/esdl_binding.cpp
+++ b/esp/services/esdl_svc_engine/esdl_binding.cpp
@@ -664,9 +664,9 @@ bool EsdlServiceImpl::handleResultLogging(IEspContext &espcontext, IPropertyTree
     {
         Owned<IEspLogEntry> entry = m_oLoggingManager->createLogEntry();
         entry->setOption(LOGGINGDBSINGLEINSERT);
-        entry->setEspContext(&espcontext);
-        entry->setUserContextTree(reqcontext);
-        entry->setUserRequestTree(request);
+        entry->setOwnEspContext(LINK(&espcontext));
+        entry->setOwnUserContextTree(LINK(reqcontext));
+        entry->setOwnUserRequestTree(LINK(request));
         entry->setUserResp(finalresp);
         entry->setBackEndResp(rawresp);
         entry->setLogDatasets(logdata);


### PR DESCRIPTION
In https://github.com/hpcc-systems/HPCC-Platform/pull/9610,
three set methods are used to pass log entry items. The set
methods call setown on those items without using LINK. The
LINKs are added in this fix.

Signed-off-by: wangkx <kevin.wang@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [x] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
