### PR TITLE
HPCC-11822 Add new code to access archived workunits with paging

### DIFF
--- a/common/remote/hooks/git/gitfile.cpp
+++ b/common/remote/hooks/git/gitfile.cpp
@@ -227,6 +227,10 @@ public:
             return createGitRepositoryDirectoryIterator(dirName, mask, sub, includeDirs);
         }
     }
+    virtual IDirectoryIterator *directoryFilesSorted(SortDirectoryMode mode, bool rev, const char *mask, bool sub, bool includeDirs)
+    {
+        UNIMPLEMENTED;
+    }
     virtual bool getInfo(bool &isdir,offset_t &size,CDateTime &modtime)
     {
         isdir = isDir;

--- a/common/remote/hooks/libarchive/archive.cpp
+++ b/common/remote/hooks/libarchive/archive.cpp
@@ -385,6 +385,10 @@ public:
             return createArchiveDirectoryIterator(dirName, mask, sub, includeDirs);
         }
     }
+    virtual IDirectoryIterator *directoryFilesSorted(SortDirectoryMode mode, bool rev, const char *mask, bool sub, bool includeDirs)
+    {
+        UNIMPLEMENTED;
+    }
     virtual bool getInfo(bool &_isdir,offset_t &_size,CDateTime &_modtime)
     {
         _isdir = isDirectory()==foundYes;

--- a/common/remote/sockfile.cpp
+++ b/common/remote/sockfile.cpp
@@ -2015,6 +2015,11 @@ public:
         return ret;
     }
 
