### PR TITLE
HPCC-17798 Improve ESP generalized cache

### DIFF
--- a/esp/bindings/SOAP/soaplib/CMakeLists.txt
+++ b/esp/bindings/SOAP/soaplib/CMakeLists.txt
@@ -28,6 +28,7 @@ set(SRCS
     ../../../platform/espcontext.cpp
     ../../../platform/espprotocol.cpp
     ../../../platform/espthread.cpp
+    ../../../platform/espcache.cpp
     ../../../platform/sechandler.cpp
     ../../../platform/txsummary.cpp
     ../../../protocols/http/mapinfo.cpp

--- a/esp/bindings/http/platform/httptransport.cpp
+++ b/esp/bindings/http/platform/httptransport.cpp
@@ -456,9 +456,7 @@ void CHttpMessage::addParameter(const char* paramname, const char *value)
 
     m_queryparams->setProp(paramname, value);
     m_paramCount++;
-#ifdef USE_LIBMEMCACHED
     allParameterString.append("&").append(paramname).append("=").append(value);
-#endif
 }
 
 StringBuffer& CHttpMessage::getParameter(const char* paramname, StringBuffer& paramval)
@@ -1564,22 +1562,7 @@ StringBuffer& CHttpRequest::getPeer(StringBuffer& Peer)
     }
     return Peer;
 }
-#ifdef USE_LIBMEMCACHED
-unsigned CHttpRequest::createUniqueRequestHash(bool cacheGlobal, const char* msgType)
-{
-    StringBuffer idStr;
-    if (!cacheGlobal)
-    {
-        const char* userID = m_context->queryUserId();
-        if (!isEmptyString(userID))
-            idStr.append(userID).append("_");
-    }
-    if (!isEmptyString(msgType))
-        idStr.append(msgType).append("_");
-    idStr.appendf("%s_%s_%s", m_espServiceName.get(), m_espMethodName.get(), allParameterString.str());
-    return hashc((unsigned char *)idStr.str(), idStr.length(), 0);
-}
-#endif
+
 void CHttpRequest::getBasicAuthorization(StringBuffer& userid, StringBuffer& password,StringBuffer& realm)
 {
     StringBuffer authheader;

--- a/esp/bindings/http/platform/httptransport.ipp
+++ b/esp/bindings/http/platform/httptransport.ipp
@@ -77,9 +77,7 @@ protected:
     Owned<IProperties> m_queryparams;
     MapStrToBuf  m_attachments;
     StringArray  m_headers;
-#ifdef USE_LIBMEMCACHED
     StringBuffer allParameterString;
-#endif
 
     Owned<IEspContext> m_context;
     IArrayOf<CEspCookie> m_cookies;
@@ -255,6 +253,7 @@ public:
         }
         return false;
     }
+    const char* queryAllParameterString() { return allParameterString.str(); }
 };
 
 
@@ -338,9 +337,6 @@ public:
     virtual int receive(IMultiException *me);
 
     void updateContext();
-#ifdef USE_LIBMEMCACHED
-    unsigned createUniqueRequestHash(bool cacheGlobal, const char* msgType);
-#endif
 
     virtual void setMaxRequestEntityLength(int len) {m_MaxRequestEntityLength = len;}
     virtual int getMaxRequestEntityLength() { return m_MaxRequestEntityLength; }
@@ -420,224 +416,5 @@ inline bool skipXslt(IEspContext &context)
 {
     return (context.getResponseFormat()!=ESPSerializationANY);  //for now
 }
