### PR TITLE
HPCC-17304 Leaking environment iterators and return with an unlinked pointer

### DIFF
--- a/common/environment/environment.cpp
+++ b/common/environment/environment.cpp
@@ -53,7 +53,7 @@ public:
     virtual unsigned count() const override;
 
 protected:
-    IConstMachineInfo * curr = nullptr;
+    Owned<IConstMachineInfo> curr;
     Owned<CLocalEnvironment> constEnv;
     unsigned index = 1;
     unsigned maxIndex = 0;
@@ -89,7 +89,7 @@ public:
     virtual unsigned count() const override;
 
 protected:
-    IConstDropZoneInfo * curr = nullptr;
+    Owned<IConstDropZoneInfo> curr;
     Owned<CLocalEnvironment> constEnv;
     unsigned index = 1;
     unsigned maxIndex = 0;
@@ -108,7 +108,7 @@ public:
 
 protected:
     StringBuffer computerName;
-    IConstDropZoneInfo * curr = nullptr;
+    Owned<IConstDropZoneInfo> curr;
     Owned<CLocalEnvironment> constEnv;
     unsigned index = 1;
     unsigned maxIndex = 0;
@@ -1680,8 +1680,8 @@ IConstDropZoneInfo * CLocalEnvironment::getDropZoneByAddressPath(const char * ne
             }
         }
     }
-    // Both path and machine matched
-    return dropZone;
+
+    return LINK(dropZone);
 }
 
 
@@ -1725,20 +1725,20 @@ CConstMachineInfoIterator::CConstMachineInfoIterator()
 bool CConstMachineInfoIterator::first()
 {
     index = 1;
-    curr = constEnv->getMachineByIndex(index);
-    return (curr != nullptr);
+    curr.setown(constEnv->getMachineByIndex(index));
+    return curr != nullptr;
 }
 bool CConstMachineInfoIterator::next()
 {
     if (index < maxIndex)
     {
         index++;
-        curr = constEnv->getMachineByIndex(index);
+        curr.setown(constEnv->getMachineByIndex(index));
     }
     else
-        curr = nullptr;
+        curr.clear();
 
-    return (curr ? true : false);
+    return curr != nullptr;
 }
 
 bool CConstMachineInfoIterator::isValid()
@@ -1769,20 +1769,20 @@ CConstDropZoneIteratorByComputer::CConstDropZoneIteratorByComputer(const char * 
 bool CConstDropZoneIteratorByComputer::first()
 {
     index = 1;
-    curr = constEnv->getDropZoneByComputerByIndex(computerName.str(), index);
-    return (curr != nullptr);
+    curr.setown(constEnv->getDropZoneByComputerByIndex(computerName.str(), index));
+    return curr != nullptr;
 }
 bool CConstDropZoneIteratorByComputer::next()
 {
     if (index < maxIndex)
     {
         index++;
-        curr = constEnv->getDropZoneByComputerByIndex(computerName.str(), index);
+        curr.setown(constEnv->getDropZoneByComputerByIndex(computerName.str(), index));
     }
     else
-        curr = nullptr;
+        curr.clear();
 
-    return (curr ? true : false);
+    return curr != nullptr;
 }
 
 bool CConstDropZoneIteratorByComputer::isValid()
@@ -1895,8 +1895,8 @@ CConstDropZoneInfoIterator::CConstDropZoneInfoIterator()
 bool CConstDropZoneInfoIterator::first()
 {
     index = 1;
-    curr = constEnv->getDropZoneByIndex(index);
-    return (curr != nullptr);
+    curr.setown(constEnv->getDropZoneByIndex(index));
+    return curr != nullptr;
 }
 
 bool CConstDropZoneInfoIterator::next()
@@ -1904,12 +1904,12 @@ bool CConstDropZoneInfoIterator::next()
     if (index < maxIndex)
     {
         index++;
-        curr = constEnv->getDropZoneByIndex(index);
+        curr.setown(constEnv->getDropZoneByIndex(index));
     }
     else
-        curr = nullptr;
+        curr.clear();
 
-    return (curr ? true : false);
+    return curr != nullptr;
 }
 
 bool CConstDropZoneInfoIterator::isValid()


### PR DESCRIPTION
Change
- CConstMachineInfoIterator
- CConstDropZoneIteratorByComputer
- CConstDropZoneInfoIterator
implementation.

Fix unlinked return pointer.

Signed-off-by: Attila Vamos <attila.vamos@gmail.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [x] This change fixes the problem, not just the symptom
  - [x] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [x] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->
Manually
<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
