### PR TITLE
HPCC-16678 Add session based authentication to ESP

### DIFF
--- a/esp/bindings/SOAP/soaplib/CMakeLists.txt
+++ b/esp/bindings/SOAP/soaplib/CMakeLists.txt
@@ -59,6 +59,8 @@ include_directories(
     ./../../../../system/xmllib
     ./..
     ./../../../bindings/SOAP/xpp
+    ./../../../../system/mp 
+    ./../../../../dali/base
     )
 
 add_definitions(-DESPHTTP_EXPORTS)

--- a/esp/files/esp_app_tree.html
+++ b/esp/files/esp_app_tree.html
@@ -360,6 +360,20 @@ function writeESPappname(appname)
         YAHOO.util.Connect.asyncRequest('GET', sUrl, callback);
       }
 
+      var logout = function()
+      {
+        var logoutRequest = new XMLHttpRequest();
+        logoutRequest.onreadystatechange = function()
+        { 
+          if (logoutRequest.readyState == 4 && logoutRequest.status == 200)
+            parent.location = '/esp/files/eclwatch/templates/Login.html';
+          else
+            console.log("Logout failed: " + logoutRequest.status);
+        }
+        logoutRequest.open( "GET", 'esp/logout', true );            
+        logoutRequest.send( null );
+      }
+
             var copy_url = function()
                 {
                     var inner = parent.frames['main'].location;
@@ -444,6 +458,10 @@ function writeESPappname(appname)
                                     { text: "Refresh", onclick: { fn: refresh_main }}
                                 ]
                         ] }
+                    },
+                    {
+                        text: "<b>Log Out</b>",
+                        onclick: { fn: logout }
                     }
                 ];
 

--- a/esp/files/userlogon.html
+++ b/esp/files/userlogon.html
@@ -1,0 +1,50 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+        <title>User Log On</title>
+	<script>
+	    function keyupFunction()
+            {
+    		var f = document.getElementById("user_input_form");
+                if(f.username.value != '' && f.password.value != '')
+                    f.LogOn.disabled=false;
+                else
+                    f.LogOn.disabled=true;
+            }
+            function onLoad()
+            {
+                document.getElementById("username").focus();
+            }
+         </script>
+    </head>
+    <body class="yui-skin-sam" onload="onLoad()">
+        <p align="left" />
+        <h3>Please log on.</h3>
+        <form id="user_input_form" name="user_input_form" method="POST" action="/">
+            <table>
+                <tr>
+                    <td>
+                        <b>UserName: </b>
+                    </td>
+                    <td>
+                        <input type="text" id="username" name="username" size="20" onKeyUp="keyupFunction()"/>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <b>Password: </b>
+                    </td>
+                    <td>
+                        <input type="password" name="password" size="20" value="" onKeyUp="keyupFunction()"/>
+                    </td>
+                </tr>
+                <tr>
+                    <td/>
+                    <td>
+                        <input type="submit" id="LogOn" name="LogOn" value="Log on" disabled="true"/>
+                    </td>
+                </tr>
+            </table>
+        </form>
+    </body>
+</html>

--- a/esp/files/userlogout.html
+++ b/esp/files/userlogout.html
@@ -1,0 +1,17 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+        <title>User Log Out</title>
+	<script>
+            function onLoad()
+            {
+                //document.getElementById("username").focus();
+            }
+         </script>
+    </head>
+    <body class="yui-skin-sam" onload="onLoad()">
+        <p align="left" />
+        <h3>ESP log out.</h3>
+        <h4><a href="userlogon.html" target="_top">Click here to login.</a> </h4>
+    </body>
+</html>

--- a/esp/platform/espcfg.ipp
+++ b/esp/platform/espcfg.ipp
@@ -30,6 +30,8 @@
 #include "environment.hpp"
 #include <dalienv.hpp>
 
+#include "bindutil.hpp"
+
 //STL
 #include <list>
 #include <map>
@@ -166,12 +168,17 @@ public:
 
     const SocketEndpoint &getLocalEndpoint(){return m_address;}
 