-
-#ifdef USE_LIBMEMCACHED
-#include <libmemcached/memcached.hpp>
-#include <libmemcached/util.h>
-
-class ESPMemCached : public CInterface
-{
-    memcached_st* connection = nullptr;
-    memcached_pool_st* pool = nullptr;
-    StringAttr options;
-    bool initialized = false;
-
-public :
-    ESPMemCached()
-    {
-#if (LIBMEMCACHED_VERSION_HEX < 0x01000010)
-        VStringBuffer msg("Memcached Plugin: libmemcached version '%s' incompatible with min version>=1.0.10", LIBMEMCACHED_VERSION_STRING);
-        ESPLOG(LogNormal, "%s", msg.str());
-#endif
-    }
-
-    ~ESPMemCached()
-    {
-        if (pool)
-        {
-            memcached_pool_release(pool, connection);
-            connection = nullptr;//For safety (from changing this destructor) as not implicit in either the above or below.
-            memcached_st *memc = memcached_pool_destroy(pool);
-            if (memc)
-                memcached_free(memc);
-        }
-        else if (connection)//This should never be needed but just in case.
-        {
-            memcached_free(connection);
-        }
-    };
-
-    bool init(const char * _options)
-    {
-        if (initialized)
-            return initialized;
-
-        options.set(_options);
-        pool = memcached_pool(_options, strlen(_options));
-        assertPool();
-
-        setPoolSettings();
-        connect();
-        if (connection)
-            initialized = checkServersUp();
-        return initialized;
-    }
-
-    void setPoolSettings()
-    {
-        assertPool();
-        const char * msg = "memcached_pool_behavior_set failed - ";
-        assertOnError(memcached_pool_behavior_set(pool, MEMCACHED_BEHAVIOR_KETAMA, 1), msg);//NOTE: alias of MEMCACHED_DISTRIBUTION_CONSISTENT_KETAMA amongst others.
-        memcached_pool_behavior_set(pool, MEMCACHED_BEHAVIOR_USE_UDP, 0);  // Note that this fails on early versions of libmemcached, so ignore result
-        assertOnError(memcached_pool_behavior_set(pool, MEMCACHED_BEHAVIOR_NO_BLOCK, 0), msg);
-        assertOnError(memcached_pool_behavior_set(pool, MEMCACHED_BEHAVIOR_CONNECT_TIMEOUT, 1000), msg);//units of ms.
-        assertOnError(memcached_pool_behavior_set(pool, MEMCACHED_BEHAVIOR_SND_TIMEOUT, 1000000), msg);//units of mu-s.
-        assertOnError(memcached_pool_behavior_set(pool, MEMCACHED_BEHAVIOR_RCV_TIMEOUT, 1000000), msg);//units of mu-s.
-        assertOnError(memcached_pool_behavior_set(pool, MEMCACHED_BEHAVIOR_BUFFER_REQUESTS, 0), msg);
-        assertOnError(memcached_pool_behavior_set(pool, MEMCACHED_BEHAVIOR_BINARY_PROTOCOL, 1), "memcached_pool_behavior_set failed - ");
-    }
-
-    void connect()
-    {
-        assertPool();
-        if (connection)
-#if (LIBMEMCACHED_VERSION_HEX<0x53000)
-            memcached_pool_push(pool, connection);
-        memcached_return_t rc;
-        connection = memcached_pool_pop(pool, (struct timespec *)0 , &rc);
-#else
-            memcached_pool_release(pool, connection);
-        memcached_return_t rc;
-        connection = memcached_pool_fetch(pool, (struct timespec *)0 , &rc);
-#endif
-        assertOnError(rc, "memcached_pool_pop failed - ");
-    }
-
-    bool checkServersUp()
-    {
-        memcached_return_t rc;
-        char* args = nullptr;
-        OwnedMalloc<memcached_stat_st> stats;
-        stats.setown(memcached_stat(connection, args, &rc));
-
-        unsigned int numberOfServers = memcached_server_count(connection);
-        if (numberOfServers < 1)
-        {
-            ESPLOG(LogMin,"Memcached: no server connected.");
-            return false;
-        }
-
-        unsigned int numberOfServersDown = 0;
-        for (unsigned i = 0; i < numberOfServers; ++i)
-        {
-            if (stats[i].pid == -1)//perhaps not the best test?
-            {
-                numberOfServersDown++;
-                VStringBuffer msg("Memcached: Failed connecting to entry %u\nwithin the server list: %s", i+1, options.str());
-                ESPLOG(LogMin, "%s", msg.str());
-            }
-        }
-        if (numberOfServersDown == numberOfServers)
-        {
-            ESPLOG(LogMin,"Memcached: Failed connecting to ALL servers. Check memcached on all servers and \"memcached -B ascii\" not used.");
-            return false;
-        }
-
-        //check memcached version homogeneity
-        for (unsigned i = 0; i < numberOfServers-1; ++i)
-        {
-            if (!streq(stats[i].version, stats[i+1].version))
-                DBGLOG("Memcached: Inhomogeneous versions of memcached across servers.");
-        }
-        return true;
-    };
-
-    bool exists(const char* partitionKey, const char* key)
-    {
-#if (LIBMEMCACHED_VERSION_HEX<0x53000)
-        throw makeStringException(0, "memcached_exist not supported in this version of libmemcached");
-#else
-        memcached_return_t rc;
-        size_t partitionKeyLength = strlen(partitionKey);
-        if (partitionKeyLength)
-            rc = memcached_exist_by_key(connection, partitionKey, partitionKeyLength, key, strlen(key));
-        else
-            rc = memcached_exist(connection, key, strlen(key));
-
-        if (rc == MEMCACHED_NOTFOUND)
-            return false;
-        else
-        {
-            assertOnError(rc, "'Exists' request failed - ");
-            return true;
-        }
-#endif
-    };
-
-    const char* get(const char* partitionKey, const char* key, StringBuffer& out)
-    {
-        uint32_t flag = 0;
-        size_t returnLength;
-        memcached_return_t rc;
-
-        OwnedMalloc<char> value;
-        size_t partitionKeyLength = strlen(partitionKey);
-        if (partitionKeyLength)
-            value.setown(memcached_get_by_key(connection, partitionKey, partitionKeyLength, key, strlen(key), &returnLength, &flag, &rc));
-        else
-            value.setown(memcached_get(connection, key, strlen(key), &returnLength, &flag, &rc));
-
-        if (value)
-            out.set(value);
-
-        StringBuffer keyMsg = "'Get' request failed - ";
-        assertOnError(rc, appendIfKeyNotFoundMsg(rc, key, keyMsg));
-        return out.str();
-    };
-
-    void set(const char* partitionKey, const char* key, const char* value, unsigned __int64 expireSec)
-    {
-        size_t partitionKeyLength = strlen(partitionKey);
-        const char * msg = "'Set' request failed - ";
-        if (partitionKeyLength)
-            assertOnError(memcached_set_by_key(connection, partitionKey, partitionKeyLength, key, strlen(key), value, strlen(value), (time_t)expireSec, 0), msg);
-        else
-            assertOnError(memcached_set(connection, key, strlen(key), value, strlen(value), (time_t)expireSec, 0), msg);
-    };
-
-    void deleteKey(const char* partitionKey, const char* key)
-    {
-        memcached_return_t rc;
-        size_t partitionKeyLength = strlen(partitionKey);
-        if (partitionKeyLength)
-            rc = memcached_delete_by_key(connection, partitionKey, partitionKeyLength, key, strlen(key), (time_t)0);
-        else
-            rc = memcached_delete(connection, key, strlen(key), (time_t)0);
-        assertOnError(rc, "'Delete' request failed - ");
-    };
-
-    void clear(unsigned when)
-    {
-        //NOTE: memcached_flush is the actual cache flush/clear/delete and not an io buffer flush.
-        assertOnError(memcached_flush(connection, (time_t)(when)), "'Clear' request failed - ");
-    };
-
-    void assertOnError(memcached_return_t rc, const char * _msg)
-    {
-        if (rc != MEMCACHED_SUCCESS)
-        {
-            VStringBuffer msg("Memcached: %s%s", _msg, memcached_strerror(connection, rc));
-            ESPLOG(LogNormal, "%s", msg.str());
-        }
-    };
-
-    const char * appendIfKeyNotFoundMsg(memcached_return_t rc, const char * key, StringBuffer & target) const
-    {
-        if (rc == MEMCACHED_NOTFOUND)
-            target.append("(key: '").append(key).append("') ");
-        return target.str();
-    };
-
-    void assertPool()
-    {
-        if (!pool)
-        {
-            StringBuffer msg = "Memcached: Failed to instantiate server pool with:";
-            msg.newline().append(options);
-            ESPLOG(LogNormal, "%s", msg.str());
-        }
-    }
-};
-#endif //USE_LIBMEMCACHED
 
 #endif

