### PR TITLE
HPCC-17464 A sink with an UPDATE, could cause balanced splitter stall

### DIFF
--- a/testing/regress/ecl/key/splitter-partialstart.xml
+++ b/testing/regress/ecl/key/splitter-partialstart.xml
@@ -1,0 +1,6 @@
+<Dataset name='Result 1'>
+</Dataset>
+<Dataset name='Result 2'>
+</Dataset>
+<Dataset name='Result 3'>
+</Dataset>

--- a/testing/regress/ecl/splitter-partialstart.ecl
+++ b/testing/regress/ecl/splitter-partialstart.ecl
@@ -1,0 +1,53 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2017 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+//noRoxie
+//nolocal
+
+import Std;
+
+#onwarning(10125, ignore); // ignore UPDATE 'up to date' messages, so that output is consistent across engines
+
+rec := RECORD
+  unsigned4 id;
+  string100 str;
+END;
+
+unsigned num := 1000000;
+ds := DATASET(num, TRANSFORM(rec, SELF.id := COUNTER; SELF.str := (string)HASH(COUNTER);), DISTRIBUTED);
+
+p1 := PROJECT(ds, TRANSFORM(rec, SELF.id := LEFT.id*2; SELF := LEFT));
+p2 := PROJECT(ds, TRANSFORM(rec, SELF.id := LEFT.id*3; SELF := LEFT));
+
+gc1 := 0 : STORED('gc1');
+ifp2 := IF(gc1=1, p2);
+
+fname1 := '~regress::splitout1';
+fname2 := '~regress::splitout2';
+SEQUENTIAL(
+ PARALLEL(
+  OUTPUT(p1, , fname1, OVERWRITE, UPDATE);
+  OUTPUT(p2, , fname2, OVERWRITE, UPDATE);
+ );
+ Std.File.DeleteLogicalFile(fname1);
+ PARALLEL(
+  OUTPUT(p1, , fname1, OVERWRITE, UPDATE);
+  OUTPUT(p2, , fname2, OVERWRITE, UPDATE);
+ );
+ Std.File.DeleteLogicalFile(fname1);
+ Std.File.DeleteLogicalFile(fname2);
+);


### PR DESCRIPTION
If a OUTPUT/BUILD,UPDATE was pruned/never executed and there was an
upstream balanced splitter, the splitter was unaware of the
non-executing arm and would deadlock when it wasn't pulled once the
balanced splitter buffer was full.

In the case of an unbalanced splitter, it would not stall, but the
splitter input would never be stopped, which cause other issues.

Signed-off-by: Jake Smith <jake.smith@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [x] I have added tests to cover my changes.
  - [x] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

New regression test added
Full regression suite ran/passed.

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
