### PR TITLE
HPCC-17632  Handle "required" entry in AppInfo

### DIFF
--- a/configuration/configurator/schemas/SchemaAppInfo.cpp
+++ b/configuration/configurator/schemas/SchemaAppInfo.cpp
@@ -56,6 +56,8 @@ CAppInfo* CAppInfo::load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchema
     strXPathDocID.append("/").append(TAG_DOC_ID);
     StringBuffer strXPathDocLineBreak(xpath);
     strXPathDocLineBreak.append("/").append(TAG_DOC_USE_LINE_BREAK);
+    StringBuffer strXPathRequired(xpath);
+    strXPathRequired.append("/").append(TAG_REQUIRED);
 
     StringBuffer strViewType;
     StringBuffer strColIndex;
@@ -68,6 +70,7 @@ CAppInfo* CAppInfo::load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchema
     StringBuffer strViewChildNodes;
     StringBuffer strXPath;
     StringBuffer strDocTableID;
+    StringBuffer strRequired;
     bool bDocLineBreak = false;
 
     if (pSchemaRoot->queryPropTree(strXPathViewType.str()) != NULL)
@@ -94,8 +97,10 @@ CAppInfo* CAppInfo::load(CXSDNodeBase* pParentNode, const IPropertyTree *pSchema
         strDocTableID.append(pSchemaRoot->queryPropTree(strXPathDocID.str())->queryProp(""));
     if (pSchemaRoot->queryPropTree(strXPathDocLineBreak.str()) != NULL)
         bDocLineBreak = true;
+    if (pSchemaRoot->queryPropTree(strXPathRequired.str()) != NULL)
+        strRequired.append(pSchemaRoot->queryPropTree(strXPathRequired.str())->queryProp(""));
 
-    CAppInfo *pAppInfo = new CAppInfo(pParentNode, strViewType.str(),  strColIndex.str(), strToolTip.str(), strTitle.str(), strWidth.str(), strAutoGenForWizard.str(), strAutoGenDefaultValue.str(), NULL, strViewChildNodes.str(), strXPath.str(), strDocTableID.str(), bDocLineBreak);
+    CAppInfo *pAppInfo = new CAppInfo(pParentNode, strViewType.str(),  strColIndex.str(), strToolTip.str(), strTitle.str(), strWidth.str(), strAutoGenForWizard.str(), strAutoGenDefaultValue.str(), NULL, strViewChildNodes.str(), strXPath.str(), strDocTableID.str(), bDocLineBreak, strRequired.str());
     pAppInfo->setXSDXPath(xpath);
 
     return pAppInfo;
@@ -118,6 +123,7 @@ void CAppInfo::dump(::std::ostream &cout, unsigned int offset) const
     QUICK_OUT(cout, ViewChildNodes, offset);
     QUICK_OUT(cout, XPath, offset);
     QUICK_OUT(cout, XSDXPath, offset);
+    QUICK_OUT(cout, Required, offset);
 
     quickOutFooter(cout, XSD_APP_INFO_STR, offset);
 }

--- a/configuration/configurator/schemas/SchemaAppInfo.hpp
+++ b/configuration/configurator/schemas/SchemaAppInfo.hpp
@@ -44,6 +44,7 @@ public:
     GETTERSETTER(ViewChildNodes)
     GETTERSETTER(XPath)
     GETTERSETTER(DocTableID)
+    GETTERSETTER(Required)
 
     virtual void dump(::std::ostream &cout, unsigned int offset = 0) const;
     virtual void getDocumentation(StringBuffer &strDoc) const;
@@ -58,10 +59,11 @@ public:
 protected:
 
     CAppInfo(CXSDNodeBase* pParentNode, const char *pViewType = NULL, const char *pColIndex = NULL, const char* pToolTip = NULL, const char* pTitle = NULL, const char* pWidth = NULL, const char* pAutoGenForWizard = NULL,\
-             const char* pAutoGenDefaultValue = NULL, const char* pAutoGenDefaultForMultiNode = NULL, const char* pViewChildNodes = NULL, const char* pXPath = NULL, const char* pDocTableID = NULL, bool bDocLineBreak = false)\
+             const char* pAutoGenDefaultValue = NULL, const char* pAutoGenDefaultForMultiNode = NULL, const char* pViewChildNodes = NULL, const char* pXPath = NULL, const char* pDocTableID = NULL, bool bDocLineBreak = false, \
+			 const char* pRequired = NULL ) \
         : CXSDNodeBase::CXSDNodeBase(pParentNode, XSD_APP_INFO), m_strViewType(pViewType), m_strColIndex(pColIndex), m_strToolTip(pToolTip), m_strTitle(pTitle), m_strWidth(pWidth), m_strAutoGenForWizard(pAutoGenForWizard),\
-          m_strAutoGenDefaultValue(pAutoGenDefaultValue), m_strAutoGenDefaultValueForMultiNode(pAutoGenDefaultForMultiNode), m_strViewChildNodes(pViewChildNodes), m_strXPath(pXPath), m_strDocTableID(pDocTableID),\
-          m_bDocLineBreak(bDocLineBreak)
+          m_strAutoGenDefaultValue(pAutoGenDefaultValue), m_strAutoGenDefaultValueForMultiNode(pAutoGenDefaultForMultiNode), m_strViewChildNodes(pViewChildNodes), m_strXPath(pXPath), m_strDocTableID(pDocTableID), \
+          m_bDocLineBreak(bDocLineBreak), m_strRequired(pRequired)
     {
     }
 

--- a/configuration/configurator/schemas/SchemaAttributes.cpp
+++ b/configuration/configurator/schemas/SchemaAttributes.cpp
@@ -105,6 +105,10 @@ void CAttribute::getDocumentation(StringBuffer &strDoc) const
             return; // HIDDEN
         else
             pToolTip = pAppInfo->getToolTip();
+
+        const char* pReq = pAppInfo->getRequired();
+        if (pReq != nullptr && stricmp("True", pReq) == 0)
+            pRequired = TAG_REQUIRED;
     }
 
     strDoc.appendf("<%s>\n", DM_TABLE_ROW);

--- a/configuration/configurator/schemas/SchemaCommon.hpp
+++ b/configuration/configurator/schemas/SchemaCommon.hpp
@@ -248,6 +248,7 @@ static const char* TAG_AUTOGENDEFAULTVALUEFORMULTINODE("autogendefaultformultino
 static const char* TAG_XPATH("xpath");
 static const char* TAG_DOC_ID("docid");
 static const char* TAG_DOC_USE_LINE_BREAK("docuselinebreak");
+static const char* TAG_REQUIRED("required");
 static const char* TAG_UNBOUNDED("unbounded");
 
 #define TAG_OPTIONAL                   "optional"


### PR DESCRIPTION
For some attributes in xsd file the "use" is set as "optional". But following anontation/appinfo it may have "<required>true</required>". We currently ignore this setting. The fix is to add processing it to overwrite "use" setting if it is available.

Signed-off-by: Xiaoming Wang <xiaoming.wang@lexisnexi.com> 

@g-pan please help to check the output docs and xml
@rpastrana , @kenrowland please help to review the change.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [ ] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->
Test build: http://10.240.32.243/job/CE-Candidate-docs-JIRA-17632/
Greg will verify the output

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
