### PR TITLE
HPCC-18626 Ensure value subscriber notification for replaced trees.

### DIFF
--- a/dali/base/dasds.cpp
+++ b/dali/base/dasds.cpp
@@ -1713,11 +1713,11 @@ public:
 
     void noteChange(PDState _local, PDState _state) { local = _local; state = _state; }
 
-    void addChildBranch(CBranchChange &child) { children.append(child); }
+    void addChildBranch(CBranchChange &child) { changedChildren.append(child); }
 
     const void *queryFindParam() const { return (const void *) &tree; }
 
-    CBranchChangeChildren children;
+    CBranchChangeChildren changedChildren;
     Linked<CRemoteTreeBase> tree;
     PDState local, state; // change info
 };
@@ -8405,7 +8405,7 @@ public:
             }
             else
             {
-                if (0 == changes.children.ordinality())
+                if (0 == changes.changedChildren.ordinality())
                 {
                     ForEachItemInRev(s, subs)
                     {
@@ -8426,9 +8426,13 @@ public:
                 }
                 else
                 {
-                    ForEachItemIn (c, changes.children)
+                    /* NB: scan the changes in reverse, so that new values proceed recorded delete changes
+                     * This ensures that a tree that has been deleted but replaced with a new tree will
+                     * cause a notification of the new value in favour of the delete.
+                     */
+                    ForEachItemInRev (c, changes.changedChildren)
                     {
-                        CBranchChange &childChange = changes.children.item(c);
+                        CBranchChange &childChange = changes.changedChildren.item(c);
                         PushPop pp(stack, *childChange.tree);
                         size32_t parentLength = xpath.length();
                         xpath.append('/').append(childChange.tree->queryName());
@@ -8498,9 +8502,13 @@ public:
                 }
             }
         }
-        ForEachItemIn(c, changes.children)
+        /* NB: scan the changes in reverse, so that new values proceed recorded delete changes
+         * This ensures that a tree that has been deleted but replaced with a new tree will
+         * cause a notification of the new value in favour of the delete.
+         */
+        ForEachItemInRev(c, changes.changedChildren)
         {
-            CBranchChange &childChanges = changes.children.item(c);
+            CBranchChange &childChanges = changes.changedChildren.item(c);
             size32_t parentLength = xpath.length();
             xpath.append('/').append(childChanges.tree->queryName());
             CSubscriberArray pruned;


### PR DESCRIPTION
When a subscriber subscribes to a tree which is replaced by
another, the value in the notificaiton was lost.
A replaced tree generates a delete event and a new value
event, in that order, ensure that the new value gets
through, by scanning the changes per node in reverse order.

Signed-off-by: Jake Smith <jake.smith@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

New tests have been added to dali unit tests in HPCC-18617

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
