### PR TITLE
HPCC-17721 Ensure serialized lengths have correct endian format.

### DIFF
--- a/system/jlib/jlzma.cpp
+++ b/system/jlib/jlzma.cpp
@@ -95,16 +95,18 @@ void LZMACompressToBuffer(MemoryBuffer & out, size32_t len, const void * src)
 {
     CLZMA lzma;
     size32_t outbase = out.length();
-    size32_t *sz = (size32_t *)out.reserve(len+sizeof(size32_t)*2);
-    *sz = len;
-    sz++;
-    *sz = lzma.compress(src,len,sz+1);
-    if (*sz>len) {
-        *sz = len;
-        memcpy(sz+1,src,len);
+    out.append(len);
+    DelayedMarker<size32_t> cmpSzMarker(out);
+    void *cmpData = out.reserve(len);
+    size32_t sz = lzma.compress(src, len, cmpData);
+    if (sz>len)
+    {
+        sz = len;
+        memcpy(cmpData, src, len);
     }
     else 
-        out.setLength(outbase+sizeof(size32_t)*2+*sz);
+        out.setLength(outbase+sizeof(size32_t)*2+sz);
+    cmpSzMarker.write(sz);
 }
 
 void LZMADecompressToBuffer(MemoryBuffer & out, const void * src)


### PR DESCRIPTION
The compression to MemoryBuffer routines were raw writing the
lengths, but their counter part deserialization methods were
deserializing them with MemoryBuffer methods.
This results in corrupt values if the endianness of the
MemoryBuffer was swapped.

Signed-off-by: Jake Smith <jake.smith@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

Tested all 3 varieties in context of HPCC-17690

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
