### PR TITLE
HPCC-17209 Global join with pre-sorted primary side crash

### DIFF
--- a/testing/regress/ecl/joinpresorted.ecl
+++ b/testing/regress/ecl/joinpresorted.ecl
@@ -1,15 +1,18 @@
 lhsRec := RECORD
+ string5 dummy1 := '';
+ unsigned4 dummy2 := 0x7fffffff;
  string lhsstr := '';
  boolean abool;
 end;
 
 rhsRec := RECORD
  string5 rhsstr := '';
+ string blah := '';
  unsigned4 auint;
 end;
 
-lhs := DATASET(2, TRANSFORM(lhsRec, SELF.lhsstr := (string)COUNTER, SELF.abool := false));
-rhs := DATASET(2, TRANSFORM(rhsRec, SELF.rhsstr := (string)COUNTER, SELF.auint := 1), DISTRIBUTED);
+lhs := DATASET(10, TRANSFORM(lhsRec, SELF.lhsstr := (string)COUNTER, SELF.abool := false));
+rhs := DATASET(10, TRANSFORM(rhsRec, SELF.rhsstr := (string)COUNTER, SELF.auint := 1), DISTRIBUTED);
 
 slhs := SORT(lhs, lhsstr);
 j := JOIN(NOFOLD(slhs), NOFOLD(rhs), LEFT.lhsstr=RIGHT.rhsstr);

--- a/testing/regress/ecl/key/joinpresorted.xml
+++ b/testing/regress/ecl/key/joinpresorted.xml
@@ -1,9 +1,9 @@
 <Dataset name='Result 1'>
- <Row><Result_1>2</Result_1></Row>
+ <Row><Result_1>10</Result_1></Row>
 </Dataset>
 <Dataset name='Result 2'>
- <Row><Result_2>2</Result_2></Row>
+ <Row><Result_2>10</Result_2></Row>
 </Dataset>
 <Dataset name='Result 3'>
- <Row><Result_3>2</Result_3></Row>
+ <Row><Result_3>10</Result_3></Row>
 </Dataset>

--- a/thorlcr/activities/join/thjoin.cpp
+++ b/thorlcr/activities/join/thjoin.cpp
@@ -295,7 +295,7 @@ public:
                 }
                 else // only sort non-partition side
                 {
-                    imaster->SortSetup(secondaryRowIf, secondaryCompare, primaryKeySerializer, true, true, NULL, primaryRowIf);
+                    imaster->SortSetup(secondaryRowIf, secondaryCompare, primaryKeySerializer, false, true, NULL, primaryRowIf);
                     ActPrintLog("JOIN waiting for barrier.1");
                     if (barrier->wait(false)) // local sort complete
                     {

--- a/thorlcr/msort/tsorts.cpp
+++ b/thorlcr/msort/tsorts.cpp
@@ -1196,6 +1196,7 @@ public:
         )
     {
         ActPrintLog(activity, "Gather in");
+        globalCount = 0;
         loop {
             if (abort)
                 return;
@@ -1210,14 +1211,6 @@ public:
         dbgassertex(transferserver);
         transferserver->setRowIF(rowif);
 
-        if (_auxrowif && (0 == globalCount)) // cosorting, but 0 partitions because primary side is empty, revert to primary serializer
-        {
-            _keyserializer = nullptr;
-            _auxrowif = nullptr;
-            _primarySecondaryCompare = nullptr;
-            _primarySecondaryUpperCompare = nullptr;
-            primaryCompare = nullptr;
-        }
         if (_auxrowif&&_auxrowif->queryRowMetaData())
             auxrowif.set(_auxrowif);
         else
@@ -1326,6 +1319,7 @@ public:
     {
         return spillStats.getStatisticValue(kind);
     }
+    virtual rowcount_t getGlobalCount() const { return globalCount; }
 };
 
 

--- a/thorlcr/msort/tsorts.hpp
+++ b/thorlcr/msort/tsorts.hpp
@@ -52,6 +52,7 @@ public:
     virtual IRowStream * startMerge(rowcount_t &totalrows)=0;
     virtual void stopMerge()=0;
     virtual unsigned __int64 getStatistic(StatisticKind kind) = 0;
+    virtual rowcount_t getGlobalCount() const = 0;
 };
 
 interface IDiskUsage;


### PR DESCRIPTION
If the primary side is pre-sorted, partitioning is based on the
1st row from the primary side stream.
The wrong serializer was being used in this situation.

Signed-off-by: Jake Smith <jake.smith@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [x] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

NB: OBT did not spot this issue, because it requires a multi-thor setup to hit this code.

There was a test added in the previous version of this fix, which was hitting the code involved on a multi-slave setup, however the serialization usually succeeded in this test albeit with too much/invalid data and wouldn't effect the partitioning in this 2 record test.

Test has been extended to deliberately expose the serialization mismatch.

Ran/passed full regression suite.

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