--- a/esp/platform/espcache.cpp
+++ b/esp/platform/espcache.cpp
@@ -1,0 +1,304 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2017 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include "espcontext.hpp"
+#include "espcache.hpp"
+
+
+#ifdef USE_LIBMEMCACHED
+#include <libmemcached/memcached.hpp>
+#include <libmemcached/util.h>
+
+class ESPMemCached : implements IEspCache, public CInterface
+{
+    memcached_st* connection = nullptr;
+    memcached_pool_st* pool = nullptr;
+    StringAttr options;
+    bool initialized = false;
+    CriticalSection cacheCrit;
+
+    void setPoolSettings();
+    void connect();
+    bool checkServersUp();
+
+    void assertOnError(memcached_return_t rc, const char * _msg);
+    void assertPool();
+
+    virtual bool checkAndGet(const char* groupID, const char* cacheID, StringBuffer& out);
+
+public :
+    IMPLEMENT_IINTERFACE;
+    ESPMemCached();
+    ~ESPMemCached();
+
+    virtual bool cacheResponse(const char* cacheID, const unsigned cacheSeconds, const char* content, const char* contentType);
+    virtual bool readResponseCache(const char* cacheID, StringBuffer& content, StringBuffer& contentType);
+
+    bool init(const char * _options);
+    ESPCacheResult exists(const char* groupID, const char* cacheID);
+    ESPCacheResult get(const char* groupID, const char* cacheID, StringBuffer& out);
+    ESPCacheResult set(const char* groupID, const char* cacheID, const char* value, unsigned __int64 expireSec);
+    void remove(const char* groupID, const char* cacheID);
+    void flush(unsigned when);
+};
+
+ESPMemCached::ESPMemCached()
+{
+#if (LIBMEMCACHED_VERSION_HEX < 0x01000010)
+    VStringBuffer msg("ESPMemCached: libmemcached version '%s' incompatible with min version>=1.0.10", LIBMEMCACHED_VERSION_STRING);
+    ESPLOG(LogNormal, "%s", msg.str());
+#endif
+}
+
+ESPMemCached::~ESPMemCached()
+{
+    if (pool)
+    {
+        memcached_pool_release(pool, connection);
+        connection = nullptr;//For safety (from changing this destructor) as not implicit in either the above or below.
+        memcached_st *memc = memcached_pool_destroy(pool);
+        if (memc)
+            memcached_free(memc);
+    }
+    else if (connection)//This should never be needed but just in case.
+    {
+        memcached_free(connection);
+    }
+}
+
+bool ESPMemCached::init(const char * _options)
+{
+    CriticalBlock block(cacheCrit);
+
+    if (initialized)
+        return initialized;
+
+    if (!isEmptyString(_options))
+        options.set(_options);
+    else
+        options.set("--SERVER=127.0.0.1");
+    pool = memcached_pool(options.get(), options.length());
+    assertPool();
+
+    setPoolSettings();
+    connect();
+    if (connection)
+        initialized = checkServersUp();
+    return initialized;
+}
+
+bool ESPMemCached::cacheResponse(const char* cacheID, unsigned cacheSeconds, const char* content, const char* contentType)
+{
+    VStringBuffer contentTypeID("ContentType_%s", cacheID);
+
+    CriticalBlock block(cacheCrit);
+    ESPCacheResult ret = set("ESPResponse", cacheID, content, cacheSeconds);
+    if (ret != ESPCacheSuccess)
+        return false;
+    return set("ESPResponse", contentTypeID.str(), contentType, cacheSeconds) == ESPCacheSuccess;
+}
+
+bool ESPMemCached::readResponseCache(const char* cacheID, StringBuffer& content, StringBuffer& contentType)
+{
+    VStringBuffer contentTypeID("ContentType_%s", cacheID);
+
+    CriticalBlock block(cacheCrit);
+    if (!checkAndGet("ESPResponse", cacheID, content))
+        return false;
+    return checkAndGet("ESPResponse", contentTypeID.str(), contentType);
+}
+
+void ESPMemCached::setPoolSettings()
+{
+    assertPool();
+    const char * msg = "memcached_pool_behavior_set failed - ";
+    assertOnError(memcached_pool_behavior_set(pool, MEMCACHED_BEHAVIOR_KETAMA, 1), msg);//NOTE: alias of MEMCACHED_DISTRIBUTION_CONSISTENT_KETAMA amongst others.
+    memcached_pool_behavior_set(pool, MEMCACHED_BEHAVIOR_USE_UDP, 0);  // Note that this fails on early versions of libmemcached, so ignore result
+    assertOnError(memcached_pool_behavior_set(pool, MEMCACHED_BEHAVIOR_NO_BLOCK, 0), msg);
+    assertOnError(memcached_pool_behavior_set(pool, MEMCACHED_BEHAVIOR_CONNECT_TIMEOUT, 1000), msg);//units of ms.
+    assertOnError(memcached_pool_behavior_set(pool, MEMCACHED_BEHAVIOR_SND_TIMEOUT, 1000000), msg);//units of mu-s.
+    assertOnError(memcached_pool_behavior_set(pool, MEMCACHED_BEHAVIOR_RCV_TIMEOUT, 1000000), msg);//units of mu-s.
+    assertOnError(memcached_pool_behavior_set(pool, MEMCACHED_BEHAVIOR_BUFFER_REQUESTS, 0), msg);
+    assertOnError(memcached_pool_behavior_set(pool, MEMCACHED_BEHAVIOR_BINARY_PROTOCOL, 1), "memcached_pool_behavior_set failed - ");
+}
+
+void ESPMemCached::connect()
+{
+    assertPool();
+#if (LIBMEMCACHED_VERSION_HEX<0x53000)
+    if (connection)
+        memcached_pool_push(pool, connection);
+    memcached_return_t rc;
+    connection = memcached_pool_pop(pool, (struct timespec *)0 , &rc);
+#else
+    if (connection)
+        memcached_pool_release(pool, connection);
+    memcached_return_t rc;
+    connection = memcached_pool_fetch(pool, (struct timespec *)0 , &rc);
+#endif
+    assertOnError(rc, "memcached_pool_pop failed - ");
+}
+
+bool ESPMemCached::checkServersUp()
+{
+    memcached_return_t rc;
+    char* args = nullptr;
+    OwnedMalloc<memcached_stat_st> stats;
+    stats.setown(memcached_stat(connection, args, &rc));
+
+    unsigned int numberOfServers = memcached_server_count(connection);
+    if (numberOfServers < 1)
+    {
+        ESPLOG(LogMin,"ESPMemCached: no server connected.");
+        return false;
+    }
+
+    unsigned int numberOfServersDown = 0;
+    for (unsigned i = 0; i < numberOfServers; ++i)
+    {
+        if (stats[i].pid == -1)//perhaps not the best test?
+        {
+            numberOfServersDown++;
+            VStringBuffer msg("ESPMemCached: Failed connecting to entry %u\nwithin the server list: %s", i+1, options.str());
+            ESPLOG(LogMin, "%s", msg.str());
+        }
+    }
+    if (numberOfServersDown == numberOfServers)
+    {
+        ESPLOG(LogMin,"ESPMemCached: Failed connecting to ALL servers. Check memcached on all servers and \"memcached -B ascii\" not used.");
+        return false;
+    }
+
+    //check memcached version homogeneity
+    for (unsigned i = 0; i < numberOfServers-1; ++i)
+    {
+        if (!streq(stats[i].version, stats[i+1].version))
+            DBGLOG("ESPMemCached: Inhomogeneous versions of memcached across servers.");
+    }
+    return true;
+}
+
+ESPCacheResult ESPMemCached::exists(const char* groupID, const char* cacheID)
+{
+#if (LIBMEMCACHED_VERSION_HEX<0x53000)
+    throw makeStringException(0, "memcached_exist not supported in this version of libmemcached");
+#endif
+
+    memcached_return_t rc;
+    size_t groupIDLength = strlen(groupID);
+    if (groupIDLength)
+        rc = memcached_exist_by_key(connection, groupID, groupIDLength, cacheID, strlen(cacheID));
+    else
+        rc = memcached_exist(connection, cacheID, strlen(cacheID));
+
+    if (rc != MEMCACHED_NOTFOUND)
+        assertOnError(rc, "'Exists' request failed - ");
+    return rc == MEMCACHED_NOTFOUND ? ESPCacheNotFound : (rc == MEMCACHED_SUCCESS ? ESPCacheSuccess : ESPCacheError);
+}
+
+ESPCacheResult ESPMemCached::get(const char* groupID, const char* cacheID, StringBuffer& out)
+{
+    uint32_t flag = 0;
+    size_t returnLength;
+    memcached_return_t rc;
+
+    OwnedMalloc<char> value;
+    size_t groupIDLength = strlen(groupID);
+    if (groupIDLength)
+        value.setown(memcached_get_by_key(connection, groupID, groupIDLength, cacheID, strlen(cacheID), &returnLength, &flag, &rc));
+    else
+        value.setown(memcached_get(connection, cacheID, strlen(cacheID), &returnLength, &flag, &rc));
+
+    if (value)
+        out.set(value);
+
+    StringBuffer msg = "'Get' request failed - ";
+    if (rc == MEMCACHED_NOTFOUND)
+        msg.append("(cacheID: '").append(cacheID).append("') ");
+    assertOnError(rc, msg.str());
+    return rc == MEMCACHED_NOTFOUND ? ESPCacheNotFound : (rc == MEMCACHED_SUCCESS ? ESPCacheSuccess : ESPCacheError);
+}
+
+bool ESPMemCached::checkAndGet(const char* groupID, const char* cacheID, StringBuffer& item)
+{
+    ESPCacheResult ret = exists(groupID, cacheID);
+    if ((ret != ESPCacheSuccess) && (ret != ESPCacheNotFound))
+        return false;
+    if (ret == ESPCacheSuccess)
+        get(groupID, cacheID, item);
+    return true;
+}
+
+ESPCacheResult ESPMemCached::set(const char* groupID, const char* cacheID, const char* value, unsigned __int64 expireSec)
+{
+    memcached_return_t rc;
+    size_t groupIDLength = strlen(groupID);
+    if (groupIDLength)
+        rc = memcached_set_by_key(connection, groupID, groupIDLength, cacheID, strlen(cacheID), value, strlen(value), (time_t)expireSec, 0);
+    else
+        rc = memcached_set(connection, cacheID, strlen(cacheID), value, strlen(value), (time_t)expireSec, 0);
+    
+    assertOnError(rc, "'Set' request failed - ");
+    return rc == MEMCACHED_NOTFOUND ? ESPCacheNotFound : (rc == MEMCACHED_SUCCESS ? ESPCacheSuccess : ESPCacheError);
+}
+
+void ESPMemCached::remove(const char* groupID, const char* cacheID)
+{
+    memcached_return_t rc;
+    size_t groupIDLength = strlen(groupID);
+    if (groupIDLength)
+        rc = memcached_delete_by_key(connection, groupID, groupIDLength, cacheID, strlen(cacheID), (time_t)0);
+    else
+        rc = memcached_delete(connection, cacheID, strlen(cacheID), (time_t)0);
+    assertOnError(rc, "'Delete' request failed - ");
+}
+
+void ESPMemCached::flush(unsigned when)
+{
+    //NOTE: memcached_flush is the actual cache flush/clear/delete and not an io buffer flush.
+    assertOnError(memcached_flush(connection, (time_t)(when)), "'Clear' request failed - ");
+}
+
+void ESPMemCached::assertOnError(memcached_return_t rc, const char * _msg)
+{
+    if (rc != MEMCACHED_SUCCESS)
+    {
+        VStringBuffer msg("ESPMemCached: %s%s", _msg, memcached_strerror(connection, rc));
+        ESPLOG(LogNormal, "%s", msg.str());
+    }
+}
+
+void ESPMemCached::assertPool()
+{
+    if (!pool)
+    {
+        StringBuffer msg = "ESPMemCached: Failed to instantiate server pool with:";
+        msg.newline().append(options);
+        ESPLOG(LogNormal, "%s", msg.str());
+    }
+}
+#endif //USE_LIBMEMCACHED
+
+extern esp_http_decl IEspCache* createESPCache(const char* setting)
+{
+#ifdef USE_LIBMEMCACHED
+    Owned<ESPMemCached> espCache = new ESPMemCached();
+    if (espCache->init(setting))
+        return espCache.getClear();
+#endif
+    return nullptr;
+}

