### PR TITLE
HPCC-17208 Regression suite test with multiple versions can run out of order and cause failures

### DIFF
--- a/testing/regress/ecl/key/setuppersist.xml
+++ b/testing/regress/ecl/key/setuppersist.xml
@@ -1,0 +1,12 @@
+<Dataset name='Result 1'>
+ <Row><country>Spain</country><population>40397842</population></Row>
+ <Row><country>Sweden</country><population>9016596</population></Row>
+ <Row><country>Switzerland</country><population>7523934</population></Row>
+ <Row><country>UK</country><population>60609153</population></Row>
+</Dataset>
+<Dataset name='Result 2'>
+ <Row><country>Spain</country><population>40397842</population></Row>
+ <Row><country>Sweden</country><population>9016596</population></Row>
+ <Row><country>Switzerland</country><population>7523934</population></Row>
+ <Row><country>United Kingdom</country><population>60609153</population></Row>
+</Dataset>

--- a/testing/regress/ecl/setup/setuppersist.ecl
+++ b/testing/regress/ecl/setup/setuppersist.ecl
@@ -15,11 +15,6 @@
     limitations under the License.
 ############################################################################## */
 
-//version persistRefresh=true
-//version persistRefresh=false
-
-import ^ as root;
-
 countryRecord := RECORD
     string country;
     integer4 population;
@@ -35,16 +30,10 @@ ds2 := DATASET([{'Spain', 40397842},
                 {'Switzerland', 7523934},
                 {'United Kingdom', 60609153}], countryRecord);
 
-persistRefresh := #IFDEFINED(root.persistRefresh, true);
+pds1 := ds1:PERSIST('~REGRESS::PersistRefresh', SINGLE, REFRESH(true));
+output(pds1);
 
-#if (persistRefresh)
-    persistFileName := '~REGRESS::PersistRefresh';
-    ds := ds2;
-#else
-    persistFileName := '~REGRESS::PersistNoRefresh';
-    ds := ds1;
-#end
+pds2 := ds2:PERSIST('~REGRESS::PersistNoRefresh', SINGLE, REFRESH(true));
+output(pds2);
 
-CountriesDS := ds:PERSIST(persistFileName, SINGLE, REFRESH(persistRefresh));
 
-OUTPUT(CountriesDS);


### PR DESCRIPTION
Fix the persist_refresh.ecl version dependency with separate the persistent
dataset setup and refresh checking operations. The former goes to setup
phase as setuppersist.ecl. It creates/setup up two persist datasets with
different content one for refresh and one without refresh.

Signed-off-by: Attila Vamos <attila.vamos@gmail.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [x] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [x] Scalability
  - [ ] Performance
  - [ ] Security
  - [x] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [x] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [x] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->
Tested manually with --pq parameter
<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
