### PR TITLE
HPCC-18114 Unicode Implementation for removeSuffix

### DIFF
--- a/ecllibrary/std/Uni.ecl
+++ b/ecllibrary/std/Uni.ecl
@@ -462,4 +462,17 @@ EXPORT BOOLEAN StartsWith(unicode src, unicode pref, string form) :=
 EXPORT BOOLEAN EndsWith(unicode src, unicode suff, string form) :=
 	lib_unicodelib.UnicodeLib.UnicodeLocaleEndsWith(src, suff, form);
 
+/**
+ * Removes the suffix from the search string, if present, and returns the result. Trailing spaces are
+ * stripped from both strings before matching.
+ *
+ * @param src           The string being searched in.
+ * @param suffix        The prefix to search for.
+ * @param form          The type of Normalization to be employed.
+ * @param return        The string excluding the suffix, if endsWith is true
+ */
+
+EXPORT RemoveSuffix(unicode src, unicode suff, string form) :=
+    lib_unicodelib.UnicodeLib.UnicodeLocaleRemoveSuffix(src, suff, form);
+
 END;

--- a/ecllibrary/teststd/uni/TestEndsWith.ecl
+++ b/ecllibrary/teststd/uni/TestEndsWith.ecl
@@ -77,7 +77,7 @@ EXPORT TestEndsWith := MODULE
     UNICODE t1 := TRANSFER(r1, UNICODE);
     DATA r2 := x'c700';
     UNICODE t2 := TRANSFER(r2, UNICODE);
-    EXPORT Test43 := ASSERT(Uni.EndsWith(t1,t2,'NFKC') = TRUE);
+    EXPORT Test43 := ASSERT(Uni.EndsWith(t1,t2,U'NFKC') = TRUE);
     DATA r1 := x'43002703';
     UNICODE t1 := TRANSFER(r1, UNICODE);
     DATA r2 := x'c700';

