### PR TITLE
Revert "HPCC-16869 Drop support for IE 8,9,&10"

### DIFF
--- a/docs/Installing_and_RunningTheHPCCPlatform/Inst-Mods/Hardware.xml
+++ b/docs/Installing_and_RunningTheHPCCPlatform/Inst-Mods/Hardware.xml
@@ -436,7 +436,7 @@
 
           <itemizedlist spacing="compact">
             <listitem>
-              <para>Internet Explorer® 11 (or later)</para>
+              <para>Internet Explorer® 9 (or later)</para>
             </listitem>
 
             <listitem>

--- a/docs/RunningHPCCinaVirtualMachine/RunningHPCCinaVirtualMachine.xml
+++ b/docs/RunningHPCCinaVirtualMachine/RunningHPCCinaVirtualMachine.xml
@@ -147,8 +147,8 @@
         </listitem>
 
         <listitem>
-          <para>Internet Explorer<superscript>®</superscript> 11, Google
-          Chrome 10, or Firefox™ 3.0 (or later)</para>
+          <para>Internet Explorer<superscript>®</superscript> 8, Google Chrome
+          10, or Firefox™ 3.0 (or later)</para>
         </listitem>
       </itemizedlist>
 


### PR DESCRIPTION
Reverts hpcc-systems/HPCC-Platform#9816 - should have targeted master