### PR TITLE
HPCC-18102 Fix Coverity warning for calling handleExceptions()

### DIFF
--- a/esp/bindings/http/platform/httptransport.cpp
+++ b/esp/bindings/http/platform/httptransport.cpp
@@ -2446,3 +2446,9 @@ bool CHttpResponse::handleExceptions(IXslProcessor *xslp, IMultiException *me, c
     }
     return false;
 }
+
+void CHttpResponse::handleExceptions(IXslProcessor *xslp, IMultiException *me, const char *serv, const char *meth, const char *errorXslt, bool logHandleExceptions)
+{
+    if (handleExceptions(xslp, me, serv, meth, errorXslt) && logHandleExceptions)
+        PROGLOG("Exception(s) handled");
+}

--- a/esp/bindings/http/platform/httptransport.ipp
+++ b/esp/bindings/http/platform/httptransport.ipp
@@ -370,6 +370,7 @@ public:
 
     virtual bool httpContentFromFile(const char *filepath);
     virtual bool handleExceptions(IXslProcessor *xslp, IMultiException *me, const char *serv, const char *meth, const char *errorXslt);
+    virtual void handleExceptions(IXslProcessor *xslp, IMultiException *me, const char *serv, const char *meth, const char *errorXslt, bool logHandleExceptions);
 
     virtual void redirect(CHttpRequest &req, const char *url)
     {

--- a/esp/services/esdl_svc_engine/esdl_binding.cpp
+++ b/esp/services/esdl_svc_engine/esdl_binding.cpp
@@ -1847,7 +1847,7 @@ int EsdlBindingImpl::onGet(CHttpRequest* request, CHttpResponse* response)
         me->append(*MakeStringExceptionDirect(-1, "Unknown Exception"));
     }
 
-    response->handleExceptions(getXslProcessor(), me, "DynamicESDL", "", StringBuffer(getCFD()).append("./smc_xslt/exceptions.xslt").str());
+    response->handleExceptions(getXslProcessor(), me, "DynamicESDL", "", StringBuffer(getCFD()).append("./smc_xslt/exceptions.xslt").str(), false);
     return 0;
 }
 

--- a/esp/services/ws_ecl/ws_ecl_service.cpp
+++ b/esp/services/ws_ecl/ws_ecl_service.cpp
@@ -2565,7 +2565,7 @@ int CWsEclBinding::onGet(CHttpRequest* request, CHttpResponse* response)
         me->append(*MakeStringExceptionDirect(-1, "Unknown Exception"));
     }
     
-    response->handleExceptions(getXslProcessor(), me, "WsEcl", "", StringBuffer(getCFD()).append("./smc_xslt/exceptions.xslt").str());
+    response->handleExceptions(getXslProcessor(), me, "WsEcl", "", StringBuffer(getCFD()).append("./smc_xslt/exceptions.xslt").str(), false);
     return 0;
 }
 

--- a/esp/services/ws_fs/ws_fsBinding.cpp
+++ b/esp/services/ws_fs/ws_fsBinding.cpp
@@ -162,7 +162,7 @@ int CFileSpraySoapBindingEx::onGetInstantQuery(IEspContext &context, CHttpReques
 
                         Owned<IMultiException> me = MakeMultiException();
                         me->append(*E);
-                        response->handleExceptions(xslp, me, "FileSpray", method, StringBuffer(getCFD()).append("./smc_xslt/exceptions.xslt").str());
+                        response->handleExceptions(xslp, me, "FileSpray", method, StringBuffer(getCFD()).append("./smc_xslt/exceptions.xslt").str(), false);
                         return 0;
                     }
                 }
@@ -511,7 +511,7 @@ int CFileSpraySoapBindingEx::onFinishUpload(IEspContext &ctx, CHttpRequest* requ
         StringBuffer msg;
         WARNLOG("Exception(s) in EspHttpBinding::onStartUpload - %s", me->errorMessage(msg).append('\n').str());
         if ((ctx.getResponseFormat() == ESPSerializationXML) || (ctx.getResponseFormat() == ESPSerializationJSON))
-            response->handleExceptions(NULL, me, "FileSpray", "UploadFile", NULL);
+            response->handleExceptions(NULL, me, "FileSpray", "UploadFile", NULL, false);
         else
             return EspHttpBinding::onFinishUpload(ctx, request, response, service, method, fileNames, files, me);
     }

--- a/esp/services/ws_packageprocess/ws_packageprocessService.cpp
+++ b/esp/services/ws_packageprocess/ws_packageprocessService.cpp
@@ -1402,7 +1402,7 @@ int CWsPackageProcessSoapBindingEx::onFinishUpload(IEspContext &ctx, CHttpReques
         WARNLOG("Exception(s) in EspHttpBinding::onFinishUpload - %s", meIn->errorMessage(msg).append('\n').str());
         if ((ctx.getResponseFormat() == ESPSerializationXML) || (ctx.getResponseFormat() == ESPSerializationJSON))
         {
-            response->handleExceptions(NULL, meIn, "FileSpray", "UploadFile", NULL);
+            response->handleExceptions(NULL, meIn, "FileSpray", "UploadFile", NULL, false);
             return 0;
         }
         else


### PR DESCRIPTION
The existing code got Coverity warning: Calling "handleExceptions"
without checking return value. In this fix, a wrapper function is
created which doesn't return anything.

Signed-off-by: wangkx <kevin.wang@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
