### PR TITLE
HPCC-17778 Update keyfiles for all test cases impacted by HPCC-17692 changes

### DIFF
--- a/testing/regress/ecl/dynamicoptflag.ecl
+++ b/testing/regress/ecl/dynamicoptflag.ecl
@@ -15,6 +15,8 @@
     limitations under the License.
 ############################################################################## */
 
+#option ('warnOnImplicitReadLimit', true);
+#onwarning (4522, ignore);
 d := dataset(DYNAMIC('regress::no::such::file'), {string10 f}, FLAT, OPT);
 output(d);
 count(d);

--- a/testing/regress/ecl/indexsubstring.ecl
+++ b/testing/regress/ecl/indexsubstring.ecl
@@ -15,6 +15,8 @@
     limitations under the License.
 ############################################################################## */
 
+#option ('warnOnImplicitReadLimit', true);
+
 //version multiPart=false
 
 import ^ as root;

--- a/testing/regress/ecl/issue13588.ecl
+++ b/testing/regress/ecl/issue13588.ecl
@@ -15,6 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
+#option ('warnOnImplicitReadLimit', true);
 
 xRec := RECORD
     integer x;

--- a/testing/regress/ecl/jsonfetch.ecl
+++ b/testing/regress/ecl/jsonfetch.ecl
@@ -15,6 +15,8 @@
     limitations under the License.
 ############################################################################## */
 
+#option ('warnOnImplicitReadLimit', true);
+
 phoneRecord :=
             RECORD
 string5         areaCode{xpath('@areaCode')};

--- a/testing/regress/ecl/key/dfs.xml
+++ b/testing/regress/ecl/key/dfs.xml
@@ -1,3 +1,4 @@
+<Warning><Code>3147</Code><Filename>dfs.ecl</Filename><Line>53</Line><Source>eclcc</Source><Message> Field dg_lastname type mismatch: DFS reports string10 but ECL declared string3</Message></Warning>
 <Dataset name='Result 1'>
  <Row><dg_parentid>0</dg_parentid><dg_firstname>DAVID     </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>1</dg_prange></Row>
  <Row><dg_parentid>1</dg_parentid><dg_firstname>DAVID     </dg_firstname><dg_lastname>BAYLISS   </dg_lastname><dg_prange>2</dg_prange></Row>

--- a/testing/regress/ecl/key/dfsfj.xml
+++ b/testing/regress/ecl/key/dfsfj.xml
@@ -1,3 +1,4 @@
+<Warning><Code>3147</Code><Filename>dfsfj.ecl</Filename><Line>54</Line><Source>eclcc</Source><Message> Field dg_lastname type mismatch: DFS reports string10 but ECL declared string3</Message></Warning>
 <Dataset name='Result 1'>
  <Row><Result_1>Full-keyed joins, RHS translated, LHS not</Result_1></Row>
 </Dataset>

--- a/testing/regress/ecl/key/dfsfj2.xml
+++ b/testing/regress/ecl/key/dfsfj2.xml
@@ -1,3 +1,5 @@
+<Warning><Code>3147</Code><Filename>dfsfj2.ecl</Filename><Line>54</Line><Source>eclcc</Source><Message> Field dg_lastname type mismatch: DFS reports string10 but ECL declared string3</Message></Warning>
+<Warning><Code>3147</Code><Filename>dfsfj2.ecl</Filename><Line>55</Line><Source>eclcc</Source><Message> Field dg_lastname type mismatch: DFS reports string10 but ECL declared string3</Message></Warning>
 <Dataset name='Result 1'>
  <Row><Result_1>Full-keyed joins, RHS and LHS translated</Result_1></Row>
 </Dataset>