--- a/ecllibrary/teststd/uni/TestRemoveSuffix.ecl
+++ b/ecllibrary/teststd/uni/TestRemoveSuffix.ecl
@@ -1,0 +1,98 @@
+﻿/*##############################################################################
+## HPCC SYSTEMS software Copyright (C) 2017 HPCC Systems®.  All rights reserved.
+############################################################################## */
+
+IMPORT Std.Uni;
+
+EXPORT TestRemoveSuffix := MODULE
+
+  EXPORT TestConst := MODULE
+
+    //Check action on strings with no entries: empty source string, search string, or return string.
+    EXPORT Test01 := ASSERT(Uni.RemoveSuffix('','','') = '', CONST);
+    EXPORT Test03 := ASSERT(Uni.RemoveSuffix('x','','') = 'x', CONST);
+    EXPORT Test05 := ASSERT(Uni.RemoveSuffix('','x','') = '', CONST);
+    EXPORT Test07 := ASSERT(Uni.RemoveSuffix('','','x') = '', CONST);
+    EXPORT Test02 := ASSERT(Uni.RemoveSuffix('x','x','') = '', CONST);
+    //Check action on a string containing a single word - with various whitespace.
+    EXPORT Test08 := ASSERT(Uni.RemoveSuffix(' x ','  x ','') = ' x ');
+    EXPORT Test09 := ASSERT(Uni.RemoveSuffix(' x','x  ','') = ' ');
+    EXPORT Test10 := ASSERT(Uni.RemoveSuffix('x ','x ','') = 'x ');
+    EXPORT Test11 := ASSERT(Uni.RemoveSuffix('  x','x','') = ' ');
+    //Functionality Test.
+    EXPORT Test12 := ASSERT(Uni.RemoveSuffix('x','xx','') = 'x');
+    EXPORT Test14 := ASSERT(Uni.RemoveSuffix('','','yw') = '');
+    //Check action on a string containg multiple words - with various whitespace combinations.
+    EXPORT Test15 := ASSERT(Uni.RemoveSuffix(' xyz abc','xyz abc','') = ' ');
+    EXPORT Test16 := ASSERT(Uni.RemoveSuffix(' xyz abc','xyz','') = ' xyz abc');
+    EXPORT Test17 := ASSERT(Uni.RemoveSuffix(' xyz abc','c','') = ' xyz ab');
+    EXPORT Test18 := ASSERT(Uni.RemoveSuffix(' xyz abc','bc','') = ' xyz a');
+    EXPORT Test19 := ASSERT(Uni.RemoveSuffix(' xyz abc','ab','') = ' xyz abc');
+    EXPORT Test20 := ASSERT(Uni.RemoveSuffix(' xyz abc','b c','') = ' xyz abc');
+    //Check action on a string containing punctuation characters.
+    EXPORT Test21 := ASSERT(Uni.RemoveSuffix(',&%$@','$@','') = ',&%');
+    //Check action on a string containing an apostrophe.
+    EXPORT Test23 := ASSERT(Uni.RemoveSuffix('I couldn\'t hear you!','couldn\'t hear you!','') = 'I ');
+    //Check action on a string containing different variations/combinations of numbers and other characters.
+    EXPORT Test24 := ASSERT(Uni.RemoveSuffix('123abc 23.6 abc123','23.6 abc123','') = '123abc ');
+    //Test other space characters (< 0x20).
+    EXPORT Test26 := ASSERT(Uni.RemoveSuffix('\nt\t','t','') = '\nt\t');
+    //Check action on a string containing latin diacritical marks.
+    EXPORT Test27 := ASSERT(Uni.RemoveSuffix(U'À à',U'à','') = U'À ');
+    EXPORT Test28 := ASSERT(Uni.RemoveSuffix(U'ȭ š',U'š','') = U'ȭ ');
+    //Check action on a string containing Spanish words with latin accents.
+    //Translation: "The deceased changed the girls"
+    EXPORT Test29 := ASSERT(Uni.RemoveSuffix(U'El difunto cambió las niñas',U'niñas','') = U'El difunto cambió las ');
+    //Check action on a string containing Chinese characters.
+    //Translation: "I am a computer"
+    EXPORT Test30 := ASSERT(Uni.RemoveSuffix(U'我是電腦',U'腦','') = U'我是電');
+    //Check action on a string containing Modern Greek characters.
+    //Translation: "Do you come here often?"
+    EXPORT Test31 := ASSERT(Uni.RemoveSuffix(U'Έρχεσαι συχνά εδώ;',U'εδώ;','') = U'Έρχεσαι συχνά ');
+    //Testcases 32 and 33 test for bidirectional capabilities with scripts in arabic and hebrew.
+    //Check action on arabic lettering with accent marks. Bidirectional.
+    //Translation: "Good morning"
+    EXPORT Test32 := ASSERT(Uni.RemoveSuffix(U'صباح الخير',U'الخير','') = U'صباح');
+    //Check action on hebrew lettering with accent marks (called pointing). Bidirectional.
+    //Translation: (not a phrase, 2 different words separated by a space)
+    EXPORT Test33 := ASSERT(Uni.RemoveSuffix(U'קָמָץ שִׁי״ן',U'שִׁי״ן','') = U'קָמָץ');
+    //Check action on surrogate pairs.
+    EXPORT Test34 := ASSERT(Uni.RemoveSuffix(U'x𐐀',U'x𐐀','') = U'');
+    EXPORT Test35 := ASSERT(Uni.RemoveSuffix(U'𐐀',U'𐐀x','') = U'𐐀');
+    EXPORT Test37 := ASSERT(Uni.RemoveSuffix(U'x𐐀',U'𐐀','') = U'x');
+    //Check action with normalization forms
+    EXPORT Test39 := ASSERT(Uni.RemoveSuffix(U'Ç̌',U'Ç̌','') = U'');
+    EXPORT Test40 := ASSERT(Uni.RemoveSuffix(U'Ç̌',U'Ç̌','NFC') = U'');
+    DATA r1 := x'43002703';
+    UNICODE t1 := TRANSFER(r1, UNICODE);
+    DATA r2 := x'c700';
+    UNICODE t2 := TRANSFER(r2, UNICODE);
+    EXPORT Test41 := ASSERT(Uni.RemoveSuffix(t1,t2,'NFC') = U'');
+    DATA r1 := x'43002703';
+    UNICODE t1 := TRANSFER(r1, UNICODE);
+    DATA r2 := x'c700';
+    UNICODE t2 := TRANSFER(r2, UNICODE);
+    EXPORT Test42 := ASSERT(Uni.RemoveSuffix(t1,t2,'NFD') = U'');
+    DATA r1 := x'43002703';
+    UNICODE t1 := TRANSFER(r1, UNICODE);
+    DATA r2 := x'c700';
+    UNICODE t2 := TRANSFER(r2, UNICODE);
+    EXPORT Test43 := ASSERT(Uni.RemoveSuffix(t1,t2,'NFKC') = U'');
+    DATA r1 := x'43002703';
+    UNICODE t1 := TRANSFER(r1, UNICODE);
+    DATA r2 := x'c700';
+    UNICODE t2 := TRANSFER(r2, UNICODE);
+    EXPORT Test44 := ASSERT(Uni.RemoveSuffix(t1,t2,'NFKD') = U'');
+    DATA r1 := x'43000C032703';
+    UNICODE t1 := TRANSFER(r1, UNICODE);
+    DATA r2 := x'0C032703';
+    UNICODE t2 := TRANSFER(r2, UNICODE);
+    EXPORT Test45 := ASSERT(Uni.RemoveSuffix(t1,t2,'NFC') = U'Ç̌');
+    DATA r1 := x'43000C032703';
+    UNICODE t1 := TRANSFER(r1, UNICODE);
+    DATA r2 := x'0C032703';
+    UNICODE t2 := TRANSFER(r2, UNICODE);
+    EXPORT Test46 := ASSERT(Uni.RemoveSuffix(t1,t2,'NFD') = U'C');
+  END;
+
+END;

