### PR TITLE
HPCC-16757 Restructure dautils::EnsureSDS

### DIFF
--- a/dali/base/dautils.cpp
+++ b/dali/base/dautils.cpp
@@ -1668,16 +1668,14 @@ void filterParts(IPropertyTree *file,UnsignedArray &partslist)
 #define SORT_NOCASE  2
 #define SORT_NUMERIC 4
 
-bool ensureSDSPath(const char * sdsPath)
+void ensureSDSPath(const char * sdsPath)
 {
     if (!sdsPath)
-        return false;
+        throw MakeStringException(-1,"Attempted to create empty DALI path");
 
     Owned<IRemoteConnection> conn = querySDS().connect(sdsPath, myProcessSession(), RTM_LOCK_WRITE | RTM_CREATE_QUERY, SDS_LOCK_TIMEOUT);
     if (!conn)
-        return false;
-
-    return true;
+        throw MakeStringException(-1,"Could not create DALI %s branch",sdsPath);
 }
 
 inline void filteredAdd(IArrayOf<IPropertyTree> &results,const char *namefilterlo,const char *namefilterhi,StringArray& unknownAttributes, IPropertyTree *item)

--- a/dali/base/dautils.hpp
+++ b/dali/base/dautils.hpp
@@ -249,7 +249,7 @@ struct da_decl TransactionLog
 extern da_decl const char * skipScope(const char *lname,const char *scope); // skips a sspecified scope (returns NULL if scope doesn't match)
 extern da_decl const char * querySdsFilesRoot();
 extern da_decl const char * querySdsRelationshipsRoot();
-extern da_decl bool ensureSDSPath(const char * sdsPath);
+extern da_decl void ensureSDSPath(const char * sdsPath);
 
 extern da_decl IPropertyTreeIterator *deserializePartAttrIterator(MemoryBuffer &mb);    // clears mb
 extern da_decl MemoryBuffer &serializePartAttr(MemoryBuffer &mb,IPropertyTree *tree); 

--- a/esp/services/esdl_svc_engine/esdl_binding.cpp
+++ b/esp/services/esdl_svc_engine/esdl_binding.cpp
@@ -1050,11 +1050,9 @@ EsdlBindingImpl::EsdlBindingImpl(IPropertyTree* cfg, const char *binding,  const
 
     try
     {
-        if(!ensureSDSPath(ESDL_DEFS_ROOT_PATH))
-            ESPLOG(LogNormal, "ESP Binding '%s' could not ensure %s element on Dali.", binding, ESDL_DEFS_ROOT_PATH);
 
-        if(!ensureSDSPath(ESDL_BINDINGS_ROOT_PATH))
-            ESPLOG(LogNormal, "ESP Binding '%s' could not ensure %s element on Dali.", binding, ESDL_BINDINGS_ROOT_PATH);
+        ensureSDSPath(ESDL_DEFS_ROOT_PATH);
+        ensureSDSPath(ESDL_BINDINGS_ROOT_PATH);
 
         m_esdlBndCfg.set(fetchESDLBinding(process, binding, m_esdlStateFilesLocation));
 

--- a/esp/services/ws_esdlconfig/ws_esdlconfigservice.cpp
+++ b/esp/services/ws_esdlconfig/ws_esdlconfigservice.cpp
@@ -201,11 +201,8 @@ void CWsESDLConfigEx::init(IPropertyTree *cfg, const char *process, const char *
     if(servicecfg == NULL)
         throw MakeStringException(-1, "config not found for service %s/%s",process, service);
 
-    if(!ensureSDSPath(ESDL_DEFS_ROOT_PATH))
-        throw MakeStringException(-1, "Could not ensure '%s' element on Dali", ESDL_DEFS_ROOT_PATH);
-
-    if(!ensureSDSPath(ESDL_BINDINGS_ROOT_PATH))
-        throw MakeStringException(-1, "Could not ensure '%s' element on Dali", ESDL_BINDINGS_ROOT_PATH);
+    ensureSDSPath(ESDL_DEFS_ROOT_PATH);
+    ensureSDSPath(ESDL_BINDINGS_ROOT_PATH);
 
 }
 


### PR DESCRIPTION
- Utility function is now void, and throws if function fails

Signed-off-by: Rodrigo Pastrana <rodrigo.pastrana@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [x] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [x] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [x] This change fixes the problem, not just the symptom
  - [x] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
