### PR TITLE
HPCC-18145 ESDL bindings and definitions to keep publish info

### DIFF
--- a/esp/services/esdl_svc_engine/esdl_binding.cpp
+++ b/esp/services/esdl_svc_engine/esdl_binding.cpp
@@ -128,7 +128,17 @@ IPropertyTree * fetchESDLBindingFromDali(const char *process, const char *bindin
         //There shouldn't be multiple entries here, but if so, we'll use the first one
         VStringBuffer xpath("%s[@id='%s.%s'][1]", ESDL_BINDING_ENTRY, process, bindingName);
 
-        return esdlBindings->getPropTree(xpath);
+        if (conn->queryRoot()->hasProp(xpath))
+            return createPTreeFromIPT(conn->queryRoot()->queryPropTree(xpath));
+        else
+            return nullptr;
+
+    }
+    catch (IException *E)
+    {
+        VStringBuffer message("ESDL Binding: Error fetching ESDL Binding %s[@EspProcess='%s'][@EspBinding='%s'][1] from Dali.", ESDL_BINDING_ENTRY, process, bindingName);
+        EXCLOG(E, message);
+        E->Release();
     }
     catch(...)
     {

--- a/esp/services/ws_esdlconfig/ws_esdlconfigservice.cpp
+++ b/esp/services/ws_esdlconfig/ws_esdlconfigservice.cpp
@@ -232,12 +232,19 @@ void CWsESDLConfigEx::addESDLDefinition(IPropertyTree * queryRegistry, const cha
             newSeq = thisSeq + 1;
     }
 
+    StringBuffer origTimestamp;
+    StringBuffer origOwner;
+
     if (deleteprev && newSeq > 1)
     {
         if (!isESDLDefinitionBound(lcName, newSeq -1))
         {
             newSeq--;
-            queryRegistry->removeTree(queryRegistry->queryPropTree(xpath.appendf("[@seq='%d']", newSeq)));
+            xpath.appendf("[@seq='%d']", newSeq);
+            origTimestamp.set(queryRegistry->queryPropTree(xpath)->queryProp("@created"));
+            origOwner.set(queryRegistry->queryPropTree(xpath)->queryProp("@publishedBy"));
+
+            queryRegistry->removeTree(queryRegistry->queryPropTree(xpath));
         }
         else
         {
@@ -245,12 +252,30 @@ void CWsESDLConfigEx::addESDLDefinition(IPropertyTree * queryRegistry, const cha
         }
     }
 
+    CDateTime dt;
+    dt.setNow();
+    StringBuffer str;
+
     newId.set(lcName).append(".").append(newSeq);
     definitionInfo->setProp("@name", lcName);
     definitionInfo->setProp("@id", newId);
     definitionInfo->setPropInt("@seq", newSeq);
-    if (userid && *userid)
-        definitionInfo->setProp("@publishedBy", userid);
+    if (origOwner.length())
+    {
+        definitionInfo->setProp("@lastEditedBy", (userid && *userid) ? userid : "Anonymous") ;
+        definitionInfo->setProp("@publishedBy", origOwner.str()) ;
+    }
+    else
+        definitionInfo->setProp("@publishedBy", (userid && *userid) ? userid : "Anonymous") ;
+
+    if (origTimestamp.length())
+    {
+        definitionInfo->setProp("@created", origTimestamp.str());
+        definitionInfo->setProp("@lastEdit",dt.getString(str).str());
+    }
+    else
+        definitionInfo->setProp("@created",dt.getString(str).str());
+
     queryRegistry->addPropTree(ESDL_DEF_ENTRY, LINK(definitionInfo));
 }
 
@@ -548,7 +573,8 @@ int CWsESDLConfigEx::publishESDLBinding(const char * bindingName,
                                          int esdlDefinitionVersion,
                                          const char * esdlServiceName,
                                          StringBuffer & message,
-                                         bool overwrite)
+                                         bool overwrite,
+                                         const char * user)
 {
     if (!esdlDefinitionName || !*esdlDefinitionName)
     {
@@ -582,10 +608,17 @@ int CWsESDLConfigEx::publishESDLBinding(const char * bindingName,
 
     bool duplicateBindings = bindings->hasProp(xpath.str());
 
+    StringBuffer origTimestamp;
+    StringBuffer origOwner;
+
     if (duplicateBindings)
     {
         if(overwrite)
+        {
+           origTimestamp.set(bindings->queryPropTree(xpath)->queryProp("@created"));
+           origOwner.set(bindings->queryPropTree(xpath)->queryProp("@publishedBy"));
            bindings->removeTree(bindings->queryPropTree(xpath));
+        }
         else
         {
            message.setf("Could not configure Service '%s' because this service has already been configured for binding '%s' on ESP Process '%s'", esdlServiceName, bindingName, espProcName);
@@ -600,6 +633,26 @@ int CWsESDLConfigEx::publishESDLBinding(const char * bindingName,
     bindingtree->setProp("@espbinding", bindingName);
     bindingtree->setProp("@id", qbindingid.str());
 
+    CDateTime dt;
+    dt.setNow();
+    StringBuffer str;
+
+    if (origTimestamp.length())
+    {
+        bindingtree->setProp("@created", origTimestamp.str());
+        bindingtree->setProp("@lastEdit", dt.getString(str).str());
+    }
+    else
+        bindingtree->setProp("@created",  dt.getString(str).str());
+
+    if (origOwner.length())
+    {
+        bindingtree->setProp("@publisheBy", origOwner.str()) ;
+        bindingtree->setProp("@lastEditedBy", (user && *user) ? user : "Anonymous");
+    }
+    else
+        bindingtree->setProp("@publishedBy", (user && *user) ? user : "Anonymous") ;
+
     if (esdlDefinitionVersion <= 0)
         esdlDefinitionVersion = 1;
 
@@ -607,9 +660,11 @@ int CWsESDLConfigEx::publishESDLBinding(const char * bindingName,
     newId.set(lcName).append(".").append(esdlDefinitionVersion);
 
     Owned<IPropertyTree> esdldeftree  = createPTree();
+
     esdldeftree->setProp("@name", lcName);
     esdldeftree->setProp("@id", newId);
     esdldeftree->setProp("@esdlservice", esdlServiceName);
+
 
     esdldeftree->addPropTree("Methods", LINK(methodsConfig));
 
@@ -761,7 +816,8 @@ bool CWsESDLConfigEx::onPublishESDLBinding(IEspContext &context, IEspPublishESDL
                                                            esdlver,
                                                            esdlServiceName.str(),
                                                            msg,
-                                                           overwrite
+                                                           overwrite,
+                                                           username.str()
                                                            ));
 
             if (ver >= 1.2)

--- a/esp/services/ws_esdlconfig/ws_esdlconfigservice.hpp
+++ b/esp/services/ws_esdlconfig/ws_esdlconfigservice.hpp
@@ -41,7 +41,7 @@ public:
     static bool existsESDLDefinition(const char * servicename, unsigned ver);
     static bool existsESDLDefinition(const char * definitionid);
     static bool existsESDLMethodDef(const char * esdlDefinitionName, unsigned ver, StringBuffer & esdlServiceName, const char * methodName);
-    static int publishESDLBinding(const char * bindingName, IPropertyTree * methodsConfig, const char * espProcName, const char * espPort, const char * esdlDefinitionName, int esdlDefinitionVersion, const char * esdlServiceName, StringBuffer & message, bool overwrite);
+    static int publishESDLBinding(const char * bindingName, IPropertyTree * methodsConfig, const char * espProcName, const char * espPort, const char * esdlDefinitionName, int esdlDefinitionVersion, const char * esdlServiceName, StringBuffer & message, bool overwrite, const char * user);
     static IPropertyTree * getEspProcessRegistry(const char * espprocname, const char * espbingingport, const char * servicename);
     static IPropertyTree * getESDLDefinitionRegistry(const char * wsEclId, bool readonly);
     static void addESDLDefinition(IPropertyTree * queryRegistry, const char * name, IPropertyTree * definitionInfo, StringBuffer &newId, unsigned &newSeq, const char *userid, bool deleteprev);


### PR DESCRIPTION
- Adds timestamps and owner information to bindings and definitions
- Retains preexisting time and owner info and adds lastedit info

Signed-off-by: Rodrigo Pastrana <rodrigo.pastrana@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
