### PR TITLE
HPCC-18297 Prevent choosen recalling input nextRow after stop

### DIFF
--- a/thorlcr/activities/csvread/thcsvrslave.cpp
+++ b/thorlcr/activities/csvread/thcsvrslave.cpp
@@ -392,21 +392,24 @@ public:
     CATCH_NEXTROW()
     {
         ActivityTimer t(totalCycles, timeActivities);
-        OwnedConstThorRow row = out->nextRow();
-        if (row)
+        if (out)
         {
-            rowcount_t c = getDataLinkCount();
-            if (0 == stopAfter || (c < stopAfter)) // NB: only slave limiter, global performed in chained choosen activity
+            OwnedConstThorRow row = out->nextRow();
+            if (row)
             {
-                if (c < limit) // NB: only slave limiter, global performed in chained limit activity
+                rowcount_t c = getDataLinkCount();
+                if (0 == stopAfter || (c < stopAfter)) // NB: only slave limiter, global performed in chained choosen activity
                 {
-                    dataLinkIncrement();
-                    return row.getClear();
+                    if (c < limit) // NB: only slave limiter, global performed in chained limit activity
+                    {
+                        dataLinkIncrement();
+                        return row.getClear();
+                    }
+                    helper->onLimitExceeded();
                 }
-                helper->onLimitExceeded();
             }
+            sendRemainingHeaderLines();
         }
-        sendRemainingHeaderLines();
         return NULL;
     }
     virtual void start()

--- a/thorlcr/activities/firstn/thfirstnslave.cpp
+++ b/thorlcr/activities/firstn/thfirstnslave.cpp
@@ -41,6 +41,11 @@ public:
         helper = (IHThorFirstNArg *)container.queryHelper();
         appendOutputLinked(this);
     }
+    void doStopInput()
+    {
+        stopInput(0);
+        abortSoon = true;
+    }
     virtual void start() override
     {
         ActivityTimer s(totalCycles, timeActivities);
@@ -100,7 +105,7 @@ public:
                     OwnedConstThorRow row = inputStream->ungroupedNextRow();
                     if (!row)
                     {
-                        stopInput(0);
+                        doStopInput();
                         return NULL;
                     }
                     skipped++;
@@ -115,7 +120,7 @@ public:
                     return row.getClear();
                 }
             }
-            stopInput(0); // NB: really whatever is pulling, should stop asap.
+            doStopInput(); // NB: really whatever is pulling, should stop asap.
         }
         return NULL;
     }
@@ -160,7 +165,7 @@ public:
                         {
                             if (0 == skipped)
                             {
-                                stopInput(0);
+                                doStopInput();
                                 return NULL;
                             }
                             skipped = 0; // reset, skip group
@@ -179,7 +184,7 @@ public:
                     }
                     else if (0 == countThisGroup && 0==skipCount)
                     {
-                        stopInput(0);
+                        doStopInput();
                         return NULL;
                     }
                 }
@@ -333,7 +338,7 @@ public:
                     OwnedConstThorRow row = inputStream->ungroupedNextRow();
                     if (!row)
                     {
-                        stopInput(0);
+                        doStopInput();
                         return NULL;
                     }
                     skipped++;
@@ -356,7 +361,7 @@ public:
                     sendCount();
                 }
             }
-            stopInput(0); // NB: really whatever is pulling, should stop asap.
+            doStopInput(); // NB: really whatever is pulling, should stop asap.
         }
         return NULL;
     }


### PR DESCRIPTION
CSV nextRow crashed if recalled after it had been stop.
It was being recalled after the choosen activity had hit the
limit, but an upstream activity recalled and firstn recalled
it's input.
Prevent choosen recalling input after stopped and protect
CSV nextRow if ever called after stop.

Signed-off-by: Jake Smith <jake.smith@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

Self-contained example that reproduced the problem in JIRA and used to test fix.
Passed full regression suite.

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
