### PR TITLE
HPCC-17370 Common up uses of CLUSTERSIZE within a workflow item

### DIFF
--- a/ecl/hql/hqlexpr.cpp
+++ b/ecl/hql/hqlexpr.cpp
@@ -4222,8 +4222,13 @@ void CHqlRealExpression::updateFlagsAfterOperands()
             break;
         }
     case no_clustersize:
-        //wrong, but improves the generated code
-        infoFlags |= (HEFnoduplicate|HEFcontextDependentException);
+        //pure is added with the wfid as a parameter which guarantees that it can be commoned up.
+        if (!hasAttribute(pureAtom))
+            infoFlags |= (HEFnoduplicate);
+
+        //Wrong, but improves the generated code (preventing it being serialized).
+        //Even better would be to evaluate once, but not serialize...
+        infoFlags |= (HEFcontextDependentException);
         break;
     case no_type:
         {

--- a/ecl/hql/hqlthql.cpp
+++ b/ecl/hql/hqlthql.cpp
@@ -2080,6 +2080,12 @@ void HqltHql::toECL(IHqlExpression *expr, StringBuffer &s, bool paren, bool inTy
             else
                 toECL(child0, s, false, inType);
             break;
+        case no_clustersize:
+            if (expandProcessed)
+                defaultToECL(expr, s, inType);
+            else
+                s.append(getEclOpString(no));
+            break;
         case no_map:
         {
             unsigned kids = expr->numChildren();

--- a/ecl/hql/hqltrans.cpp
+++ b/ecl/hql/hqltrans.cpp
@@ -1784,6 +1784,13 @@ void NewHqlTransformer::transformRoot(const HqlExprArray & in, HqlExprArray & ou
     }
 }
 
+void NewHqlTransformer::transformRoot(HqlExprArray & exprs)
+{
+    HqlExprArray temp;
+    transformRoot(exprs, temp);
+    exprs.swapWith(temp);
+}
+
 
 IHqlExpression * NewHqlTransformer::doTransformRootExpr(IHqlExpression * expr)
 {

--- a/ecl/hql/hqltrans.ipp
+++ b/ecl/hql/hqltrans.ipp
@@ -441,6 +441,7 @@ public:
     void analyseArray(const HqlExprArray & exprs, unsigned pass);
 
     void transformRoot(const HqlExprArray & in, HqlExprArray & out);
+    void transformRoot(HqlExprArray & out);
     IHqlExpression * transformRoot(IHqlExpression * expr) { return doTransformRootExpr(expr); }
 
 protected:

--- a/ecl/hqlcpp/hqlttcpp.cpp
+++ b/ecl/hqlcpp/hqlttcpp.cpp
@@ -4817,8 +4817,8 @@ IHqlExpression * CompoundActivityTransformer::createTransformed(IHqlExpression *
 //------------------------------------------------------------------------
 
 static HqlTransformerInfo optimizeActivityTransformerInfo("OptimizeActivityTransformer");
-OptimizeActivityTransformer::OptimizeActivityTransformer(bool _optimizeCountCompare, bool _optimizeNonEmpty)
-: NewHqlTransformer(optimizeActivityTransformerInfo)
+OptimizeActivityTransformer::OptimizeActivityTransformer(unsigned _wfid, bool _optimizeCountCompare, bool _optimizeNonEmpty)
+: NewHqlTransformer(optimizeActivityTransformerInfo), wfid(_wfid)
 {
     optimizeCountCompare = _optimizeCountCompare; optimizeNonEmpty = _optimizeNonEmpty;
 }
@@ -5161,7 +5161,14 @@ IHqlExpression * OptimizeActivityTransformer::doCreateTransformed(IHqlExpression
             unwindChildren(args, expr, 2);
             return expr->clone(args);
         }
-
+    case no_clustersize:
+        if (wfid && !expr->hasAttribute(pureAtom))
+        {
+            OwnedHqlExpr attribute = createExprAttribute(pureAtom, getSizetConstant(wfid));
+            OwnedHqlExpr modified = appendOwnedOperand(expr, attribute.getClear());
+            return expr->cloneAllAnnotations(modified);
+        }
+        break;
     case no_eq:
     case no_ne:
     case no_le:
@@ -5187,21 +5194,11 @@ IHqlExpression * OptimizeActivityTransformer::doCreateTransformed(IHqlExpression
 }
 
 
-void optimizeActivities(HqlExprArray & exprs, bool optimizeCountCompare, bool optimizeNonEmpty)
+void optimizeActivities(unsigned wfid, HqlExprArray & exprs, bool optimizeCountCompare, bool optimizeNonEmpty)
 {
-    OptimizeActivityTransformer transformer(optimizeCountCompare, optimizeNonEmpty);
-    HqlExprArray results;
+    OptimizeActivityTransformer transformer(wfid, optimizeCountCompare, optimizeNonEmpty);
     transformer.analyseArray(exprs, 0);
-    transformer.transformRoot(exprs, results);
-    replaceArray(exprs, results);
-}
-
-IHqlExpression * optimizeActivities(IHqlExpression * expr, bool optimizeCountCompare, bool optimizeNonEmpty)
-{
-    OptimizeActivityTransformer transformer(optimizeCountCompare, optimizeNonEmpty);
-    HqlExprArray results;
-    transformer.analyse(expr, 0);
-    return transformer.transformRoot(expr);
+    transformer.transformRoot(exprs);
 }
 
 IHqlExpression * GlobalAttributeInfo::queryAlias(IHqlExpression * value)
@@ -7701,6 +7698,8 @@ bool ScalarGlobalTransformer::isComplex(IHqlExpression * expr, bool checkGlobal)
     case no_constant:
     case no_globalscope:
     case no_libraryinput:
+    case no_clustersize:
+    case no_nothor:
         return false;
     case no_cast:
     case no_implicitcast:
@@ -10780,6 +10779,7 @@ void LeftRightTransformer::process(HqlExprArray & exprs)
     transformRoot(exprs, transformed);
     replaceArray(exprs, transformed);
 }
+
 //---------------------------------------------------------------------------------------------------------------------
 
 /*
@@ -13355,9 +13355,7 @@ void normalizeHqlTree(HqlCppTranslator & translator, HqlExprArray & exprs)
     {
         cycle_t startCycles = get_cycles_now();
         HqlScopeTagger normalizer(translator.queryErrorProcessor(), translator.queryLocalOnWarningMapper());
-        HqlExprArray transformed;
-        normalizer.transformRoot(exprs, transformed);
-        replaceArray(exprs, transformed);
+        normalizer.transformRoot(exprs);
         translator.noteFinishedTiming("compile:tree transform: normalize.scope", startCycles);
     }
 
@@ -13730,7 +13728,7 @@ void HqlCppTranslator::transformWorkflowItem(WorkflowItem & curWorkflow)
     //sort(x)[n] -> topn(x, n)[]n, count(x)>n -> count(choosen(x,n+1)) > n and possibly others
     {
         cycle_t startCycles = get_cycles_now();
-        optimizeActivities(curWorkflow.queryExprs(), !targetThor(), options.optimizeNonEmpty);
+        optimizeActivities(curWorkflow.queryWfid(), curWorkflow.queryExprs(), !targetThor(), options.optimizeNonEmpty);
         noteFinishedTiming("compile:tree transform: optimize activities", startCycles);
     }
     checkNormalized(curWorkflow);

--- a/ecl/hqlcpp/hqlttcpp.ipp
+++ b/ecl/hqlcpp/hqlttcpp.ipp
@@ -363,7 +363,7 @@ private:
 class OptimizeActivityTransformer : public NewHqlTransformer
 {
 public:
-    OptimizeActivityTransformer(bool _optimizeCountCompare, bool _optimizeNonEmpty);
+    OptimizeActivityTransformer(unsigned _wfid, bool _optimizeCountCompare, bool _optimizeNonEmpty);
 
     virtual void analyseExpr(IHqlExpression * expr);
     virtual IHqlExpression * createTransformed(IHqlExpression * expr);
@@ -379,6 +379,7 @@ protected:
     inline bool isShared(IHqlExpression * expr)                 { return queryBodyExtra(expr)->isShared(); }
 
 protected:
+    unsigned wfid;
     bool optimizeCountCompare;
     bool optimizeNonEmpty;
 };
@@ -1299,8 +1300,7 @@ void mergeThorGraphs(WorkflowItem & curWorkflow, bool resourceConditionalActions
 void migrateExprToNaturalLevel(WorkflowItem & curWorkflow, IWorkUnit * wu, HqlCppTranslator & translator);
 void removeTrivialGraphs(WorkflowItem & curWorkflow);
 void extractWorkflow(HqlCppTranslator & translator, HqlExprArray & exprs, WorkflowArray & out);
-void optimizeActivities(HqlExprArray & exprs, bool optimizeCountCompare, bool optimizeNonEmpty);
-IHqlExpression * optimizeActivities(IHqlExpression * expr, bool optimizeCountCompare, bool optimizeNonEmpty);
+void optimizeActivities(unsigned wfid, HqlExprArray & exprs, bool optimizeCountCompare, bool optimizeNonEmpty);
 IHqlExpression * insertImplicitProjects(HqlCppTranslator & translator, IHqlExpression * expr, bool optimizeSpills);
 void insertImplicitProjects(HqlCppTranslator & translator, HqlExprArray & exprs);
 


### PR DESCRIPTION
Signed-off-by: Gavin Halliday <gavin.halliday@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [x] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [x] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [x] Existing deployed queries will not be broken
  - [x] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->
Ran full reqgression test.  The following tests change:
testing/regress/ecl: keyed_join4.ecl
ecl/regress: bench.ecl radix1.ecl radix2.ecl
private suite: several.  A few the graphs get simpler, but the c++ gets larger (because different helpers are being generated) e.g., jake43.   Others get drastically better (roger1, jholt75)

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
