### PR TITLE
HPCC-17083 Spurious 'different version of index already loaded' error

### DIFF
--- a/system/jhtree/jhtree.cpp
+++ b/system/jhtree/jhtree.cpp
@@ -59,7 +59,7 @@
 #include "keybuild.hpp"
 #include "layouttrans.hpp"
 
-static CKeyStore *keyStore = NULL;
+static std::atomic<CKeyStore *> keyStore(nullptr);
 static unsigned defaultKeyIndexLimit = 200;
 static CNodeCache *nodeCache = NULL;
 static CriticalSection *initCrit = NULL;
@@ -79,7 +79,7 @@ MODULE_INIT(INIT_PRIORITY_JHTREE_JHTREE)
 MODULE_EXIT()
 {
     delete initCrit;
-    delete keyStore;
+    delete keyStore.load(std::memory_order_relaxed);
     ::Release((CInterface*)nodeCache);
 }
 
@@ -1282,6 +1282,7 @@ void CKeyStore::clearCacheEntry(const char *keyName)
     if (!keyName || !*keyName)
         return;  // nothing to do
 
+    synchronized block(mutex);
     Owned<CKeyIndexMRUCache::CMRUIterator> iter = keyIndexCache.getIterator();
 
     StringArray goers;
@@ -1294,6 +1295,28 @@ void CKeyStore::clearCacheEntry(const char *keyName)
             const char *name = mapping.queryFindString();
             if (strstr(name, keyName) != 0)  // keyName doesn't have drive or part number associated with it
                 goers.append(name);
+        }
+    }
+    ForEachItemIn(idx, goers)
+    {
+        keyIndexCache.remove(goers.item(idx));
+    }
+}
+
+void CKeyStore::clearCacheEntry(const IFileIO *io)
+{
+    synchronized block(mutex);
+    Owned<CKeyIndexMRUCache::CMRUIterator> iter = keyIndexCache.getIterator();
+
+    StringArray goers;
+    ForEach(*iter)
+    {
+        CKeyIndexMapping &mapping = iter->query();
+        IKeyIndex &index = mapping.query();
+        if (!index.IsShared())
+        {
+            if (index.queryFileIO()==io)
+                goers.append(mapping.queryFindString());
         }
     }
     ForEachItemIn(idx, goers)
@@ -2003,6 +2026,7 @@ public:
     virtual offset_t queryMetadataHead() { return checkOpen().queryMetadataHead(); }
     virtual IPropertyTree * getMetadata() { return checkOpen().getMetadata(); }
     virtual unsigned getNodeSize() { return checkOpen().getNodeSize(); }
+    virtual const IFileIO *queryFileIO() const override { return iFileIO->queryFileIO(); }
 };
 
 extern jhtree_decl IKeyIndex *createKeyIndex(const char *keyfile, unsigned crc, IFileIO &iFileIO, bool isTLK, bool preloadAllowed)
@@ -2036,6 +2060,11 @@ extern jhtree_decl void clearKeyStoreCache(bool killAll)
 extern jhtree_decl void clearKeyStoreCacheEntry(const char *name)
 {
     queryKeyStore()->clearCacheEntry(name);
+}
+
+extern jhtree_decl void clearKeyStoreCacheEntry(const IFileIO *io)
+{
+    queryKeyStore()->clearCacheEntry(io);
 }
 
 extern jhtree_decl StringBuffer &getIndexMetrics(StringBuffer &ret)

--- a/system/jhtree/jhtree.hpp
+++ b/system/jhtree/jhtree.hpp
@@ -80,6 +80,7 @@ interface jhtree_decl IKeyIndex : public IKeyIndexBase
     virtual offset_t queryMetadataHead() = 0;
     virtual IPropertyTree * getMetadata() = 0;
     virtual unsigned getNodeSize() = 0;
+    virtual const IFileIO *queryFileIO() const = 0;
 };
 
 interface IKeyArray : extends IInterface
@@ -103,6 +104,7 @@ interface IReplicatedFile;
 
 extern jhtree_decl void clearKeyStoreCache(bool killAll);
 extern jhtree_decl void clearKeyStoreCacheEntry(const char *name);
+extern jhtree_decl void clearKeyStoreCacheEntry(const IFileIO *io);
 extern jhtree_decl unsigned setKeyIndexCacheSize(unsigned limit);
 extern jhtree_decl void clearNodeCache();
 // these methods return previous values

--- a/system/jhtree/jhtree.ipp
+++ b/system/jhtree/jhtree.ipp
@@ -49,6 +49,7 @@ public:
     IKeyIndex *load(const char *fileName, unsigned crc, IReplicatedFile &part, bool isTLK, bool allowPreload);
     void clearCache(bool killAll);
     void clearCacheEntry(const char *name);
+    void clearCacheEntry(const IFileIO *io);
     unsigned setKeyCacheLimit(unsigned limit);
     StringBuffer &getMetrics(StringBuffer &xml);
     void resetMetrics();
@@ -135,6 +136,7 @@ public:
     CMemKeyIndex(int _iD, IMemoryMappedFile *_io, const char *_name, bool _isTLK);
 
     virtual const char *queryFileName() { return name.get(); }
+    virtual const IFileIO *queryFileIO() const override { return nullptr; }
 // INodeLoader impl.
     virtual CJHTreeNode *loadNode(offset_t offset);
 };
@@ -149,6 +151,7 @@ public:
     CDiskKeyIndex(int _iD, IFileIO *_io, const char *_name, bool _isTLK, bool _allowPreload);
 
     virtual const char *queryFileName() { return name.get(); }
+    virtual const IFileIO *queryFileIO() const override { return io; }
 // INodeLoader impl.
     virtual CJHTreeNode *loadNode(offset_t offset);
 };


### PR DESCRIPTION
The jhtree cache was keeping some IFileIO objects loaded and thus preventing
Roxie from accessing updated ones. Release any matches and retry the cache
lookup after a failure.

Signed-off-by: Richard Chapman <rchapman@hpccsystems.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [x] I have checked that this change does not introduce memory leaks.
  - [x] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [x] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browers
  - [ ] The component(s) render as expected

## Testing:
Added tracing to observe objects being freed as expected. Ran using valgrind to confirm nothing was being over-freed.
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