--- a/testing/regress/ecl/key/dynamicoptflag.xml
+++ b/testing/regress/ecl/key/dynamicoptflag.xml
@@ -1,3 +1,6 @@
+<Warning><Code>4523</Code><Filename>dynamicoptflag.ecl</Filename><Line>38</Line><Source>eclcc</Source><Message> Neither LIMIT() nor CHOOSEN() supplied for index read on  'regress::nor::this'</Message></Warning>
+<Warning><Code>4523</Code><Filename>dynamicoptflag.ecl</Filename><Line>41</Line><Source>eclcc</Source><Message> Neither LIMIT() nor CHOOSEN() supplied for index read on  'regress::nor::this'</Message></Warning>
+<Warning><Code>4523</Code><Filename>dynamicoptflag.ecl</Filename><Line>51</Line><Source>eclcc</Source><Message> Neither LIMIT() nor CHOOSEN() supplied for index read on  'regress::nor::this'</Message></Warning>
 <Dataset name='Result 1'>
 </Dataset>
 <Dataset name='Result 2'>

--- a/testing/regress/ecl/key/indexsubstring.xml
+++ b/testing/regress/ecl/key/indexsubstring.xml
@@ -1,3 +1,13 @@
+<Warning><Code>4523</Code><Filename>indexsubstring.ecl</Filename><Line>55</Line><Source>eclcc</Source><Message> Neither LIMIT() nor CHOOSEN() supplied for index read on  'TST::postcode.key'</Message></Warning>
+<Warning><Code>4523</Code><Filename>indexsubstring.ecl</Filename><Line>56</Line><Source>eclcc</Source><Message> Neither LIMIT() nor CHOOSEN() supplied for index read on  'TST::postcode.key'</Message></Warning>
+<Warning><Code>4523</Code><Filename>indexsubstring.ecl</Filename><Line>57</Line><Source>eclcc</Source><Message> Neither LIMIT() nor CHOOSEN() supplied for index read on  'TST::postcode.key'</Message></Warning>
+<Warning><Code>4523</Code><Filename>indexsubstring.ecl</Filename><Line>58</Line><Source>eclcc</Source><Message> Neither LIMIT() nor CHOOSEN() supplied for index read on  'TST::postcode.key'</Message></Warning>
+<Warning><Code>4523</Code><Filename>indexsubstring.ecl</Filename><Line>59</Line><Source>eclcc</Source><Message> Neither LIMIT() nor CHOOSEN() supplied for index read on  'TST::postcode.key'</Message></Warning>
+<Warning><Code>4523</Code><Filename>indexsubstring.ecl</Filename><Line>60</Line><Source>eclcc</Source><Message> Neither LIMIT() nor CHOOSEN() supplied for index read on  'TST::postcode.key'</Message></Warning>
+<Warning><Code>4523</Code><Filename>indexsubstring.ecl</Filename><Line>64</Line><Source>eclcc</Source><Message> Neither LIMIT() nor CHOOSEN() supplied for index read on  'TST::postcode.key'</Message></Warning>
+<Warning><Code>4523</Code><Filename>indexsubstring.ecl</Filename><Line>65</Line><Source>eclcc</Source><Message> Neither LIMIT() nor CHOOSEN() supplied for index read on  'TST::postcode.key'</Message></Warning>
+<Warning><Code>4523</Code><Filename>indexsubstring.ecl</Filename><Line>66</Line><Source>eclcc</Source><Message> Neither LIMIT() nor CHOOSEN() supplied for index read on  'TST::postcode.key'</Message></Warning>
+<Warning><Code>4523</Code><Filename>indexsubstring.ecl</Filename><Line>67</Line><Source>eclcc</Source><Message> Neither LIMIT() nor CHOOSEN() supplied for index read on  'TST::postcode.key'</Message></Warning>
 <Dataset name='Result 1'>
 </Dataset>
 <Dataset name='Result 2'>