+    virtual IDirectoryIterator *directoryFilesSorted(SortDirectoryMode mode, bool rev, const char *mask,bool sub,bool includedirs)
+    {
+        UNIMPLEMENTED;
+    }
+
     IDirectoryDifferenceIterator *monitorDirectory(
                                   IDirectoryIterator *prev=NULL,    // in (NULL means use current as baseline)
                                   const char *mask=NULL,

--- a/dali/sasha/saarch.cpp
+++ b/dali/sasha/saarch.cpp
@@ -85,213 +85,343 @@ static void mkDateCompare(bool dfu,const char *dt,StringBuffer &out,char fill)
 
 void WUiterate(ISashaCommand *cmd, const char *mask)
 {
-    bool dfu = cmd->getDFU();
-    const char *beforedt = cmd->queryBefore();
-    const char *afterdt = cmd->queryAfter();
-    const char *owner = cmd->queryOwner();
-    const char *state = cmd->queryState();
-    const char *cluster = cmd->queryCluster();
-    const char *jobname = cmd->queryJobName();
-    const char *outputformat = cmd->queryOutputFormat();
-    const char *priority = cmd->queryPriority();
-    const char *fileread = cmd->queryFileRead();
-    const char *filewritten = cmd->queryFileWritten();
-    const char *eclcontains = cmd->queryEclContains();
-    const char *cmdname = cmd->queryDfuCmdName();
-    unsigned start = cmd->getStart(); 
-    unsigned num = cmd->getLimit();
-    StringBuffer before;
-    StringBuffer after;
-    StringBuffer tmppath;
-    mkDateCompare(dfu,afterdt,after,'0');
-    mkDateCompare(dfu,beforedt,before,'9');
-    bool haswusoutput = cmd->getAction()==SCA_WORKUNIT_SERVICES_GET;
-    bool hasdtoutput = cmd->getAction()==SCA_LISTDT;
-    MemoryBuffer WUSbuf;
-    if (haswusoutput)
-        cmd->setWUSresult(WUSbuf);  // swap in/out (in case ever do multiple)
+    class CWUData : public CInterface
+    {
+    public:
+        IMPLEMENT_IINTERFACE_USING(CInterface);
 
-    StringBuffer baseXPath = dfu ? "DFU/WorkUnits" : "WorkUnits";
-    Owned<IRemoteConnection> conn;
-    bool isWild = !mask || !*mask || isWildString(mask);
-    bool unfiltered = !mask || !*mask || (0==strcmp(mask,"*"));
-    if (cmd->getArchived()) {
-        // used to check not online
-        StringBuffer path;
-        if (dfu)
-            getLdsPath("Archive/DFUWorkUnits",path);
-        else
-            getLdsPath("Archive/WorkUnits",path);
-        Owned<IFile> dir = createIFile(path.str());
-        StringBuffer masktmp;
-        if (unfiltered&&after.length()&&before.length()) {
-            const char *lo = after.str();
-            const char *hi = before.str();
-            while (*lo&&(toupper(*lo)==toupper(*hi))) {
-                masktmp.append((char)toupper(*lo));
-                lo++;
-                hi++;
+        CWUData() { };
+
+        CDateTime modifiedTime;
+        Owned<IPropertyTree> wuTree;
+    };
+
+    class CWUReader : public CInterface
+    {
+        StringAttr owner, cluster, jobName, state, priority, eclContains, fileRead, fileWritten, cmdName;
+        StringBuffer mask, fromDT, toDT, fromDir, toDir, afterWU;
+        bool dfu, hasWUSOutput, outputModifiedTime, outputXML;
+        MemoryBuffer WUSbuf; //Not sure what this is.
+
+        void getMasks(const char *beforeWU, const char *afterWU, StringBuffer &dirMask, StringBuffer &fileMask)
+        {
+            //The fromDT and toDT are the filters which defines a search range.
+            //The afterWU (beforeWU) defines paging within the search range. 
+            //For the first page, a user may define the fromDT and/or toDT without afterWU or beforeWU.
+                    
+            StringBuffer from, to;
+            if (!isEmptyString(afterWU) && (fromDT.isEmpty() || (strcmp(afterWU, fromDT.str()) > 0)))
+                from.set(afterWU);
+            else if (!fromDT.isEmpty())
+                from.set(fromDT.str());
+            if (!isEmptyString(beforeWU) && (toDT.isEmpty() || (strcmp(beforeWU, toDT.str()) < 0)))
+                to.set(beforeWU);
+            else if (!toDT.isEmpty())
+                to.set(toDT.str());
+
+            if (!isEmptyString(from))
+                splitWUID(from, fromDir);
+            if (!isEmptyString(to))
+                splitWUID(to, toDir);
+
+            bool unfiltered = mask.isEmpty() || streq(mask.str(), "*");
+
+            //The following code is a clone of the pre-existing code. hmask -> dirMask. tmask -> fileMask.
+            //The dirMask is used to filter out the directories (ex: W20171010) which store archived WU files.
+            //The fileMask is used to filter out the WU files (ex: W20171010-101010*.xml).
+            StringBuffer masktmp;
+            if (unfiltered && !from.isEmpty() && !to.isEmpty())
+            {
+                const char *lo = from.str();
+                const char *hi = to.str();
+                while (*lo && (toupper(*lo) == toupper(*hi)))
+                {
+                    masktmp.append((char)toupper(*lo));
+                    lo++;
+                    hi++;
+                }
+                masktmp.append("*");
+                mask = masktmp.str();
             }
-            masktmp.append("*");
-            mask = masktmp.str();
+
+            StringBuffer head;
+            if (!mask.isEmpty())
+            {
+                splitWUID(mask.str(), head);
+                if (!head.isEmpty())
+                    dirMask = head.str();
+                fileMask.set(mask.str()).toUpperCase();
+            }
+            else
+                fileMask.append("*");
+            fileMask.append(".xml");
         }
-        StringBuffer head, tmask;
-        const char *hmask = NULL;
-        if (mask&&*mask) {
-            splitWUID(mask,head);
-            if (head.length())
-                hmask = head.str();
-            tmask.clear().append(mask).toUpperCase();
+        bool checkDirs(const char *dir)
+        {
+            if (!fromDir.isEmpty() && (strcmp(dir, fromDir.str()) < 0))
+                return false;
+            if (!toDir.isEmpty() && (strcmp(dir, toDir.str()) > 0))
+                return false;
+            return true;
         }
-        else
-            tmask.append("*");
-        tmask.append(".xml");
-        Owned<IDirectoryIterator> di = dir->directoryFiles(hmask,false,true);
-        StringBuffer name;
-        unsigned index = 0;
-        StringBuffer xb;
-        bool overflowed = false;
-        ForEach(*di) {
-            if (overflowed||(index>start+num))
-                break;
-            if (di->isDir()) {
-                Owned<IDirectoryIterator> di2 = di->query().directoryFiles(tmask.str(),false);
+        bool parseAndCheckWUID(bool &checkBeforeOrAfterWU, const char *beforeWU,
+            const char *afterWU, StringBuffer &name)
+        {
+            if (name.length() < 5)
+                return false;
+
+            name.setLength(name.length()-4);
+            name.toUpperCase();
+            const char *wuid = name.str();
+            if ((name.length()>6) && strieq(wuid+name.length()-6, "_HINTS"))
+                return false;
+
+            if (!mask.isEmpty() && !WildMatch(wuid, mask.str(),true))
+                return false;
+
+            if (checkBeforeOrAfterWU)
+            {
+                if (!isEmptyString(afterWU) && (stricmp(wuid, afterWU) <= 0))
+                    return false;
+                if (!isEmptyString(beforeWU) && (stricmp(wuid, beforeWU) >= 0))
+                    return false;
+                if (isEmptyString(beforeWU) || isEmptyString(afterWU))
+                    checkBeforeOrAfterWU = false; //Found the starting point. So, do not need to check anymore.
+            }
+            return true;
+        }
+        bool checkFilters(IPropertyTree *t)
+        {
+            //The following code is a clone of the pre-existing code.
+            StringBuffer path, val;
+            if (!owner.isEmpty() && (!t->getProp("@submitID", val.clear()) || !WildMatch(val.str(), owner.get(), true)))
+                return false;
+            if (!state.isEmpty() && (!t->getProp(dfu?"Progress/@state":"@state", val.clear()) || !WildMatch(val.str(), state.get(), true)))
+                return false;
+            if (!cluster.isEmpty() && (!t->getProp("@clusterName", val.clear()) || !WildMatch(val.str(), cluster.get(), true)))
+                return false;
+            if (!jobName.isEmpty() && (!t->getProp("@jobName", val.clear()) || !WildMatch(val.str(), jobName.get(), true)))
+                return false;
+            if (!cmdName.isEmpty() && (!t->getProp("@command", val.clear()) || !WildMatch(val.str(), cmdName.get(), true)))
+                return false;
+            if (!priority.isEmpty() && (!t->getProp("@priorityClass", val.clear()) || !WildMatch(val.str(), priority.get(), true)))
+                return false;
+            if (!fileRead.isEmpty() && !t->hasProp(path.setf("FilesRead/File[@name=~?\"%s\"]", fileRead.get()).str()))
+                return false;
+            if (!fileWritten.isEmpty() && !t->hasProp(path.setf("Files/File[@name=~?\"%s\"]", fileWritten.get()).str()))
+                return false;
+            if (!eclContains.isEmpty() && !t->hasProp(path.setf("Query[Text=~?\"*%s*\"]", eclContains.get()).str()))
+                return false;
+            return true;
+        }
+        bool setOutput(ISashaCommand *cmd, StringArray &outputFields, IPropertyTree *wuTree, CDateTime &modifiedTime)
+        {
+            if (hasWUSOutput)
+            { //cmd->getAction()==SCA_WORKUNIT_SERVICES_GET
+                if (!serializeWUSrow(*wuTree, WUSbuf, false))
+                    return false; //Log overflowed?
+            }
+            else if (outputXML)
+            { //cmd->getAction()==SCA_GET
+                StringBuffer xml;
+                toXML(wuTree, xml);
+                if (!cmd->addResult(xml.str()))
+                    return false; //Log overflowed?
+            }
+            else
+            {
+                if (outputFields.length() == 0)
+                    cmd->addId(wuTree->queryName());
+                else
+                {
+                    StringBuffer output = wuTree->queryName();
+                    setWUDataTree(wuTree, outputFields, output);
+                    cmd->addId(output.str());
+                }
+                if (outputModifiedTime)
+                    cmd->addDT(modifiedTime);
+            }
+            return true;
+        }
+        void setWUDataTree(IPropertyTree *wu, StringArray &outputFields, StringBuffer &output)
+        {
+            ForEachItemIn(i, outputFields)
+            {
+                const char* outputField = (const char*)outputFields.item(i);
+
                 StringBuffer val;
-                ForEach(*di2) {
-                    di2->getName(name.clear());
-                    if (!di2->isDir()&&(name.length()>4)) {
-                        name.setLength(name.length()-4);
-                        name.toUpperCase();
-                        const char *wuid = name.str();
-                        if ((name.length()>6)&&(stricmp(wuid+name.length()-6,"_HINTS")==0))
+                bool found = true;
+                if (strieq(outputField, "owner"))
+                    wu->getProp("@submitID", val);
+                else if (strieq(outputField, "cluster"))
+                    wu->getProp("@clusterName", val);
+                else if (strieq(outputField, "jobname"))
+                    wu->getProp("@jobName",val);
+                else if (strieq(outputField,"state"))
+                    wu->getProp("@state", val);
+                else
+                    found = false;
+                if (found)
+                    output.append(',').append(val);
+            }
+        }
+
+    public:
+        IMPLEMENT_IINTERFACE_USING(CInterface);
+
+        CWUReader(ISashaCommand *cmd, const char *_mask)
+        {
+            mask.set(_mask);
+            owner.set(cmd->queryOwner());
+            cluster.set(cmd->queryCluster());
+            jobName.set(cmd->queryJobName());
+            state.set(cmd->queryState());
+            priority.set(cmd->queryPriority());
+            eclContains.set(cmd->queryEclContains());
+            fileRead.set(cmd->queryFileRead());
+            fileWritten.set(cmd->queryFileWritten());
+            cmdName.set(cmd->queryDfuCmdName());
+
+            dfu = cmd->getDFU();
+            hasWUSOutput = cmd->getAction()==SCA_WORKUNIT_SERVICES_GET;
+            outputModifiedTime = cmd->getAction()==SCA_LISTDT;
+            outputXML = cmd->getAction()==SCA_GET;
+
+            //In WUiterate(), the queryAfter() is used as fromDT and the queryBefore() is used as toDT.
+            mkDateCompare(dfu, cmd->queryAfter(), fromDT, '0');
+            mkDateCompare(dfu, cmd->queryBefore(), toDT, '9');
+        }
+        void getWUs(ISashaCommand *cmd, const char *beforeWU, const char *afterWU, unsigned numWUs)
+        {
+            StringBuffer path;
+            if (dfu)
+                getLdsPath("Archive/DFUWorkUnits", path);
+            else
+                getLdsPath("Archive/WorkUnits", path);
+            Owned<IFile> dir = createIFile(path.str());
+
+            StringArray outputFields;
+            const char *outputFormat = cmd->queryOutputFormat();
+            outputFields.appendList(outputFormat, "|,");
+
+            StringBuffer dirMask, fileMask;
+            getMasks(beforeWU, afterWU, dirMask, fileMask);
+            bool checkBeforeOrAfterWU = !isEmptyString(beforeWU) || !isEmptyString(afterWU);
+            bool sortInc = !isEmptyString(beforeWU) && isEmptyString(afterWU);
+
+            if (hasWUSOutput)
+                cmd->setWUSresult(WUSbuf);  // swap in/out (in case ever do multiple)
+
+            CIArrayOf<CWUData> wus;
+            unsigned wuCount = 0;
+            bool overflowed = false;
+            StringBuffer output;
+            Owned<IDirectoryIterator> dirIterator = dir->directoryFilesSorted(SD_bynameNC, sortInc, dirMask.isEmpty() ? nullptr : dirMask.str(), false, true);
+            ForEach(*dirIterator)
+            {
+                dirIterator->getName(output.clear());
+                if (!dirIterator->isDir() || !checkDirs(output.str()))
+                    continue;
+
+                Owned<IDirectoryIterator> fileIterator = dirIterator->query().directoryFilesSorted(SD_bynameNC, sortInc, fileMask.str(), false);
+                ForEach(*fileIterator)
+                {
+                    fileIterator->getName(output.clear());
+                    if (!parseAndCheckWUID(checkBeforeOrAfterWU, beforeWU, afterWU, output))
+                        continue;
+    
+                    const char *wuid = output.str();
+   
+                    Owned<IPropertyTree> wuTree;
+                    if (outputXML || hasWUSOutput || !isEmptyString(outputFormat) || !owner.isEmpty() || !state.isEmpty() || !cluster.isEmpty() ||
+                        !jobName.isEmpty() || !cmdName.isEmpty() || !priority.isEmpty() || !fileRead.isEmpty() ||
+                        !fileWritten.isEmpty() || !eclContains.isEmpty())
+                    {
+                        try
+                        {
+                            wuTree.setown(createPTree(fileIterator->query()));
+                            if (!wuTree || isEmptyString(wuTree->queryName()) || !checkFilters(wuTree))
+                                continue;
+                        }
+                        catch (IException *e)
+                        {
+                            VStringBuffer msg("WUiterate: Workunit %s failed to load", wuid);
+                            EXCLOG(e,msg.str());
+                            e->Release();
                             continue;
-                        if ((!mask||!*mask||WildMatch(wuid,mask,true)) &&
-                            ((before.length()==0)||(stricmp(wuid,before.str())<=0)) &&
-                            ((after.length()==0)||(stricmp(wuid,after.str())>=0))) {
-                            if (isWild) {
-                                if (!conn)
-                                    conn.setown(querySDS().connect(baseXPath.str(), myProcessSession(), 0, 5*60*1000)); // connection to all
-                            }
-                            else {
-                                VStringBuffer xpath("%s/%s", baseXPath.str(), mask);
-                                conn.setown(querySDS().connect(xpath.str(), myProcessSession(), 0, 5*60*1000));
-                            }
-                            if ((isWild && !conn->queryRoot()->hasProp(wuid)) || (!isWild && !conn)) { // check not online
-                                Owned<IPropertyTree> t;
-                                bool hasowner = owner&&*owner;
-                                bool hascluster = cluster&&*cluster;
-                                bool hasstate = state&&*state;
-                                bool hasjobname = jobname&&*jobname;
-                                bool hasoutput = outputformat&&*outputformat;
-                                bool inrange = (index>=start)&&(index<start+num);
-                                bool hascommand = cmdname&&*cmdname;
-                                bool haspriority = priority&&*priority;
-                                bool hasfileread = fileread&&*fileread;
-                                bool hasfilewritten = filewritten&&*filewritten;
-                                bool haseclcontains = eclcontains&&*eclcontains;
-                                if ((cmd->getAction()==SCA_GET)||haswusoutput||hasowner||hasstate||hascluster||hasjobname||hascommand||(hasoutput&&inrange)||haspriority||hasfileread||hasfilewritten||haseclcontains) {
-                                    try {
-                                        t.setown(createPTree(di2->query()));
-                                        if (!t)
-                                            continue;
-                                        if (hasowner&&(!t->getProp("@submitID",val.clear())||!WildMatch(val.str(),owner,true)))
-                                            continue;
-                                        if (hasstate&&(!t->getProp(dfu?"Progress/@state":"@state",val.clear())||!WildMatch(val.str(),state,true)))
-                                            continue;
-                                        if (hascluster&&(!t->getProp("@clusterName",val.clear())||!WildMatch(val.str(),cluster,true)))
-                                            continue;
-                                        if (hasjobname&&(!t->getProp("@jobName",val.clear())||!WildMatch(val.str(),jobname,true)))
-                                            continue;
-                                        if (hascommand&&(!t->getProp("@command",val.clear())||!WildMatch(val.str(),cmdname,true)))
-                                            continue;
-                                        if (haspriority&&(!t->getProp("@priorityClass",val.clear())||!WildMatch(val.str(),priority,true)))
-                                            continue;
-                                        if (hasfileread&&!t->hasProp(tmppath.clear().appendf("FilesRead/File[@name=~?\"%s\"]",fileread).str()))
-                                            continue;
-                                        if (hasfilewritten&&!t->hasProp(tmppath.clear().appendf("Files/File[@name=~?\"%s\"]",filewritten).str()))
-                                            continue;
-                                        if (haseclcontains&&!t->hasProp(tmppath.clear().appendf("Query[Text=~?\"*%s*\"]",eclcontains).str()))
-                                            continue;
-                                    }
-                                    catch (IException *e) {
-                                        StringBuffer msg;
-                                        msg.appendf("WUiterate: Workunit %s failed to load", wuid);
-                                        EXCLOG(e,msg.str());
-                                        e->Release();
-                                        continue;
-                                    }
-                                }
-                                index++;
-                                if (!inrange)
-                                    continue;
-                                if (hasoutput) {
-                                    char *saveptr;
-                                    char *parse = strdup(outputformat);
-                                    char *tok = strtok_r(parse, "|,",&saveptr);
-                                    while (tok) {
-                                        val.clear();
-                                        bool found = true;
-                                        if (stricmp(tok,"owner")==0)
-                                            t->getProp("@submitID",val);
-                                        else if (stricmp(tok,"cluster")==0)
-                                            t->getProp("@clusterName",val);
-                                        else if (stricmp(tok,"jobname")==0)
-                                            t->getProp("@jobName",val);
-                                        else if (stricmp(tok,"state")==0)
-                                            t->getProp(dfu?"Progress/@state":"@state",val);
-                                        else if (stricmp(tok,"command")==0)
-                                            t->getProp("@command",val);
-                                        else if (stricmp(tok,"wuid")==0)
-                                            t->getName(val);
-                                        else
-                                            found = false;
-                                        if (found) {
-                                            // remove commas TBD
-                                            name.append(',').append(val);
-                                        }
-                                        tok = strtok_r(NULL, "|,",&saveptr);
-                                    }
-                                    free(parse);
-                                }
-                                if (haswusoutput) {
-                                    if (!serializeWUSrow(*t,WUSbuf,false)) {
-                                        overflowed = true;
-                                        break;
-                                    }
-                                }
-                                else {
-                                    cmd->addId(name.str());
-                                    if (hasdtoutput) {
-                                        CDateTime dt;
-                                        di2->getModifiedTime(dt);
-                                        cmd->addDT(dt);
-                                    }
-                                }
-                                if (cmd->getAction()==SCA_GET) {
-                                    StringBuffer xml;
-                                    toXML(t,xml);
-                                    if (!cmd->addResult(xml.str()))
-                                        break;
-                                }
-                            }
                         }
                     }
-                    if (index>start+num)
+
+                    if (sortInc)
+                    {//The output should contain WUs from new to old. So, we need to reverse the order before output.
+                        Owned<CWUData> wu = new CWUData();
+                        if (outputXML || !isEmptyString(outputFormat))
+                            wu->wuTree.setown(wuTree.getClear());
+                        if (outputModifiedTime)
+                            fileIterator->getModifiedTime(wu->modifiedTime);
+                        wus.append(*wu.getClear());
+                    }
+                    else
+                    {
+                        CDateTime dt;
+                        if (outputModifiedTime)
+                            fileIterator->getModifiedTime(dt);
+
+                        if (!setOutput(cmd, outputFields, wuTree, dt))
+                        {
+                            overflowed = true;
+                            break;
+                        }
+                    }
+                    wuCount++;
+                    if (wuCount == numWUs)
+                        break;
+                }
+                if (overflowed || (wuCount == numWUs))
+                    break;
+            }
+            if (sortInc)
+            {
+                ForEachItemInRev(i, wus)
+                {
+                    CWUData &wuData = wus.item(i);
+                    if (!setOutput(cmd, outputFields, wuData.wuTree, wuData.modifiedTime))  //Log an error?
                         break;
                 }
             }
+
+            if (hasWUSOutput)
+                cmd->setWUSresult(WUSbuf);
         }
-    }
-    if (cmd->getOnline()) {
-        if (haswusoutput)
+    };
+
+    Owned<CWUReader> reader = new CWUReader(cmd, mask);
+    if (!cmd->getOnline())
+        reader->getWUs(cmd, cmd->queryBeforeWU(), cmd->queryAfterWU(), cmd->getLimit());
+    else
+    {//The following code is from the pre-existing code.
+        bool dfu = cmd->getDFU();
+        const char *beforedt = cmd->queryBefore();
+        const char *afterdt = cmd->queryAfter();
+        const char *owner = cmd->queryOwner();
+        const char *state = cmd->queryState();
+        const char *cluster = cmd->queryCluster();
+        const char *jobname = cmd->queryJobName();
+        const char *outputformat = cmd->queryOutputFormat();
+        unsigned start = cmd->getStart(); 
+        unsigned num = cmd->getLimit();
+        StringBuffer before;
+        StringBuffer after;
+        StringBuffer tmppath;
+        mkDateCompare(dfu,afterdt,after,'0');
+        mkDateCompare(dfu,beforedt,before,'9');
+        if (cmd->getAction()==SCA_WORKUNIT_SERVICES_GET)
             throw MakeStringException(-1,"SCA_WORKUNIT_SERVICES_GET not implemented for online workunits!");
-        StringBuffer xpath(baseXPath);
-        if (!conn)
-        {
-            if (!isWild)
-                xpath.append("/").append(mask);
-            conn.setown(querySDS().connect(xpath.str(), myProcessSession(), 0, 5*60*1000));
-        }
+        bool isWild = !mask || !*mask || isWildString(mask);
+        StringBuffer xpath = dfu ? "DFU/WorkUnits" : "WorkUnits";
+        if (!isWild)
+            xpath.append("/").append(mask);
+        Owned<IRemoteConnection> conn = querySDS().connect(xpath.str(), myProcessSession(), 0, 5*60*1000);
         if (conn)
         {
             Owned<IPropertyTreeIterator> iter = conn->queryRoot()->getElements(isWild ? "*" : NULL);
@@ -372,10 +502,7 @@ void WUiterate(ISashaCommand *cmd, const char *mask)
             }
         }
     }
-    if (haswusoutput)
-        cmd->setWUSresult(WUSbuf);
 }
-
 
 interface IBranchItem: extends IInterface
 {

--- a/dali/sasha/sacmd.cpp
+++ b/dali/sasha/sacmd.cpp
@@ -22,8 +22,10 @@ class CSashaCommand: public CInterface, implements ISashaCommand
     CDateTime *dts;
     unsigned numdts;
 
-    StringAttr after;
-    StringAttr before;
+    StringAttr after; //datetime
+    StringAttr before; //datetime
+    StringAttr afterWU;
+    StringAttr beforeWU;
     StringAttr state;
     StringAttr owner;
     StringAttr cluster;
@@ -150,6 +152,10 @@ public:
                 }
             }
         }
+        if (mb.remaining() > 0) {
+            mb.read(afterWU);
+            mb.read(beforeWU);
+        }
     }
 
     void serialize(MemoryBuffer &mb)
@@ -195,6 +201,10 @@ public:
         for (i=0;i<numdts;i++) 
             dts[i].serialize(mb);
 
+        if (afterWU.get() || beforeWU.get()) {
+            mb.append(afterWU);
+            mb.append(beforeWU);
+        }
     }
 
     SashaCommandAction getAction()
@@ -278,6 +288,26 @@ public:
     void setBefore(const char *val)
     {
         before.set(val);
+    }
+
+    const char *queryAfterWU()
+    {
+        return retstr(afterWU);
+    }
+
+    void setAfterWU(const char *val)
+    {
+        afterWU.set(val);
+    }
+
+    const char *queryBeforeWU()
+    {
+        return retstr(beforeWU);
+    }
+
+    void setBeforeWU(const char *val)
+    {
+        beforeWU.set(val);
     }
 
     const char *queryState()

--- a/dali/sasha/sacmd.hpp
+++ b/dali/sasha/sacmd.hpp
@@ -35,6 +35,10 @@ interface ISashaCommand: extends IInterface
     virtual void setAfter(const char *val) = 0;
     virtual const char *queryBefore() = 0;
     virtual void setBefore(const char *val) = 0;
+    virtual const char *queryAfterWU() = 0;
+    virtual void setAfterWU(const char *val) = 0;
+    virtual const char *queryBeforeWU() = 0;
+    virtual void setBeforeWU(const char *val) = 0;
     virtual const char *queryState() = 0;
     virtual void setState(const char *val) = 0;
     virtual const char *queryOwner() = 0;

--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -437,9 +437,11 @@ ESPrequest [nil_remove] WUQueryRequest
     [depr_ver("1.57")] string ApplicationKey;
     [depr_ver("1.57")] string ApplicationData;
     [min_ver("1.57")] ESParray<ESPstruct ApplicationValue> ApplicationValues;
+    [min_ver("1.71")] string BeforeWU;
+    [min_ver("1.71")] string AfterWU;
 
-    string After;
-    string Before;
+    [depr_ver("1.02")] string After; //Not used since 1.02
+    [depr_ver("1.02")] string Before; //Not used since 1.02
     int Count;
     [min_ver("1.03")] int64 PageSize(0);
     [min_ver("1.03")] int64 PageStartFrom(0);
@@ -499,6 +501,8 @@ ESPrequest [nil_remove] WULightWeightQueryRequest
     string JobName;
     string StartDate;
     string EndDate;
+    [min_ver("1.71")] string BeforeWU;
+    [min_ver("1.71")] string AfterWU;
     string State;
 
     ESParray<ESPstruct ApplicationValue> ApplicationValues;
@@ -1933,7 +1937,7 @@ ESPresponse [exceptions_inline, nil_remove] WUGetNumFileToCopyResponse
 
 ESPservice [
     auth_feature("DEFERRED"), //This declares that the method logic handles feature level authorization
-    version("1.70"), default_client_version("1.70"),
+    version("1.71"), default_client_version("1.71"),
     noforms,exceptions_inline("./smc_xslt/exceptions.xslt"),use_method_name] WsWorkunits
 {
     ESPmethod [cache_seconds(60), resp_xsl_default("/esp/xslt/workunits.xslt")]     WUQuery(WUQueryRequest, WUQueryResponse);

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -2143,6 +2143,8 @@ class CArchivedWUsReader : public CInterface, implements IArchivedWUsReader
         addToFilterString("state", req.getState());
         addToFilterString("timeFrom", req.getStartDate());
         addToFilterString("timeTo", req.getEndDate());
+        addToFilterString("beforeWU", req.getBeforeWU());
+        addToFilterString("afterWU", req.getAfterWU());
         addToFilterString("pageStart", pageFrom);
         addToFilterString("pageSize", pageSize);
         if (sashaServerIP && *sashaServerIP)
@@ -2162,6 +2164,8 @@ class CArchivedWUsReader : public CInterface, implements IArchivedWUsReader
         addToFilterString("state", req.getState());
         addToFilterString("timeFrom", req.getStartDate());
         addToFilterString("timeTo", req.getEndDate());
+        addToFilterString("beforeWU", req.getBeforeWU());
+        addToFilterString("afterWU", req.getAfterWU());
         addToFilterString("pageStart", pageFrom);
         addToFilterString("pageSize", pageSize);
         if (sashaServerIP && *sashaServerIP)
@@ -2200,6 +2204,10 @@ class CArchivedWUsReader : public CInterface, implements IArchivedWUsReader
             cmd->setAfter(timeFrom.str());
         if (timeTo.length())
             cmd->setBefore(timeTo.str());
+        if (notEmpty(req.getBeforeWU()))
+            cmd->setBeforeWU(req.getBeforeWU());
+        if (notEmpty(req.getAfterWU()))
+            cmd->setAfterWU(req.getAfterWU());
         return;
     }
 

--- a/system/jlib/jfile.hpp
+++ b/system/jlib/jfile.hpp
@@ -80,6 +80,8 @@ interface ICopyFileProgress
 class RemoteFilename;
 
 enum fileBool { foundNo = false, foundYes = true, notFound = 2 };
+typedef enum { SD_nosort, SD_byname, SD_bynameNC, SD_bydate, SD_bysize }  SortDirectoryMode;
+
 interface IFile :extends IInterface
 {
     virtual bool exists() = 0; // NB this can raise exceptions if the machine doesn't exist or other fault
@@ -107,6 +109,7 @@ interface IFile :extends IInterface
 // Directory functions
     virtual bool createDirectory() = 0;
     virtual IDirectoryIterator *directoryFiles(const char *mask=NULL,bool sub=false,bool includedirs=false)=0;
+    virtual IDirectoryIterator *directoryFilesSorted(SortDirectoryMode mode, bool rev, const char *mask=NULL,bool sub=false,bool includedirs=false)=0;
     virtual IDirectoryDifferenceIterator *monitorDirectory(
                                   IDirectoryIterator *prev=NULL,    // in (NULL means use current as baseline)
                                   const char *mask=NULL,
@@ -136,14 +139,16 @@ public:
         name.set(iter.getName(tmp));
         iter.getModifiedTime(modifiedTime);
     }
+    CDirectoryEntry(IFile *_file, const char *_name, bool _isdir, __int64 _size, CDateTime &_modifiedTime)
+        : file(_file), name(_name), isdir(_isdir), size(_size), modifiedTime(_modifiedTime)
+    {
+    }
     Linked<IFile> file;
     StringAttr name;
     bool isdir;
     __int64 size;
     CDateTime modifiedTime;
 };
-
-typedef enum { SD_nosort, SD_byname, SD_bynameNC, SD_bydate, SD_bysize }  SortDirectoryMode;
 
 
 extern jlib_decl unsigned sortDirectory( 

--- a/system/jlib/jfile.hpp
+++ b/system/jlib/jfile.hpp
@@ -80,7 +80,7 @@ interface ICopyFileProgress
 class RemoteFilename;
 
 enum fileBool { foundNo = false, foundYes = true, notFound = 2 };
-typedef enum { SD_nosort, SD_byname, SD_bynameNC, SD_bydate, SD_bysize }  SortDirectoryMode;
+typedef enum { SD_nosort, SD_byname, SD_bynameNC, SD_bydate, SD_bysize } SortDirectoryMode;
 
 interface IFile :extends IInterface
 {
@@ -109,7 +109,7 @@ interface IFile :extends IInterface
 // Directory functions
     virtual bool createDirectory() = 0;
     virtual IDirectoryIterator *directoryFiles(const char *mask=NULL,bool sub=false,bool includedirs=false)=0;
-    virtual IDirectoryIterator *directoryFilesSorted(SortDirectoryMode mode, bool rev, const char *mask=NULL,bool sub=false,bool includedirs=false)=0;
+    virtual IDirectoryIterator *directoryFilesSorted(SortDirectoryMode mode, bool rev, const char *mask=NULL, bool sub=false, bool includedirs=false)=0;
     virtual IDirectoryDifferenceIterator *monitorDirectory(
                                   IDirectoryIterator *prev=NULL,    // in (NULL means use current as baseline)
                                   const char *mask=NULL,

--- a/system/jlib/jfile.ipp
+++ b/system/jlib/jfile.ipp
@@ -60,6 +60,7 @@ public:
 
     virtual bool createDirectory();
     virtual IDirectoryIterator *directoryFiles(const char *mask=NULL,bool sub=false,bool includedirs=false);
+    virtual IDirectoryIterator *directoryFilesSorted(SortDirectoryMode mode, bool rev, const char *mask=NULL,bool sub=false,bool includedirs=false);
     virtual IDirectoryDifferenceIterator *monitorDirectory(
                                   IDirectoryIterator *prev=NULL,        // in
                                   const char *mask=NULL,


### PR DESCRIPTION
In saarch.cpp, WUiterateSorted() is added to retrieve archived workunits
sorted by WUID. The new code is based on sortDirectory(). The beforeWU/
afterWU and/or StartDate/EndDate are used to skip the directories which
store WUs not in the date range. The beforeWU/afterWU is also used to
skip the WUs which are not in the time range. The exisitng filters in
the WUiterate() are supported by WUiterateSorted().

WUiterateSorted() is used by WsWorkunits.WUQuery to access archived
workunits with paging. An ESP client may ask for next page by specifing
afterWU or ask for previous page by specifing beforeWU.

Signed-off-by: wangkx <kevin.wang@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