--- a/esp/platform/espcache.hpp
+++ b/esp/platform/espcache.hpp
@@ -1,0 +1,43 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2017 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef _ESPCACHE_IPP__
+#define _ESPCACHE_IPP__
+
+#include "esp.hpp"
+
+#ifdef ESPHTTP_EXPORTS
+    #define esp_http_decl DECL_EXPORT
+#else
+    #define esp_http_decl DECL_IMPORT
+#endif
+
+enum ESPCacheResult
+{
+    ESPCacheSuccess,
+    ESPCacheError,
+    ESPCacheNotFound
+};
+
+interface IEspCache : extends IInterface
+{
+    virtual bool cacheResponse(const char* cacheID, const unsigned cacheSeconds, const char* content, const char* contentType) = 0;
+    virtual bool readResponseCache(const char* cacheID, StringBuffer& content, StringBuffer& contentType) = 0;
+};
+
+extern esp_http_decl IEspCache* createESPCache(const char* setting);
+#endif

--- a/esp/platform/espcfg.cpp
+++ b/esp/platform/espcfg.cpp
@@ -799,3 +799,21 @@ IEspPlugin* CEspConfig::getPlugin(const char* name)
     return NULL;
 }
 
+bool CEspConfig::checkESPCache()
+{
+    bool espCacheAvailable = false ;
+    list<binding_cfg*>::iterator iter = m_bindings.begin();
+    while (iter!=m_bindings.end())
+    {
+        binding_cfg& xcfg = **iter;
+        if (xcfg.bind->getCacheMethodCount() > 0)
+        {
+            Owned<IEspCache> espCache = createESPCache(m_cfg->queryProp("@espCacheInitString"));
+            espCacheAvailable = (espCache != nullptr);
+            break;
+        }
+        iter++;
+    }
+    return espCacheAvailable;
+}
+

