### PR TITLE
HPCC-17248 DFS numSubFiles(true) should recurse all supers.

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -5803,7 +5803,7 @@ public:
                 IDistributedFile &f=subfiles.item(i);
                 IDistributedSuperFile *super = f.querySuperFile();
                 if (super)
-                    ret += super->numSubFiles();
+                    ret += super->numSubFiles(sub);
                 else
                     ret++;
             }

--- a/testing/regress/ecl/key/superkey1.xml
+++ b/testing/regress/ecl/key/superkey1.xml
@@ -583,3 +583,13 @@
  <Row><id>132</id><title>death to the pixies                                                             </title><artist>Pixies                                                          </artist><tracks>21</tracks><mins>55</mins><secs>37</secs><player>0</player><position>132</position><filepos>10560</filepos></Row>
  <Row><id>276</id><title>live from the Bataclan                                                          </title><artist>Jeff Buckley                                                    </artist><tracks>4</tracks><mins>34</mins><secs>47</secs><player>0</player><position>277</position><filepos>5376</filepos></Row>
 </Dataset>
+<Dataset name='Result 9'>
+ <Row><artist>Pixies                                                          </artist><title>At the BBC                                                                      </title><filepos>98496</filepos></Row>
+ <Row><artist>Pixies                                                          </artist><title>Bossanova                                                                       </title><filepos>28800</filepos></Row>
+ <Row><artist>Pixies                                                          </artist><title>Complete `B` Sides                                                              </title><filepos>14208</filepos></Row>
+ <Row><artist>Pixies                                                          </artist><title>Doolittle                                                                       </title><filepos>11520</filepos></Row>
+ <Row><artist>Pixies                                                          </artist><title>Pixies                                                                          </title><filepos>82560</filepos></Row>
+ <Row><artist>Pixies                                                          </artist><title>Surfer Rosa &amp; Come on Pilgrim                                                   </title><filepos>90624</filepos></Row>
+ <Row><artist>Pixies                                                          </artist><title>Trompe Le Monde                                                                 </title><filepos>93888</filepos></Row>
+ <Row><artist>Pixies                                                          </artist><title>death to the pixies                                                             </title><filepos>10560</filepos></Row>
+</Dataset>

--- a/testing/regress/ecl/superkey1.ecl
+++ b/testing/regress/ecl/superkey1.ecl
@@ -582,6 +582,8 @@ albumIndex  := INDEX(albumTable,{ Artist, Title, filepos }, '~REGRESS::superalbu
 SEQUENTIAL(
   OUTPUT(ds,,'~REGRESS::albums.d00',OVERWRITE),
   FileServices.DeleteSuperFile('~REGRESS::superalbums.key'),
+  FileServices.DeleteSuperFile('~REGRESS::superalbums-sub.key'),
+  FileServices.DeleteSuperFile('~REGRESS::superalbums-sub-sub.key'),
   FileServices.DeleteSuperFile('~REGRESS::superalbums'),
   BUILDINDEX(albumIndex3,OVERWRITE),
   BUILDINDEX(albumIndex1,OVERWRITE,DISTRIBUTE(albumIndex3)),
@@ -604,6 +606,19 @@ SEQUENTIAL(
   FileServices.RemoveSuperFile('~REGRESS::superalbums.key','~REGRESS::albums4.key'),
   FileServices.RemoveSuperFile('~REGRESS::superalbums.key','~REGRESS::albums3.key'),
   FileServices.FinishSuperFileTransaction(),
-  OUTPUT(SORT(FETCH(albumTable, albumIndex, RIGHT.filepos),Title,filepos))
+  OUTPUT(SORT(FETCH(albumTable, albumIndex, RIGHT.filepos),Title,filepos));
+
+  FileServices.ClearSuperFile('~REGRESS::superalbums.key');
+  FileServices.CreateSuperFile('~REGRESS::superalbums-sub.key');
+  FileServices.CreateSuperFile('~REGRESS::superalbums-sub-sub.key');
+  FileServices.AddSuperFile('~REGRESS::superalbums.key','~REGRESS::albums1.key'),
+  FileServices.AddSuperFile('~REGRESS::superalbums-sub-sub.key','~REGRESS::albums2.key'),
+  FileServices.AddSuperFile('~REGRESS::superalbums-sub-sub.key','~REGRESS::albums3.key'),
+  FileServices.AddSuperFile('~REGRESS::superalbums-sub-sub.key','~REGRESS::albums4.key'),
+  FileServices.AddSuperFile('~REGRESS::superalbums-sub-sub.key','~REGRESS::albums5.key'),
+  FileServices.AddSuperFile('~REGRESS::superalbums-sub.key', '~REGRESS::superalbums-sub-sub.key');
+  FileServices.AddSuperFile('~REGRESS::superalbums.key', '~REGRESS::superalbums-sub.key');
+
+  OUTPUT(SORT(albumIndex(Artist='Pixies'), Artist, Title, filepos));
 );
 


### PR DESCRIPTION
IDistributedSuperFile::numSubFiles(bool sub) was not passing
the sub parameter recursively.
Consequently the total subfile count was wrong if there were
multiple nested levels of super files.

As a result of this bug, index reads and keyedjoins and a few
other things would miscalcualte offsets etc. and give incorrect
results on nested superfiles/superindexes like this.

Signed-off-by: Jake Smith <jake.smith@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [x] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

Extended existing test (superkey1.ecl) to test nested superfiles.
Run/passed complete regression suite.

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
