### PR TITLE
HPCC-17855 DynamicESDL support for get_data_from

### DIFF
--- a/common/thorhelper/thorxmlwrite.hpp
+++ b/common/thorhelper/thorxmlwrite.hpp
@@ -40,7 +40,9 @@ interface IXmlWriterExt : extends IXmlWriter
     virtual const char *str() const = 0;
     virtual IInterface *saveLocation() const = 0;
     virtual void rewindTo(IInterface *location) = 0;
+    virtual void cutFrom(IInterface *location, StringBuffer& databuf) = 0;
     virtual void outputNumericString(const char *field, const char *fieldname) = 0;
+    virtual void outputInline(const char* text) = 0;
 };
 
 class thorhelper_decl CommonXmlPosition : public CInterface, implements IInterface
@@ -71,6 +73,7 @@ public:
     void outputEndNested(const char *fieldname, bool doIndent);
 
     virtual void outputInlineXml(const char *text){closeTag(); out.append(text); flush(false);} //for appending raw xml content
+    virtual void outputInline(const char* text) { outputInlineXml(text); }
     virtual void outputQuoted(const char *text);
     virtual void outputQString(unsigned len, const char *field, const char *fieldname);
     virtual void outputString(unsigned len, const char *field, const char *fieldname);
@@ -119,6 +122,7 @@ public:
             nestLimit = position->nestLimit;
         }
     }
+    virtual void cutFrom(IInterface *location, StringBuffer& databuf);
 
     virtual void outputNumericString(const char *field, const char *fieldname)
     {
@@ -159,6 +163,7 @@ public:
         if (text && *text)
             outputUtf8(strlen(text), text, "xml");
     }
+    virtual void outputInline(const char* text) { out.append(text); }
     virtual void outputQuoted(const char *text);
     virtual void outputQString(unsigned len, const char *field, const char *fieldname);
     virtual void outputString(unsigned len, const char *field, const char *fieldname);
@@ -209,6 +214,7 @@ public:
             nestLimit = position->nestLimit;
         }
     }
+    virtual void cutFrom(IInterface *location, StringBuffer& databuf);
 
     void outputBeginRoot(){out.append('{');}
     void outputEndRoot(){out.append('}');}
@@ -315,6 +321,7 @@ public:
     virtual void outputUInt(unsigned __int64 field, unsigned size, const char *fieldname);
 
     void newline();
+
 protected:
     StringBuffer out;
 };
@@ -517,6 +524,7 @@ public:
     virtual unsigned length() const { return out.length(); }
     virtual const char* str() const { return out.str(); }
     virtual void rewindTo(IInterface* location) { };
+    virtual void cutFrom(IInterface *location, StringBuffer& databuf) { };
     virtual IInterface* saveLocation() const
     {
         if (flusher)
@@ -555,6 +563,7 @@ public:
         //if (text && *text)
           //outputUtf8(strlen(text), text, "xml");
     };
+    virtual void outputInline(const char* text) { out.append(text); }
 
     //IXmlWriterExt
     virtual void outputNumericString(const char* field, const char* fieldName);

--- a/esp/esdllib/esdl_transformer2.cpp
+++ b/esp/esdllib/esdl_transformer2.cpp
@@ -164,7 +164,7 @@ void Esdl2LocalContext::handleDataFor(IXmlWriterExt & writer)
             {
                 IMapping& et = it.query();
                 auto val = m_dataFor->mapToValue(&et)->get();
-                writer.outputUtf8(rtlUtf8Length(strlen(val),val),val, "@xsi:schemaLocation");
+                writer.outputInline(val);
             }
         }
     }
@@ -1111,8 +1111,9 @@ void Esdl2Struct::process(Esdl2TransformerContext &ctx, const char *out_name, Es
                                 if (ctx.writer->length() > len)
                                 {
                                     ESDL_DBG("Taking out data for DataFor '%s' from out buffer", chd.queryDataFor()->queryName());
-                                    local.setDataFor(chd.queryDataFor()->queryName(), ctx.writer->str()+len);
-                                    ctx.writer->rewindTo(location);
+                                    StringBuffer databuf;
+                                    ctx.writer->cutFrom(location, databuf);
+                                    local.setDataFor(chd.queryDataFor()->queryName(), databuf.str());
                                     if (esdlListItemCount == 1)
                                     {// Not call outputEndArray()
                                         esdlListName.clear();


### PR DESCRIPTION
- Output DataFor "verbatim" because the value has already gone through
  the writer once.
- Add method outputVerbatim to the writer interface and classes
- Add method checkCloseLength to the writer interface and classes. The
  method is necessary because when the closeTag function gets called, it
  creates a leading greater than sign and a newline to the output, which
  should be skipped for the DataFor field.

Signed-off-by: mayx <yanrui.ma@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [x] I have added tests to cover my changes.
  - [x] All new and existing tests passed.
  - [x] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [x] Scalability
  - [x] Performance
  - [x] Security
  - [x] Thread-safety
  - [x] Premature optimization
  - [x] Existing deployed queries will not be broken
  - [x] This change fixes the problem, not just the symptom
  - [x] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [x] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
