### PR TITLE
HPCC-17931 Add an INLINE operator to force function expansion with --fastsyntax

### DIFF
--- a/ecl/hql/hqlattr.cpp
+++ b/ecl/hql/hqlattr.cpp
@@ -527,6 +527,7 @@ unsigned getOperatorMetaFlags(node_operator op)
 //Multiple types
     case no_outofline:
     case no_create_initializer:
+    case no_inline:
 
 //Actions
     case no_buildindex:
@@ -631,7 +632,7 @@ unsigned getOperatorMetaFlags(node_operator op)
 
     case no_unused6:
     case no_unused13: case no_unused14: case no_unused15:
-    case no_unused32: case no_unused33: case no_unused34: case no_unused35: case no_unused36: case no_unused37: case no_unused38:
+    case no_unused33: case no_unused34: case no_unused35: case no_unused36: case no_unused37: case no_unused38:
     case no_unused40: case no_unused41: case no_unused42: case no_unused43: case no_unused44: case no_unused45: case no_unused46: case no_unused47: case no_unused48: case no_unused49:
     case no_unused50: case no_unused52:
     case no_unused80:
@@ -2571,6 +2572,7 @@ IHqlExpression * calcRowInformation(IHqlExpression * expr)
     case no_spill:
     case no_spillgraphresult:
     case no_outofline:
+    case no_inline:
     case no_globalscope:
     case no_throughaggregate:
     case no_alias_scope:

--- a/ecl/hql/hqlerrors.hpp
+++ b/ecl/hql/hqlerrors.hpp
@@ -240,6 +240,7 @@
 #define ERR_STRING_UNENDED          2195  /* Unended string constant: string must end in one line */
 #define ERR_STRING_ILLDELIMITER     2196  /* " is illegal string delimiter: use ' instead */
 #define ERR_IFBLOCK_EMPTYDEF        2197  /* Empty ifblock definition */
+#define ERR_CONCRETE_RECORD         2198  /* Requires a real record definition */
 
 /* hash commands */
 #define ERR_TMPLT_EOFINFOR          2200 /* EOF encountered inside #FOR */

--- a/ecl/hql/hqlexpr.cpp
+++ b/ecl/hql/hqlexpr.cpp
@@ -1306,6 +1306,7 @@ const char *getOpString(node_operator op)
     case no_left: return "LEFT";
     case no_right: return "RIGHT";
     case no_outofline: return "OUTOFLINE";
+    case no_inline: return "INLINE";
     case no_dedup: return "DEDUP";
     case no_enth: return "ENTH";
     case no_sample: return "SAMPLE";
@@ -1756,7 +1757,7 @@ const char *getOpString(node_operator op)
 
     case no_unused6:
     case no_unused13: case no_unused14: case no_unused15:
-    case no_unused32: case no_unused33: case no_unused34: case no_unused35: case no_unused36: case no_unused37: case no_unused38:
+    case no_unused33: case no_unused34: case no_unused35: case no_unused36: case no_unused37: case no_unused38:
     case no_unused40: case no_unused41: case no_unused42: case no_unused43: case no_unused44: case no_unused45: case no_unused46: case no_unused47: case no_unused48: case no_unused49:
     case no_unused50: case no_unused52:
     case no_unused80:
@@ -2233,6 +2234,7 @@ childDatasetType getChildDatasetType(IHqlExpression * expr)
     case no_thisnode:
     case no_sectioninput:
     case no_outofline:
+    case no_inline:
         if (expr->isDataset())
             return childdataset_dataset_noscope;
         return childdataset_none;
@@ -2570,6 +2572,7 @@ inline unsigned doGetNumChildTables(IHqlExpression * dataset)
     case no_thisnode:
     case no_sectioninput:
     case no_outofline:
+    case no_inline:
         if (dataset->isDataset())
             return 1;
         return 0;
@@ -2740,6 +2743,7 @@ bool definesColumnList(IHqlExpression * dataset)
     case no_sectioninput:
     case no_related:
     case no_outofline:
+    case no_inline:
     case no_fieldmap:
     case no_owned_ds:
         return false;
