### PR TITLE
HPCC-17650 Definition dropdown has stale data

### DIFF
--- a/esp/src/eclwatch/DynamicESDLDetailsWidget.js
+++ b/esp/src/eclwatch/DynamicESDLDetailsWidget.js
@@ -104,10 +104,22 @@ define([
             this.bindingRefresh = registry.byId(this.id + "BindingRefresh");
             this.refreshButton = registry.byId(this.id + "Refresh");
 
+            this.dialog = new Dialog({
+                title: context.i18n.PleasePickADefinition,
+                style: "width: 300px;"
+            });
             this.addBindingButton = new Button({
                 id: this.id + "AddBinding",
                 disabled: true,
                 onClick: function (val) {
+                    if (context.definitionDropDown) {
+                        context.definitionDropDown.destroyRecursive();
+                    }
+                    context.definitionDropDown = new TargetSelectWidget({});
+                    context.dialog.addChild(context.definitionDropDown);
+                    context.definitionDropDown.init({
+                        LoadDESDLDefinitions: true
+                    });
                     context.dialog.show();
                 },
                 label: context.i18n.AddBinding
@@ -143,15 +155,6 @@ define([
                 },
                 label: context.i18n.DeleteBinding
             }).placeAt(this.addBindingButton.domNode, "after");
-            this.definitionDropDown = new TargetSelectWidget({});
-            this.definitionDropDown.init({
-                LoadDESDLDefinitions: true
-            });
-            this.dialog = new Dialog({
-                title: context.i18n.PleasePickADefinition,
-                style: "width: 300px;"
-            });
-            this.dialog.addChild(this.definitionDropDown);
             this.addDefinitionButton = new Button({
                 disabled: false,
                 style: "float:right;",


### PR DESCRIPTION
The definition drop down can have stale data due to the initialization happeningonce, which is when the call is made. If the user is adding a definition somewhere else they will need to reload the page to get the new definition list. I have modified the initialization to happen everytime someone opens the dialog to always have the latest values.

Signed-off by: Miguel Vazquez <miguel.vazquez@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [ ] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [ ] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [x] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
