### PR TITLE
HPCC-17982 DynamicESDL: Forms should indicate visible optional fields

### DIFF
--- a/esp/xslt/esxdl2xsd.xslt
+++ b/esp/xslt/esxdl2xsd.xslt
@@ -165,7 +165,7 @@
                 </xsl:attribute>
             </xsl:if>
             <xsl:if test="boolean($all_annot_Param)">
-                <xsl:if test="@html_head or @form_ui or @collapsed or @cols or @rows">
+                <xsl:if test="@html_head or @form_ui or @collapsed or @cols or @rows or @optional">
                     <xsd:annotation>
                         <xsd:appinfo>
                             <form>
@@ -188,6 +188,9 @@
                                 </xsl:if>
                                 <xsl:if test="@rows">
                                     <xsl:attribute name="formRows"><xsl:value-of select="@rows"/></xsl:attribute>
+                                </xsl:if>
+                                <xsl:if test="@optional">
+                                    <xsl:attribute name="optional"><xsl:value-of select="@optional"/></xsl:attribute>
                                 </xsl:if>
                             </form>
                         </xsd:appinfo>

--- a/esp/xslt/gen_form.xsl
+++ b/esp/xslt/gen_form.xsl
@@ -768,6 +768,7 @@
             <xsl:with-param name="inputCtrlHtml" select="$inputCtrlHtml"/>
             <xsl:with-param name="isAttr" select="name($node)='xsd:attribute'"/>
             <xsl:with-param name="isBool" select="$node/@type='xsd:boolean'"/>
+            <xsl:with-param name="optional" select="$node/xsd:annotation/xsd:appinfo/form/@optional | $node/xsd:annotation/xsd:appinfo/xsd:form/@optional"/>
         </xsl:call-template>
     </xsl:template >
     
@@ -781,6 +782,7 @@
         <xsl:param name="inputCtrlHtml" select="''"/>
         <xsl:param name="isAttr" select="false()"/>
         <xsl:param name="isBool" select="false()"/>
+        <xsl:param name="optional" select="''"/>
 
         <!--    <xsl:if test="$verbose"><xsl:value-of select="concat('GenOneInputCtrlHtmlRaw(parentId=', $parentId, ', fieldId=', $fieldId, ', ui=', $ui, ', inputCtrlHtml=', $inputCtrlHtml, ')&lt;br/&gt;') "/> </xsl:if> -->     
 
@@ -824,6 +826,9 @@
                                 <xsl:text disable-output-escaping="yes"><![CDATA['> <b>]]></xsl:text>
                 <xsl:value-of select="$fieldName"/>
                 <xsl:text disable-output-escaping="yes"><![CDATA[</b>]]></xsl:text>
+                <xsl:call-template name="showOptionalSupscript">
+                    <xsl:with-param name="optional" select="$optional"/>
+                </xsl:call-template>
                 <xsl:value-of select="$ctrlId"/>
                 <xsl:choose>
                     <xsl:when test="$isBool">
@@ -844,6 +849,9 @@
                 <xsl:value-of select="$fieldName"/>
                 <xsl:if test="$isAttr"><![CDATA[</i>]]></xsl:if>
                 <xsl:text disable-output-escaping="yes"><![CDATA[</b></span>]]></xsl:text>
+                <xsl:call-template name="showOptionalSupscript">
+                    <xsl:with-param name="optional" select="$optional"/>
+                </xsl:call-template>
                 <xsl:value-of select="$ctrlId"/>
                 <xsl:choose>
                     <xsl:when test="$isBool">
@@ -1463,6 +1471,15 @@
                     </xsl:choose>
             </xsl:otherwise>
         </xsl:choose>
+    </xsl:template>
+    <xsl:template name="showOptionalSupscript">
+      <xsl:param name="optional" select="''"/>
+      <!-- optional starts with _ is deeemed as implementation specific and don't show it -->
+      <xsl:if test="$optional and substring($optional,1,1)!='_' and substring($optional,1,2)!='!_'">
+        <xsl:text><![CDATA[<sup style='color:red'>]]></xsl:text>
+        <xsl:value-of select="$optional"/>
+        <xsl:text><![CDATA[</sup>]]></xsl:text>
+      </xsl:if>
     </xsl:template>
 </xsl:stylesheet>
 


### PR DESCRIPTION
- Change esxdl2xsd.xslt file to include the optional attribute in the
  generated xsd.
- Change gen_form.xsl to add value of the optional next to the field
  name in the generated html form.

Signed-off-by: mayx <yanrui.ma@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [x] I have added tests to cover my changes.
  - [x] All new and existing tests passed.
  - [x] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [x] Scalability
  - [x] Performance
  - [x] Security
  - [x] Thread-safety
  - [x] Premature optimization
  - [x] Existing deployed queries will not be broken
  - [x] This change fixes the problem, not just the symptom
  - [x] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [x] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [x] This is a user interface / front-end modification
  - [x] I have tested my changes in multiple modern browers
  - [x] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
