### PR TITLE
HPCC-18279 Prevent deadlock dealing with super CSV's with HEADING

### DIFF
--- a/thorlcr/activities/csvread/thcsvrslave.cpp
+++ b/thorlcr/activities/csvread/thcsvrslave.cpp
@@ -284,6 +284,16 @@ class CCsvReadSlaveActivity : public CDiskReadSlaveActivityBase
         CMessageBuffer msgMb;
         msgMb.append(subFile);
         msgMb.append(headerLinesRemaining[subFile]);
+        // inform next slave about all subfiles I'm not dealing with.
+        for (unsigned s=0; s<subFiles; s++)
+        {
+            if (NotFound == localLastPart[s])
+            {
+                sentHeaderLines->testSet(s);
+                msgMb.append(s);
+                msgMb.append(headerLinesRemaining[s]);
+            }
+        }
         queryJobChannel().queryJobComm().send(msgMb, queryJobChannel().queryMyRank()+1, mpTag);
     }
     void sendRemainingHeaderLines()
@@ -347,7 +357,9 @@ public:
             mpTag = container.queryJobChannel().deserializeMPTag(data);
             data.read(subFiles);
             superFDesc = partDescs.ordinality() ? partDescs.item(0).queryOwner().querySuperFileDescriptor() : NULL;
-            localLastPart.allocateN(subFiles, true);
+            localLastPart.allocateN(subFiles);
+            for (unsigned llp=0; llp<subFiles; llp++)
+                localLastPart[llp] = NotFound;
             ForEachItemIn(p, partDescs)
             {
                 IPartDescriptor &partDesc = partDescs.item(p);
@@ -360,7 +372,7 @@ public:
                         throw MakeActivityException(this, 0, "mapSubPart failed, file=%s, partnum=%d", logicalFilename.get(), pnum);
                     pnum = lnum;
                 }
-                if (pnum > localLastPart[subFile]) // don't think they can really be out of order
+                if ((NotFound == localLastPart[subFile]) || (pnum > localLastPart[subFile])) // don't think they can really be out of order
                     localLastPart[subFile] = pnum;
             }
             headerLinesRemaining.allocateN(subFiles);


### PR DESCRIPTION
If reading a CSV super file with a HEADING specification where the
subfiles width mismatches the cluster width the query is running
on, a deadlock can occur.

Signed-off-by: Jake Smith <jake.smith@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

Reproduced in a self-contained example (attached to JIRA)
Run regression suites.

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