+    void ensureESPSessionInTree(IPropertyTree* sessionRoot, const char* procName);
+    void ensureSDSSessionDomains();
+
     void loadProtocols();
     void loadServices();
     void loadBindings();
 
     void loadAll()
     {
+        ensureSDSSessionDomains();
+
         DBGLOG("loadServices");
         loadServices();
         loadProtocols();

--- a/esp/platform/espcontext.cpp
+++ b/esp/platform/espcontext.cpp
@@ -78,6 +78,8 @@ private:
     unsigned    m_exceptionTime;
     bool        m_hasException;
     int         m_exceptionCode;
+    StringAttr  authenticationMethod;
+    AuthType    domainAuthType;
 
     ESPSerializationFormat respSerializationFormat;
 
@@ -162,6 +164,16 @@ public:
     virtual const char * queryPassword()
     {
         return m_password.get();
+    }
+    virtual bool addUserToken(unsigned token)
+    {
+        if (!m_user)
+            return false;
+
+        MemoryBuffer buf;
+        buf.append(token);
+        m_user->credentials().addToken(&buf);
+        return true;
     }
 
     virtual void setRealm(const char* realm)
@@ -485,6 +497,19 @@ public:
         m_txSummary->clear();
         m_txSummary.clear();
     }
+
+    virtual void setAuthenticationMethod(const char* method)
+    {
+        authenticationMethod.set(method);
+    }
+
+    virtual const char * getAuthenticationMethod()
+    {
+        return authenticationMethod.get();
+    }
+
+    virtual void setDomainAuthType(AuthType type) { domainAuthType = type; }
+    virtual AuthType getDomainAuthType(){ return domainAuthType; }
 
     virtual ESPSerializationFormat getResponseFormat(){return respSerializationFormat;}
     virtual void setResponseFormat(ESPSerializationFormat fmt){respSerializationFormat = fmt;}

--- a/esp/platform/espcontext.hpp
+++ b/esp/platform/espcontext.hpp
@@ -31,6 +31,62 @@
 #include "esp.hpp"
 #include "esphttp.hpp"
 
+#define SESSION_SDS_LOCK_TIMEOUT (30*1000) // 30 seconds
+#define ESP_SESSION_TIMEOUT (600) // 10 Mins
+#define ESP_CHECK_SESSION_TIMEOUT (30) // 30 seconds
+
+static const char* const SESSION_ID_COOKIE = "ESPSessionID";
+static const char* const SESSION_START_URL_COOKIE = "ESPAuthURL";
+static const char* const DEFAULT_LOGIN_URL = "/esp/files/eclwatch/templates/Login.html";
+static const char* const DEFAULT_UNRESTRICTED_RESOURCE1 = "/favicon.ico";
+static const char* const DEFAULT_UNRESTRICTED_RESOURCE2 = "/esp/files/*,/esp/xslt/*";
+
+//xpath in dali
+static const char* const PathSessionRoot="Sessions";
+static const char* const PathSessionProcess="Process";
+static const char* const PathSessionApplication="Application";
+static const char* const PathSessionSession="Session";
+static const char* const PropSessionID = "@id";
+static const char* const PropSessionExternalID = "@externalid";
+static const char* const PropSessionUserID = "@userid";
+static const char* const PropSessionNetworkAddress = "@netaddr";
+static const char* const PropSessionState = "@state";
+static const char* const PropSessionCreateTime = "@createtime";
+static const char* const PropSessionLastAccessed = "@lastaccessed";
+static const char* const PropSessionTimeoutAt = "@timeoutAt";
+static const char* const PropSessionTimeoutByAdmin = "@timeoutByAdmin";
+static const char* const PropSessionLoginURL = "@loginurl";
+/* The following is an example of session data stored in Dali.
+<Sessions>
+ <Process name="myesp">
+   <Application port="8010">
+    <Session createtime="1497376914"
+             id="3831947145"
+             lastaccessed="1497377015"
+             loginurl="/"
+             netaddr="10.176.152.200"
+             state="1"
+             userid="TheAdmin"/>
+    <Session createtime="1497377427"
+             id="4106750941"
+             lastaccessed="1497377427"
+             loginurl="/"
+             netaddr="10.176.152.200"
+             state="0"/>
+   </Application>
+   <Application port="8002">
+    <Session createtime="1497376989"
+             id="3680948651"
+             lastaccessed="1497377003"
+             loginurl="/"
+             netaddr="10.176.152.200"
+             state="1"
+             userid="TheAdmin"/>
+   </Application>
+ </Process>
+</Sessions>
+ */
+
 interface IEspSecureContext;
 
 ESPHTTP_API IEspContext* createEspContext(IEspSecureContext* secureContext = NULL);

