### PR TITLE
HPCC-17612 DFUPlus eraseHistory can lose backup info

### DIFF
--- a/dali/dfuplus/dfuplus.cpp
+++ b/dali/dfuplus/dfuplus.cpp
@@ -1669,22 +1669,24 @@ int CDfuPlusHelper::erasehistory()
 
     progress("\nErase history of '%s' with%s backup.\n", lfn, (backup ? "" : "out"));
 
-    Owned<IClientEraseHistoryRequest> req = dfuclient->createEraseHistoryRequest();
-    req->setName(lfn);
-
-    Owned<IClientEraseHistoryResponse> resp = dfuclient->EraseHistory(req);
-
-    const IMultiException* excep = &resp->getExceptions();
-    if (excep != nullptr && excep->ordinality() > 0)
-    {
-        StringBuffer errmsg;
-        excep->errorMessage(errmsg);
-        error("%s\n", errmsg.str());
-        return -1;
-    }
-
     if (backup)
     {
+        // Get and backup file history before erased.
+        // If any problem happens during the backup the history remain intact.
+        Owned<IClientListHistoryRequest> req = dfuclient->createListHistoryRequest();
+        req->setName(lfn);
+
+        Owned<IClientListHistoryResponse> resp = dfuclient->ListHistory(req);
+
+        const IMultiException* excep = &resp->getExceptions();
+        if (excep != nullptr && excep->ordinality() > 0)
+        {
+            StringBuffer errmsg;
+            excep->errorMessage(errmsg);
+            error("%s\n", errmsg.str());
+            return -1;
+        }
+
         IArrayOf<IConstHistory>& arrHistory = resp->getHistory();
         if (0 == arrHistory.length())
         {
@@ -1699,19 +1701,35 @@ int CDfuPlusHelper::erasehistory()
 
         int ofile = open(dstxml, _O_WRONLY | _O_CREAT | _O_TRUNC, _S_IREAD | _S_IWRITE);
         if(ofile == -1)
-            throw MakeStringException(-1, "can't open file %s\n", dstxml);
+            throw MakeStringException(-1, "can't open file %s, erase history cancelled.\n", dstxml);
 
         ssize_t written = write(ofile, xmlDump.str(), xmlDump.length());
         if (written < 0)
-            throw MakeStringException(-1, "can't write to file %s\n", dstxml);
+            throw MakeStringException(-1, "can't write to file %s, erase history cancelled.\n", dstxml);
 
         if (written != xmlDump.length())
-            throw MakeStringException(-1, "truncated write to file %s\n", dstxml);
+            throw MakeStringException(-1, "truncated write to file %s, erase history cancelled.\n", dstxml);
 
         close(ofile);
 
         info("History written into %s.\n",dstxml);
     }
+
+    Owned<IClientEraseHistoryRequest> req = dfuclient->createEraseHistoryRequest();
+    req->setName(lfn);
+
+    Owned<IClientEraseHistoryResponse> resp = dfuclient->EraseHistory(req);
+
+    const IMultiException* excep = &resp->getExceptions();
+    if (excep != nullptr && excep->ordinality() > 0)
+    {
+        StringBuffer errmsg;
+        excep->errorMessage(errmsg);
+        error("%s\n", errmsg.str());
+        return -1;
+    }
+
+    info("History erased.\n");
 
     return 0;
 }


### PR DESCRIPTION
Reorganise the code to ensure the backup file created before
the history erased.

Signed-off-by: Attila Vamos <attila.vamos@gmail.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [x] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->
Tested 'action=erasehistory' manually w/wo backup flag and with wrong and good backup file path.
<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
