### PR TITLE
HPCC-17966 - JPTree inline strings are not safe if tree modified

### DIFF
--- a/system/jlib/jptree.cpp
+++ b/system/jlib/jptree.cpp
@@ -2942,7 +2942,7 @@ void LocalPTree::setName(const char *_name)
     if (_name==name.get())
         return;
     AttrStr *oname = name.getPtr();  // Don't free until after we copy - they could overlap
-    if (!name.set(_name))
+    if (!name.set(_name, true))
         name.setPtr(AttrStr::create(_name));
     if (oname)
         AttrStr::destroy(oname);
@@ -2981,10 +2981,10 @@ void LocalPTree::setAttribute(const char *key, const char *val)
     {
         attrs = (AttrValue *)realloc(attrs, (numAttrs+1)*sizeof(AttrValue));
         v = new(&attrs[numAttrs++]) AttrValue;  // Initialize new AttrValue
-        if (!v->key.set(key))
+        if (!v->key.set(key, true))
             v->key.setPtr(isnocase() ? AttrStr::createNC(key) : AttrStr::create(key));
     }
-    if (!v->value.set(val))
+    if (!v->value.set(val, isReadOnly()))
         v->value.setPtr(AttrStr::create(val));
     if (goer)
         AttrStr::destroy(goer);
@@ -3057,7 +3057,7 @@ void CAtomPTree::setName(const char *_name)
     {
         if (!validateXMLTag(_name))
             throw MakeIPTException(PTreeExcpt_InvalidTagName, ": %s", _name);
-        if (!name.set(_name))
+        if (!name.set(_name, true))
         {
 #ifdef TRACE_ALL_ATOM
             DBGLOG("TRACE_ALL_ATOM: %s", _name);
@@ -3156,7 +3156,7 @@ void CAtomPTree::setAttribute(const char *key, const char *val)
         if (streq(v->value.get(), val))
             return;
         AttrStr * goer = v->value.getPtr();
-        if (!v->value.set(val))
+        if (!v->value.set(val, isReadOnly()))
         {
             CriticalBlock block(hashcrit);
             if (goer)
@@ -3175,9 +3175,9 @@ void CAtomPTree::setAttribute(const char *key, const char *val)
         AttrValue *newattrs = newAttrArray(numAttrs+1);
         memcpy(newattrs, attrs, numAttrs*sizeof(AttrValue));
         v = &newattrs[numAttrs];
-        if (!v->key.set(key))
+        if (!v->key.set(key, true))
             v->key.setPtr(attrHT->addkey(key, isnocase()));
-        if (!v->value.set(val))
+        if (!v->value.set(val, isReadOnly()))
             v->value.setPtr(attrHT->addval(val));
         freeAttrArray(attrs, numAttrs);
         numAttrs++;

--- a/system/jlib/jptree.hpp
+++ b/system/jlib/jptree.hpp
@@ -185,10 +185,12 @@ enum ipt_flags
     ipt_ordered = 0x04,   // Preserve element ordering
     ipt_fast    = 0x08,   // Prioritize speed over low memory usage
     ipt_lowmem  = 0x10,   // Prioritize low memory usage over speed
-    ipt_ext3    = 0x20,   // Unused
+    ipt_readonly= 0x20,   // Tree cannot be modified once created
     ipt_ext4    = 0x40,   // Used internally in Dali
     ipt_ext5    = 0x80    // Used internally in Dali
 };
+
+constexpr ipt_flags operator|(ipt_flags a, ipt_flags b) { return (ipt_flags) ((int) a | (int) b); }
 
 jlib_decl IPTreeMaker *createPTreeMaker(byte flags=ipt_none, IPropertyTree *root=NULL, IPTreeNodeCreator *nodeCreator=NULL);
 jlib_decl IPTreeMaker *createRootLessPTreeMaker(byte flags=ipt_none, IPropertyTree *root=NULL, IPTreeNodeCreator *nodeCreator=NULL);

--- a/system/jlib/jptree.ipp
+++ b/system/jlib/jptree.ipp
@@ -429,9 +429,9 @@ struct PtrStrUnion
         if (isPtr() && ptr)
             PTR::destroy(ptr);
     }
-    bool set(const char *key)
+    bool set(const char *key, bool useInline)
     {
-        if (key)
+        if (key && useInline)
         {
             size32_t l = strnlen(key, sizeof(PTR *));  // technically sizeof(PTR)-1 would do, but I suspect 8 bytes is actually more optimal to search than 7
             if (l <= sizeof(PTR *)-2)
@@ -498,9 +498,9 @@ struct AttrStrUnionWithTable : public AttrStrUnion
             return roNameTable->getIndex(idx2)->str_DO_NOT_USE_DIRECTLY;  // Should probably rename this back now!
         return AttrStrUnion::get();
     }
-    bool set(const char *key)
+    bool set(const char *key, bool useInline)
     {
-        if (AttrStrUnion::set(key))
+        if (AttrStrUnion::set(key, useInline))
             return true;
         if (key && key[0]=='@')
         {
@@ -547,6 +547,8 @@ public:
     ChildMap *queryChildren() { return children; }
     aindex_t findChild(IPropertyTree *child, bool remove=false);
     inline bool isnocase() const { return IptFlagTst(flags, ipt_caseInsensitive); }
+    inline bool isWriteable() const { return !IptFlagTst(flags, ipt_readonly); }
+    inline bool isReadOnly() const { return IptFlagTst(flags, ipt_readonly); }
     ipt_flags queryFlags() const { return (ipt_flags) flags; }
     void serializeSelf(MemoryBuffer &tgt);
     void serializeCutOff(MemoryBuffer &tgt, int cutoff=-1, int depth=0);


### PR DESCRIPTION
Stop using the inline strings for attribute values unless specifically
requested when tree created.

Signed-off-by: Richard Chapman <rchapman@hpccsystems.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [ ] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [x] Scalability
  - [x] Performance
  - [x] Security
  - [x] Thread-safety
  - [x] Premature optimization
  - [x] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browers
  - [ ] The component(s) render as expected

## Testing:
Not yet tested - will update when I have
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