--- a/esp/platform/espcfg.ipp
+++ b/esp/platform/espcfg.ipp
@@ -41,6 +41,7 @@ using namespace std;
 //ESP
 #include "esp.hpp"
 #include "espplugin.hpp"
+#include "espcache.hpp"
 
 struct binding_cfg
 {
@@ -180,9 +181,13 @@ public:
         DBGLOG("loadServices");
         loadServices();
         loadProtocols();
-        loadBindings();      
+        loadBindings();
+
+        if (m_cfg->getPropBool("@ensureESPCache", false) && !checkESPCache())
+            throw MakeStringException(-1, "Failed in checking ESP cache service using %s", m_cfg->queryProp("@espCacheInitString"));
     }
 
+    bool checkESPCache();
     IEspPlugin* getPlugin(const char* name);
 
     void loadBuiltIns();

--- a/esp/protocols/http/CMakeLists.txt
+++ b/esp/protocols/http/CMakeLists.txt
@@ -43,6 +43,7 @@ set(SRCS
     ../../platform/espcontext.cpp
     ../../platform/espprotocol.cpp
     ../../platform/espthread.cpp
+    ../../platform/espcache.cpp
     ../../platform/sechandler.cpp
     ../../platform/txsummary.cpp
     mapinfo.cpp

--- a/esp/scm/esp.ecm
+++ b/esp/scm/esp.ecm
@@ -311,6 +311,7 @@ SCMinterface IEspRpcBinding(IInterface)
     void setContainer(IEspContainer *ic);
     void setXslProcessor(IInterface *xslp);
     IEspContainer* queryContainer();
+    unsigned getCacheMethodCount();
 };
 
 SCMinterface IEspUriMap(IInterface)

