### PR TITLE
HPCC-17209 Regression in global join if LHS pre-sorted.

### DIFF
--- a/testing/regress/ecl/joinpresorted.ecl
+++ b/testing/regress/ecl/joinpresorted.ecl
@@ -1,0 +1,26 @@
+lhsRec := RECORD
+ string lhsstr := '';
+ boolean abool;
+end;
+
+rhsRec := RECORD
+ string5 rhsstr := '';
+ unsigned4 auint;
+end;
+
+lhs := DATASET(2, TRANSFORM(lhsRec, SELF.lhsstr := (string)COUNTER, SELF.abool := false));
+rhs := DATASET(2, TRANSFORM(rhsRec, SELF.rhsstr := (string)COUNTER, SELF.auint := 1), DISTRIBUTED);
+
+slhs := SORT(lhs, lhsstr);
+j := JOIN(NOFOLD(slhs), NOFOLD(rhs), LEFT.lhsstr=RIGHT.rhsstr);
+
+srhs := SORT(rhs, rhsstr);
+j2 := JOIN(lhs, NOFOLD(srhs), LEFT.lhsstr=RIGHT.rhsstr);
+
+j3 := JOIN(NOFOLD(slhs), NOFOLD(srhs), LEFT.lhsstr=RIGHT.rhsstr);
+
+SEQUENTIAL(
+ COUNT(NOFOLD(j));
+ COUNT(NOFOLD(j2));
+ COUNT(NOFOLD(j3));
+);

--- a/testing/regress/ecl/key/joinpresorted.xml
+++ b/testing/regress/ecl/key/joinpresorted.xml
@@ -1,0 +1,9 @@
+<Dataset name='Result 1'>
+ <Row><Result_1>2</Result_1></Row>
+</Dataset>
+<Dataset name='Result 2'>
+ <Row><Result_2>2</Result_2></Row>
+</Dataset>
+<Dataset name='Result 3'>
+ <Row><Result_3>2</Result_3></Row>
+</Dataset>

--- a/thorlcr/msort/tsortm.cpp
+++ b/thorlcr/msort/tsortm.cpp
@@ -384,12 +384,11 @@ public:
         rowif.set(_rowif);
         if (cosort)
         {
-            if (!partitioninfo->IsOK()) // i.e. no split points (0 rows on primary side)
+            if (!partitioninfo || !partitioninfo->IsOK()) // i.e. no split points (0 rows on primary side)
             {
                 _auxrowif = nullptr;
                 _keyserializer = nullptr;
             }
-            cosort = false;
         }
         if (_auxrowif&&_auxrowif->queryRowMetaData())
             auxrowif.set(_auxrowif);
@@ -416,12 +415,8 @@ public:
         maxrecsonnode = 0;
         numnodes = slaves.ordinality();
         estrecsize = 100;
-        if (!partitioninfo) // if cosort use aux
-        {
-            if (cosort)
-                ActPrintLog(activity, "Cosort with no prior partition");
+        if (!partitioninfo)
             partitioninfo = new PartitionInfo(activity, keyIf);
-        }
         free(partitioninfo->nodes);
         free(partitioninfo->mpports);
         partitioninfo->numnodes=numnodes;


### PR DESCRIPTION
Regression introduced by HPCC-17155, which checked if partition
info was valid and avoided using keyserializers if so.
In the case where LHS is already marked as sorted, there is no
partition info (it hasn't been created), the check need to
test for non-existence too.

Signed-off-by: Jake Smith <jake.smith@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [x] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

New regression suite test added.
Full regression suite run/passed.

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
