### PR TITLE
HPCC-18007 Dfuplus spray to dafilesrv with SSLFirst problem

### DIFF
--- a/common/remote/rmtfile.cpp
+++ b/common/remote/rmtfile.cpp
@@ -308,27 +308,26 @@ public:
     }
 } *DaliServixIntercept = NULL;
 
-bool testDaliServixPresent(const SocketEndpoint &_ep)
+unsigned short getActiveDaliServixPort(const IpAddress &ip)
 {
-    SocketEndpoint ep(_ep);
+    if (ip.isNull())
+        return 0;
+    SocketEndpoint ep(0, ip);
     setDafsEndpointPort(ep);
-    if (ep.isNull())
-        return false;
     try {
         Owned<ISocket> socket = connectDafs(ep, 10000);
-        return true;
+        return ep.port;
     }
     catch (IException *e)
     {
         e->Release();
     }
-    return false;
+    return 0;
 }
 
 bool testDaliServixPresent(const IpAddress &ip)
 {
-    SocketEndpoint ep(0,ip);
-    return testDaliServixPresent(ep);
+    return getActiveDaliServixPort(ip) != 0;
 }
 
 unsigned getDaliServixVersion(const SocketEndpoint &_ep,StringBuffer &ver)

--- a/common/remote/rmtfile.hpp
+++ b/common/remote/rmtfile.hpp
@@ -54,7 +54,7 @@ extern REMOTE_API void setDaliServixSocketCaching(bool set);
 extern REMOTE_API bool canAccessDirectly(const RemoteFilename & file);
 extern REMOTE_API IFile *createDaliServixFile(const RemoteFilename & file);
 extern REMOTE_API bool testDaliServixPresent(const IpAddress &ip);
-extern REMOTE_API bool testDaliServixPresent(const SocketEndpoint &ep);
+extern REMOTE_API unsigned short getActiveDaliServixPort(const IpAddress &ip);
 extern REMOTE_API unsigned getDaliServixVersion(const IpAddress &ip,StringBuffer &ver);
 extern REMOTE_API unsigned getDaliServixVersion(const SocketEndpoint &ep,StringBuffer &ver);
 extern REMOTE_API DAFS_OS getDaliServixOs(const SocketEndpoint &ep);

--- a/common/remote/sockfile.hpp
+++ b/common/remote/sockfile.hpp
@@ -78,7 +78,7 @@ extern void remoteExtractBlobElements(const SocketEndpoint &ep, const char * pre
 extern int getDafsInfo(ISocket * socket, unsigned level, StringBuffer &retstr);
 extern void setDafsEndpointPort(SocketEndpoint &ep);
 extern void setDafsLocalMountRedirect(const IpAddress &ip,const char *dir,const char *mountdir);
-extern REMOTE_API ISocket *connectDafs(SocketEndpoint &ep, unsigned timeoutms);
+extern REMOTE_API ISocket *connectDafs(SocketEndpoint &ep, unsigned timeoutms); // NOTE: might alter ep.port if configured for multiple ports ...
 extern REMOTE_API ISocket *checkSocketSecure(ISocket *socket);
 
 // client only

--- a/dali/dfuXRefLib/dfuxreflib.cpp
+++ b/dali/dfuXRefLib/dfuxreflib.cpp
@@ -335,10 +335,11 @@ static unsigned short getDafsPort(const SocketEndpoint &ep,unsigned &numfails,Cr
     }
     else if (numfails>5)
         return 0;
-    if (testDaliServixPresent(ep)) 
-        return ep.port?ep.port:getDaliServixPort();
+    unsigned short nPort = getActiveDaliServixPort(ep);
+    if (nPort)
+        return nPort;
     StringBuffer err("Failed to connect to DaFileSrv on ");
-    ep.getUrlStr(err);
+    ep.getIpText(err);
 #ifdef _WIN32
     ERRLOG("%s",err.str());
     if (sect) {


### PR DESCRIPTION
Code change so that if remote connections to dafilesrv are configured for SSLFirst and an issue happens after the initial connection that another connection to the other (unsecure) port is attempted.

Signed-off-by: Mark Kelly <mark.kelly@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [x] All new and existing tests passed.
  - [x] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [x] Scalability
  - [x] Performance
  - [x] Security
  - [x] Thread-safety
  - [ ] Premature optimization
  - [x] Existing deployed queries will not be broken
  - [x] This change fixes the problem, not just the symptom
  - [x] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

Full QA suite and also several tests with dafilesrv and rest of platform at different security settings of SSLNone, SSLFirst, UnsecureFirst, SSLOnly

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