--- a/esp/scm/ws_topology.ecm
+++ b/esp/scm/ws_topology.ecm
@@ -633,25 +633,25 @@ ESPservice [auth_feature("DEFERRED"), noforms, version("1.26"), exceptions_inlin
     ESPuses ESPstruct TpServices;
     ESPuses ESPstruct TpTargetCluster;
 
-    ESPmethod [cache_seconds(180), cache_globel(1), resp_xsl_default("/esp/xslt/targetclusters.xslt")] TpTargetClusterQuery(TpTargetClusterQueryRequest, TpTargetClusterQueryResponse);
+    ESPmethod [cache_seconds(180), cache_global(1), resp_xsl_default("/esp/xslt/targetclusters.xslt")] TpTargetClusterQuery(TpTargetClusterQueryRequest, TpTargetClusterQueryResponse);
     ESPmethod [cache_seconds(180), cache_global(1), resp_xsl_default("/esp/xslt/topology.xslt")] TpClusterQuery(TpClusterQueryRequest, TpClusterQueryResponse);
     ESPmethod [cache_seconds(180), cache_global(1)] TpLogicalClusterQuery(TpLogicalClusterQueryRequest, TpLogicalClusterQueryResponse);
     ESPmethod [cache_seconds(180), cache_global(1)] TpGroupQuery(TpGroupQueryRequest, TpGroupQueryResponse);
-    ESPmethod [cache_seconds(180), cache_globel(1), resp_xsl_default("/esp/xslt/machines.xslt")] TpMachineQuery(TpMachineQueryRequest, TpMachineQueryResponse);
-    ESPmethod [cache_seconds(180), cache_globel(1), resp_xsl_default("/esp/xslt/cluster_info.xslt")] TpClusterInfo(TpClusterInfoRequest, TpClusterInfoResponse);
-    ESPmethod [cache_seconds(180), cache_globel(1), resp_xsl_default("/esp/xslt/thor_status.xslt")] TpThorStatus(TpThorStatusRequest, TpThorStatusResponse);
+    ESPmethod [cache_seconds(180), cache_global(1), resp_xsl_default("/esp/xslt/machines.xslt")] TpMachineQuery(TpMachineQueryRequest, TpMachineQueryResponse);
+    ESPmethod [cache_seconds(180), cache_global(1), resp_xsl_default("/esp/xslt/cluster_info.xslt")] TpClusterInfo(TpClusterInfoRequest, TpClusterInfoResponse);
+    ESPmethod [cache_seconds(180), cache_global(1), resp_xsl_default("/esp/xslt/thor_status.xslt")] TpThorStatus(TpThorStatusRequest, TpThorStatusResponse);
 
-    ESPmethod [cache_seconds(180), cache_globel(1), min_ver("1.26")] TpDropZoneQuery(TpDropZoneQueryRequest, TpDropZoneQueryResponse);
-    ESPmethod [cache_seconds(180), cache_globel(1), resp_xsl_default("/esp/xslt/services.xslt")] TpServiceQuery(TpServiceQueryRequest, TpServiceQueryResponse);
+    ESPmethod [cache_seconds(180), cache_global(1), min_ver("1.26")] TpDropZoneQuery(TpDropZoneQueryRequest, TpDropZoneQueryResponse);
+    ESPmethod [cache_seconds(180), cache_global(1), resp_xsl_default("/esp/xslt/services.xslt")] TpServiceQuery(TpServiceQueryRequest, TpServiceQueryResponse);
     ESPmethod TpSetMachineStatus(TpSetMachineStatusRequest, TpSetMachineStatusResponse);
     ESPmethod TpSwapNode(TpSwapNodeRequest, TpSwapNodeResponse);
     ESPmethod [cache_seconds(180)] TpXMLFile(TpXMLFileRequest, TpXMLFileResponse);
     ESPmethod [resp_xsl_default("/esp/xslt/tplog.xslt")] TpLogFile(TpLogFileRequest, TpLogFileResponse);
     ESPmethod [resp_xsl_default("/esp/xslt/tplogdisplay.xslt")] TpLogFileDisplay(TpLogFileRequest, TpLogFileResponse);
     ESPmethod TpGetComponentFile(TpGetComponentFileRequest, TpGetComponentFileResponse);
-    ESPmethod [cache_seconds(180), cache_globel(1)] TpGetServicePlugins(TpGetServicePluginsRequest, TpGetServicePluginsResponse);
-    ESPmethod [cache_seconds(180), cache_globel(1)] TpListTargetClusters(TpListTargetClustersRequest, TpListTargetClustersResponse);
-    ESPmethod [cache_seconds(180), cache_globel(1), min_ver(1.25)] TpMachineInfo(TpMachineInfoRequest, TpMachineInfoResponse);
+    ESPmethod [cache_seconds(180), cache_global(1)] TpGetServicePlugins(TpGetServicePluginsRequest, TpGetServicePluginsResponse);
+    ESPmethod [cache_seconds(180), cache_global(1)] TpListTargetClusters(TpListTargetClustersRequest, TpListTargetClustersResponse);
+    ESPmethod [cache_seconds(180), cache_global(1), min_ver(1.25)] TpMachineInfo(TpMachineInfoRequest, TpMachineInfoResponse);
 
     ESPmethod SystemLog(SystemLogRequest, SystemLogResponse);
 };

