### PR TITLE
HPCC-18596 Avoid patching workunit XML patching

### DIFF
--- a/common/workunit/workunit.hpp
+++ b/common/workunit/workunit.hpp
@@ -1512,7 +1512,7 @@ interface IExtendedWUInterface
     virtual bool archiveWorkUnit(const char *base,bool del,bool ignoredllerrors,bool deleteOwned,bool exportAssociatedFiles) = 0;
     virtual IPropertyTree *getUnpackedTree(bool includeProgress) const = 0;
     virtual IPropertyTree *queryPTree() const = 0;
-    
+    virtual IPropertyTree *exportTree(bool unpack, bool includeProgress, bool hidePasswords) const = 0;
 };
 
 //Do not mark this as WORKUNIT_API - all functions are inline, and it causes windows link errors

--- a/common/workunit/workunit.ipp
+++ b/common/workunit/workunit.ipp
@@ -326,6 +326,7 @@ public:
     virtual unsigned calculateHash(unsigned prevHash);
     virtual void copyWorkUnit(IConstWorkUnit *cached, bool copyStats, bool all);
     virtual IPropertyTree *queryPTree() const;
+    virtual IPropertyTree *exportTree(bool unpack, bool includeProgress, bool hidePasswords) const;
     virtual unsigned queryFileUsage(const char *filename) const;
     virtual IConstWUFileUsageIterator * getFieldUsage() const;
     virtual bool getFieldUsageArray(StringArray & filenames, StringArray & columnnames, const char * clusterName) const;

--- a/system/jlib/jptree.hpp
+++ b/system/jlib/jptree.hpp
@@ -105,6 +105,9 @@ interface jlib_decl IPropertyTree : extends serializable
     virtual IPropertyTree *setPropTree(const char *xpath) = 0;
     virtual IPropertyTree *addPropTree(const char *xpath) = 0;
 
+    virtual IPropertyTree *addPropTree(IPropertyTree *val) = 0;
+    virtual IPropertyTree *setPropTree(IPropertyTree *val) = 0;
+
     virtual bool removeProp(const char *xpath) = 0;
     virtual bool removeTree(IPropertyTree *child) = 0;
     virtual aindex_t queryChildIndex(IPropertyTree *child) = 0;

--- a/system/jlib/jptree.ipp
+++ b/system/jlib/jptree.ipp
@@ -638,6 +638,8 @@ public:
     virtual IPropertyTree *addPropTree(const char *xpath, IPropertyTree *val) override;
     virtual IPropertyTree *setPropTree(const char *xpath) override { return setPropTree(xpath, create()); }
     virtual IPropertyTree *addPropTree(const char *xpath) override { return addPropTree(xpath, create()); }
+    virtual IPropertyTree *setPropTree(IPropertyTree *val) override { return setPropTree(val->queryName(), val); }
+    virtual IPropertyTree *addPropTree(IPropertyTree *val) override { return addPropTree(val->queryName(), val); }
     virtual bool removeTree(IPropertyTree *child) override;
     virtual bool removeProp(const char *xpath) override;
     virtual aindex_t queryChildIndex(IPropertyTree *child) override;


### PR DESCRIPTION
Exporting a workunit to XML invovled serializing it to XML
and spotting parts which were sensitive and removing them on
the fly. Followed by a later stage which inserted another piece
of XML into the XML text block.

Instead get a copy of the workunit tree, prune the unwanted into,
add the extra info (in the form of their original trees) and
serialize the whole cleaned workunit in one go.

Signed-off-by: Jake Smith <jake.smith@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [x] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
