### PR TITLE
HPCC-17506 SPRAY VARIABLE without at least one TERMINATOR fails

### DIFF
--- a/dali/ft/daftformat.cpp
+++ b/dali/ft/daftformat.cpp
@@ -928,6 +928,20 @@ size32_t CCsvPartitioner::getSplitRecordSize(const byte * start, unsigned maxToR
         cur += matchLen;
     }
 
+    numOfProcessedBytes += maxToRead;
+
+    if (isFirstRow)
+    {
+        // It seems there is only one row/record and it is terminated
+        // by EOF instead of TERMINATOR therefore the record structure definition
+        // generation doesn't finish yet.
+        isFirstRow = false;
+
+        // Process last field
+        storeFieldName((const char*)firstGood, lastGood-firstGood);
+        recordStructure.append("END;");
+    }
+
     if (processFullBuffer && (last != start))
     {
         return last - start;
@@ -936,7 +950,6 @@ size32_t CCsvPartitioner::getSplitRecordSize(const byte * start, unsigned maxToR
     if (!ateof)
         throwError(DFTERR_EndOfRecordNotFound);
 
-    numOfProcessedBytes += (unsigned)(end - start);
 
     LOG(MCdebugProgress, unknownJob, "CSV splitRecordSize(%d) at end of file", (unsigned) (end - start));
 

--- a/testing/regress/ecl/key/spray_header_test.xml
+++ b/testing/regress/ecl/key/spray_header_test.xml
@@ -1,0 +1,11 @@
+<Dataset name='Result 1'>
+</Dataset>
+<Dataset name='Result 2'>
+ <Row><result>Despray Pass</result></Row>
+</Dataset>
+<Dataset name='Result 3'>
+ <Row><result>Spray Pass</result></Row>
+</Dataset>
+<Dataset name='Result 4'>
+ <Row><Result_4>Pass</Result_4></Row>
+</Dataset>

--- a/testing/regress/ecl/spray_header_test.ecl
+++ b/testing/regress/ecl/spray_header_test.ecl
@@ -1,0 +1,139 @@
+/*##############################################################################
+
+    Copyright (C) 2017 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+import Std.File AS FileServices;
+
+// This is not an engine test, but a DFU.
+// Doesn't matter much which engine does it, so we restrict to only one
+
+//noRoxie
+//noThorLCR
+
+//class=spray
+
+//version isTerminated=false
+//version isTerminated=true
+
+import ^ as root;
+
+isTerminated := #IFDEFINED(root.isTerminated, false);
+
+unsigned VERBOSE := 0;
+
+Layout := RECORD
+    STRING field1;
+    STRING field2;
+    STRING field3;
+    STRING field4;
+    STRING field5;
+END;
+
+header := DATASET([{'Id', 'Field1', 'Field2', 'Field3', 'Field4'}], Layout);
+
+#if (isTerminated)
+    sprayPrepFileName := '~REGRESS::spray_prep_terminated';
+    // Create a one record CSV logical file with terminator a the end
+    setup := output(header, , sprayPrepFileName, CSV, OVERWRITE);
+
+    desprayOutFileName := '/var/lib/HPCCSystems/mydropzone/spray_input_terminated';
+    sprayOutFileName := '~REGRESS::spray_test_terminated';
+#else
+    sprayPrepFileName := '~REGRESS::spray_prep_not_terminated';
+    // Create a one record CSV logical file without terminator a the end
+    setup := output(header, , sprayPrepFileName, CSV(TERMINATOR('')), OVERWRITE);
+
+    desprayOutFileName := '/var/lib/HPCCSystems/mydropzone/spray_input_not_terminated';
+    sprayOutFileName := '~REGRESS::spray_test_not_terminated';
+#end
+
+rec := RECORD
+  string result;
+  string msg;
+end;
+
+
+// Despray it to default drop zone to create one record/row CVS file w/wo terminator
+rec despray(rec l) := TRANSFORM
+  SELF.msg := FileServices.fDespray(
+                       LOGICALNAME := sprayPrepFileName
+                      ,DESTINATIONIP := '.'
+                      ,DESTINATIONPATH := desprayOutFileName
+                      ,ALLOWOVERWRITE := True
+                      );
+  SELF.result := 'Despray Pass';
+end;
+
+dst1 := NOFOLD(DATASET([{'', ''}], rec));
+p1 := PROJECT(NOFOLD(dst1), despray(LEFT));
+c1 := CATCH(NOFOLD(p1), ONFAIL(TRANSFORM(rec,
+                                 SELF.result := 'Despray Fail',
+                                 SELF.msg := FAILMESSAGE
+                                )));
+#if (VERBOSE = 1)
+    desprayOut := output(c1);
+#else
+    desprayOut := output(c1, {result});
+#end
+
+
+// Spray the one record/row CVS file w/wo terminator file to check
+// DFU spray handles it well.
+rec spray(rec l) := TRANSFORM
+    SELF.msg := FileServices.fSprayVariable(
+                        SOURCEIP := '.',
+                        SOURCEPATH := desprayOutFileName,
+                        //RECORDSIZE := RecordSize,
+                        DESTINATIONGROUP := 'mythor',
+                        DESTINATIONLOGICALNAME := sprayOutFileName,
+                        TIMEOUT := -1,
+                        ESPSERVERIPPORT := 'http://127.0.0.1:8010/FileSpray',
+                        ALLOWOVERWRITE := true
+                        );
+    self.result := 'Spray Pass';
+end;
+
+dst2 := NOFOLD(DATASET([{'', ''}], rec));
+p2 := PROJECT(NOFOLD(dst2), spray(LEFT));
+c2 := CATCH(NOFOLD(p2), ONFAIL(TRANSFORM(rec,
+                                 SELF.result := 'Spray Fail',
+                                 SELF.msg := FAILMESSAGE
+                                )));
+#if (VERBOSE = 1)
+    sprayOut := output(c2);
+#else
+    sprayOut := output(c2, {result});
+#end
+
+ds := DATASET(sprayOutFileName, Layout, csv);
+
+string compareDatasets(dataset(Layout) ds1, dataset(Layout) ds2) := FUNCTION
+   boolean result := (0 = COUNT(JOIN(ds1, ds2, left.field1=right.field1, FULL ONLY)));
+   RETURN if(result, 'Pass', 'Fail');
+END;
+
+
+SEQUENTIAL(
+    setup,
+    desprayOut,
+    sprayOut,
+    output(compareDatasets(header,ds)),
+
+    // Clean-up
+    FileServices.DeleteExternalFile('.', desprayOutFileName),
+    FileServices.DeleteLogicalFile(sprayOutFileName),
+    FileServices.DeleteLogicalFile(sprayPrepFileName),
+);


### PR DESCRIPTION
Add code to handle the "there is only one row/record and it is
terminated by EOF instead of TERMINATOR and the record structure
definition generation doesn't finish yet" case in the
CCsvPartitioner::getSplitRecordSize() method.

Create Regression Suite test case to test spray a file contains only one
record/row with and without terminator at the end situation.

Signed-off-by: Attila Vamos <attila.vamos@gmail.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [x] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [x] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [x] This change fixes the problem, not just the symptom
  - [x] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [x] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->
Tested manually together with all other Spray and Despray test cases w/wo --pq.
<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