--- a/testing/regress/ecl/key/issue13588.xml
+++ b/testing/regress/ecl/key/issue13588.xml
@@ -1,3 +1,4 @@
+<Warning><Code>4523</Code><Filename>issue13588.ecl</Filename><Line>39</Line><Source>eclcc</Source><Message> Neither LIMIT() nor CHOOSEN() supplied for index read on  'REGRESS::TEMP::ISSUE13588'</Message></Warning>
 <Dataset name='Result 1'>
 </Dataset>
 <Dataset name='Result 2'>

--- a/testing/regress/ecl/key/jsonfetch.xml
+++ b/testing/regress/ecl/key/jsonfetch.xml
@@ -1,3 +1,4 @@
+<Warning><Code>4523</Code><Filename>jsonfetch.ecl</Filename><Line>74</Line><Source>eclcc</Source><Message> Neither LIMIT() nor CHOOSEN() supplied for index read on  'REGRESS::TEMP::jsonfetch.json.index'</Message></Warning>
 <Dataset name='Result 1'>
 </Dataset>
 <Dataset name='Result 2'>

--- a/testing/regress/ecl/key/loopif.xml
+++ b/testing/regress/ecl/key/loopif.xml
@@ -1,3 +1,4 @@
+<Warning><Code>2168</Code><Filename>loopif.ecl</Filename><Line>27</Line><Source>eclcc</Source><Message> Field 'i' in TABLE does not appear to be properly defined by grouping conditions</Message></Warning>
 <Dataset name='Result 1'>
  <Row><i>61</i><j>1</j><c>4</c></Row>
  <Row><i>62</i><j>2</j><c>4</c></Row>

--- a/testing/regress/ecl/key/xmlfetch2.xml
+++ b/testing/regress/ecl/key/xmlfetch2.xml
@@ -1,3 +1,4 @@
+<Warning><Code>4523</Code><Filename>xmlfetch2.ecl</Filename><Line>73</Line><Source>eclcc</Source><Message> Neither LIMIT() nor CHOOSEN() supplied for index read on  'REGRESS::TEMP::xmlfetch2.xml.index'</Message></Warning>
 <Dataset name='Result 1'>
 </Dataset>
 <Dataset name='Result 2'>

--- a/testing/regress/ecl/xmlfetch2.ecl
+++ b/testing/regress/ecl/xmlfetch2.ecl
@@ -15,6 +15,8 @@
     limitations under the License.
 ############################################################################## */
 
+#option ('warnOnImplicitReadLimit', true);
+
 phoneRecord :=
             RECORD
 string5         areaCode{xpath('@areaCode')};

--- a/testing/regress/hpcc/util/ecl/command.py
+++ b/testing/regress/hpcc/util/ecl/command.py
@@ -18,10 +18,13 @@
 '''
 
 import logging
+import os
 
 from ...common.shell import Shell
 from ...common.error import Error
 from ...util.util import queryWuid
+
+import xml.etree.ElementTree as ET
 
 class ECLcmd(Shell):
     def __init__(self):
@@ -107,6 +110,17 @@ class ECLcmd(Shell):
                 if "aborted" in i:
                     state = "aborted"
                 if cnt > 4:
+                    if i.startswith('<Warning>'):
+                        # Remove absolute path from filename to 
+                        # enable to compare it with same part of keyfile
+                        xml = ET.fromstring(i)
+                        path = xml.find('.//Filename').text
+                        logging.debug("%3d. path:'%s'", eclfile.getTaskId(),  path )
+                        filename = os.path.basename(path)
+                        xml.find('.//Filename').text = filename
+                        i = ET.tostring(xml)
+                        logging.debug("%3d. ret:'%s'", eclfile.getTaskId(),  i )
+                        pass
                     result += i + "\n"
                 cnt += 1
             data = '\n'.join(line for line in


### PR DESCRIPTION

Add #option ('warnOnImplicitReadLimit', true); to teest cases to force
output warning on all engines

Update keyfiles with warnings

Add code to to remove path from filename of the warnings in outputs.

Signed-off-by: Attila Vamos <attila.vamos@gmail.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [x] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->
Tested manually
<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
