### PR TITLE
HPCC-17946 Ensure that ECL workunit searches do not search the whole archive

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -2006,7 +2006,7 @@ mapEnums workunitSortFields[] =
    { WUSFpriority, "@priorityClass" },
    { WUSFprotected, "@protected" },
    { WUSFwuid, "@" },
-   { WUSFecl, "Query/Text" },
+   { WUSFecl, "Query/ShortText" },
    { WUSFfileread, "FilesRead/File/@name" },
    { WUSFtotalthortime, "@totalThorTime|"
                         "Statistics/Statistic[@c='summary'][@creator='thor'][@kind='TimeElapsed']/@value|"
@@ -7413,7 +7413,10 @@ void CLocalWUQuery::setQueryType(WUQueryType qt)
 
 IStringVal& CLocalWUQuery::getQueryText(IStringVal &str) const
 {
-    str.set(p->queryProp("Text"));
+    const char *text = p->queryProp("Text");
+    if (!text)
+        text = p->queryProp("ShortText");
+    str.set(text);
     return str;
 }
 
@@ -7498,10 +7501,10 @@ unsigned CLocalWUQuery::getQueryDllCrc() const
 
 void CLocalWUQuery::setQueryText(const char *text)
 {
-    p->setProp("Text", text);
     bool isArchive = isArchiveQuery(text);
     if (isArchive)
     {
+        p->setProp("Text", text);
         Owned<IPropertyTree> xml = createPTreeFromXMLString(text, ipt_caseInsensitive|ipt_lowmem);
         const char * path = xml->queryProp("Query/@attributePath");
         if (path)
@@ -7512,6 +7515,12 @@ void CLocalWUQuery::setQueryText(const char *text)
         }
         else
             p->setProp("ShortText", xml->queryProp("Query"));
+    }
+    else
+    {
+        p->setProp("Text", text);     // At some point in the future we may be able to remove this,
+                                      // but as long as there may be new workunits compiled by old systems, we can't
+        p->setProp("ShortText", text);
     }
     p->setPropBool("@isArchive", isArchive);
     if (isArchive)


### PR DESCRIPTION
Should only search the user query text.

Signed-off-by: Richard Chapman <rchapman@hpccsystems.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [ ] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [x] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browers
  - [ ] The component(s) render as expected

## Testing:
Compiled
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
