### PR TITLE
HPCC-18115 Submitting archive_date2str.xml for compilation causing esp crash

### DIFF
--- a/dali/base/dasess.cpp
+++ b/dali/base/dasess.cpp
@@ -2021,13 +2021,13 @@ public:
         decrypt(buf,passwordenc);
         return buf;
     }
-    const MemoryBuffer &querySessionToken()
+    const MemoryBuffer *querySessionToken()
     {
-        return sessionToken;
+        return &sessionToken;
     }
-    const MemoryBuffer &querySignature()
+    const MemoryBuffer *querySignature()
     {
-        return signature;
+        return &signature;
     }
     virtual void set(const char *name,const char *password)
     {
@@ -2036,7 +2036,7 @@ public:
         encrypt(buf,password);
         passwordenc.set(buf.str());
     }
-    void set(const char *_name, const char *_password, const MemoryBuffer &_sessionToken, const MemoryBuffer &_signature)
+    void set(const char *_name, const char *_password, const MemoryBuffer *_sessionToken, const MemoryBuffer *_signature)
     {
         set(_name, _password);
         sessionToken.clear().append(_sessionToken);

--- a/dali/base/dasess.hpp
+++ b/dali/base/dasess.hpp
@@ -75,10 +75,10 @@ interface IUserDescriptor: extends serializable
 {
     virtual StringBuffer &getUserName(StringBuffer &buf)=0;
     virtual StringBuffer &getPassword(StringBuffer &buf)=0;
-    virtual const MemoryBuffer &querySignature()=0;//user's digital signature
-    virtual const MemoryBuffer &querySessionToken()=0;//ESP session token
+    virtual const MemoryBuffer *querySignature()=0;//user's digital signature
+    virtual const MemoryBuffer *querySessionToken()=0;//ESP session token
     virtual void set(const char *name,const char *password)=0;
-    virtual void set(const char *name,const char *password, const MemoryBuffer &_sessionToken, const MemoryBuffer &_signature)=0;
+    virtual void set(const char *name,const char *password, const MemoryBuffer *_sessionToken, const MemoryBuffer *_signature)=0;
     virtual void clear()=0;
     virtual void serializeExtra(MemoryBuffer &tgt)=0;
     virtual void deserializeExtra(MemoryBuffer &src)=0;

--- a/esp/platform/espcontext.cpp
+++ b/esp/platform/espcontext.cpp
@@ -170,18 +170,18 @@ public:
         if (m_user)
             m_user->credentials().setSessionToken(&token);
     }
-    virtual const MemoryBuffer & querySessionToken()
+    virtual const MemoryBuffer * querySessionToken()
     {
-        return m_user->credentials().getSessionToken();
+        return m_user ? &m_user->credentials().getSessionToken() : nullptr;
     }
     virtual void setSignature(const MemoryBuffer & signature)
     {
         if (m_user)
             m_user->credentials().setSignature(&signature);
     }
-    virtual const MemoryBuffer & querySignature()
+    virtual const MemoryBuffer * querySignature()
     {
-        return m_user->credentials().getSignature();
+        return m_user ? &m_user->credentials().getSignature() : nullptr;
     }
     virtual void setRealm(const char* realm)
     {

--- a/esp/scm/esp.ecm
+++ b/esp/scm/esp.ecm
@@ -86,9 +86,9 @@ interface IEspContext : extends IInterface
     virtual void setUser(ISecUser * user) = 0;
     virtual ISecUser * queryUser() = 0;
     virtual void setSessionToken(const MemoryBuffer & token) = 0;
-    virtual const MemoryBuffer & querySessionToken() = 0;
+    virtual const MemoryBuffer * querySessionToken() = 0;
     virtual void setSignature(const MemoryBuffer & signature) = 0;
-    virtual const MemoryBuffer & querySignature() = 0;
+    virtual const MemoryBuffer * querySignature() = 0;
     virtual void setResources(ISecResourceList * rlist) = 0;
     virtual ISecResourceList * queryResources() = 0;
     virtual void setSecManger(ISecManager * mgr) = 0;


### PR DESCRIPTION
ESPContext dereferencing NULL pointer with user object not allocated. This PR
adds a check for NULL before dereferencing

Signed-off-by: Russ Whitehead <william.whitehead@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [x] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