@@ -4996,6 +5000,7 @@ IHqlExpression *CHqlExpressionWithType::clone(HqlExprArray &newkids)
     switch (op)
     {
     case no_outofline:
+    case no_inline:
         return createWrapper(op, newkids);
     case no_embedbody:
         {
@@ -9339,6 +9344,7 @@ bool canBeDelayed(IHqlExpression * expr)
     case no_newkeyindex:
     case no_forwardscope:
     case no_type:
+    case no_inline:
         return false;
     case no_remotescope:
     case no_scope:
@@ -11531,8 +11537,10 @@ struct CallExpansionContext
             {
             case no_outofline:
                 return forceOutOfLineExpansion;
+            case no_inline:
+                return true;
             }
-            return true;
+            return expandNestedCalls;
         }
         return false;
     }
@@ -11701,7 +11709,7 @@ protected:
         }
 
         OwnedHqlExpr transformed = QuickHqlTransformer::createTransformedBody(expr);
-        if ((op == no_call) && ctx.expandNestedCalls)
+        if (op == no_call)
         {
             if (ctx.expandFunctionCall(transformed))
                 return expandFunctionCall(ctx, transformed);
@@ -11772,6 +11780,9 @@ IHqlExpression * ParameterBindTransformer::createBoundBody(IHqlExpression *funcd
                 newFuncdef.setown(completeTransform(funcdef, args));
                 break;
             }
+        case no_inline:
+            body = body->queryChild(0);
+            //fall through
         default:
             //No arguments to the function => transforming will do nothing
             if (actuals.ordinality() == 0)

--- a/ecl/hql/hqlexpr.hpp
+++ b/ecl/hql/hqlexpr.hpp
@@ -354,7 +354,7 @@ enum node_operator : unsigned short {
         no_critical,
         no_likely,
         no_unlikely,
-    no_unused32,
+        no_inline,
     no_unused33,
     no_unused34,
     no_unused35,

--- a/ecl/hql/hqlfold.cpp
+++ b/ecl/hql/hqlfold.cpp
@@ -6690,6 +6690,7 @@ HqlConstantPercolator * CExprFolderTransformer::gatherConstants(IHqlExpression *
     case no_executewhen:
     case no_callsideeffect:
     case no_outofline:
+    case no_inline:
     case no_owned_ds:
     case no_dataset_alias:
     case no_createdictionary:

--- a/ecl/hql/hqlgram.hpp
+++ b/ecl/hql/hqlgram.hpp
@@ -512,6 +512,7 @@ public:
     bool isSingleValuedExpressionList(const attribute & attr);
     bool convertAllToAttribute(attribute &atr);
     IHqlExpression * convertToOutOfLineFunction(const ECLlocation & errpos, IHqlExpression  * expr);
+    IHqlExpression * convertToInlineFunction(const ECLlocation & errpos, IHqlExpression  * expr);
 
     void ensureBoolean(attribute &a);
     void ensureDataset(attribute & attr);
@@ -805,6 +806,7 @@ protected:
     void normalizeStoredNameExpression(attribute & a);
     void checkPatternFailure(attribute & attr);
     void checkDistributer(const ECLlocation & errPos, HqlExprArray & args);
+    void checkConcreteRecord(attribute & cur);
     IHqlExpression * createScopedSequenceExpr();
     IHqlExpression * createPatternOr(HqlExprArray & args, const attribute & errpos);
     IHqlExpression * mapAlienArg(IHqlSimpleScope * scope, IHqlExpression * expr);

--- a/ecl/hql/hqlgram.y
+++ b/ecl/hql/hqlgram.y
@@ -1008,6 +1008,13 @@ goodObject
                             OwnedHqlExpr value = $2.getExpr();
                             $$.setExpr(parser->convertToOutOfLineFunction($2.pos, value), $1);
                         }
+    | INLINE goodObject
+                        {
+                            //Ugly internal unsupported syntax for defining an out of line function
+                            //Needs a lot more work.
+                            OwnedHqlExpr value = $2.getExpr();
+                            $$.setExpr(parser->convertToInlineFunction($2.pos, value), $1);
+                        }
     ;
 
 goodTypeObject
@@ -4198,6 +4205,8 @@ recordDef
     | simpleRecord
     | recordDef AND recordDef
                         {
+                            parser->checkConcreteRecord($1);
+                            parser->checkConcreteRecord($3);
                             OwnedHqlExpr left = $1.getExpr();
                             OwnedHqlExpr right = $3.getExpr();
                             $$.setExpr(parser->createRecordIntersection(left, right, $1));
@@ -4206,6 +4215,8 @@ recordDef
                         }
     | recordDef OR recordDef
                         {
+                            parser->checkConcreteRecord($1);
+                            parser->checkConcreteRecord($3);
                             OwnedHqlExpr left = $1.getExpr();
                             OwnedHqlExpr right = $3.getExpr();
                             $$.setExpr(parser->createRecordUnion(left, right, $1));
@@ -4213,6 +4224,8 @@ recordDef
                         }
     | recordDef '-' recordDef
                         {
+                            parser->checkConcreteRecord($1);
+                            parser->checkConcreteRecord($3);
                             OwnedHqlExpr left = $1.getExpr();
                             OwnedHqlExpr right = $3.getExpr();
                             $$.setExpr(parser->createRecordDifference(left, right, $1));
@@ -4221,6 +4234,7 @@ recordDef
                         }
     | recordDef '-' UNKNOWN_ID
                         {
+                            parser->checkConcreteRecord($1);
                             OwnedHqlExpr left = $1.getExpr();
                             OwnedHqlExpr right = createId($3.getId());
                             $$.setExpr(parser->createRecordExcept(left, right, $1));
@@ -4229,6 +4243,7 @@ recordDef
                         }
     | recordDef '-' '[' UnknownIdList ']'
                         {
+                            parser->checkConcreteRecord($1);
                             OwnedHqlExpr left = $1.getExpr();
                             OwnedHqlExpr right = $4.getExpr();
                             $$.setExpr(parser->createRecordExcept(left, right, $1));
@@ -4237,6 +4252,8 @@ recordDef
                         }
     | recordDef AND NOT recordDef
                         {
+                            parser->checkConcreteRecord($1);
+                            parser->checkConcreteRecord($4);
                             OwnedHqlExpr left = $1.getExpr();
                             OwnedHqlExpr right = $4.getExpr();
                             $$.setExpr(parser->createRecordDifference(left, right, $1));
@@ -4245,6 +4262,7 @@ recordDef
                         }
     | recordDef AND NOT UNKNOWN_ID
                         {
+                            parser->checkConcreteRecord($1);
                             OwnedHqlExpr left = $1.getExpr();
                             OwnedHqlExpr right = createId($4.getId());
                             $$.setExpr(parser->createRecordExcept(left, right, $1));
@@ -4253,6 +4271,7 @@ recordDef
                         }
     | recordDef AND NOT '[' UnknownIdList ']'
                         {
+                            parser->checkConcreteRecord($1);
                             OwnedHqlExpr left = $1.getExpr();
                             OwnedHqlExpr right = $5.getExpr();
                             $$.setExpr(parser->createRecordExcept(left, right, $1));

--- a/ecl/hql/hqlgram2.cpp
+++ b/ecl/hql/hqlgram2.cpp
@@ -900,6 +900,16 @@ IHqlExpression * HqlGram::convertToOutOfLineFunction(const ECLlocation & errpos,
     return LINK(expr);
 }
 
+IHqlExpression * HqlGram::convertToInlineFunction(const ECLlocation & errpos, IHqlExpression  * expr)
+{
+    if (expr->getOperator() != no_inline)
+    {
+        if (queryParametered())
+            return createWrapper(no_inline, LINK(expr));
+    }
+    return LINK(expr);
+}
+
 IHqlExpression * HqlGram::processEmbedBody(const attribute & errpos, IHqlExpression * embedText, IHqlExpression * language, IHqlExpression *attribs)
 {
     HqlExprArray args;
@@ -1748,7 +1758,8 @@ IHqlExpression * HqlGram::forceEnsureExprType(IHqlExpression * expr, ITypeInfo *
 {
     //Ensure the no_outofline remains the top most node.  I suspect this casting should occur much earlier
     //or the out of line node should be added much later.
-    if (expr->getOperator() == no_outofline)
+    node_operator op = expr->getOperator();
+    if ((op == no_outofline) || (op == no_inline))
     {
         HqlExprArray args;
         args.append(*forceEnsureExprType(expr->queryChild(0), type));
@@ -7581,6 +7592,21 @@ static void unwindExtraFields(HqlExprArray & fields, IHqlExpression * expr)
     }
 }
 
+
+void HqlGram::checkConcreteRecord(attribute & cur)
+{
+    IHqlExpression * record = cur.queryExpr();
+    if (record->getOperator() != no_record)
+    {
+        OwnedHqlExpr bad = cur.getExpr();
+        if (!bad->isFullyBound())
+            reportError(ERR_CONCRETE_RECORD, cur, "Record cannot contain unresolved function calls");
+        else
+            reportError(ERR_CONCRETE_RECORD, cur, "Expected a concrete record");
+
+        cur.setExpr(LINK(bad->queryRecord()));
+    }
+}
 
 IHqlExpression * HqlGram::createRecordUnion(IHqlExpression * left, IHqlExpression * right, const attribute & errpos)
 {

--- a/ecl/hql/hqlir.cpp
+++ b/ecl/hql/hqlir.cpp
@@ -288,7 +288,7 @@ const char * getOperatorIRText(node_operator op)
     EXPAND_CASE(no,critical);
     EXPAND_CASE(no,likely);
     EXPAND_CASE(no,unlikely);
-    EXPAND_CASE(no,unused32);
+    EXPAND_CASE(no,inline);
     EXPAND_CASE(no,unused33);
     EXPAND_CASE(no,unused34);
     EXPAND_CASE(no,unused35);

--- a/ecl/hql/hqlmeta.cpp
+++ b/ecl/hql/hqlmeta.cpp
@@ -2063,6 +2063,7 @@ CHqlMetaProperty * querySimpleDatasetMeta(IHqlExpression * expr)
     case no_related:
     case no_executewhen:
     case no_outofline:
+    case no_inline:
     case no_fieldmap:
     case no_owned_ds:
     case no_dataset_alias:
@@ -2177,6 +2178,7 @@ void calculateDatasetMeta(CHqlMetaInfo & meta, IHqlExpression * expr)
     case no_related:
     case no_executewhen:
     case no_outofline:
+    case no_inline:
     case no_fieldmap:
     case no_owned_ds:
     case no_dataset_alias:
@@ -3373,6 +3375,7 @@ ITypeInfo * calculateDatasetType(node_operator op, const HqlExprArray & parms)
     case no_related:
     case no_executewhen:
     case no_outofline:
+    case no_inline:
     case no_fieldmap:
     case no_owned_ds:
     case no_dataset_alias:

--- a/ecl/hql/hqlpmap.cpp
+++ b/ecl/hql/hqlpmap.cpp
@@ -335,6 +335,7 @@ bool NewProjectMapper2::ensureMapping()
     case no_none:
     case no_externalcall:
     case no_outofline:
+    case no_inline:
     case no_attr:
         return false;              // avoid internal error when values not provided for a record structure
     default:

--- a/ecl/hql/hqlthql.cpp
+++ b/ecl/hql/hqlthql.cpp
@@ -2607,6 +2607,7 @@ void HqltHql::toECL(IHqlExpression *expr, StringBuffer &s, bool paren, bool inTy
         case no_alias:
         case no_activerow:
         case no_outofline:
+        case no_inline:
             if (expandProcessed)
                 defaultToECL(expr, s, inType);
             else

--- a/ecl/hql/hqlutil.cpp
+++ b/ecl/hql/hqlutil.cpp
@@ -4926,7 +4926,7 @@ void getStoredDescription(StringBuffer & text, IHqlExpression * sequence, IHqlEx
             break;
         case ResultSequenceInternal:
             text.append("Internal");
-            if (includeInternalName)
+            if (includeInternalName && name)
                 name->toString(text.append("(")).append(")");
             break;
         default:

--- a/ecl/regress/issue14052.ecl
+++ b/ecl/regress/issue14052.ecl
@@ -9,7 +9,7 @@ derived1 := {
   unsigned4 doc_id;
 };
 
-inline := dataset([
+inlineDs := dataset([
    {1,u'one',3,u'three',3}
   ,{2,u'two',4,u'four',4}
   ,{3,u'three',5,u'five',5}
@@ -48,7 +48,7 @@ getStuff(dataset(derived1) ds1) := function
   return ret;
 end;
 
-example := getStuff(inline);
+example := getStuff(inlineDs);
 
 // example.debugger;  // works if not commented
 output(example.finalout,all);

--- a/ecl/regress/issue17931.ecl
+++ b/ecl/regress/issue17931.ecl
@@ -1,0 +1,31 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2017 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+w(unsigned i) := INLINE MODULE
+   export v := i * 10;
+END;
+
+x(unsigned i) := INLINE MODULE
+    export y := w(i).v * 2;
+END;
+
+r := record,maxlength(x(10).y)
+    unsigned i;
+end;
+
+ds := dataset('x', r, THOR);
+output(ds);


### PR DESCRIPTION
Signed-off-by: Gavin Halliday <gavin.halliday@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [x] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [x] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [ ] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [x] I have added tests to cover my changes.
  - [x] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
