### PR TITLE
HPCC-18329 Only test chinese breakiterator semantics if ICU version >= 50

### DIFF
--- a/ecl/regress/icuversion.ecl
+++ b/ecl/regress/icuversion.ecl
@@ -1,0 +1,20 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2017 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+import Std.Uni;
+Uni.version();
+(integer)Uni.Version();

--- a/ecllibrary/std/Uni.ecl
+++ b/ecllibrary/std/Uni.ecl
@@ -462,4 +462,10 @@ EXPORT BOOLEAN StartsWith(unicode src, unicode pref, string form) :=
 EXPORT BOOLEAN EndsWith(unicode src, unicode suff, string form) :=
 	lib_unicodelib.UnicodeLib.UnicodeLocaleEndsWith(src, suff, form);
 
+/**
+ * Returns a string containing the version of icu being used to implement the unicode library.
+ */
+
+EXPORT STRING Version() := lib_unicodelib.UnicodeLib.UnicodeVersion();
+
 END;

--- a/ecllibrary/teststd/uni/TestExcludeFirstWord.ecl
+++ b/ecllibrary/teststd/uni/TestExcludeFirstWord.ecl
@@ -36,7 +36,7 @@ EXPORT TestExcludeFirstWord := MODULE
     EXPORT Test16 := ASSERT(Uni.ExcludeFirstWord(U'Cambió las niñas')+U'!' = U'las niñas!');
     //Check action on a string containing Chinese characters.
     //Translation: "I am a computer"
-    EXPORT Test17 := ASSERT(Uni.ExcludeFirstWord(U'我是電腦')+U'!' = U'電腦!');
+    EXPORT Test17 := ASSERT(((integer)Uni.Version() < 50) OR Uni.ExcludeFirstWord(U'我是電腦')+U'!' = U'電腦!'); // Chinese dictionary based iterators added in ICU 50
     //Check action on a string containing Modern Greek characters.
     //Translation: "Do you come here often?"
     EXPORT Test18 := ASSERT(Uni.ExcludeFirstWord(U' Έρχεσαι συχνά εδώ; ')+U'!' = U'συχνά εδώ; !');

--- a/ecllibrary/teststd/uni/TestExcludeLastWord.ecl
+++ b/ecllibrary/teststd/uni/TestExcludeLastWord.ecl
@@ -36,7 +36,7 @@ EXPORT TestExcludeLastWord := MODULE
     EXPORT Test16 := ASSERT(Uni.ExcludeLastWord(U'El difunto cambió las niñas')+U'!' = U'El difunto cambió las !');
     //Check action on a string containing Chinese characters.
     //Translation: "I am a computer"
-    EXPORT Test17 := ASSERT(Uni.ExcludeLastWord(U'我是電腦')+U'!' = U'我是!');
+    EXPORT Test17 := ASSERT(((integer)Uni.Version() < 50) OR Uni.ExcludeLastWord(U'我是電腦')+U'!' = U'我是!'); // Chinese dictionary based iterators added in ICU 50
     //Check action on a string containing Modern Greek characters.
     //Translation: "Do you come here often?"
     EXPORT Test18 := ASSERT(Uni.ExcludeLastWord(U' Έρχεσαι συχνά εδώ; ')+U'!' = U' Έρχεσαι συχνά !');

--- a/ecllibrary/teststd/uni/TestExcludeNthWord.ecl
+++ b/ecllibrary/teststd/uni/TestExcludeNthWord.ecl
@@ -74,7 +74,7 @@
     EXPORT Test42 := ASSERT(Uni.ExcludeNthWord(U'El difunto cambió las niñas',5)+U'!' = U'El difunto cambió las !');
     //Check action on a string containing Chinese characters.
     //Translation: "I am a computer" --> "I am"
-    EXPORT Test43 := ASSERT(Uni.ExcludeNthWord(U'我是電腦',2)+U'!' = U'我是!');
+    EXPORT Test43 := ASSERT(((integer)Uni.Version() < 50) OR Uni.ExcludeNthWord(U'我是電腦',2)+U'!' = U'我是!'); // Chinese dictionary based iterators added in ICU 50
     //Check action on a string containing Modern Greek characters.
     //Translation: "Do you come here often?" --> "come here often?"
     EXPORT Test44 := ASSERT(Uni.ExcludeNthWord(U' Έρχεσαι συχνά εδώ; ',1)+U'!' = U'συχνά εδώ; !');

--- a/ecllibrary/teststd/uni/TestGetNthWord.ecl
+++ b/ecllibrary/teststd/uni/TestGetNthWord.ecl
@@ -65,7 +65,7 @@ EXPORT TestGetNthWord := MODULE
     EXPORT Test42 := ASSERT(Uni.GetNthWord(U'El difunto cambió las niñas',5)+U'!' = U'niñas!');
     //Check action on a string containing Chinese characters
     //Translation: "I am a computer" --> "computer"
