### PR TITLE
HPCC-17155 Fix crash in global join if LHS is empty

### DIFF
--- a/testing/regress/ecl/joinemptylhs.ecl
+++ b/testing/regress/ecl/joinemptylhs.ecl
@@ -1,0 +1,18 @@
+lhsRec := RECORD
+ string lhsstr := '';
+ boolean abool;
+end;
+
+rhsRec := RECORD
+ string5 rhsstr := '';
+ unsigned4 auint;
+end;
+
+lhs := DATASET(NOFOLD(0), TRANSFORM(lhsRec, SELF.lhsstr := (string)COUNTER, SELF.abool := false));
+rhs := DATASET(1, TRANSFORM(rhsRec, SELF.rhsstr := (string)COUNTER, SELF.auint := 1), DISTRIBUTED);
+
+j := JOIN(NOFOLD(lhs), NOFOLD(rhs), LEFT.lhsstr=RIGHT.rhsstr);
+
+SEQUENTIAL(
+ COUNT(NOFOLD(j));
+);

--- a/testing/regress/ecl/key/joinemptylhs.xml
+++ b/testing/regress/ecl/key/joinemptylhs.xml
@@ -1,0 +1,3 @@
+<Dataset name='Result 1'>
+ <Row><Result_1>0</Result_1></Row>
+</Dataset>

--- a/thorlcr/activities/msort/thmsort.cpp
+++ b/thorlcr/activities/msort/thmsort.cpp
@@ -175,7 +175,9 @@ protected:
         }
 
         Owned<IThorRowInterfaces> rowif = createRowInterfaces(container.queryInput(0)->queryHelper()->queryOutputMeta());
-        Owned<IThorRowInterfaces> auxrowif = createRowInterfaces(helper->querySortedRecordSize());
+        Owned<IThorRowInterfaces> auxrowif;
+        if (helper->querySortedRecordSize())
+            auxrowif.setown(createRowInterfaces(helper->querySortedRecordSize()));
         try
         {
             imaster->SortSetup(rowif,helper->queryCompare(),helper->querySerialize(),cosortfilenames.length()!=0,true,cosortfilenames.str(),auxrowif);

--- a/thorlcr/activities/msort/thmsortslave.cpp
+++ b/thorlcr/activities/msort/thmsortslave.cpp
@@ -105,7 +105,9 @@ public:
             }
             
             Linked<IThorRowInterfaces> rowif = queryRowInterfaces(input);
-            Owned<IThorRowInterfaces> auxrowif = createRowInterfaces(helper->querySortedRecordSize());
+            Owned<IThorRowInterfaces> auxrowif;
+            if (helper->querySortedRecordSize())
+                auxrowif.setown(createRowInterfaces(helper->querySortedRecordSize()));
             sorter->Gather(
                 rowif,
                 inputStream,

--- a/thorlcr/msort/tsortm.cpp
+++ b/thorlcr/msort/tsortm.cpp
@@ -386,6 +386,15 @@ public:
         ActPrintLog(activity, "Sort setup cosort=%s, needconnect=%s %s",cosort?"true":"false",needconnect?"true":"false",_keyserializer?"has key serializer":"");
         assertex(_icompare);
         rowif.set(_rowif);
+        if (cosort)
+        {
+            if (!partitioninfo->IsOK()) // i.e. no split points (0 rows on primary side)
+            {
+                _auxrowif = nullptr;
+                _keyserializer = nullptr;
+            }
+            cosort = false;
+        }
         if (_auxrowif&&_auxrowif->queryRowMetaData())
             auxrowif.set(_auxrowif);
         else
@@ -1422,9 +1431,9 @@ public:
                     char url[100];
                     slave.endpoint.getUrlStr(url,sizeof(url));
                     if (splitMapUpper)
-                        slave.MultiMergeBetween(numnodes*numnodes,splitMap,splitMapUpper,numnodes,endpoints);
+                        slave.MultiMergeBetween(total, numnodes*numnodes,splitMap,splitMapUpper,numnodes,endpoints);
                     else
-                        slave.MultiMerge(numnodes*numnodes,splitMap,numnodes,endpoints);
+                        slave.MultiMerge(total, numnodes*numnodes,splitMap,numnodes,endpoints);
     //              ActPrintLog(activity, "Merge %d started: %d rows on %s",i,tot[i],url);
                 }
             }

--- a/thorlcr/msort/tsortmp.cpp
+++ b/thorlcr/msort/tsortmp.cpp
@@ -188,10 +188,11 @@ rowcount_t SortSlaveMP::OverflowAdjustMapStop( unsigned mapsize, rowcount_t *map
     return ret;
 }
 
