### PR TITLE
HPCC-18284 Problem with ECLCC after C++11 support merged.

### DIFF
--- a/system/jlib/jcomp.cpp
+++ b/system/jlib/jcomp.cpp
@@ -59,8 +59,8 @@
 #define BASE_ADDRESS "0x00480000"
 //#define BASE_ADDRESS        "0x10000000"
 
-static const char * CC_NAME[] =   { "\"#" PATHSEPSTR "bin" PATHSEPSTR "cl.bat\"",   "\"#" PATHSEPSTR "bin" PATHSEPSTR "g++\"" };
-static const char * LINK_NAME[] = { "\"#" PATHSEPSTR "bin" PATHSEPSTR "link.bat\"", "\"#" PATHSEPSTR "bin" PATHSEPSTR "g++\"" };
+static const char * CC_NAME[] =   { "\"#" PATHSEPSTR "bin" PATHSEPSTR "cl.bat\"",   "\"g++\"" };
+static const char * LINK_NAME[] = { "\"#" PATHSEPSTR "bin" PATHSEPSTR "link.bat\"", "\"g++\"" };
 static const char * LIB_DIR[] = { "\"#\\lib\"", "\"#/lib\"" };
 static const char * LIB_OPTION_PREFIX[] = { "", "-Wl," };
 static const char * USE_LIBPATH_FLAG[] = { "/libpath:\"", "-L" };
@@ -131,7 +131,7 @@ static void doSetCompilerPath(const char * path, const char * includes, const ch
         PrintLog("Include directory set to %s", includes);
         PrintLog("Library directory set to %s", libs);
     }
-    compilerRoot.set(path ? path : targetCompiler==GccCppCompiler ? "/usr" : ".\\CL");
+    compilerRoot.set(path ? path : targetCompiler==GccCppCompiler ? "" : ".\\CL");
     stdIncludes.set(includes);
     stdLibs.clear();
     for (;;)
@@ -149,6 +149,9 @@ static void doSetCompilerPath(const char * path, const char * includes, const ch
             break;
         libs++;
     }
+#ifdef _DEBUG
+    PrintLog("Path is: %s", path);
+#endif
     StringBuffer fname;
     if (path)
     {
@@ -163,17 +166,53 @@ static void doSetCompilerPath(const char * path, const char * includes, const ch
         }
 
 #if defined(__linux__)
+        StringBuffer typeCmd = "type ";
+        typeCmd.append(fname);
+
+        const unsigned resultLength = 4096;
+        char result[resultLength];
+
+        FILE* fp = popen(typeCmd.str(), "r");
+        if (fp != nullptr)
+        {
+            fgets(result, resultLength - 1, fp);
+            pclose(fp);
+        }
+#ifdef _DEBUG
+        PrintLog("'%s' command result is: '%s'", typeCmd.str(), result);
+#endif
+        const char* pathStart = strstr(result, PATHSEPSTR);
+        if (pathStart)
+        {
+            // If the PATHSEPSTR changed from "/" to something longer in future
+            assert(strlen(PATHSEPSTR) == 1);
+            // Not a nice solution but we have not strrstr() to search PATHSEPSTR from the end.
+            const char* pathEnd = strrchr(pathStart + 1, PATHSEPSTR[0]);
+            if (pathEnd)
+            {
+                StringBuffer compilerName(CC_NAME[targetCompiler]);
+                dequote(compilerName);
+                fname.clear().append((pathEnd - pathStart + 1), pathStart).append(compilerName);
+            }
+            else
+            {
+                fname.set(pathStart);
+                // Should remove the \n from the end
+                fname.replaceString("\n", nullptr);
+            }
+        }
+
         StringBuffer clbin_dir;
-        const char* dir_end = strrchr(fname, '/');
-        if(dir_end == NULL)
+        const char* dir_end = strstr(fname, PATHSEPSTR);
+        if(dir_end == nullptr)
             clbin_dir.append(".");
         else
             clbin_dir.append((dir_end - fname.str()) + 1, fname.str());
-        
+
         StringBuffer pathenv(clbin_dir.str());
         const char* oldpath = getenv("PATH");
-        if(oldpath != NULL && *oldpath != '\0')
-        pathenv.append(":").append(oldpath);
+        if(oldpath != nullptr && *oldpath != '\0')
+            pathenv.append(":").append(oldpath);
         setenv("PATH", pathenv.str(), 1);
 #endif
     }
@@ -255,7 +294,7 @@ CppCompiler::CppCompiler(const char * _coreName, const char * _sourceDir, const 
     setDebug(false);
     setDebugLibrary(false);
 #endif
-    
+
     setDirectoryPrefix(sourceDir, _sourceDir);
     setDirectoryPrefix(targetDir, _targetDir);
     maxCompileThreads = 1;
@@ -348,7 +387,7 @@ void CppCompiler::addInclude(const char * paths)
 
 void CppCompiler::addLinkOption(const char * option)
 {
-    if (option && *option)	
+    if (option && *option)
         linkerOptions.append(' ').append(LIB_OPTION_PREFIX[targetCompiler]).append(option);
 }
 
@@ -486,7 +525,7 @@ bool CppCompiler::compileFile(IThreadPool * pool, const char * filename, Semapho
         cmdline.append(" ").append(LIBFLAG_RELEASE[targetCompiler]);
 
     _addInclude(cmdline, stdIncludes);
-    
+
     if (targetCompiler == Vs6CppCompiler)
     {
         if (targetDir.get())
@@ -505,7 +544,7 @@ bool CppCompiler::compileFile(IThreadPool * pool, const char * filename, Semapho
             getObjectName(cmdline, filename);
         cmdline.append("\"");
     }
-    
+
     StringBuffer expanded;
     expandRootDirectory(expanded, cmdline);
     StringBuffer logFile;
@@ -757,9 +796,9 @@ void CppCompiler::setDebugLibrary(bool debug)
     useDebugLibrary = debug;
 }
 
-void CppCompiler::setCreateExe(bool _createExe) 
-{ 
-    createDLL = !_createExe; 
+void CppCompiler::setCreateExe(bool _createExe)
+{
+    createDLL = !_createExe;
 }
 
 


### PR DESCRIPTION
Query the current g++ path from the Linux environmnet

Signed-off-by: Attila Vamos <attila.vamos@gmail.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [x] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [x] This change fixes the problem, not just the symptom
  - [x] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->
Tested manually on single gcc version
   - Ubuntu 16.04: gcc (Ubuntu 5.4.0-6ubuntu1~16.04.5) 5.4.0 20160609
   - CentOS 7.x: gcc (GCC) 4.8.5 20150623 (Red Hat 4.8.5-4))

and multiple gcc versions (CentOS 6.x)
   - gcc (GCC) 4.4.7 20120313 (Red Hat 4.4.7-18)
   - gcc (GCC) 4.8.2 20140120 (Red Hat 4.8.2-15)
environments
<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