--- a/esp/services/esdl_svc_engine/esdl_binding.hpp
+++ b/esp/services/esdl_svc_engine/esdl_binding.hpp
@@ -375,6 +375,7 @@ public:
 
     bool usesESDLDefinition(const char * name, int version);
     bool usesESDLDefinition(const char * id);
+    virtual unsigned getCacheMethodCount(){return 0;}
 
 private:
     int onGetRoxieBuilder(CHttpRequest* request, CHttpResponse* response, const char *serv, const char *method);

--- a/esp/services/ws_ecl/ws_ecl_service.hpp
+++ b/esp/services/ws_ecl/ws_ecl_service.hpp
@@ -149,6 +149,7 @@ public:
     StringBuffer &generateNamespace(IEspContext &context, CHttpRequest* request, const char *serv, const char *method, StringBuffer &ns);
 
     virtual int getQualifiedNames(IEspContext& ctx, MethodInfoArray & methods){return 0;}
+    virtual unsigned getCacheMethodCount(){return 0;}
 
     void getNavigationData(IEspContext &context, IPropertyTree & data);
     void getRootNavigationFolders(IEspContext &context, IPropertyTree & data);

--- a/initfiles/componentfiles/configxml/esp.xsd.in
+++ b/initfiles/componentfiles/configxml/esp.xsd.in
@@ -863,10 +863,17 @@
                     </xs:appinfo>
                 </xs:annotation>
             </xs:attribute>
