### PR TITLE
HPCC-17078 Dedup ALL in child query could lose rows if not fully read

### DIFF
--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -7311,12 +7311,10 @@ public:
 
     virtual void reset()
     {
-#ifdef _DEBUG
         while (survivors.isItem(survivorIndex))
         {
             ReleaseRoxieRow(survivors.item(survivorIndex++));
         }
-#endif
         survivors.kill();
         eof = false;
         first = true;

--- a/testing/regress/ecl/dedupchild.ecl
+++ b/testing/regress/ecl/dedupchild.ecl
@@ -1,0 +1,53 @@
+cRec := RECORD
+ unsigned4 cid;
+END;
+
+pRec := RECORD
+ unsigned4 id;
+ DATASET(cRec) kids;
+END;
+
+pSetSize := 2000;
+
+cRec makeC(unsigned4 c) := TRANSFORM
+  SELF.cid := c;
+END;
+
+pRec makeP(unsigned4 c) := TRANSFORM
+  SELF.id := c;
+  SELF.kids := DATASET(1+(c%10), makeC(COUNTER%2));
+END;
+
+pSet := DATASET(pSetSize, makeP(COUNTER), DISTRIBUTED);
+
+kids  := pSet.kids;
+
+outRec := RECORD
+ unsigned val1;
+ unsigned val2;
+ unsigned val3;
+ unsigned val4;
+ unsigned val5;
+END;
+
+outRec doTrans(pRec l) := TRANSFORM
+ SortedKids := SORT(l.kids, cid);
+ DedupKids1 := DEDUP(SortedKids, cid);
+ DedupKids2 := DEDUP(l.kids, cid, ALL);
+ DedupKids3 := DEDUP(l.kids(cid<99999), cid, ALL); // filter to prevent CSE of dedup
+ DedupKids4 := DEDUP(l.kids(cid<99998), cid, ALL); // filter to prevent CSE of dedup
+ 
+ SELF.val1 := SUM(DedupKids1, cid);
+ SELF.val2 := SUM(DedupKids2, cid);
+ SELF.val3 := IF(EXISTS(DedupKids1), 1, 0);
+ SELF.val4 := IF(EXISTS(DedupKids3), 1, 0);
+ SELF.val5 := COUNT(CHOOSEN(DedupKids4, 2));
+END;
+
+p := PROJECT(pSet, doTrans(LEFT));
+
+DATASET([{'SumDedupVals', SUM(p, val1)},
+         {'SumDedupAllVals', SUM(p, val2)},
+         {'ExistsDedupTotal', SUM(p, val3)},
+         {'ExistsDedupAllTotal', SUM(p, val4)},
+         {'ChoosenDedupAllTotal', SUM(p, val5)} ], {string type, unsigned8 val});

--- a/testing/regress/ecl/key/dedupchild.xml
+++ b/testing/regress/ecl/key/dedupchild.xml
@@ -1,0 +1,7 @@
+<Dataset name='Result 1'>
+ <Row><type>SumDedupVals</type><val>2000</val></Row>
+ <Row><type>SumDedupAllVals</type><val>2000</val></Row>
+ <Row><type>ExistsDedupTotal</type><val>2000</val></Row>
+ <Row><type>ExistsDedupAllTotal</type><val>2000</val></Row>
+ <Row><type>ChoosenDedupAllTotal</type><val>3800</val></Row>
+</Dataset>

--- a/thorlcr/activities/hashdistrib/thhashdistribslave.cpp
+++ b/thorlcr/activities/hashdistrib/thhashdistribslave.cpp
@@ -3005,7 +3005,11 @@ void CHashTableRowTable::init(rowidx_t sz)
     // reinitialize if need bigger or if requested size is much smaller than existing
     rowidx_t newMaxRows = activity.queryRowManager()->getExpectedCapacity(sz * sizeof(rowidx_t *), activity.allocFlags) / sizeof(rowidx_t *);
     if (newMaxRows <= maxRows && ((maxRows-newMaxRows) <= HASHDEDUP_HT_INC_SIZE))
+    {
+        clear();
         return;
+    }
+    clearRows();
     ReleaseThorRow(rows);
     OwnedConstThorRow newRows = allocateRowTable(sz);
     if (!newRows)


### PR DESCRIPTION
If a hash dedup in a child query was only partially read, e.g. if
upstream from a CHOOSEN or EXISTS, then the hash tables might not
be cleared on the next iteration.
That led to records being dedupped on the next child query
iteration that shouldn't have been.

Signed-off-by: Jake Smith <jake.smith@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [x] I have added tests to cover my changes.
  - [x] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

New regression test added.
Full regression suite run/passed.

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