-void SortSlaveMP::MultiMerge(unsigned mapsize,rowcount_t *map,unsigned num,SocketEndpoint* endpoints) /* async */
+void SortSlaveMP::MultiMerge(rowcount_t globalCount, unsigned mapsize,rowcount_t *map,unsigned num,SocketEndpoint* endpoints) /* async */
 {
     CMessageBuffer mb;
     mb.append((byte)FN_MultiMerge);
+    mb.append(globalCount);
     mb.append(mapsize).append(mapsize*sizeof(rowcount_t),map);
     mb.append(num);
     while (num--) {
@@ -202,10 +203,11 @@ void SortSlaveMP::MultiMerge(unsigned mapsize,rowcount_t *map,unsigned num,Socke
 }
 
 
-void SortSlaveMP::MultiMergeBetween(unsigned mapsize,rowcount_t *map,rowcount_t *mapupper,unsigned num,SocketEndpoint* endpoints) /* async */
+void SortSlaveMP::MultiMergeBetween(rowcount_t globalCount, unsigned mapsize,rowcount_t *map,rowcount_t *mapupper,unsigned num,SocketEndpoint* endpoints) /* async */
 {
     CMessageBuffer mb;
     mb.append((byte)FN_MultiMergeBetween);
+    mb.append(globalCount);
     mb.append(mapsize).append(mapsize*sizeof(rowcount_t),map);
     mb.append(mapsize*sizeof(rowcount_t),mapupper);
     mb.append(num);
@@ -413,6 +415,8 @@ bool SortSlaveMP::marshall(ISortSlaveMP &slave, ICommunicator* comm, mptag_t tag
             case FN_MultiMerge: {
                 replydone = true;
                 comm->reply(mbout);
+                rowcount_t globalCount;
+                mb.read(globalCount);
                 unsigned mapsize;
                 mb.read(mapsize);
                 const void *map = mb.readDirect(mapsize*sizeof(rowcount_t));
@@ -424,12 +428,14 @@ bool SortSlaveMP::marshall(ISortSlaveMP &slave, ICommunicator* comm, mptag_t tag
                     ep.deserialize(mb);
                     epa.append(ep);
                 }
-                slave.MultiMerge(mapsize,(rowcount_t *)map,num,epa.getArray());
+                slave.MultiMerge(globalCount, mapsize,(rowcount_t *)map,num,epa.getArray());
             }
             break;
             case FN_MultiMergeBetween: {
                 replydone = true;
                 comm->reply(mbout);
+                rowcount_t globalCount;
+                mb.read(globalCount);
                 unsigned mapsize;
                 mb.read(mapsize);
                 const void *map = mb.readDirect(mapsize*sizeof(rowcount_t));
@@ -442,7 +448,7 @@ bool SortSlaveMP::marshall(ISortSlaveMP &slave, ICommunicator* comm, mptag_t tag
                     ep.deserialize(mb);
                     epa.append(ep);
                 }
-                slave.MultiMergeBetween(mapsize,(rowcount_t *)map,(rowcount_t *)mapupper,num,epa.getArray());
+                slave.MultiMergeBetween(globalCount, mapsize,(rowcount_t *)map,(rowcount_t *)mapupper,num,epa.getArray());
             }
             break;
             case FN_SingleMerge: {

--- a/thorlcr/msort/tsortmp.hpp
+++ b/thorlcr/msort/tsortmp.hpp
@@ -24,8 +24,8 @@ interface ISortSlaveMP
     virtual void MultiBinChopStop(unsigned num,rowcount_t *pos)=0;
     virtual void OverflowAdjustMapStart(unsigned mapsize,rowcount_t *map,size32_t keybuffsize,const byte *keybuff, byte cmpfn, bool useaux)=0; /* async */
     virtual rowcount_t OverflowAdjustMapStop(unsigned mapsize, rowcount_t *map)=0;
-    virtual void MultiMerge(unsigned mapsize,rowcount_t *map,unsigned num,SocketEndpoint* endpoints)=0; /* async */
-    virtual void MultiMergeBetween(unsigned mapsize,rowcount_t *map,rowcount_t *mapupper,unsigned num,SocketEndpoint* endpoints)=0; /* async */
+    virtual void MultiMerge(rowcount_t globalCount, unsigned mapsize,rowcount_t *map,unsigned num,SocketEndpoint* endpoints)=0; /* async */
+    virtual void MultiMergeBetween(rowcount_t globalCount, unsigned mapsize,rowcount_t *map,rowcount_t *mapupper,unsigned num,SocketEndpoint* endpoints)=0; /* async */
     virtual void SingleMerge()=0; /* async */
     virtual bool FirstRowOfFile(const char *filename,size32_t &rowbuffsize, byte * &rowbuf)=0;
     virtual void GetMultiNthRow(unsigned numsplits,size32_t &mkeybuffsize, void * &mkeybuf)=0;              
@@ -58,8 +58,8 @@ public:
     void MultiBinChopStop(unsigned num,rowcount_t *pos);
     void OverflowAdjustMapStart(unsigned mapsize,rowcount_t *map,size32_t keybuffsize,const byte *keybuff, byte cmpfn,bool useaux); /* async */
     rowcount_t OverflowAdjustMapStop(unsigned mapsize, rowcount_t *map);
-    void MultiMerge(unsigned mapsize,rowcount_t *map,unsigned num,SocketEndpoint* endpoints); /* async */
-    void MultiMergeBetween(unsigned mapsize,rowcount_t *map,rowcount_t *mapupper,unsigned num,SocketEndpoint* endpoints); /* async */
+    void MultiMerge(rowcount_t globalCount, unsigned mapsize,rowcount_t *map,unsigned num,SocketEndpoint* endpoints); /* async */
+    void MultiMergeBetween(rowcount_t globalCount, unsigned mapsize,rowcount_t *map,rowcount_t *mapupper,unsigned num,SocketEndpoint* endpoints); /* async */
     void SingleMerge(); /* async */
     bool FirstRowOfFile(const char *filename,size32_t &rowbuffsize, byte * &rowbuf);
     void GetMultiNthRow(unsigned numsplits,size32_t &mkeybuffsize, void * &mkeybuf);                


### PR DESCRIPTION
When the LHS of a global join is empty, it partitions the RHS
without the [non-existent] partition table from the LHS.
A regression was introduced by HPCC-13791.

Signed-off-by: Jake Smith <jake.smith@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [x] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

Added new regression suite test - joinemptylhs.ecl

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
