### PR TITLE
HPCC-18218 Upgrade ESP to timeout session after client

### DIFF
--- a/esp/bindings/http/platform/httpbinding.hpp
+++ b/esp/bindings/http/platform/httpbinding.hpp
@@ -164,8 +164,9 @@ private:
 
     StringAttr              loginURL;
     StringAttr              logoutURL;
-    int                     sessionTimeoutSeconds = ESP_SESSION_TIMEOUT; //-1: never
-    int                     checkSessionTimeoutSeconds = ESP_CHECK_SESSION_TIMEOUT;
+    int                     clientSessionTimeoutSeconds = 60 * ESP_SESSION_TIMEOUT;
+    int                     serverSessionTimeoutSeconds = 120 * ESP_SESSION_TIMEOUT;
+    int                     checkSessionTimeoutSeconds = ESP_CHECK_SESSION_TIMEOUT; //the duration to clean timed out sesssions
     BoolHash                domainAuthResources;
     StringArray             domainAuthResourcesWildMatch;
 
@@ -342,7 +343,8 @@ public:
     AuthType getDomainAuthType() const { return domainAuthType; }
     const char* queryLoginURL() const { return loginURL.get(); }
     const char* queryLogoutURL() const { return logoutURL.get(); }
-    int getSessionTimeoutSeconds() const { return sessionTimeoutSeconds; }
+    int getClientSessionTimeoutSeconds() const { return clientSessionTimeoutSeconds; }
+    int getServerSessionTimeoutSeconds() const { return serverSessionTimeoutSeconds; }
     int getCheckSessionTimeoutSeconds() const { return checkSessionTimeoutSeconds; }
     bool isDomainAuthResources(const char* resource)
     {

--- a/esp/platform/espcontext.hpp
+++ b/esp/platform/espcontext.hpp
@@ -32,12 +32,14 @@
 #include "esphttp.hpp"
 
 #define SESSION_SDS_LOCK_TIMEOUT (30*1000) // 30 seconds
-#define ESP_SESSION_TIMEOUT (120*60) // 120 Mins
+#define ESP_SESSION_TIMEOUT (120) // 120 Mins
+#define ESP_SESSION_NEVER_TIMEOUT   -1
 #define ESP_CHECK_SESSION_TIMEOUT (30) // 30 seconds
 
 static const char* const USER_NAME_COOKIE = "ESPUserName";
 static const char* const SESSION_ID_COOKIE = "ESPSessionID";
 static const char* const SESSION_START_URL_COOKIE = "ESPAuthURL";
+static const char* const SESSION_TIMEOUT_COOKIE = "ESPSessionTimeoutSeconds";
 static const char* const SESSION_ID_TEMP_COOKIE = "ESPAuthIDTemp";
 static const char* const DEFAULT_LOGIN_URL = "/esp/files/eclwatch/templates/Login.html";
 static const char* const DEFAULT_UNRESTRICTED_RESOURCES = "/favicon.ico,/esp/files/*,/esp/xslt/*";

--- a/initfiles/componentfiles/configxml/esp.xsd.in
+++ b/initfiles/componentfiles/configxml/esp.xsd.in
@@ -415,20 +415,29 @@
 	                </xs:appinfo>
 	              </xs:annotation>
 	            </xs:attribute>
-	            <xs:attribute name="sessionTimeoutMinutes" use="optional" default="120">
+	            <xs:attribute name="clientSessionTimeoutMinutes" use="optional" default="120">
 	              <xs:annotation>
 	                <xs:appinfo>
-	                  <tooltip>Inactive session duration, in minutes. Specify 0 for default timeout, -1 for never time out.</tooltip>
+	                  <tooltip>Inactive session duration, in minutes, that is used to timeout a session on ESP client. Specify 0 for default timeout, -1 for never time out.</tooltip>
 	                  <colIndex>5</colIndex>
 	                </xs:appinfo>
 	              </xs:annotation>
 	            </xs:attribute>
+                <xs:attribute name="serverSessionTimeoutMinutes" use="optional" default="240">
+                  <xs:annotation>
+                    <xs:appinfo>
+                      <tooltip>Considering network delay, serverSessionTimeoutMinutes should be greater than clientSessionTimeoutMinutes.
+                      If serverSessionTimeoutMinutes < clientSessionTimeoutMinutes, serverSessionTimeoutMinutes = 2 * clientSessionTimeoutMinutes. -1 for never time out.</tooltip>
+                      <colIndex>6</colIndex>
+                    </xs:appinfo>
+                  </xs:annotation>
+                </xs:attribute>
 	            <xs:attribute name="unrestrictedResources" type="xs:string" use="optional" default="/favicon.ico,/esp/files/*,/esp/xslt/*">
 	              <xs:annotation>
 	                <xs:appinfo>
 	                  <width>50</width>
 	                  <tooltip>unrestricted resources for user authentication</tooltip>
-	                  <colIndex>6</colIndex>
+	                  <colIndex>7</colIndex>
 	                </xs:appinfo>
 	              </xs:annotation>
 	            </xs:attribute>


### PR DESCRIPTION
The existing ESP/ECLwatch controls session timeout using the same timeout value. 
It is difficult to make sure a session to be timed out on both sides at the same time 
due to network delay or different clock times on ESP server and ECLwatch client 
box. In this fix, two timeout values, one for client side and one for server side, are
used to controls session timeout. ECLwatch or other ESP client may use the timeout 
value for client side to force a session timeout. ESP will clean the session based on 
the timeout value for server side. The code forces that the timeout value for server 
side is not less than the timeout value for client side.

Signed-off-by: wangkx <kevin.wang@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
