### PR TITLE
HPCC-17833 Unable to run regression suite when HTTPS enabled

### DIFF
--- a/testing/regress/README.rst
+++ b/testing/regress/README.rst
@@ -566,8 +566,8 @@ The format of the output is the same as 'run', except there is a log, result and
 |         End.
 
 
-6. Tags used in testcases:
---------------------------
+6. Tags used in test cases:
+---------------------------
 
     To exclude testcase from cluster or clusters, the tag is:
 //no<cluster_name>
@@ -688,10 +688,13 @@ So if you have a new test case and it works well on all clusters (or some of the
 
         "roxieTestSocket": ":9876",                     - Roxie test socket address (not used)
         "espIp": "127.0.0.1",                           - ESP server IP
-        "espSocket": ":8010",                           - ESP service address
+        "espSocket": "8010",                            - ESP service address
+        "useSsl" : "False",                             - Control SSL encryption in communication with ESP server
+                                                          If it is set to 'True' then espSocket, username and password 
+                                                          should be updated accordingly
         "username": "regress",                          - Regression Suite dedicated username and pasword
         "password": "regress",
-        "suiteDir": "",                                 - default suite directory location - ""-> current directory
+        "suiteDir": "",                                 - Default suite directory location - ""-> current directory
         "eclDir": "ecl",                                - ECL test cases directory source
         "setupDir": "ecl/setup",                        - ECL setup source directory
         "keyDir": "ecl/key",                            - XML key files directory to check testcases result

--- a/testing/regress/ecl-test.json
+++ b/testing/regress/ecl-test.json
@@ -2,7 +2,8 @@
     "Regress":{
         "roxieTestSocket": ":9876",
         "espIp" : "127.0.0.1",
-        "espSocket": ":8010",
+        "espSocket": "8010",
+        "useSsl" : "False",
         "username": "regress",
         "password": "regress",
         "suiteDir": "",

--- a/testing/regress/hpcc/regression/regress.py
+++ b/testing/regress/hpcc/regression/regress.py
@@ -25,10 +25,9 @@ import thread
 import threading
 import inspect
 
-from ..common.config import Config
 from ..common.error import Error
 from ..common.logger import Logger
-from ..common.report import Report, Tee
+from ..common.report import Report
 from ..regression.suite import Suite
 from ..util.ecl.cc import ECLCC
 from ..util.ecl.command import ECLcmd
@@ -555,7 +554,11 @@ class Regression:
             wuid="N/A"
 
         if wuid and wuid.startswith("W"):
-            url = "http://" + self.config.espIp+self.config.espSocket
+            if self.config.useSsl.lower() == 'true':
+                url = "https://"
+            else:
+                url = "http://"
+            url += self.config.espIp + ":" + self.config.espSocket
             url += "/?Widget=WUDetailsWidget&Wuid="
             url += wuid
         elif query.testFail():

--- a/testing/regress/hpcc/util/ecl/command.py
+++ b/testing/regress/hpcc/util/ecl/command.py
@@ -24,7 +24,7 @@ import inspect
 
 from ...common.shell import Shell
 from ...common.error import Error
-from ...util.util import queryWuid
+from ...util.util import queryWuid, getConfig
 
 import xml.etree.ElementTree as ET
 
@@ -32,6 +32,7 @@ class ECLcmd(Shell):
     def __init__(self):
         self.defaults = []
         self.cmd = 'ecl'
+        self.config = getConfig()
 
     def __ECLcmd(self):
         return self.command(self.cmd, *self.defaults)
@@ -43,6 +44,9 @@ class ECLcmd(Shell):
         args.append('-fpickBestEngine=false')
         args.append('--target=' + cluster)
         args.append('--cluster=' + cluster)
+        args.append('--port=' + self.config.espSocket)
+        if self.config.useSsl.lower() == 'true':
+            args.append('--ssl')
         
         retryCount = int(kwargs.pop('retryCount',  1))
         args.append('--wait='+str(retryCount * eclfile.getTimeout() * 1000))  # ms


### PR DESCRIPTION
Add "useSsl" field to configuration file (ecl-test.json) with "False"
default value to controll Regression Test Engine communication mode.

Extend ecl command generations to use "useSsl" config and generate
proper command line.

Common same parts of different workunit related functions.

Update ZAP file generation. Actually Regression Test Engine doesn't support
ZAP generation via SSL connection. There is a different JIRA (HPCC-18210)
for it.

Update workunit link generation in test result list to generate proper
http or https reference.

Add "useSsl" field and information to README.rst

Clean up the code: remove unused imports, variables.

Signed-off-by: Attila Vamos <attila.vamos@gmail.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [x] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [x] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [x] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->
Tested manually in standard, LDAP and LDAP + ESP SSL enabled environments.
<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