--- a/plugins/unicodelib/unicodelib.hpp
+++ b/plugins/unicodelib/unicodelib.hpp
@@ -106,6 +106,7 @@ UNICODELIB_API void UNICODELIB_CALL ulUnicodeLocaleExcludeLastWord(unsigned & tg
 UNICODELIB_API void UNICODELIB_CALL ulUnicodeLocaleTranslate(unsigned & tgtLen, UChar * & tgt, unsigned textLen, UChar const * text, unsigned searLen, UChar const * sear, unsigned replLen, UChar * repl);
 UNICODELIB_API bool UNICODELIB_CALL ulUnicodeLocaleStartsWith(unsigned srcLen, UChar const * src, unsigned prefLen, UChar const * pref, unsigned formLen, char const * form);
 UNICODELIB_API bool UNICODELIB_CALL ulUnicodeLocaleEndsWith(unsigned srcLen, UChar const * src, unsigned suffLen, UChar const * suff, unsigned formLen, char const * form);
+UNICODELIB_API void UNICODELIB_CALL ulUnicodeLocaleRemoveSuffix(unsigned & tgtLen, UChar * & tgt, unsigned srcLen, UChar const * src, unsigned suffLen, UChar const * suff, unsigned formLen, char const * form);
 }
 
 #endif


### PR DESCRIPTION
- Adds test cases in ecllibrary/teststd/uni/TestRemoveSuffix.ecl
- Adds documentation for removeSuffix in ecllibrary/std/uni/uni.ecl
- Adds code for RemoveSuffix in plugins/unicodelib/unicodelib.cpp and .hpp

Signed-off-by: David Skaff <david.skaff@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [x] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [x] I have added tests to cover my changes.
  - [x] All new and existing tests passed.
  - [x] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [x] Scalability
  - [x] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [x] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
