### PR TITLE
HPCC-17143 Potential SmartJoin row leak if failing over to std join

### DIFF
--- a/thorlcr/activities/lookupjoin/thlookupjoinslave.cpp
+++ b/thorlcr/activities/lookupjoin/thlookupjoinslave.cpp
@@ -2255,8 +2255,10 @@ protected:
             }
             virtual bool spill(bool critical) // called from OOM callback
             {
+                if (!channelCollector->spill(critical))
+                    return false;
                 atomic_set(&spilt, 1);
-                return channelCollector->spill(critical);
+                return true;
             }
             virtual roxiemem::IBufferedRowCallback *queryCallback() { return this; }
         } channelDistributor(*this, cmp);
@@ -2742,7 +2744,7 @@ public:
         {
             if (0 != (sendItem->queryFlags() & bcastflag_spilt))
             {
-                VStringBuffer msg("Notification that node %d spilt", sendItem->queryNode());
+                VStringBuffer msg("Notification that node %d spilt", sendItem->queryNode()+1);
                 clearAllNonLocalRows(msg.str());
             }
         }

--- a/thorlcr/thorutil/thmem.cpp
+++ b/thorlcr/thorutil/thmem.cpp
@@ -1437,9 +1437,10 @@ bool CThorSpillableRowArray::_flush(bool force)
     }
 }
 
-bool CThorSpillableRowArray::shrink() // NB: if read active should be protected inside a CThorArrayLockBlock
+bool CThorSpillableRowArray::shrink()
 {
     // NB: Should only be called from writer thread
+    CThorArrayLockBlock block(*this);
     _flush(true);
     rowidx_t prevMaxRows = maxRows;
     shrink(numRows);


### PR DESCRIPTION
During spilling involved when failing over from a local smart join
to a standard join, a row array could be shrank whilst rows were
being added, this had the effect of losing a few rows if it hit
that race condition.

Signed-off-by: Jake Smith <jake.smith@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

I have a test query I ran 100's of times that reproduced the problem ~50% of the time before the fix.
And left running over night with the fix to verify.

+ Full regression suite run.


<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
