### PR TITLE
HPCC-17194 Send "No job queue found" in WsSMC.Activity response

### DIFF
--- a/esp/services/ws_smc/ws_smcService.cpp
+++ b/esp/services/ws_smc/ws_smcService.cpp
@@ -319,6 +319,8 @@ void CActivityInfo::readTargetClusterInfo(IConstWUClusterInfo& cluster, IPropert
     targetCluster->queueName.set(smcQueue->queueName.str());
 
     bool validQueue = readJobQueue(smcQueue->queueName.str(), targetCluster->queuedWUIDs, smcQueue->queueState, smcQueue->queueStateDetails);
+    if (!validQueue)
+        smcQueue->notFoundInJobQueues = true;
     if (validQueue && smcQueue->queueState.length())
         targetCluster->queueStatus.set(smcQueue->queueState.str());
 
@@ -329,24 +331,41 @@ void CActivityInfo::readTargetClusterInfo(IConstWUClusterInfo& cluster, IPropert
             targetCluster->clusterStatusDetails.appendf("Cluster %s not listening for workunits; ", clusterName.str());
     }
 
-    readJobQueue(targetCluster->serverQueue.queueName.str(), targetCluster->wuidsOnServerQueue, targetCluster->serverQueue.queueState, targetCluster->serverQueue.queueStateDetails);
+    targetCluster->serverQueue.notFoundInJobQueues = !readJobQueue(targetCluster->serverQueue.queueName.str(), targetCluster->wuidsOnServerQueue, targetCluster->serverQueue.queueState, targetCluster->serverQueue.queueStateDetails);
 }
 
 bool CActivityInfo::readJobQueue(const char* queueName, StringArray& wuids, StringBuffer& state, StringBuffer& stateDetails)
 {
     if (!queueName || !*queueName)
+    {
+        state.set("Unknown");
+        stateDetails.set("Empty queue name");
         return false;
+    }
 
     if (!jobQueueSnapshot)
     {
+        state.set("Unknown");
+        stateDetails.set("jobQueueSnapshot not found");
         WARNLOG("CActivityInfo::readJobQueue: jobQueueSnapshot not found.");
         return false;
     }
 
-    Owned<IJobQueueConst> jobQueue = jobQueueSnapshot->getJobQueue(queueName);
-    if (!jobQueue)
+    Owned<IJobQueueConst> jobQueue;
+    try
     {
-        WARNLOG("CActivityInfo::readJobQueue: failed to get info for job queue %s", queueName);
+        jobQueue.setown(jobQueueSnapshot->getJobQueue(queueName));
+        if (!jobQueue)
+        {
+            WARNLOG("CActivityInfo::readJobQueue: failed to get info for job queue %s", queueName);
+            return false;
+        }
+    }
+    catch(IException* e)
+    {
+        state.set("Unknown");
+        e->errorMessage(stateDetails);
+        e->Release();
         return false;
     }
 
@@ -1028,6 +1047,8 @@ void CWsSMCEx::getClusterQueueStatus(const CWsSMCTargetCluster& targetCluster, C
         else
             queueStatusType = QueueRunningNotFound;
     }
+    else if (jobQueue->notFoundInJobQueues)
+        queueStatusType = QueueNotFound;
     else if (!queuePausedOrStopped)
         queueStatusType = RunningNormal;
     else if (jobQueue->countRunningJobs > 0)
@@ -1050,6 +1071,8 @@ void CWsSMCEx::setClusterStatus(IEspContext& context, const CWsSMCTargetCluster&
         returnCluster->setWarning("Cluster not listening for workunits");
     else if (queueStatusType == QueuePausedOrStoppedNotFound)
         returnCluster->setWarning("Queue paused or stopped - Cluster not listening for workunits");
+    else if (queueStatusType == QueueNotFound)
+        returnCluster->setWarning("Queue not found");
     else if (queueStatusType != RunningNormal)
         returnCluster->setWarning("Queue paused or stopped");
     //Set 'StatusDetails' which may be displayed when a mouse is moved over cluster icon

--- a/esp/services/ws_smc/ws_smcService.hpp
+++ b/esp/services/ws_smc/ws_smcService.hpp
@@ -40,7 +40,8 @@ enum ClusterStatusType
     QueuePausedOrStoppedWithJobs = 1,
     QueuePausedOrStoppedWithNoJob = 2,
     QueuePausedOrStoppedNotFound = 3,
-    QueueRunningNotFound = 4
+    QueueRunningNotFound = 4,
+    QueueNotFound = 5
 };
 
 enum WsSMCStatusServerType
@@ -60,6 +61,7 @@ public:
     SCMStringBuffer queueName;
     StringBuffer queueState, queueStateDetails;
     bool foundQueueInStatusServer;
+    bool notFoundInJobQueues = false;
     unsigned countRunningJobs;
     unsigned countQueuedJobs;
     ClusterStatusType statusType;


### PR DESCRIPTION
Existing WsSMC.Activity forwards "No job queue found" exception if
a job queue is not found in JobQueues. In this fix, the Activity
method will catch the exception. An error flag and error message
will be returned inside the Activity response.

Signed-off-by: wangkx <kevin.wang@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
