### PR TITLE
HPCC-18263 Avoid crashes with very large type conversions

### DIFF
--- a/rtl/eclrtl/eclrtl.cpp
+++ b/rtl/eclrtl/eclrtl.cpp
@@ -796,9 +796,12 @@ char * rtlInt8ToVStrX(__int64 val)
 
 //---------------------------------------------------------------------------
 
+static const unsigned largeAllocaThreshold = 1024*10;
+#define CONDSTACKALLOC(MA, SZ) ((SZ>largeAllocaThreshold) ? MA.allocate(SZ) : alloca(SZ))
 double rtlStrToReal(size32_t l, const char * t)
 {
-    char * temp = (char *)alloca(l+1);
+    MemoryAttr heapMem;
+    char * temp = (char *)CONDSTACKALLOC(heapMem, l+1);
     memcpy(temp, t, l);
     temp[l] = 0;
     return rtlVStrToReal(temp);
@@ -806,10 +809,9 @@ double rtlStrToReal(size32_t l, const char * t)
 
 double rtlEStrToReal(size32_t l, const char * t)
 {
-    char * astr = (char*)alloca(l);
-    rtlEStrToStr(l,astr,l,t);
-    char * temp = (char *)alloca(l+1);
-    memcpy(temp, astr, l);
+    MemoryAttr heapMem;
+    char * temp = (char *)CONDSTACKALLOC(heapMem, l+1);
+    rtlEStrToStr(l,temp,l,t);
     temp[l] = 0;
     return rtlVStrToReal(temp);
 }
@@ -822,11 +824,7 @@ double rtlVStrToReal(const char * t)
 
 double rtl_ex2f(const char * t)
 {
-    unsigned len = strlen(t);
-    char * astr = (char*)alloca(len+1);
-    rtlEStrToStr(len,astr,len,t);
-    astr[len] = 0;
-    return rtlVStrToReal(astr);
+    return rtlEStrToReal(strlen(t), t);
 }
 
 double rtlUnicodeToReal(size32_t l, UChar const * t)
@@ -1095,35 +1093,40 @@ bool rtlCsvStrToBool(size32_t l, const char * t)
 
 unsigned rtlEStrToUInt4(size32_t l, const char * t)
 {
-    char * astr = (char*)alloca(l);
+    MemoryAttr heapMem;
+    char * astr = (char *)CONDSTACKALLOC(heapMem, l);
     rtlEStrToStr(l,astr,l,t);
     return rtlStrToUInt4(l,astr);
 }
 
 unsigned __int64 rtlEStrToUInt8(size32_t l, const char * t)
 {
-    char * astr = (char*)alloca(l);
+    MemoryAttr heapMem;
+    char * astr = (char *)CONDSTACKALLOC(heapMem, l);
     rtlEStrToStr(l,astr,l,t);
     return rtlStrToUInt8(l,astr);
 }
 
 int rtlEStrToInt4(size32_t l, const char * t)
 {
-    char * astr = (char*)alloca(l);
+    MemoryAttr heapMem;
+    char * astr = (char *)CONDSTACKALLOC(heapMem, l);
     rtlEStrToStr(l,astr,l,t);
     return rtlStrToInt4(l,astr);
 }
 
 __int64 rtlEStrToInt8(size32_t l, const char * t)
 {
-    char * astr = (char*)alloca(l);
+    MemoryAttr heapMem;
+    char * astr = (char *)CONDSTACKALLOC(heapMem, l);
     rtlEStrToStr(l,astr,l,t);
     return rtlStrToInt8(l,astr);
 }
 
 bool rtl_en2b(size32_t l, const char * t)
 {
-    char * astr = (char*)alloca(l);
+    MemoryAttr heapMem;
+    char * astr = (char *)CONDSTACKALLOC(heapMem, l);
     rtlEStrToStr(l,astr,l,t);
     return rtlStrToBool(l,astr);
 }
@@ -3521,7 +3524,8 @@ char * rtlStrToVStrX(unsigned slen, const void * src)
 
 char * rtlEStrToVStrX(unsigned slen, const char * src)
 {
-    char * astr = (char*)alloca(slen);
+    MemoryAttr heapMem;
+    char * astr = (char *)CONDSTACKALLOC(heapMem, slen);
     rtlEStrToStr(slen,astr,slen,src);
     return rtlStrToVStrX(slen, astr);
 }


### PR DESCRIPTION
Avoid using stack for very large real and EBCDIC conversions.
Also spotted an optimization in rtlEStrToReal, where it was doing an unecessary allocation.

Signed-off-by: Jake Smith <jake.smith@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

Tested rtlEStrToReal in query from user that raised the issue.
A full regression run/passed.

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
