### PR TITLE
HPCC-16870 Add method to rebuild a query from its ECL archive

### DIFF
--- a/ecl/eclcmd/eclcmd_common.hpp
+++ b/ecl/eclcmd/eclcmd_common.hpp
@@ -67,6 +67,7 @@ typedef IEclCommand *(*EclCommandFactory)(const char *cmdname);
 #define ECLOPT_PASSWORD_ENV "ECL_PASSWORD"
 
 #define ECLOPT_NORELOAD "--no-reload"
+#define ECLOPT_NOPUBLISH "--no-publish"
 #define ECLOPT_OVERWRITE "--overwrite"
 #define ECLOPT_REPLACE "--replace"
 #define ECLOPT_OVERWRITE_S "-O"

--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -597,6 +597,62 @@ ESPresponse [exceptions_inline] WUResubmitResponse
     [min_ver("1.40")] ESParray<ESPstruct ResubmittedWU, WU> WUs;
 };
 
+ESPenum WUQueryActivationMode : int
+{
+    NoActivate(0, "Do not activate query"),
+    Activate(1, "Activate query"),
+    ActivateSuspendPrevious(2, "Activate query, suspend previous"),
+    ActivateDeletePrevious(3, "Activate query, delete previous")
+};
+
+ESPrequest [nil_remove] WURecreateQueryRequest
+{
+    string Target;
+    string QueryId;
+    ESParray<ESPstruct NamedValue> DebugValues;
+    string DestTarget;
+    bool Republish(0);
+    ESPEnum WUQueryActivationMode Activate;
+    bool NoReload(0);
+
+    string MemoryLimit;
+    nonNegativeInteger TimeLimit(0);
+    nonNegativeInteger WarnTimeLimit(0);
+    string Priority;
+    string Comment;
+
+    string RemoteDali;
+    bool DontCopyFiles(false);
+    string SourceProcess;
+    bool AllowForeignFiles(false);
+    bool UpdateDfs(false);
+    bool UpdateSuperFiles(false); //update content of superfiles if changed
+    bool UpdateCloneFrom(false); //explicity wan't to change where roxie will grab from
+    bool AppendCluster(true); //file exists on other local cluster, add new one, make optional in case of locking issues, but should be made to work
+    bool IncludeFileErrors(false);
+
+    int Wait(-1);
+};
+
+ESPresponse [exceptions_inline, nil_remove] WURecreateQueryResponse
+{
+    string Wuid;
+    string QuerySet;
+    string QueryName;
+    string QueryId;
+
+    string MemoryLimit;
+    nonNegativeInteger TimeLimit;
+    nonNegativeInteger WarnTimeLimit;
+    string Priority;
+    string Comment;
+
+    bool ReloadFailed;
+    bool Suspended;
+    string ErrorMessage;
+    ESParray<ESPStruct LogicalFileError, File> FileErrors;
+};
+
 ESPenum WUExceptionSeverity : string
 {
     INFO("info"),
@@ -1221,14 +1277,6 @@ ESPresponse [exceptions_inline] WUCopyLogicalFilesResponse
 };
 
 