--- a/esp/platform/espprotocol.cpp
+++ b/esp/platform/espprotocol.cpp
@@ -153,14 +153,16 @@ const StringBuffer &CEspApplicationPort::getTitleBarHtml(IEspContext& ctx, bool 
 {
     if (xslp)
     {
-        StringBuffer titleBarXml;
+        VStringBuffer titleBarXml("<EspHeader><BuildVersion>%s</BuildVersion><ConfigAccess>%d</ConfigAccess>", build_ver, viewConfig);
+
+        const char* authMethod = ctx.getAuthenticationMethod();
+        if (authMethod && !strieq(authMethod, "none") && (ctx.getDomainAuthType() != AuthPerRequestOnly))
+            titleBarXml.append("<LogOut>1</LogOut>");
+
         const char* user = ctx.queryUserId();
-                if (!user || !*user)
-            titleBarXml.appendf("<EspHeader><BuildVersion>%s</BuildVersion><ConfigAccess>%d</ConfigAccess>"
-                "<LoginId>&lt;nobody&gt;</LoginId><NoUser>1</NoUser></EspHeader>", build_ver, viewConfig);
-                else
-            titleBarXml.appendf("<EspHeader><BuildVersion>%s</BuildVersion><ConfigAccess>%d</ConfigAccess>"
-                "<LoginId>%s</LoginId></EspHeader>", build_ver, viewConfig, user);
+        if (user && *user)
+            titleBarXml.appendf("<LoginId>%s</LoginId>", user);
+        titleBarXml.append("</EspHeader>");
 
         if (rawXml)
         {

--- a/esp/platform/espsession.ipp
+++ b/esp/platform/espsession.ipp
@@ -36,7 +36,10 @@ private:
     int        m_maxage;
     StringAttr m_path;
     bool       m_secure;
+    bool       m_httponly;
     bool       m_discard;
+    StringAttr expires;
+    StringAttr sameSite;
 
 public:
     IMPLEMENT_IINTERFACE;
@@ -49,6 +52,7 @@ public:
         m_version = version;
 
         m_secure = false;
+        m_httponly = false; //For backward compatible
         m_discard = false;
         m_path.set("/");
     }
@@ -156,6 +160,15 @@ public:
         m_secure = flag;
     }
 
+    bool getHTTPOnly()
+    {
+        return m_httponly;
+    }
+    void setHTTPOnly(bool flag)
+    {
+        m_httponly = flag;
+    }
+
     bool getDiscard()
     {
         return m_discard;
@@ -172,6 +185,26 @@ public:
     void setVersion(int version)
     {
         m_version = version;
+    }
+
+    const char* getExpires()
+    {
+        return expires.get();
+    }
+
+    void setExpires(const char* _expires)
+    {
+        expires.set(_expires);
+    }
+
+    const char* getSameSite()
+    {
+        return sameSite.get();
+    }
+
+    void setSameSite(const char* _sameSite)
+    {
+        sameSite.set(_sameSite);
     }
 
     void appendToRequestHeader(StringBuffer& buf)
@@ -197,6 +230,12 @@ public:
             buf.append("; Domain=").append(m_domain.get());
         if(m_secure)
             buf.append("; Secure");
+        if(m_httponly)
+            buf.append("; HttpOnly");
+        if (expires.length() > 0)
+            buf.append("; Expires=").append(expires.get());
+        if (sameSite.length() > 0)
+            buf.append("; SameSite=").append(sameSite.get());
         if(m_version >= 1)
         {
             buf.append("; Version=").append(m_version);     

--- a/esp/protocols/http/CMakeLists.txt
+++ b/esp/protocols/http/CMakeLists.txt
@@ -61,6 +61,8 @@ include_directories(
     ./../../services/common
     ./../../../system/security/shared
     ./../../../system/security/LdapSecurity
+    ./../../../system/mp 
+    ./../../../dali/base
     )
 
 add_definitions(-DESPHTTP_EXPORTS -DESP_TIMING -D_USRDLL -DESP_PLUGIN)

--- a/esp/scm/esp.ecm
+++ b/esp/scm/esp.ecm
@@ -55,6 +55,13 @@ typedef enum ESPSerializationFormat_
     ESPSerializationCSV
 } ESPSerializationFormat;
 
+typedef enum AuthType_
+{
+    AuthTypeMixed,
+    AuthPerSessionOnly,
+    AuthPerRequestOnly
+} AuthType;
+
 #define ESPCTX_NO_NAMESPACES    0x00000001
 #define ESPCTX_WSDL             0x00000010
 #define ESPCTX_WSDL_EXT         0x00000100
@@ -169,6 +176,12 @@ interface IEspContext : extends IInterface
 
     virtual void setTransactionID(const char * trxid) = 0;
     virtual const char * queryTransactionID() = 0;
+
+    virtual const char * getAuthenticationMethod()=0;
+    virtual void setAuthenticationMethod(const char * method)=0;
+    virtual void setDomainAuthType(AuthType type)=0;
+    virtual AuthType getDomainAuthType()=0;
+    virtual bool addUserToken(unsigned id)=0;
 };
 
 

--- a/esp/scm/ws_espcontrol.ecm
+++ b/esp/scm/ws_espcontrol.ecm
@@ -30,9 +30,74 @@ ESPresponse [exceptions_inline, nil_remove, http_encode(0)] SetLoggingResponse
     string Message;
 };
 
-ESPservice [auth_feature("NONE"), version("1.00"), default_client_version("1.00"), exceptions_inline("./smc_xslt/exceptions.xslt")] WSESPControl
+ESPStruct [nil_remove] Session
+{
+    string ID;
+    string UserID;
+    string NetworkAddress;
+    string CreateTime;
+    string LastAccessed;
+    string TimeoutAt;
+    int    Port;
+    bool   TimeoutByAdmin;
+};
+
+ESPrequest [nil_remove] SessionQueryRequest
+{
+    int    Port;
+    string FromIP;
+};
+
+ESPresponse [exceptions_inline, nil_remove, http_encode(0)] SessionQueryResponse
+{
+    ESParray<ESPstruct Session> Sessions;
+};
+
+ESPrequest [nil_remove] SessionInfoRequest
+{
+    int    Port;
+    string ID;
+};
+
+ESPresponse [exceptions_inline, nil_remove, http_encode(0)] SessionInfoResponse
+{
+    ESPstruct Session Session;
+};
+
+ESPrequest [nil_remove] CleanSessionRequest
+{
+    string ID;
+    string FromIP;
+    int    Port;
+};
+
+ESPresponse [exceptions_inline, nil_remove, http_encode(0)] CleanSessionResponse
+{
+    int Status;
+    string Message;
+};
+
+ESPrequest [nil_remove] SetSessionTimeoutRequest
+{
+    string ID;
+    string FromIP;
+    int    Port;
+    int    TimeoutMinutes;
+};
+
+ESPresponse [exceptions_inline, nil_remove, http_encode(0)] SetSessionTimeoutResponse
+{
+    int Status;
+    string Message;
+};
+
+ESPservice [auth_feature("NONE"), version("1.01"), default_client_version("1.01"), exceptions_inline("./smc_xslt/exceptions.xslt")] WSESPControl
 {
     ESPmethod SetLogging(SetLoggingRequest, SetLoggingResponse);
+    ESPmethod [min_ver("1.01")] SessionQuery(SessionQueryRequest, SessionQueryResponse);
+    ESPmethod [min_ver("1.01")] SessionInfo(SessionInfoRequest, SessionInfoResponse);
+    ESPmethod [min_ver("1.01")] CleanSession(CleanSessionRequest, CleanSessionResponse);
+    ESPmethod [min_ver("1.01")] SetSessionTimeout(SetSessionTimeoutRequest, SetSessionTimeoutResponse);
 };
 
 SCMexportdef(WSESPControl);

--- a/esp/services/espcontrol/CMakeLists.txt
+++ b/esp/services/espcontrol/CMakeLists.txt
@@ -41,6 +41,8 @@ include_directories (
          ./../../../system/security/securesocket
          ./../../../system/security/LdapSecurity
          ./../../../system/security/shared
+         ./../../../system/mp 
+         ./../../../dali/base
          ./../../clients
          ./../../bindings
          ./../../bindings/SOAP/xpp

--- a/esp/services/espcontrol/ws_espcontrolservice.cpp
+++ b/esp/services/espcontrol/ws_espcontrolservice.cpp
@@ -22,6 +22,59 @@
 #include "ws_espcontrolservice.hpp"
 #include "jlib.hpp"
 #include "exception_util.hpp"
+#include "dasds.hpp"
+
+#define SDS_LOCK_TIMEOUT (5*60*1000) // 5 mins
+
+const char* CWSESPControlEx::readSessionTimeStamp(int t, StringBuffer& str)
+{
+    CDateTime time;
+    time.set(t);
+    return time.getString(str).str();
+}
+
+IEspSession* CWSESPControlEx::setSessionInfo(const char* id, IPropertyTree* espSessionTree, unsigned port, IEspSession* session)
+{
+    if (espSessionTree == nullptr)
+        return nullptr;
+
+    StringBuffer createTimeStr, lastAccessedStr, TimeoutAtStr;
+    int lastAccessed = espSessionTree->getPropInt(PropSessionLastAccessed, 0);
+
+    session->setPort(port);
+    session->setID(id);
+    session->setUserID(espSessionTree->queryProp(PropSessionUserID));
+    session->setNetworkAddress(espSessionTree->queryProp(PropSessionNetworkAddress));
+    session->setCreateTime(readSessionTimeStamp(espSessionTree->getPropInt(PropSessionCreateTime, 0), createTimeStr));
+    session->setLastAccessed(readSessionTimeStamp(espSessionTree->getPropInt(PropSessionLastAccessed, 0), lastAccessedStr));
+    session->setTimeoutAt(readSessionTimeStamp(espSessionTree->getPropInt(PropSessionTimeoutAt, 0), TimeoutAtStr));
+    session->setTimeoutByAdmin(espSessionTree->getPropBool(PropSessionTimeoutByAdmin, false));
+    return session;
+}
+
+void CWSESPControlEx::init(IPropertyTree *cfg, const char *process, const char *service)
+{
+    if(cfg == NULL)
+        throw MakeStringException(-1, "Can't initialize CWSESPControlEx, cfg is NULL");
+
+    espProcess.set(process);
+
+    VStringBuffer xpath("Software/EspProcess[@name=\"%s\"]", process);
+    IPropertyTree* espCFG = cfg->queryPropTree(xpath.str());
+    if (!espCFG)
+        throw MakeStringException(-1, "Can't find EspBinding for %s", process);
+
+    Owned<IPropertyTreeIterator> it = espCFG->getElements("AuthDomains/AuthDomain");
+    ForEach(*it)
+    {
+        IPropertyTree& authDomain = it->query();
+        StringBuffer name = authDomain.queryProp("@domainName");
+        if (name.isEmpty())
+            name.set("default");
+        sessionTimeoutMinutesMap.setValue(name.str(), authDomain.getPropInt("@sessionTimeoutMinutes", 0));
+    }
+}
+
 
 bool CWSESPControlEx::onSetLogging(IEspContext& context, IEspSetLoggingRequest& req, IEspSetLoggingResponse& resp)
 {
@@ -44,6 +97,186 @@ bool CWSESPControlEx::onSetLogging(IEspContext& context, IEspSetLoggingRequest& 
             m_container->setLogResponses(req.getLogResponses());
         resp.setStatus(0);
         resp.setMessage("Logging settings are updated.");
+    }
+    catch(IException* e)
+    {
+        FORWARDEXCEPTION(context, e, ECLWATCH_INTERNAL_ERROR);
+    }
+    return true;
+}
+
+IRemoteConnection* CWSESPControlEx::querySDSConnection(const char* xpath, unsigned mode, unsigned timeout)
+{
+    Owned<IRemoteConnection> globalLock = querySDS().connect(xpath, myProcessSession(), RTM_LOCK_READ, SESSION_SDS_LOCK_TIMEOUT);
+    if (!globalLock)
+        throw MakeStringException(ECLWATCH_INTERNAL_ERROR, "Unable to connect to ESP Session information in dali %s", xpath);
+    return globalLock.getClear();
+}
+
+bool CWSESPControlEx::onSessionQuery(IEspContext& context, IEspSessionQueryRequest& req, IEspSessionQueryResponse& resp)
+{
+    try
+    {
+#ifdef _USE_OPENLDAP
+        CLdapSecManager* secmgr = dynamic_cast<CLdapSecManager*>(context.querySecManager());
+        if(secmgr && !secmgr->isSuperUser(context.queryUser()))
+            throw MakeStringException(ECLWATCH_SUPER_USER_ACCESS_DENIED, "Failed to query session. Permission denied.");
+#endif
+
+        StringBuffer fromIP = req.getFromIP();
+        unsigned port = 8010;
+        if (!req.getPort_isNull())
+            port = req.getPort();
+
+        VStringBuffer xpath("/%s/%s[@name='%s']/%s[@port='%d']", PathSessionRoot, PathSessionProcess,
+            espProcess.get(), PathSessionApplication, port);
+        Owned<IRemoteConnection> globalLock = querySDSConnection(xpath.str(), RTM_LOCK_READ, SESSION_SDS_LOCK_TIMEOUT);
+
+        IArrayOf<IEspSession> sessions;
+        if (!fromIP.trim().isEmpty())
+            xpath.setf("%s[%s='%s']", PathSessionSession, PropSessionNetworkAddress, fromIP.str());
+        else
+            xpath.set("*");
+        Owned<IPropertyTreeIterator> iter = globalLock->queryRoot()->getElements(xpath.str());
+        ForEach(*iter)
+        {
+            IPropertyTree& sessionTree = iter->query();
+            Owned<IEspSession> s = createSession();
+            setSessionInfo(sessionTree.queryProp(PropSessionExternalID), &sessionTree, port, s);
+            sessions.append(*s.getLink());
+        }
+        resp.setSessions(sessions);
+    }
+    catch(IException* e)
+    {
+        FORWARDEXCEPTION(context, e, ECLWATCH_INTERNAL_ERROR);
+    }
+    return true;
+}
+
+bool CWSESPControlEx::onSessionInfo(IEspContext& context, IEspSessionInfoRequest& req, IEspSessionInfoResponse& resp)
+{
+    try
+    {
+#ifdef _USE_OPENLDAP
+        CLdapSecManager* secmgr = dynamic_cast<CLdapSecManager*>(context.querySecManager());
+        if(secmgr && !secmgr->isSuperUser(context.queryUser()))
+            throw MakeStringException(ECLWATCH_SUPER_USER_ACCESS_DENIED, "Failed to get session information. Permission denied.");
+#endif
+
+        StringBuffer id = req.getID();
+        if (id.trim().isEmpty())
+            throw MakeStringException(ECLWATCH_INVALID_INPUT, "ID not specified.");
+
+        unsigned port = 8010;
+        if (!req.getPort_isNull())
+            port = req.getPort();
+
+        VStringBuffer xpath("/%s/%s[@name='%s']/%s[@port='%d']/%s[%s='%s']", PathSessionRoot, PathSessionProcess, espProcess.get(),
+            PathSessionApplication, port, PathSessionSession, PropSessionExternalID, id.str());
+        Owned<IRemoteConnection> globalLock = querySDSConnection(xpath.str(), RTM_LOCK_READ, SESSION_SDS_LOCK_TIMEOUT);
+        setSessionInfo(id.str(), globalLock->queryRoot(), port, &resp.updateSession());
+    }
+    catch(IException* e)
+    {
+        FORWARDEXCEPTION(context, e, ECLWATCH_INTERNAL_ERROR);
+    }
+    return true;
+}
+
+bool CWSESPControlEx::onCleanSession(IEspContext& context, IEspCleanSessionRequest& req, IEspCleanSessionResponse& resp)
+{
+    try
+    {
+#ifdef _USE_OPENLDAP
+        CLdapSecManager* secmgr = dynamic_cast<CLdapSecManager*>(context.querySecManager());
+        if(secmgr && !secmgr->isSuperUser(context.queryUser()))
+            throw MakeStringException(ECLWATCH_SUPER_USER_ACCESS_DENIED, "Failed to clean session. Permission denied.");
+#endif
+
+        StringBuffer id = req.getID();
+        StringBuffer fromIP = req.getFromIP();
+        if ((id.trim().isEmpty()) && (fromIP.trim().isEmpty()))
+            throw MakeStringException(ECLWATCH_INVALID_INPUT, "ID or FromIP has to be specified.");
+
+        unsigned port = 8010;
+        if (!req.getPort_isNull())
+            port = req.getPort();
+
+        VStringBuffer xpath("/%s/%s[@name='%s']/%s[@port='%d']", PathSessionRoot, PathSessionProcess,
+            espProcess.get(), PathSessionApplication, port);
+        Owned<IRemoteConnection> globalLock = querySDSConnection(xpath.str(), RTM_LOCK_WRITE, SESSION_SDS_LOCK_TIMEOUT);
+
+        IArrayOf<IPropertyTree> toRemove;
+        if (!id.isEmpty())
+            xpath.setf("%s[%s='%s']", PathSessionSession, PropSessionExternalID, id.str());
+        else
+            xpath.setf("%s[%s='%s']", PathSessionSession, PropSessionNetworkAddress, fromIP.str());
+        Owned<IPropertyTreeIterator> iter = globalLock->queryRoot()->getElements(xpath.str());
+        ForEach(*iter)
+            toRemove.append(*LINK(&iter->query()));
+        ForEachItemIn(i, toRemove)
+            globalLock->queryRoot()->removeTree(&toRemove.item(i));
+
+        resp.setStatus(0);
+        resp.setMessage("Session is cleaned.");
+    }
+    catch(IException* e)
+    {
+        FORWARDEXCEPTION(context, e, ECLWATCH_INTERNAL_ERROR);
+    }
+    return true;
+}
+
+bool CWSESPControlEx::onSetSessionTimeout(IEspContext& context, IEspSetSessionTimeoutRequest& req, IEspSetSessionTimeoutResponse& resp)
+{
+    try
+    {
+#ifdef _USE_OPENLDAP
+        CLdapSecManager* secmgr = dynamic_cast<CLdapSecManager*>(context.querySecManager());
+        if(secmgr && !secmgr->isSuperUser(context.queryUser()))
+            throw MakeStringException(ECLWATCH_SUPER_USER_ACCESS_DENIED, "Failed to set session timeout. Permission denied.");
+#endif
+
+        StringBuffer id = req.getID();
+        StringBuffer fromIP = req.getFromIP();
+        if (id.trim().isEmpty() && fromIP.trim().isEmpty())
+            throw MakeStringException(ECLWATCH_INVALID_INPUT, "ID or FromIP has to be specified.");
+
+        unsigned port = 8010;
+        if (!req.getPort_isNull())
+            port = req.getPort();
+
+        VStringBuffer xpath("/%s/%s[@name='%s']/%s[@port='%d']", PathSessionRoot, PathSessionProcess,
+            espProcess.get(), PathSessionApplication, port);
+        Owned<IRemoteConnection> globalLock = querySDSConnection(xpath.str(), RTM_LOCK_WRITE, SESSION_SDS_LOCK_TIMEOUT);
+
+        IArrayOf<IPropertyTree> toRemove;
+        int timeoutMinutes = req.getTimeoutMinutes_isNull() ? 0 : req.getTimeoutMinutes();
+        if (!id.isEmpty())
+            xpath.setf("%s[%s='%s']", PathSessionSession, PropSessionExternalID, id.str());
+        else
+            xpath.setf("%s[%s='%s']", PathSessionSession, PropSessionNetworkAddress, fromIP.str());
+        Owned<IPropertyTreeIterator> iter = globalLock->queryRoot()->getElements(xpath.str());
+        ForEach(*iter)
+        {
+            IPropertyTree& item = iter->query();
+            if (timeoutMinutes <= 0)
+                toRemove.append(*LINK(&item));
+            else
+            {
+                CDateTime timeNow;
+                timeNow.setNow();
+                time_t simple = timeNow.getSimple() + timeoutMinutes*60;
+                item.setPropInt64(PropSessionTimeoutAt, simple);
+                item.setPropBool(PropSessionTimeoutByAdmin, true);
+            }
+        }
+        ForEachItemIn(i, toRemove)
+            globalLock->queryRoot()->removeTree(&toRemove.item(i));
+
+        resp.setStatus(0);
+        resp.setMessage("Session timeout is updated.");
     }
     catch(IException* e)
     {

--- a/esp/services/espcontrol/ws_espcontrolservice.hpp
+++ b/esp/services/espcontrol/ws_espcontrolservice.hpp
@@ -22,7 +22,15 @@
 
 class CWSESPControlEx : public CWSESPControl
 {
+    StringAttr espProcess;
+    MapStringTo<int> sessionTimeoutMinutesMap;
     IEspContainer* m_container;
+
+    const char* readSessionTimeStamp(int t, StringBuffer& str);
+    float readSessionTimeoutMin(int sessionTimeoutMinutes, int lastAccessed);
+    IRemoteConnection* querySDSConnection(const char* xpath, unsigned mode, unsigned timeout);
+    IEspSession* setSessionInfo(const char* sessionID, IPropertyTree* espSessionTree, unsigned port, IEspSession* session);
+
 public:
     IMPLEMENT_IINTERFACE;
 
@@ -31,7 +39,12 @@ public:
         m_container = container;
     }
 
+    virtual void init(IPropertyTree *cfg, const char *process, const char *service);
     virtual bool onSetLogging(IEspContext &context, IEspSetLoggingRequest &req, IEspSetLoggingResponse &resp);
+    virtual bool onSessionQuery(IEspContext& context, IEspSessionQueryRequest& req, IEspSessionQueryResponse& resp);
+    virtual bool onSessionInfo(IEspContext& context, IEspSessionInfoRequest& req, IEspSessionInfoResponse& resp);
+    virtual bool onCleanSession(IEspContext& context, IEspCleanSessionRequest& req, IEspCleanSessionResponse& resp);
+    virtual bool onSetSessionTimeout(IEspContext& context, IEspSetSessionTimeoutRequest& req, IEspSetSessionTimeoutResponse& resp);
 };
 
 #endif //_ESPWIZ_ws_espcontrol_HPP__

--- a/esp/src/eclwatch/templates/HPCCPlatformWidget.html
+++ b/esp/src/eclwatch/templates/HPCCPlatformWidget.html
@@ -36,6 +36,7 @@
                         <span data-dojo-type="dijit.MenuSeparator"></span>
                         <div id="${id}Configuration" data-dojo-attach-event="onClick:_onOpenConfiguration" data-dojo-type="dijit.MenuItem">${i18n.Configuration}</div>
                         <div id="${id}About" data-dojo-attach-event="onClick:_onAbout" data-dojo-type="dijit.MenuItem">${i18n.About}</div>
+                        <div id="${id}Logout" data-dojo-attach-event="onClick:_onLogout" data-dojo-type="dijit.MenuItem">Logout</div>
                         <div data-dojo-props="hidden:true" data-dojo-type="dijit.PopupMenuItem">
                             <span>${i18n.Debug}</span>
                             <div data-dojo-type="dijit.Menu">

--- a/esp/xslt/appframe.xsl
+++ b/esp/xslt/appframe.xsl
@@ -62,7 +62,7 @@
             ]]></xsl:text>
         </script>
       </head>
-      <frameset rows="62,*" FRAMEPADDING="0" PADDING="0" SPACING="0" FRAMEBORDER="0" onload="onLoad()">
+      <frameset rows="72,*" FRAMEPADDING="0" PADDING="0" SPACING="0" FRAMEBORDER="0" onload="onLoad()">
                 <frame src="esp/titlebar" name="header" target="main" scrolling="no"/>
                 <frameset FRAMEPADDING="0" PADDING="0" SPACING="0" FRAMEBORDER="{@navResize}" BORDERCOLOR="black" FRAMESPACING="1">
                     <xsl:attribute name="cols"><xsl:value-of select="@navWidth"/>,*</xsl:attribute>

--- a/esp/xslt/espheader.xsl
+++ b/esp/xslt/espheader.xsl
@@ -37,6 +37,20 @@
                 return false;
           }
 
