### PR TITLE
HPCC-17331 Prevent Smartjoin crash when failing over to local

### DIFF
--- a/thorlcr/activities/lookupjoin/thlookupjoinslave.cpp
+++ b/thorlcr/activities/lookupjoin/thlookupjoinslave.cpp
@@ -1750,12 +1750,13 @@ protected:
     inline bool hasFailedOverToLocal() const { return 0 != atomic_read(&failedOverToLocal); }
     inline bool hasFailedOverToStandard() const { return 0 != atomic_read(&failedOverToStandard); }
     inline bool isRhsCollated() const { return rhsCollated; }
-    rowidx_t clearNonLocalRows(CThorRowArrayWithFlushMarker &rows)
+    rowidx_t clearNonLocalRows(CThorRowArrayWithFlushMarker &rows, unsigned slave)
     {
         CThorArrayLockBlock block(rows);
         rowidx_t clearedRows = 0;
-        rowidx_t numRows = rows.numCommitted();
-        for (rowidx_t r=rows.flushMarker; r<numRows; r++)
+        rowidx_t committedRows = rows.numCommitted();
+        ActPrintLog("clearNonLocalRows[slave=%u], numCommitted=%" RIPF "u, totalRows(inc uncommitted)=%" RIPF "u, flushMarker=%" RIPF "u", slave, committedRows, rows.queryTotalRows(), rows.flushMarker);
+        for (rowidx_t r=rows.flushMarker; r<committedRows; r++)
         {
             unsigned hv = rightHash->hash(rows.query(r));
             if (myNodeNum != (hv % numNodes))
@@ -1767,7 +1768,7 @@ protected:
         /* Record point to which clearNonLocalRows will reach
          * so that can resume from that point, when recalled.
          */
-        rows.flushMarker = numRows;
+        rows.flushMarker = committedRows;
         return clearedRows;
     }
     // Annoyingly similar to above, used post broadcast when rhsSlaveRows collated into 'rhs'
@@ -1811,10 +1812,10 @@ protected:
                 /* NB: It is likely that there will be unflushed rows in the rhsSlaveRows arrays after we are done here.
                  * These will need flushing when all is done and clearNonLocalRows will need recalling to process rest
                  */
-                ForEachItemIn(a, rhsSlaveRows)
+                ForEachItemIn(slave, rhsSlaveRows)
                 {
-                    CThorRowArrayWithFlushMarker &rows = *rhsSlaveRows.item(a);
-                    clearedRows += clearNonLocalRows(rows);
+                    CThorRowArrayWithFlushMarker &rows = *rhsSlaveRows.item(slave);
+                    clearedRows += clearNonLocalRows(rows, slave);
                 }
             }
             ActPrintLog("handleLowMem: clearedRows = %" RIPF "d", clearedRows);