-ESPenum WUQueryActivationMode : int
-{
-    NoActivate(0, "Do not activate query"),
-    Activate(1, "Activate query"),
-    ActivateSuspendPrevious(2, "Activate query, suspend previous"),
-    ActivateDeletePrevious(3, "Activate query, delete previous")
-};
-
 ESPrequest [nil_remove] WUPublishWorkunitRequest
 {
     string Wuid;
@@ -1828,7 +1876,7 @@ ESPresponse [exceptions_inline, nil_remove] WUGetNumFileToCopyResponse
 
 ESPservice [
     auth_feature("DEFERRED"), //This declares that the method logic handles feature level authorization
-    version("1.69"), default_client_version("1.69"),
+    version("1.70"), default_client_version("1.70"),
     noforms,exceptions_inline("./smc_xslt/exceptions.xslt"),use_method_name] WsWorkunits
 {
     ESPmethod [cache_seconds(60), resp_xsl_default("/esp/xslt/workunits.xslt")]     WUQuery(WUQueryRequest, WUQueryResponse);
@@ -1864,6 +1912,7 @@ ESPservice [
 
     ESPmethod WUAbort(WUAbortRequest, WUAbortResponse);
     ESPmethod WUProtect(WUProtectRequest, WUProtectResponse);
+    ESPmethod [min_ver("1.70")] WURecreateQuery(WURecreateQueryRequest, WURecreateQueryResponse);
     ESPmethod WUResubmit(WUResubmitRequest, WUResubmitResponse); //????
     ESPmethod WURun(WURunRequest, WURunResponse);
 

--- a/esp/services/ws_workunits/ws_workunitsHelpers.cpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.cpp
@@ -2066,15 +2066,14 @@ IConstWUQuery* WsWuInfo::getEmbeddedQuery()
     return NULL;
 }
 
-void WsWuInfo::getWorkunitArchiveQuery(MemoryBuffer& buf)
+void WsWuInfo::getWorkunitArchiveQuery(IStringVal& str)
 {
     Owned<IConstWUQuery> query = cw->getQuery();
     if(!query)
         throw MakeStringException(ECLWATCH_QUERY_NOT_FOUND_FOR_WU,"No query for workunit %s.",wuid.str());
 
-    SCMStringBuffer queryText;
-    query->getQueryText(queryText);
-    if ((queryText.length() < 1) || !isArchiveQuery(queryText.str()))
+    query->getQueryText(str);
+    if ((str.length() < 1) || !isArchiveQuery(str.str()))
     {
         if (!query->hasArchive())
             throw MakeStringException(ECLWATCH_CANNOT_GET_WORKUNIT, "Archive query not found for workunit %s.", wuid.str());
@@ -2083,10 +2082,22 @@ void WsWuInfo::getWorkunitArchiveQuery(MemoryBuffer& buf)
         if (!embeddedQuery)
             throw MakeStringException(ECLWATCH_CANNOT_GET_WORKUNIT, "Embedded query not found for workunit %s.", wuid.str());
 
-        embeddedQuery->getQueryText(queryText);
-        if ((queryText.length() < 1) || !isArchiveQuery(queryText.str()))
+        embeddedQuery->getQueryText(str);
+        if ((str.length() < 1) || !isArchiveQuery(str.str()))
             throw MakeStringException(ECLWATCH_CANNOT_GET_WORKUNIT, "Archive query not found for workunit %s.", wuid.str());
     }
+}
+
+void WsWuInfo::getWorkunitArchiveQuery(StringBuffer& buf)
+{
+    StringBufferAdaptor queryText(buf);
+    getWorkunitArchiveQuery(queryText);
+}
+
+void WsWuInfo::getWorkunitArchiveQuery(MemoryBuffer& buf)
+{
+    SCMStringBuffer queryText;
+    getWorkunitArchiveQuery(queryText);
     buf.append(queryText.length(), queryText.str());
 }
 

--- a/esp/services/ws_workunits/ws_workunitsHelpers.hpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.hpp
@@ -191,7 +191,9 @@ public:
     void getWorkunitThorLog(const char *processName, MemoryBuffer& buf);
     void getWorkunitThorSlaveLog(const char *groupName, const char *ipAddress, const char* logDate, const char* logDir, int slaveNum, MemoryBuffer& buf, bool forDownload);
     void getWorkunitResTxt(MemoryBuffer& buf);
-    void getWorkunitArchiveQuery(MemoryBuffer& buf);
+    void getWorkunitArchiveQuery(IStringVal& str);
+    void getWorkunitArchiveQuery(StringBuffer& str);
+    void getWorkunitArchiveQuery(MemoryBuffer& mb);
     void getWorkunitDll(StringBuffer &name, MemoryBuffer& buf);
     void getWorkunitXml(const char* plainText, MemoryBuffer& buf);
     void getWorkunitQueryShortText(MemoryBuffer& buf);

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -434,7 +434,7 @@ bool CWsWorkunitsEx::onWUCreate(IEspContext &context, IEspWUCreateRequest &req, 
     return true;
 }
 
-static bool origValueChanged(const char *newValue, const char *origValue, StringBuffer &s, bool nillable=true)
+bool origValueChanged(const char *newValue, const char *origValue, StringBuffer &s, bool nillable)
 {
     if (!nillable && isEmpty(newValue))
         return false;
@@ -826,6 +826,7 @@ bool CWsWorkunitsEx::onWUResubmit(IEspContext &context, IEspWUResubmitRequest &r
     }
     return true;
 }
+
 
 bool CWsWorkunitsEx::onWUPushEvent(IEspContext &context, IEspWUPushEventRequest &req, IEspWUPushEventResponse &resp)
 {

--- a/esp/services/ws_workunits/ws_workunitsService.hpp
+++ b/esp/services/ws_workunits/ws_workunitsService.hpp
@@ -230,6 +230,7 @@ public:
     bool onWURun(IEspContext &context, IEspWURunRequest &req, IEspWURunResponse &resp);
     bool onWUCreate(IEspContext &context, IEspWUCreateRequest &req, IEspWUCreateResponse &resp);
     bool onWUCreateAndUpdate(IEspContext &context, IEspWUUpdateRequest &req, IEspWUUpdateResponse &resp);
+    bool onWURecreateQuery(IEspContext &context, IEspWURecreateQueryRequest &req, IEspWURecreateQueryResponse &resp);
     bool onWUResubmit(IEspContext &context, IEspWUResubmitRequest &req, IEspWUResubmitResponse &resp);
     bool onWUPushEvent(IEspContext &context, IEspWUPushEventRequest &req, IEspWUPushEventResponse &resp);
 
@@ -402,5 +403,7 @@ public:
         return new CClusterQueryStateThread();
     }
 };
+
+bool origValueChanged(const char *newValue, const char *origValue, StringBuffer &s, bool nillable=true);
 
 #endif


### PR DESCRIPTION
This will be really usefull when upgrading the ECL compiler, allowing
the user to rebuild their query from the exact same code.

Signed-off-by: Anthony Fishbeck <anthony.fishbeck@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [x] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [x] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