+          function logout()
+          {
+            var logoutRequest = new XMLHttpRequest();
+            logoutRequest.onreadystatechange = function()
+            { 
+              if (logoutRequest.readyState == 4 && logoutRequest.status == 200)
+                parent.location = '/esp/files/eclwatch/templates/Login.html';
+              else
+                console.log("Logout failed: " + logoutRequest.status);
+            }
+            logoutRequest.open( "GET", 'logout', true );            
+            logoutRequest.send( null );
+          }
+
           function copy_url(inner)
           {
             var ploc = top.location;
@@ -129,6 +143,12 @@
                     <xsl:text disable-output-escaping="yes">&amp;nbsp;</xsl:text>
                     <img border="0" src="files_/img/topurl.png" title="No Frames" width="13" height="15" style="cursor:pointer"
                     onclick="top.location.href=top.frames['main'].location.href"/>
+                    <xsl:if test="LogOut = '1'">
+                        <xsl:text disable-output-escaping="yes">&amp;nbsp;</xsl:text>
+                        <a onclick="return logout();">
+                            Logout
+                        </a>
+                    </xsl:if>
                     <noscript>
                       <span style="color:red;">
                         <small>JavaScript needs to be enabled for the Enterprise Services Platform to work correctly.</small>

--- a/initfiles/componentfiles/configxml/esp.xsd.in
+++ b/initfiles/componentfiles/configxml/esp.xsd.in
@@ -408,11 +408,11 @@
 	                </xs:appinfo>
 	              </xs:annotation>
 	            </xs:attribute>
-	            <xs:attribute name="resourceURL" type="xs:string" use="optional" default="/favicon.ico,/esp/files/img/favicon.ico,/esp/files/eclwatch/img/Loginlogo.png,/esp/files/dojo/*,/esp/files/eclwatch/nls/*">
+	            <xs:attribute name="unrestrictedResources" type="xs:string" use="optional" default="/favicon.ico,/esp/files/*,/esp/xslt/*">
 	              <xs:annotation>
 	                <xs:appinfo>
 	                  <width>50</width>
-	                  <tooltip>Resource URL</tooltip>
+	                  <tooltip>unrestricted resources for user authentication</tooltip>
 	                  <colIndex>6</colIndex>
 	                </xs:appinfo>
 	              </xs:annotation>
@@ -867,6 +867,13 @@
                 <xs:annotation>
                     <xs:appinfo>
                         <tooltip>Option string used by ESP memcached client.</tooltip>
+                    </xs:appinfo>
+                </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="checkSessionTimeoutSeconds" type="xs:nonNegativeInteger" use="optional">
+                <xs:annotation>
+                    <xs:appinfo>
+                        <tooltip>Check Session Timeout in every given seconds.</tooltip>
                     </xs:appinfo>
                 </xs:annotation>
             </xs:attribute>


### PR DESCRIPTION
ESP session Information is stored into dali. Add default
login/logout html page and hide password input. Add code to
handle logon from expired logon page. SOAP Test page, HTTP
test form, and other ECLWatch pages may lost session ID after
cookie is timed out. Add code to detect the problem and ask
for re-login. UI may need some resources (ico file, css file,
etc) to show logon page. Add code to allow those files bypass
authentication. Those files, as well as logon/logout pages, is
configurable. Add espcontrol methods for admin to access
session information. Set ISecUser after auth. If logout URL is
not set, 200 OK is sent back after logout. UI may do redirect
by itself. Call LDAP AddToken after login.

Signed-off-by: wangkx <kevin.wang@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