-    EXPORT Test43 := ASSERT(Uni.GetNthWord(U'我是電腦',2)+U'!' = U'電腦!');
+    EXPORT Test43 := ASSERT(((integer)Uni.Version() < 50) OR Uni.GetNthWord(U'我是電腦',2)+U'!' = U'電腦!'); // Chinese dictionary based iterators added in ICU 50
     //Check action on a string containing Modern Greek characters
     //Translation: "Do you come here often?" --> "often"
     EXPORT Test44 := ASSERT(Uni.GetNthWord(U' Έρχεσαι συχνά εδώ; ',2)+U'!' = U'συχνά!');

--- a/ecllibrary/teststd/uni/TestWordCount.ecl
+++ b/ecllibrary/teststd/uni/TestWordCount.ecl
@@ -36,7 +36,7 @@ EXPORT TestWordCount := MODULE
     EXPORT Test16 := ASSERT(Uni.WordCount(U'El difunto cambió las niñas') = 5);
     //Check action on a string containing Chinese characters.
     //Translation: "I am a computer"
-    EXPORT Test17 := ASSERT(Uni.WordCount(U'我是電腦') = 2);
+    EXPORT Test17 := ASSERT(((integer)Uni.Version() < 50) OR Uni.WordCount(U'我是電腦') = 2); // Chinese dictionary based iterators added in ICU 50
     //Check action on a string containing Modern Greek characters.
     //Translation: "Do you come here often?"
     EXPORT Test18 := ASSERT(Uni.WordCount(U' Έρχεσαι συχνά εδώ; ') = 3);

--- a/plugins/unicodelib/unicodelib.cpp
+++ b/plugins/unicodelib/unicodelib.cpp
@@ -87,6 +87,7 @@ static const char * EclDefinition =
 "  unicode UnicodeLocaleTranslate(const unicode text, unicode sear, unicode repl) :c,pure,entrypoint='ulUnicodeLocaleTranslate';\n"
 "  boolean UnicodeLocaleStartsWith(const unicode src, unicode pref, string form) :c,pure,entrypoint='ulUnicodeLocaleStartsWith';\n"
 "  boolean UnicodeLocaleEndsWith(const unicode src, const unicode suff, const string form) :c,pure,entrypoint='ulUnicodeLocaleEndsWith';\n"
+"  string UnicodeVersion():c,pure,entrypoint='ulUnicodeVersion';\n"
 "END;\n";
 
 static const char * compatibleVersions[] = {
@@ -1694,4 +1695,15 @@ UNICODELIB_API bool UNICODELIB_CALL ulUnicodeLocaleEndsWith(unsigned srcLen, UCh
         normalizationFormCheck(suf, form);
     }
     return endsWith(pro, suf);
+}
+
+UNICODELIB_API void UNICODELIB_CALL ulUnicodeVersion(unsigned & tgtLen, char * & tgt)
+{
+    char version[U_MAX_VERSION_STRING_LENGTH];
+    UVersionInfo versionInfo;
+    u_getVersion(versionInfo);
+    u_versionToString(versionInfo, version);
+    tgtLen = strlen(version);
+    tgt = (char *)CTXMALLOC(parentCtx, tgtLen);
+    memcpy(tgt, version, tgtLen);
 }

--- a/plugins/unicodelib/unicodelib.hpp
+++ b/plugins/unicodelib/unicodelib.hpp
@@ -106,6 +106,7 @@ UNICODELIB_API void UNICODELIB_CALL ulUnicodeLocaleExcludeLastWord(unsigned & tg
 UNICODELIB_API void UNICODELIB_CALL ulUnicodeLocaleTranslate(unsigned & tgtLen, UChar * & tgt, unsigned textLen, UChar const * text, unsigned searLen, UChar const * sear, unsigned replLen, UChar * repl);
 UNICODELIB_API bool UNICODELIB_CALL ulUnicodeLocaleStartsWith(unsigned srcLen, UChar const * src, unsigned prefLen, UChar const * pref, unsigned formLen, char const * form);
 UNICODELIB_API bool UNICODELIB_CALL ulUnicodeLocaleEndsWith(unsigned srcLen, UChar const * src, unsigned suffLen, UChar const * suff, unsigned formLen, char const * form);
+UNICODELIB_API void UNICODELIB_CALL ulUnicodeVersion(unsigned & tgtLen, char * & tgt);
 }
 
 #endif


### PR DESCRIPTION
Signed-off-by: Gavin Halliday <gavin.halliday@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [x] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [x] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [x] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [ ] The change has been fully tested:
  - [x] I have added tests to cover my changes.
  - [x] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [x] This change fixes the problem, not just the symptom
  - [x] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
