### PR TITLE
HPCC-18269 Avoid repeatedly processing long CSV line text.

### DIFF
--- a/common/thorhelper/csvsplitter.hpp
+++ b/common/thorhelper/csvsplitter.hpp
@@ -56,6 +56,8 @@
  * Also, many CSV producers (including commercial databases) use slash (\) as escaping
  * char, while the RFC mentions re-using quotes (""). We implement both.
  */
+
+interface ISerialStream;
 class THORHELPER_API CSVSplitter
 {
 public:
@@ -70,6 +72,7 @@ public:
     void init(unsigned maxColumns, ICsvParameters * csvInfo, const char * dfsQuotes, const char * dfsSeparators, const char * dfsTerminators, const char * dfsEscapes);
     void reset();
     size32_t splitLine(size32_t maxLen, const byte * start);
+    size32_t splitLine(ISerialStream *stream, size32_t maxRowSize);
 
     inline unsigned * queryLengths() { return lengths; }
     inline const byte * * queryData() { return data; }

--- a/ecl/hthor/hthor.cpp
+++ b/ecl/hthor/hthor.cpp
@@ -9002,28 +9002,9 @@ const void *CHThorCsvReadActivity::nextRow()
         checkOpenNext();
         if (eofseen)
             break;
-        if (!inputstream->eos())
+        size32_t thisLineLength = csvSplitter.splitLine(inputstream, maxRowSize);
+        if (thisLineLength)
         {
-            size32_t rowSize = 4096; // MORE - make configurable
-            size32_t thisLineLength;
-            for (;;)
-            {
-                size32_t avail;
-                const void *peek = inputstream->peek(rowSize, avail);
-                thisLineLength = csvSplitter.splitLine(avail, (const byte *)peek);
-                if (thisLineLength < rowSize || avail < rowSize)
-                    break;
-                if (rowSize == maxRowSize)
-                {
-                    OwnedRoxieString fileName(helper.getFileName());
-                    throw MakeStringException(99, "File %s contained a line of length greater than %d bytes.", fileName.get(), rowSize);
-                }
-                if (rowSize >= maxRowSize/2)
-                    rowSize = maxRowSize;
-                else
-                    rowSize += rowSize;
-            }
-
             RtlDynamicRowBuilder rowBuilder(rowAllocator);
             unsigned thisSize;
             try

--- a/roxie/ccd/ccdactivities.cpp
+++ b/roxie/ccd/ccdactivities.cpp
@@ -1600,28 +1600,8 @@ public:
         csvSplitter.init(helper->getMaxColumns(), csvInfo, quotes, separators, terminators, escapes);
         while (!aborted)
         {
-            // MORE - there are rumours of a  csvSplitter that operates on a stream... if/when it exists, this should use it
-            if (reader->eos())
-            {
-                break;
-            }
-            size32_t rowSize = 4096; // MORE - make configurable
-            size32_t thisLineLength;
-            for (;;)
-            {
-                size32_t avail;
-                const void *peek = reader->peek(rowSize, avail);
-                thisLineLength = csvSplitter.splitLine(avail, (const byte *)peek);
-                if (thisLineLength < rowSize || avail < rowSize)
-                    break;
-                if (rowSize == maxRowSize)
-                    throw MakeStringException(0, "File contained a line of length greater than %d bytes.", maxRowSize);
-                if (rowSize >= maxRowSize/2)
-                    rowSize = maxRowSize;
-                else
-                    rowSize += rowSize;
-            }
-            if (!thisLineLength)
+            size32_t thisLineLength = csvSplitter.splitLine(reader, maxRowSize);
+            if (0 == thisLineLength)
                 break;
             if (headerLines)
             {

--- a/thorlcr/activities/fetch/thfetchslave.cpp
+++ b/thorlcr/activities/fetch/thfetchslave.cpp
@@ -562,23 +562,8 @@ public:
         Owned<ISerialStream> inputStream = createFileSerialStream(partIO, localFpos);
         if (inputStream->eos())
             return 0;
-        size32_t minRequired = 4096; // MORE - make configurable
         size32_t maxRowSize = 10*1024*1024; // MORE - make configurable
-        size32_t thisLineLength;
-        for (;;)
-        {
-            size32_t avail;
-            const void *peek = inputStream->peek(minRequired, avail);
-            thisLineLength = csvSplitter.splitLine(avail, (const byte *)peek);
-            if (thisLineLength < minRequired || avail < minRequired)
-                break;
-            if (minRequired == maxRowSize)
-                throw MakeActivityException(this, 0, "CSV fetch line of length greater than %d bytes.", minRequired);
-            if (minRequired >= maxRowSize/2)
-                minRequired = maxRowSize;
-            else
-                minRequired += minRequired;
-        }
+        size32_t thisLineLength = csvSplitter.splitLine(inputStream, maxRowSize);
         return ((IHThorCsvFetchArg *)fetchBaseHelper)->transform(rowBuilder, csvSplitter.queryLengths(), (const char * *)csvSplitter.queryData(), keyRow, localFpos);
     }
     virtual void onLimitExceeded()


### PR DESCRIPTION
The CSV reading code that processed long lines had a bug in it
that caused it to re-process text too many times when trying to
read to the end of the line.
Instead of asking for more than had been returned by the last
read call, it asked for double what it had previously asked for.
Which was usually a lot smaller than what had been returned.
Consequently, the loop would spin for a while re-processing the
partial CSV line until the amount asked for actually exceeded the
amount available.

Also commoned up code into a stream reading method.

Signed-off-by: Jake Smith <jake.smith@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [x] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

Full regression suite runs (all engines) run/passed.
Performance testing a fairly pathological case - 10,000 records, 1MB each:
Without fix : 359 seconds (avg. of 3 runs)
With fix      : 85 seconds (avg. of 3 runs)

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
