### PR TITLE
HPCC-17432 Pre-populate "ManagedBy" in Group Create

### DIFF
--- a/esp/scm/ws_account.ecm
+++ b/esp/scm/ws_account.ecm
@@ -40,6 +40,7 @@ ESPresponse [exceptions_inline] MyAccountResponse
     int    passwordDaysRemaining;
     [min_ver("1.01")] int passwordExpirationWarningDays;
     [min_ver("1.02")] string employeeID;
+    [min_ver("1.03")] string distinguishedName;
 };
 
 
@@ -69,7 +70,7 @@ ESPresponse [exceptions_inline] VerifyUserResponse
 };
 
 //Kevin/russ does this method need feature level check?
-ESPservice [auth_feature("NONE"), version("1.02"), default_client_version("1.02"), exceptions_inline("./smc_xslt/exceptions.xslt")] ws_account
+ESPservice [auth_feature("NONE"), version("1.03"), default_client_version("1.03"), exceptions_inline("./smc_xslt/exceptions.xslt")] ws_account
 {
     ESPmethod [client_xslt("/esp/xslt/account_myaccount.xslt")] MyAccount(MyAccountRequest, MyAccountResponse);
     ESPmethod [client_xslt("/esp/xslt/account_input.xslt")] UpdateUserInput(UpdateUserInputRequest, UpdateUserInputResponse);

--- a/esp/services/ws_account/ws_accountService.cpp
+++ b/esp/services/ws_account/ws_accountService.cpp
@@ -175,6 +175,9 @@ bool Cws_accountEx::onMyAccount(IEspContext &context, IEspMyAccountRequest &req,
 
             if (version >= 1.02)
                 resp.setEmployeeID(user->getEmployeeID());
+
+            if (version >= 1.03)
+                resp.setDistinguishedName(user->getDistinguishedName());
         }
     }
     catch(IException* e)

--- a/system/security/LdapSecurity/ldapconnection.cpp
+++ b/system/security/LdapSecurity/ldapconnection.cpp
@@ -1493,7 +1493,7 @@ public:
                 filter.append("uid=");
             filter.append(username);
 
-            char* attrs[] = {"cn", "userAccountControl", "pwdLastSet", "givenName", "sn", "employeeNumber", NULL};
+            char* attrs[] = {"cn", "userAccountControl", "pwdLastSet", "givenName", "sn", "employeeNumber", "distinguishedName",NULL};
 
             Owned<ILdapConnection> lconn = m_connections->getConnection();
             LDAP* sys_ld = ((CLdapConnection*)lconn.get())->getLd();
@@ -1608,6 +1608,12 @@ public:
                     CLDAPGetValuesLenWrapper vals(sys_ld, entry, attribute);
                     if (vals.hasValues())
                         user.setEmployeeID(vals.queryCharValue(0));
+                }
+                else if(stricmp(attribute, "distinguishedName") == 0)
+                {
+                    CLDAPGetValuesLenWrapper vals(sys_ld, entry, attribute);
+                    if (vals.hasValues())
+                        user.setDistinguishedName(vals.queryCharValue(0));
                 }
             }
 

--- a/system/security/LdapSecurity/ldapsecurity.cpp
+++ b/system/security/LdapSecurity/ldapsecurity.cpp
@@ -129,6 +129,17 @@ bool CLdapSecUser::setEmployeeID(const char * emplID)
     return true;
 }
 
+const char * CLdapSecUser::getDistinguishedName()
+{
+    return m_distinguishedName.get();
+}
+
+bool CLdapSecUser::setDistinguishedName(const char * dn)
+{
+    m_distinguishedName.set(dn);
+    return true;
+}
+
 const char * CLdapSecUser::getRealm()
 {
     return m_realm.get();

--- a/system/security/LdapSecurity/ldapsecurity.ipp
+++ b/system/security/LdapSecurity/ldapsecurity.ipp
@@ -47,6 +47,7 @@ private:
     StringAttr   m_lastname;
     StringAttr   m_pw;
     StringAttr   m_employeeID;
+    StringAttr   m_distinguishedName;
     StringAttr   m_Fqdn;
     StringAttr   m_Peer;
     authStatus   m_authenticateStatus;
@@ -88,6 +89,8 @@ public:
     virtual bool setLastName(const char * lname);
     virtual const char * getEmployeeID();
     virtual bool setEmployeeID(const char * emplID);
+    virtual const char * getDistinguishedName();
+    virtual bool setDistinguishedName(const char * dn);
     const char * getRealm();
     bool setRealm(const char * name);
     ISecCredentials & credentials();

--- a/system/security/shared/SecureUser.hpp
+++ b/system/security/shared/SecureUser.hpp
@@ -34,6 +34,7 @@ private:
     StringBuffer    m_firstname;
     StringBuffer    m_lastname;
     StringBuffer    m_employeeID;
+    StringBuffer    m_distinguishedName;
     unsigned        m_userID;
     StringBuffer    m_Fqdn;
     StringBuffer    m_Peer;
@@ -111,6 +112,17 @@ public:
     bool setEmployeeID(const char * emplID)
     {
         m_employeeID.set(emplID);
+        return true;
+    }
+
+    const char * getDistinguishedName()
+    {
+        return m_distinguishedName.str();
+    }
+
+    bool setDistinguishedName(const char * dn)
+    {
+        m_distinguishedName.set(dn);
         return true;
     }
 

--- a/system/security/shared/seclib.hpp
+++ b/system/security/shared/seclib.hpp
@@ -172,6 +172,8 @@ interface ISecUser : extends IInterface
     virtual bool setLastName(const char * lname) = 0;
     virtual const char * getEmployeeID() = 0;
     virtual bool setEmployeeID(const char * emplID) = 0;
+    virtual const char * getDistinguishedName() = 0;
+    virtual bool setDistinguishedName(const char * dn) = 0;
     virtual const char * getRealm() = 0;
     virtual bool setRealm(const char * realm) = 0;
     virtual const char * getFqdn() = 0;


### PR DESCRIPTION
Currently an admin has to enter a complex LDAP Distinguished Name (DN) in order
to create an LDAP group. This PR adds the fully qualified DN as part of the
MyAccountResponse so ECLWatch can pre-populate that field for the admin

Signed-off-by: Russ Whitehead <william.whitehead@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
