### PR TITLE
HPCC-11822 Add new code to access archived workunits with paging

### DIFF
--- a/dali/sasha/sacmd.cpp
+++ b/dali/sasha/sacmd.cpp
@@ -22,8 +22,10 @@ class CSashaCommand: public CInterface, implements ISashaCommand
     CDateTime *dts;
     unsigned numdts;
 
-    StringAttr after;
-    StringAttr before;
+    StringAttr after; //datetime
+    StringAttr before; //datetime
+    StringAttr afterWU;
+    StringAttr beforeWU;
     StringAttr state;
     StringAttr owner;
     StringAttr cluster;
@@ -107,6 +109,11 @@ public:
         }
         mb.read(after);
         mb.read(before);
+        if (action == SCA_LISTSORTED)
+        {
+            mb.read(afterWU);
+            mb.read(beforeWU);
+        }
         mb.read(state);
         mb.read(owner);
         mb.read(cluster);
@@ -164,6 +171,11 @@ public:
             mb.append(ids.item(i).text);
         mb.append(after);
         mb.append(before);
+        if (action == SCA_LISTSORTED)
+        {
+            mb.append(afterWU);
+            mb.append(beforeWU);
+        }
         mb.append(state);
         mb.append(owner);
         mb.append(cluster);
@@ -278,6 +290,26 @@ public:
     void setBefore(const char *val)
     {
         before.set(val);
+    }
+
+    const char *queryAfterWU()
+    {
+        return retstr(afterWU);
+    }
+
+    void setAfterWU(const char *val)
+    {
+        afterWU.set(val);
+    }
+
+    const char *queryBeforeWU()
+    {
+        return retstr(beforeWU);
+    }
+
+    void setBeforeWU(const char *val)
+    {
+        beforeWU.set(val);
     }
 
     const char *queryState()

--- a/dali/sasha/sacmd.hpp
+++ b/dali/sasha/sacmd.hpp
@@ -15,7 +15,8 @@ enum SashaCommandAction
     SCA_COALESCE_SUSPEND,
     SCA_COALESCE_RESUME,
     SCA_WORKUNIT_SERVICES_GET,
-    SCA_LISTDT
+    SCA_LISTDT,
+    SCA_LISTSORTED
 };
 
 
@@ -35,6 +36,10 @@ interface ISashaCommand: extends IInterface
     virtual void setAfter(const char *val) = 0;
     virtual const char *queryBefore() = 0;
     virtual void setBefore(const char *val) = 0;
+    virtual const char *queryAfterWU() = 0;
+    virtual void setAfterWU(const char *val) = 0;
+    virtual const char *queryBeforeWU() = 0;
+    virtual void setBeforeWU(const char *val) = 0;
     virtual const char *queryState() = 0;
     virtual void setState(const char *val) = 0;
     virtual const char *queryOwner() = 0;

--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -437,9 +437,11 @@ ESPrequest [nil_remove] WUQueryRequest
     [depr_ver("1.57")] string ApplicationKey;
     [depr_ver("1.57")] string ApplicationData;
     [min_ver("1.57")] ESParray<ESPstruct ApplicationValue> ApplicationValues;
+    [min_ver("1.71")] string BeforeWU;
+    [min_ver("1.71")] string AfterWU;
 
-    string After;
-    string Before;
+    [depr_ver("1.02")] string After; //Not used since 1.02
+    [depr_ver("1.02")] string Before; //Not used since 1.02
     int Count;
     [min_ver("1.03")] int64 PageSize(0);
     [min_ver("1.03")] int64 PageStartFrom(0);
@@ -499,6 +501,8 @@ ESPrequest [nil_remove] WULightWeightQueryRequest
     string JobName;
     string StartDate;
     string EndDate;
+    [min_ver("1.71")] string BeforeWU;
+    [min_ver("1.71")] string AfterWU;
     string State;
 
     ESParray<ESPstruct ApplicationValue> ApplicationValues;
@@ -1933,7 +1937,7 @@ ESPresponse [exceptions_inline, nil_remove] WUGetNumFileToCopyResponse
 
 ESPservice [
     auth_feature("DEFERRED"), //This declares that the method logic handles feature level authorization
-    version("1.70"), default_client_version("1.70"),
+    version("1.71"), default_client_version("1.71"),
     noforms,exceptions_inline("./smc_xslt/exceptions.xslt"),use_method_name] WsWorkunits
 {
     ESPmethod [cache_seconds(60), resp_xsl_default("/esp/xslt/workunits.xslt")]     WUQuery(WUQueryRequest, WUQueryResponse);

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -2143,6 +2143,8 @@ class CArchivedWUsReader : public CInterface, implements IArchivedWUsReader
         addToFilterString("state", req.getState());
         addToFilterString("timeFrom", req.getStartDate());
         addToFilterString("timeTo", req.getEndDate());
+        addToFilterString("beforeWU", req.getBeforeWU());
+        addToFilterString("afterWU", req.getAfterWU());
         addToFilterString("pageStart", pageFrom);
         addToFilterString("pageSize", pageSize);
         if (sashaServerIP && *sashaServerIP)
@@ -2162,6 +2164,8 @@ class CArchivedWUsReader : public CInterface, implements IArchivedWUsReader
         addToFilterString("state", req.getState());
         addToFilterString("timeFrom", req.getStartDate());
         addToFilterString("timeTo", req.getEndDate());
+        addToFilterString("beforeWU", req.getBeforeWU());
+        addToFilterString("afterWU", req.getAfterWU());
         addToFilterString("pageStart", pageFrom);
         addToFilterString("pageSize", pageSize);
         if (sashaServerIP && *sashaServerIP)
@@ -2173,7 +2177,7 @@ class CArchivedWUsReader : public CInterface, implements IArchivedWUsReader
 
     void initSashaCommand(ISashaCommand* cmd)
     {
-        cmd->setAction(SCA_LIST);
+        cmd->setAction(SCA_LISTSORTED);
         cmd->setOutputFormat("owner,jobname,cluster,state");
         cmd->setOnline(false);
         cmd->setArchived(true);
@@ -2200,6 +2204,10 @@ class CArchivedWUsReader : public CInterface, implements IArchivedWUsReader
             cmd->setAfter(timeFrom.str());
         if (timeTo.length())
             cmd->setBefore(timeTo.str());
+        if (notEmpty(req.getBeforeWU()))
+            cmd->setBeforeWU(req.getBeforeWU());
+        if (notEmpty(req.getAfterWU()))
+            cmd->setAfterWU(req.getAfterWU());
         return;
     }
 


### PR DESCRIPTION
In saarch.cpp, WUiterateSorted() is added to retrieve archived workunits
sorted by WUID. The new code is based on sortDirectory(). The beforeWU/
afterWU and/or StartDate/EndDate are used to skip the directories which
store WUs not in the date range. The beforeWU/afterWU is also used to
skip the WUs which are not in the time range. The exisitng filters in
the WUiterate() are supported by WUiterateSorted().

WUiterateSorted() is used by WsWorkunits.WUQuery to access archived
workunits with paging. An ESP client may ask for next page by specifing
afterWU or ask for previous page by specifing beforeWU.

Signed-off-by: wangkx <kevin.wang@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
