### PR TITLE
HPCC-17900 Ability to capture git status through eclcc

### DIFF
--- a/ecl/eclcc/eclcc.cpp
+++ b/ecl/eclcc/eclcc.cpp
@@ -373,6 +373,7 @@ protected:
     bool logTimings = false;
     bool optArchive = false;
     bool optCheckEclVersion = true;
+    bool optCheckDirty = false;
     bool optDebugMemLeak = false;
     bool optEvaluateResult = false;
     bool optGenerateMeta = false;
@@ -1148,6 +1149,7 @@ void EclCC::processSingleQuery(EclCompileInstance & instance,
         if (optMaxErrors > 0)
             parseCtx.maxErrors = optMaxErrors;
         parseCtx.unsuppressImmediateSyntaxErrors = optUnsuppressImmediateSyntaxErrors;
+        parseCtx.checkDirty = optCheckDirty;
         if (!instance.archive)
             parseCtx.globalDependTree.setown(createPTree(ipt_none)); //to locate associated manifests, keep separate from user specified MetaOptions
         if (optGenerateMeta || optIncludeMeta)
@@ -1697,7 +1699,48 @@ void EclCC::generateOutput(EclCompileInstance & instance)
                 addManifestResourcesToArchive(instance.archive, resourceManifestFiles.item(i));
 
             if (optArchive)
+            {
+                if (optCheckDirty)
+                {
+                    Owned<IPipeProcess> pipe = createPipeProcess();
+                    if (!pipe->run("git", "git describe --tags --dirty --long", ".", false, true, false, 0, false))
+                    {
+                        WARNLOG("Failed to run git describe");
+                    }
+                    else
+                    {
+                        try
+                        {
+                            unsigned retcode = pipe->wait();
+                            StringBuffer buf;
+                            Owned<ISimpleReadStream> pipeReader = pipe->getOutputStream();
+                            const size32_t chunkSize = 128;
+                            for (;;)
+                            {
+                                size32_t sizeRead = pipeReader->read(chunkSize, buf.reserve(chunkSize));
+                                if (sizeRead < chunkSize)
+                                {
+                                    buf.setLength(buf.length() - (chunkSize - sizeRead));
+                                    break;
+                                }
+                            }
+                            if (retcode)
+                                WARNLOG("Failed to run git describe: returned %d (%s)", retcode, buf.str());
+                            else if (buf.length())
+                            {
+                                buf.replaceString("\n","");
+                                instance.archive->setProp("@git", buf);
+                            }
+                        }
+                        catch (IException *e)
+                        {
+                            EXCLOG(e, "Exception running git describe");
+                            e->Release();
+                        }
+                    }
+                }
                 outputXmlToOutputFile(instance, instance.archive);
+            }
         }
     }
 
@@ -2136,6 +2179,9 @@ int EclCC::parseCommandLineOptions(int argc, const char* argv[])
         {
         }
         else if (iter.matchFlag(optCheckEclVersion, "-checkVersion"))
+        {
+        }
+        else if (iter.matchFlag(optCheckDirty, "-checkDirty"))
         {
         }
         else if (iter.matchOption(optDFS, "-dfs") || /*deprecated*/ iter.matchOption(optDFS, "-dali"))

--- a/ecl/eclcc/eclcc.hpp
+++ b/ecl/eclcc/eclcc.hpp
@@ -77,6 +77,7 @@ const char * const helpText[] = {
     "!   -b            Batch mode.  Each source file is processed in turn.  Output",
     "!                 name depends on the input filename",
     "!   -checkVersion Enable/disable ecl version checking from archives",
+    "    -checkDirty   Report any modified attributes using git status",
     "!   --component   Set the name of the component this is executing on behalf of",
 #ifdef _WIN32
     "!   -brk <n>      Trigger a break point in eclcc after nth allocation",

--- a/ecl/eclcmd/eclcmd_common.cpp
+++ b/ecl/eclcmd/eclcmd_common.cpp
@@ -481,7 +481,10 @@ public:
                 IEspNamedValue &item = cmd.debugValues.item(i);
                 const char *name = item.getName();
                 const char *value = item.getValue();
-                cmdLine.append(" -f").append(name);
+                cmdLine.append(' ');
+                if (!name || name[0]!='-')
+                    cmdLine.append("-f");
+                cmdLine.append(name);
                 if (value)
                     cmdLine.append('=').append(value);
             }

--- a/ecl/hql/hqlcollect.cpp
+++ b/ecl/hql/hqlcollect.cpp
@@ -695,6 +695,18 @@ IProperties * CXmlEclElement::getProperties()
     //MORE: This should set individual properties rather than the "flags", or use flags defined in hqlexpr.hpp
     switch (type)
     {
+    case ESTdefinition:
+        {
+            unsigned flags = extraFlags;
+            if (elemTree->getPropBool("@dirty", false))
+                flags |= ob_sandbox;
+            if (flags)
+            {
+                properties.setown(createProperties());
+                properties->setProp(str(flagsAtom), flags);
+            }
+            break;
+        }
     case ESTplugin:
         {
             properties.setown(createProperties());

--- a/ecl/hql/hqlexpr.hpp
+++ b/ecl/hql/hqlexpr.hpp
@@ -819,6 +819,7 @@ public:
     virtual size32_t length() = 0;
     virtual bool isImplicitlySigned() = 0;
     virtual IHqlExpression * queryGpgSignature() = 0;
+    virtual bool isDirty() = 0;
 };
 
 //This class ensures that the pointer to the owner is cleared before both links are released, which allows
@@ -904,9 +905,11 @@ public:
     bool ignoreUnknownImport;
     bool ignoreSignatures;
     bool aborting;
+    bool checkDirty = false;
     Linked<ICodegenContextCallback> codegenCtx;
 
 private:
+    void setDefinitionText(IPropertyTree * target, const char * prop, IFileContents * contents);
     bool checkBeginMeta();
     bool checkEndMeta();
     void finishMeta();
@@ -958,6 +961,7 @@ public:
     inline unsigned numErrors() const { return errs ? errs->errCount() : 0; }
     inline bool isAborting() const { return parseCtx.isAborting(); }
     inline void setAborting() { parseCtx.setAborting(); }
+    inline bool checkDirty() const { return parseCtx.checkDirty; }
 
 protected:
 


### PR DESCRIPTION
New option -checkDirty stores git information into archive (if available).

Signed-off-by: Richard Chapman <rchapman@hpccsystems.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [x] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [x] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browers
  - [ ] The component(s) render as expected

## Testing:
Tested manually
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
