### PR TITLE
HPCC-17338 Remove duplicate excessive scans warnings from memory manager

### DIFF
--- a/roxie/roxiemem/roxiemem.cpp
+++ b/roxie/roxiemem/roxiemem.cpp
@@ -2370,7 +2370,7 @@ public:
     {
         if (heap)
         {
-            heap->checkScans();
+            heap->checkScans(allocatorId);
             if (flags & RHFunique)
                 heap->noteOrphaned();
         }
@@ -2389,7 +2389,7 @@ public:
     virtual void clearRowManager()
     {
         if (heap)
-            heap->checkScans();
+            heap->checkScans(allocatorId);
         heap.clear();
         CRoxieFixedRowHeapBase::clearRowManager();
     }
@@ -2986,8 +2986,8 @@ public:
         flags |= RHForphaned;
     }
 
-    void checkScans();
-    virtual void reportScanProblem(unsigned __int64 numScans, const HeapletStats & mergedStats) = 0;
+    void checkScans(unsigned allocatorId);
+    virtual void reportScanProblem(unsigned allocatorId, unsigned __int64 numScans, const HeapletStats & mergedStats) = 0;
 
     void gatherStats(CRuntimeStatisticCollection & stats);
 
@@ -3000,6 +3000,7 @@ protected:
 protected:
     size32_t chunkSize;
     unsigned chunksPerPage;
+    unsigned __int64 totalAllocsLastScanCheck = 0;
 };
 
 class CFixedChunkedHeap : public CChunkedHeap
@@ -3020,7 +3021,7 @@ public:
                (searchFlags == flags);
     }
 
-    virtual void reportScanProblem(unsigned __int64 numScans, const HeapletStats & mergedStats) override;
+    virtual void reportScanProblem(unsigned allocatorId, unsigned __int64 numScans, const HeapletStats & mergedStats) override;
 
 protected:
     virtual ChunkedHeaplet * allocateHeaplet();
@@ -3047,7 +3048,7 @@ public:
                (allocatorId == searchActivity);
     }
 
-    virtual void reportScanProblem(unsigned __int64 numScans, const HeapletStats & mergedStats) override;
+    virtual void reportScanProblem(unsigned allocatorId, unsigned __int64 numScans, const HeapletStats & mergedStats) override;
 
 protected:
     virtual ChunkedHeaplet * allocateHeaplet();
@@ -5378,7 +5379,7 @@ void * CChunkedHeap::doAllocate(unsigned activityId, unsigned maxSpillCost)
     return doAllocateRow(activityId, maxSpillCost);
 }
 
-void CChunkedHeap::checkScans()
+void CChunkedHeap::checkScans(unsigned allocatorId)
 {
     HeapletStats merged(stats);
 
@@ -5396,11 +5397,17 @@ void CChunkedHeap::checkScans()
                     break;
             }
         }
+
+        //If nothing has changed since the last time this was called then don't report anything
+        //often happens if multiple allocators share the same heap
+        if (merged.totalAllocs == totalAllocsLastScanCheck)
+            return;
+        totalAllocsLastScanCheck = merged.totalAllocs;
     }
 
     unsigned __int64 numScans = merged.totalDistanceScanned / chunkSize;
     if (numScans && (numScans >= merged.totalAllocs * ScanReportThreshold))
-        reportScanProblem(numScans, merged);
+        reportScanProblem(allocatorId, numScans, merged);
 }
 
 //================================================================================
@@ -5427,10 +5434,11 @@ unsigned CFixedChunkedHeap::allocateBlock(unsigned activityId, unsigned maxRows,
 }
 
 
-void CFixedChunkedHeap::reportScanProblem(unsigned __int64 numScans, const HeapletStats & mergedStats)
+void CFixedChunkedHeap::reportScanProblem(unsigned allocatorId, unsigned __int64 numScans, const HeapletStats & mergedStats)
 {
-    logctx.CTXLOG("Excessive scans in heap manager (%.2f).  Size(%u) scans(%" I64F "u/%" I64F "u)",
-           (double)numScans / mergedStats.totalAllocs, chunkSize-FixedSizeHeaplet::chunkHeaderSize, numScans, mergedStats.totalAllocs);
+    unsigned activityId = getRealActivityId(allocatorId, allocatorCache);
+    logctx.CTXLOG("Excessive scans in shared heap{%x:%u} (%.2f).  Size(%u) scans(%" I64F "u/%" I64F "u)",
+           flags, activityId, (double)numScans / mergedStats.totalAllocs, chunkSize-FixedSizeHeaplet::chunkHeaderSize, numScans, mergedStats.totalAllocs);
 }
 
 ChunkedHeaplet * CPackedChunkingHeap::allocateHeaplet()
@@ -5455,11 +5463,11 @@ unsigned CPackedChunkingHeap::allocateBlock(unsigned activityId, unsigned maxRow
 }
 
 
-void CPackedChunkingHeap::reportScanProblem(unsigned __int64 numScans, const HeapletStats & mergedStats)
+void CPackedChunkingHeap::reportScanProblem(unsigned, unsigned __int64 numScans, const HeapletStats & mergedStats)
 {
     unsigned activityId = getRealActivityId(allocatorId, allocatorCache);
-    logctx.CTXLOG("Excessive scans in heap manager for activity %u (%.2f).  Size(%u) scans(%" I64F "u/%" I64F "u)",
-           activityId, (double)numScans / mergedStats.totalAllocs, chunkSize-PackedFixedSizeHeaplet::chunkHeaderSize, numScans, mergedStats.totalAllocs);
+    logctx.CTXLOG("Excessive scans in heap{%x} for activity %u (%.2f).  Size(%u) scans(%" I64F "u/%" I64F "u)",
+           flags, activityId, (double)numScans / mergedStats.totalAllocs, chunkSize-PackedFixedSizeHeaplet::chunkHeaderSize, numScans, mergedStats.totalAllocs);
 }
 
 //================================================================================


### PR DESCRIPTION
Signed-off-by: Gavin Halliday <gavin.halliday@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [x] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [x] Performance
  - [ ] Security
  - [x] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->
Ran regression suite, and in particular selfjoin2 which was generating these warnings.  Interestingly the scanning code appeared to perform better despite the warnings - possibly because the reduction in atomic contention was even more significant.

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