-            <xs:attribute name="memCachedOptionString" type="xs:string" use="optional">
+            <xs:attribute name="ensureESPCache" type="xs:boolean" use="optional" default="false">
                 <xs:annotation>
                     <xs:appinfo>
-                        <tooltip>Option string used by ESP memcached client.</tooltip>
+                        <tooltip>If true, ESP will not be started if no ESP cache service is available.</tooltip>
+                    </xs:appinfo>
+                </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="espCacheInitString" type="xs:string" use="optional">
+                <xs:annotation>
+                    <xs:appinfo>
+                        <tooltip>String used for initializing ESP cache client.</tooltip>
                     </xs:appinfo>
                 </xs:annotation>
             </xs:attribute>

--- a/tools/hidl/hidlcomp.cpp
+++ b/tools/hidl/hidlcomp.cpp
@@ -5530,6 +5530,7 @@ void EspServInfo::write_esp_binding_ipp()
     outf("\tC%sSoapBinding(IPropertyTree* cfg, const char *bindname=NULL, const char *procname=NULL, http_soap_log_level level=hsl_none);\n", name_);
 
     outs("\tvirtual void init_strings();\n");
+    outs("\tvirtual unsigned getCacheMethodCount(){return m_cacheMethodCount;}\n");
 
     //method ==> processRequest
     outs("\tvirtual int processRequest(IRpcMessage* rpc_call, IRpcMessage* rpc_response);\n");
@@ -5622,6 +5623,7 @@ void EspServInfo::write_esp_binding_ipp()
 
     outs("private:\n");
     outs("\tMapStringTo<SecAccessFlags> m_accessmap;\n");
+    outs("\tunsigned m_cacheMethodCount = 0;\n");
 
     outs("};\n\n");
 }
@@ -5670,13 +5672,14 @@ void EspServInfo::write_esp_binding()
             StrBuffer tmp; 
             outf("\taddMethodHelp(\"%s\", \"%s\");\n", mthi->getName(), printfEncode(val.str(), tmp).str());
         }
+        int cacheGlobal = mthi->getMetaInt("cache_global", 0);
         int cacheSeconds = mthi->getMetaInt("cache_seconds", -1);
         if (cacheSeconds > -1) {
-            outf("\taddMemCachedSeconds(\"%s\", %d);\n", mthi->getName(), cacheSeconds);
-        }
-        int cacheGlobel = mthi->getMetaInt("cache_globel", 0);
-        if (cacheGlobel > 0) {
-            outf("\taddMemCachedGlobal(\"%s\", 1);\n", mthi->getName());
+            if (cacheGlobal > 0)
+                outf("\tsetCacheTimeout(\"%s\", %d, 1);\n", mthi->getName(), cacheSeconds);
+            else
+                outf("\tsetCacheTimeout(\"%s\", %d, 0);\n", mthi->getName(), cacheSeconds);
+            outs("\tm_cacheMethodCount++;\n");
         }
     }
     outs("}\n");


### PR DESCRIPTION
Implement a general cache interface and move the memcached code into
espcache.cpp; replace addMemCachedGlobal() and addMemCachedSeconds()
with setCacheTimeout(); add code for thread safe; add code to force
esp generalized cache.

Signed-off-by: wangkx <kevin.wang@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
