### PR TITLE
HPCC-17555 Fix various chained stop() issues and conditional loop initialization

### DIFF
--- a/thorlcr/activities/selfjoin/thselfjoinslave.cpp
+++ b/thorlcr/activities/selfjoin/thselfjoinslave.cpp
@@ -41,7 +41,6 @@ private:
     unsigned portbase;
     bool isLocal;
     bool isLightweight;
-    bool inputStopped;
     Owned<IRowStream> strm;     
     ICompare * compare;
     ISortKeySerializer * keyserializer;
@@ -103,7 +102,6 @@ public:
         portbase = 0;
         compare = NULL;
         keyserializer = NULL;
-        inputStopped = false;
         mpTagRPC = TAG_NULL;
         if (isLocal)
             setRequireInitData(false);

--- a/thorlcr/activities/thactivityutil.cpp
+++ b/thorlcr/activities/thactivityutil.cpp
@@ -61,8 +61,8 @@ class CRowStreamLookAhead : public CSimpleInterfaceOf<IStartableEngineRowStream>
     CSlaveActivity &activity;
     bool allowspill, preserveGrouping;
     ILookAheadStopNotify *notify;
-    bool running;
-    bool stopped;
+    bool running = false;
+    bool started = false;
     rowcount_t required;
     Semaphore startSem;
     Owned<IException> getexception;
@@ -207,7 +207,6 @@ public:
         running = true;
         required = _required;
         count = 0;
-        stopped = true;
     }
     ~CRowStreamLookAhead()
     {
@@ -235,7 +234,7 @@ public:
 #ifdef _FULL_TRACE
         ActPrintLog(&activity, "CRowStreamLookAhead start %x",(unsigned)(memsize_t)this);
 #endif
-        stopped = false;
+        started = true;
         running = true;
         thread.start();
         startSem.wait();
@@ -248,13 +247,19 @@ public:
 #ifdef _FULL_TRACE
         ActPrintLog(&activity, "CRowStreamLookAhead stop %x",(unsigned)(memsize_t)this);
 #endif
-        if (!stopped)
+        if (!started) // never started
+        {
+            // still want to chain stop()'s even if never started
+            if (inputStream)
+                inputStream->stop();
+        }
+        else
         {
             running = false;
             if (smartbuf)
                 smartbuf->stop(); // just in case blocked
             thread.join();
-            stopped = true;
+            started = false;
             if (getexception)
                 throw getexception.getClear();
         }

--- a/thorlcr/activities/topn/thtopnslave.cpp
+++ b/thorlcr/activities/topn/thtopnslave.cpp
@@ -111,7 +111,7 @@ public:
     }
     IRowStream *getNextSortGroup(IRowStream *input)
     {
-        if (inputStopped) return NULL;
+        if (inputStopped) return NULL; // JCSMORE - should not be possible. getNextSortGroup() is called from nextRow() and should never be called after stop()
         sortedRows.clearRows(); // NB: In a child query, this will mean the rows ptr will remain at high-water mark
         for (;;)
         {

--- a/thorlcr/graph/thgraphmaster.cpp
+++ b/thorlcr/graph/thgraphmaster.cpp
@@ -2287,10 +2287,10 @@ void CMasterGraph::sendActivityInitData()
     unsigned pos = msg.length();
     unsigned w=0;
     unsigned sentTo = 0;
+    Owned<IThorActivityIterator> iter = getConnectedIterator(!isLoopSubGraph()); // if loop graph, need to initialize all activities (not just 1st time conditional path)
     for (; w<queryJob().querySlaves(); w++)
     {
         unsigned needActInit = 0;
-        Owned<IThorActivityIterator> iter = getConnectedIterator();
         ForEach(*iter)
         {
             CGraphElementBase &element = iter->query();
@@ -2305,7 +2305,6 @@ void CMasterGraph::sendActivityInitData()
             try
             {
                 msg.rewrite(pos);
-                Owned<IThorActivityIterator> iter = getConnectedIterator();
                 serializeActivityInitData(w, msg, *iter);
             }
             catch (IException *e)


### PR DESCRIPTION
A number of activities would not call their input stop() methods
if they had never been started.
Also, a loop graph would not initialize all activities if some
activities were conditional branches.

Signed-off-by: Jake Smith <jake.smith@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [x] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

Specific modified test (from PR of HPCC-17179) ran / passed (looprpn2.ecl)
Full regression suite ran/passed.

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
