### PR TITLE
HPCC-17818 Make debug port based on Thor port bases.

### DIFF
--- a/system/include/portlist.h
+++ b/system/include/portlist.h
@@ -96,7 +96,6 @@
 
 #define ROXIE_SERVER_PORT               9876
 
-#define THOR_DEBUG_PORT                 16000
 #define HTHOR_DEBUG_BASE_PORT           17000
 #define HTHOR_DEBUG_PORT_RANGE          10
 

--- a/thorlcr/master/thgraphmanager.cpp
+++ b/thorlcr/master/thgraphmanager.cpp
@@ -78,7 +78,8 @@ class CJobManager : public CSimpleInterface, implements IJobManager, implements 
     public:
         CThorDebugListener(CJobManager &_mgr) : threaded("CThorDebugListener", this), mgr(_mgr)
         {
-            port = globals->getPropInt("DebugPort", THOR_DEBUG_PORT);
+            unsigned defaultThorDebugPort = getFixedPort(getMasterPortBase(), TPORT_debug);
+            port = globals->getPropInt("DebugPort", defaultThorDebugPort);
             running = true;
             threaded.start();
         }

--- a/thorlcr/thorutil/thorport.cpp
+++ b/thorlcr/thorutil/thorport.cpp
@@ -37,6 +37,7 @@
 
 #define MPPORT       0
 #define WATCHDOGPORT 1
+#define DEBUGPORT 2
 
 static CriticalSection *portallocsection;
 static IBitSet *portmap;
@@ -46,6 +47,7 @@ MODULE_INIT(INIT_PRIORITY_STANDARD)
     portmap = createThreadSafeBitSet();
     portmap->set(MPPORT, true);
     portmap->set(WATCHDOGPORT, true);
+    portmap->set(DEBUGPORT, true);
     return true;
 }
 MODULE_EXIT()
@@ -77,6 +79,8 @@ unsigned short getExternalFixedPort(unsigned short masterBase, unsigned short ma
         return machineBase+WATCHDOGPORT;
     case TPORT_mp:
         return machineBase+MPPORT; 
+    case TPORT_debug:
+        return machineBase+DEBUGPORT;
     }
     LOG(MCerror,unknownJob,"getFixedPort: Unknown Port Kind!");
     return 0;

--- a/thorlcr/thorutil/thorport.hpp
+++ b/thorlcr/thorutil/thorport.hpp
@@ -31,7 +31,8 @@
 enum ThorPortKind
 {
     TPORT_watchdog,
-    TPORT_mp
+    TPORT_mp,
+    TPORT_debug
 };
 
 graph_decl unsigned short getFixedPort(ThorPortKind category);


### PR DESCRIPTION
Avoid multiple Thor instances clashing on their debug ports, by
using a port based on base port as with other ports.

Signed-off-by: Jake Smith <jake.smith@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

Test correct port published (by examining workunit XML)
Test debugging still worked in long running job with #option('TRACEROWS', true).

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
