### PR TITLE
HPCC-17436 Remove unused fields before optimizing the graph

### DIFF
--- a/ecl/hql/hqlthql.cpp
+++ b/ecl/hql/hqlthql.cpp
@@ -967,6 +967,34 @@ void HqltHql::toECL(IHqlExpression *expr, StringBuffer &s, bool paren, bool inTy
                 break;
             }
         }
+        else if (expandProcessed && no == no_alias)
+        {
+            if (!isNamedSymbol)
+            {
+                if (!expr->queryTransformExtra())
+                {
+                    bool wasInsideNewTransform = insideNewTransform;
+                    insideNewTransform = false;
+
+                    StringBuffer temp;
+                    scope.append(NULL);
+                    temp.appendf("alias%p ", expr);
+                    temp.append(":= ");
+
+                    toECL(expr, temp, false, false, 0, true);
+                    temp.append(";").newline();
+                    addExport(temp);
+
+                    scope.pop();
+                    insideNewTransform = wasInsideNewTransform;
+                    expr->setTransformExtra(expr);
+                }
+                s.appendf("alias%p", expr);
+                if (paren)
+                    s.append(')');
+                return;
+            }
+        }
 
         if (expandProcessed && !isNamedSymbol && no == no_record)
         {

--- a/ecl/hqlcpp/hqlhtcpp.cpp
+++ b/ecl/hqlcpp/hqlhtcpp.cpp
@@ -9384,6 +9384,12 @@ IHqlExpression * HqlCppTranslator::getResourcedGraph(IHqlExpression * expr, IHql
     if (true)
         resourced.setown(optimizeCompoundSource(resourced, CSFpreload|csfFlags));
 
+    //Check to see if fields can be removed - this helps LOOP bodies, but also seems to help situations where hoisting
+    //expressions prevents child expressions from preventing fields from being removed.
+    //Perform before the optimizeHqlExpression() so decisions about reducing row sizes are accurate
+    traceExpression("BeforeImplicitProjectGraph", resourced);
+    resourced.setown(insertImplicitProjects(*this, resourced, false));
+
     // Call optimizer before resourcing so items get moved over conditions, and remove other items
     // which would otherwise cause extra spills.
     traceExpression("BeforeOptimize", resourced);


### PR DESCRIPTION
Also fixes problem with internal tracing getting too large

Signed-off-by: Gavin Halliday <gavin.halliday@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [ ] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [x] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [x] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [x] Premature optimization
  - [x] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->
Ran full regression suite.  A couple of minor changes to public suites (e.g. testing/regress/ecl/dict15b).  Some major changes to the private examples - e.g.crash8, mwalklin5.eclxml

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
