### PR TITLE
HPCC-17160 do not define micro _LARGEFILE64_SOURCE on Windows

### DIFF
--- a/system/include/platform.h
+++ b/system/include/platform.h
@@ -67,8 +67,10 @@
 #endif
 
 #define _FILE_OFFSET_BITS 64
+#ifndef _WIN32
 #ifndef _LARGEFILE64_SOURCE
 #define _LARGEFILE64_SOURCE 1
+#endif
 #endif
 #if defined(__linux__)
 #ifndef _GNU_SOURCE


### PR DESCRIPTION
HPCC-17160 build fails due to including unisted.h on Windows

united.h is a header file for Unix. Shouldn't be included in MS Visual Studio environment

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [ ] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [x] The change has been fully tested:
 
## Testing:
Build on all supported platforms

Signed-off-by: Xiaoming Wang <xiaoming.wang@lexisnexi.com> 

@Michael-Gardner please help reviewing