@@ -1824,12 +1825,12 @@ protected:
         if (spillRowArrays) // only do if have to due to memory pressure. Not via foreign node notification.
         {
             // no non-locals left to spill, so flush a rhsSlaveRows array
-            ForEachItemIn(a, rhsSlaveRows)
+            ForEachItemIn(slave, rhsSlaveRows)
             {
-                CThorRowArrayWithFlushMarker &rows = *rhsSlaveRows.item(a);
+                CThorRowArrayWithFlushMarker &rows = *rhsSlaveRows.item(slave);
                 if (rows.numCommitted())
                 {
-                    clearNonLocalRows(rows);
+                    clearNonLocalRows(rows, slave);
                     rows.flushMarker = 0; // reset marker, since save will cause numCommitted to shrink
                     VStringBuffer tempPrefix("spill_%d", container.queryId());
                     StringBuffer tempName;
@@ -1919,12 +1920,12 @@ protected:
              */
 
             rhsSlaveRows.sort(sortBySize); // because want biggest compacted/consumed 1st
-            ForEachItemIn(a, rhsSlaveRows)
+            ForEachItemIn(slave, rhsSlaveRows)
             {
-                CThorRowArrayWithFlushMarker &rows = *rhsSlaveRows.item(a);
-                clearNonLocalRows(rows);
+                CThorRowArrayWithFlushMarker &rows = *rhsSlaveRows.item(slave);
+                clearNonLocalRows(rows, slave);
 
-                ActPrintLog("Compacting rhsSlaveRows[%d], has %" RIPF "d rows", a, rows.numCommitted());
+                ActPrintLog("Compacting rhsSlaveRows[%u], has %" RIPF "u rows", slave, rows.numCommitted());
                 rows.compact();
             }
 
@@ -2190,8 +2191,12 @@ protected:
                 atomic_set(&spilt, 0);
                 //NB: all channels will have done this, before rows are added
             }
+#define HPCC_17331 // Whilst under investigation
             void process(IRowStream *right)
             {
+#ifdef HPCC_17331
+                unsigned skippedNonLocalRows = 0;
+#endif
                 loop
                 {
                     OwnedConstThorRow row = right->nextRow();
@@ -2200,10 +2205,40 @@ protected:
                     unsigned hv = owner.rightHash->hash(row);
                     unsigned slave = hv % owner.numSlaves;
                     unsigned channelDst = owner.queryJob().queryJobSlaveChannelNum(slave+1);
-                    dbgassertex(NotFound != channelDst); // if 0, slave is not a slave of this process
+#ifdef HPCC_17331
+                    if (NotFound == channelDst)
+                    {
+                        if (0 == skippedNonLocalRows++)
+                        {
+                            VStringBuffer errMsg("1st unexpected non-local row detected, slave: %u", slave+1);
+                            IOutputMetaData *inputOutputMeta = owner.rightITDL->queryFromActivity()->queryContainer().queryHelper()->queryOutputMeta();
+                            if (inputOutputMeta->hasXML())
+                            {
+                                CommonXmlWriter xmlWriter(0);
+                                errMsg.append(" - row: ");
+                                inputOutputMeta->toXML((byte *) row.get(), xmlWriter);
+                                errMsg.append(xmlWriter.str());
+                            }
+                            if (owner.queryJob().getOptBool("smartjoin_failonnonlocal", true))
+                            {
+                                errMsg.newline().append("Please see JIRA issue HPCC-17331 and report incident");
+                                throw MakeActivityException(&owner, 0, "%s", errMsg.str());
+                            }
+                            else
+                                owner.ActPrintLog("%s", errMsg.str());
+                        }
+                        continue; // skip row
+                    }
+#else
+                    dbgassertex(NotFound != channelDst); // if NotFound, slave is not a slave of this process
+#endif
                     dbgassertex(channelDst < owner.queryJob().queryJobChannels());
                     channelDistributors[channelDst]->putRow(row.getClear());
                 }
+#ifdef HPCC_17331
+                if (skippedNonLocalRows)
+                    owner.ActPrintLog("WARNING: %u unexpected non-local row(s) detected", skippedNonLocalRows);
+#endif
             }
             void processDistRight(IRowStream *right)
             {
@@ -2219,6 +2254,7 @@ protected:
             virtual bool freeBufferedRows(bool critical)
             {
                 CriticalBlock b(crit);
+                owner.ActPrintLog("CChannelDistributor free memory callback called");
                 unsigned startSpillChannel = nextSpillChannel;
                 loop
                 {

--- a/thorlcr/thorutil/thmem.hpp
+++ b/thorlcr/thorutil/thmem.hpp
@@ -483,6 +483,7 @@ public:
     rowidx_t save(IFile &file, unsigned _spillCompInfo, bool skipNulls, const char *tracingPrefix);
 
     inline rowidx_t numCommitted() const { return commitRows - firstRow; } //MORE::Not convinced this is very safe!
+    inline rowidx_t queryTotalRows() const { return CThorExpandingRowArray::ordinality(); } // includes uncommited rows
 
 // access to
     void swap(CThorSpillableRowArray &src);


### PR DESCRIPTION
The root of the issue is still unknown, this change guards against
what was seen to be happening (a non-local row being processed at
a late stage during local failover) and adds a little more tracing
to help diagnose.

By default the non-local row will still cause the query to fail
(with an error and log the row), so that we can see and have any
other incident of this issue reported.
However, the user can workarond the issue by enabling an option
to suppress the error.

Signed-off-by: Jake Smith <jake.smith@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

Faked the incident to check the reporting mechanism.

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
