### PR TITLE
HPCC-18517 Remove ESP direct calls to validateCache() and clean

### DIFF
--- a/common/dllserver/dllserver.cpp
+++ b/common/dllserver/dllserver.cpp
@@ -39,10 +39,8 @@ static Owned<IConstDomainInfo> hostDomain;
 
 IConstDomainInfo * getDomainFromIp(const char * ip)
 {
-    Owned<IEnvironmentFactory> ef = getEnvironmentFactory();
+    Owned<IEnvironmentFactory> ef = getEnvironmentFactory(true);
     Owned<IConstEnvironment> env = ef->openEnvironment();
-    if (!env)
-        return NULL;
     Owned<IConstMachineInfo> curMachine = env->getMachineByAddress(ip);
     if (!curMachine)
         return NULL;

--- a/common/environment/dalienv.cpp
+++ b/common/environment/dalienv.cpp
@@ -113,7 +113,7 @@ protected:
 
 SDSPasswordProvider::SDSPasswordProvider() 
 {
-    Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
+    Owned<IEnvironmentFactory> factory = getEnvironmentFactory(true);
     env.setown(factory->openEnvironment());
     map = new CIpPasswordHashTable();
 }
@@ -217,17 +217,13 @@ EnvMachineOS queryOS(const IpAddress & ip)
     if (match) 
         ret = match->os;
     else {
-        Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
-        if (factory) {
-            Owned<IConstEnvironment> env = factory->openEnvironment();
-            if (env) {
-                StringBuffer ipText;
-                ip.getIpText(ipText);
-                Owned<IConstMachineInfo> machine = env->getMachineByAddress(ipText.str());
-                if (machine) 
-                    ret = machine->getOS();
-            }
-        }
+        Owned<IEnvironmentFactory> factory = getEnvironmentFactory(true);
+        Owned<IConstEnvironment> env = factory->openEnvironment();
+        StringBuffer ipText;
+        ip.getIpText(ipText);
+        Owned<IConstMachineInfo> machine = env->getMachineByAddress(ipText.str());
+        if (machine)
+            ret = machine->getOS();
         if (ret==MachineOsUnknown) { // lets try asking dafilesrv
             SocketEndpoint ep(0,ip);
             switch (getDaliServixOs(ep)) { 
@@ -334,14 +330,14 @@ MODULE_EXIT()
 
 const char * querySlaveExecutable(const char * keyName, const char * exeName, const char * version, const IpAddress &ip, StringBuffer &progpath, StringBuffer &workdir)
 {
-    Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
+    Owned<IEnvironmentFactory> factory = getEnvironmentFactory(true);
     Owned<IConstEnvironment> env = factory->openEnvironment();
     StringBuffer addr;
     ip.getIpText(addr);
 
     StringBufferAdaptor spp(progpath);
     StringBufferAdaptor swd(workdir);
-    if (!env || !env->getRunInfo(spp, swd, keyName, version, addr.str(), exeName)) {
+    if (!env->getRunInfo(spp, swd, keyName, version, addr.str(), exeName)) {
 #ifdef _DEBUG
         //printf("slave path not found\n");
         progpath.append(exeName);
@@ -450,15 +446,12 @@ bool envGetConfigurationDirectory(const char *category, const char *component,co
     if (!sessid)
         return false;
 
-    Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
+    Owned<IEnvironmentFactory> factory = getEnvironmentFactory(true);
     Owned<IConstEnvironment> env = factory->openEnvironment();
-    if (env)
-    {
-        Owned<IPropertyTree> root = &env->getPTree();
-        IPropertyTree * child = root->queryPropTree("Software/Directories");
-        if (child)
-            return getConfigurationDirectory(child,category,component,instance,dirout);
-    }
+    Owned<IPropertyTree> root = &env->getPTree();
+    IPropertyTree * child = root->queryPropTree("Software/Directories");
+    if (child)
+        return getConfigurationDirectory(child,category,component,instance,dirout);
     return false;
 }
 
@@ -493,15 +486,12 @@ IPropertyTree *envGetNASConfiguration()
     if (!sessid)
         return NULL;
 
-    Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
+    Owned<IEnvironmentFactory> factory = getEnvironmentFactory(true);
     Owned<IConstEnvironment> env = factory->openEnvironment();
-    if (env)
-    {
-        Owned<IPropertyTree> root = &env->getPTree();
-        IPropertyTree * hardware = root->queryPropTree("Hardware");
-        if (hardware)
-            return envGetNASConfiguration(hardware);
-    }
+    Owned<IPropertyTree> root = &env->getPTree();
+    IPropertyTree * hardware = root->queryPropTree("Hardware");
+    if (hardware)
+        return envGetNASConfiguration(hardware);
     return NULL;
 }
 

--- a/common/environment/environment.hpp
+++ b/common/environment/environment.hpp
@@ -175,7 +175,7 @@ interface IEnvironmentFactory : extends IInterface
 
 
 class StringBuffer;
-extern "C" ENVIRONMENT_API IEnvironmentFactory * getEnvironmentFactory();
+extern "C" ENVIRONMENT_API IEnvironmentFactory * getEnvironmentFactory(bool update);
 extern "C" ENVIRONMENT_API void closeEnvironment();
 
 

--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -6607,10 +6607,8 @@ void getRoxieProcessServers(IPropertyTree *roxie, SocketEndpointArray &endpoints
 
 void getRoxieProcessServers(const char *process, SocketEndpointArray &servers)
 {
-    Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
+    Owned<IEnvironmentFactory> factory = getEnvironmentFactory(true);
     Owned<IConstEnvironment> env = factory->openEnvironment();
-    if (!env)
-        return;
     Owned<IPropertyTree> root = &env->getPTree();
     getRoxieProcessServers(queryRoxieProcessTree(root, process), servers);
 }
@@ -6807,27 +6805,24 @@ IStringVal &getProcessQueueNames(IStringVal &ret, const char *process, const cha
 {
     if (process)
     {
-        Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
+        Owned<IEnvironmentFactory> factory = getEnvironmentFactory(true);
         Owned<IConstEnvironment> env = factory->openEnvironment();
-        if (env)
+        Owned<IPropertyTree> root = &env->getPTree();
+        StringBuffer queueNames;
+        StringBuffer xpath;
+        xpath.appendf("%s[@process=\"%s\"]", type, process);
+        Owned<IPropertyTreeIterator> targets = root->getElements("Software/Topology/Cluster");
+        ForEach(*targets)
         {
-            Owned<IPropertyTree> root = &env->getPTree();
-            StringBuffer queueNames;
-            StringBuffer xpath;
-            xpath.appendf("%s[@process=\"%s\"]", type, process);
-            Owned<IPropertyTreeIterator> targets = root->getElements("Software/Topology/Cluster");
-            ForEach(*targets)
+            IPropertyTree &target = targets->query();
+            if (target.hasProp(xpath))
             {
-                IPropertyTree &target = targets->query();
-                if (target.hasProp(xpath))
-                {
-                    if (queueNames.length())
-                        queueNames.append(',');
-                    queueNames.append(target.queryProp("@name")).append(suffix);
-                }
+                if (queueNames.length())
+                    queueNames.append(',');
+                queueNames.append(target.queryProp("@name")).append(suffix);
             }
-            ret.set(queueNames);
         }
+        ret.set(queueNames);
     }
     return ret;
 }
@@ -6841,10 +6836,8 @@ IStringVal &getProcessQueueNames(IStringVal &ret, const char *process, const cha
 
 extern WORKUNIT_API void getDFUServerQueueNames(StringArray &ret, const char *process)
 {
-    Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
+    Owned<IEnvironmentFactory> factory = getEnvironmentFactory(true);
     Owned<IConstEnvironment> env = factory->openEnvironment();
-    if (!env)
-        return;
 
     StringBuffer xpath = "Software/DfuServerProcess";
     if (!isEmptyString(process))
@@ -6898,17 +6891,14 @@ extern WORKUNIT_API StringBuffer &getClusterThorQueueName(StringBuffer &ret, con
 
 extern WORKUNIT_API StringBuffer &getClusterThorGroupName(StringBuffer &ret, const char *cluster)
 {
-    Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
+    Owned<IEnvironmentFactory> factory = getEnvironmentFactory(true);
     Owned<IConstEnvironment> env = factory->openEnvironment();
-    if (env)
-    {
-        Owned<IPropertyTree> root = &env->getPTree();
-        StringBuffer path;
-        path.append("Software/ThorCluster[@name=\"").append(cluster).append("\"]");
-        IPropertyTree * child = root->queryPropTree(path);
-        if (child)
-            getClusterGroupName(*child, ret);
-    }
+    Owned<IPropertyTree> root = &env->getPTree();
+    StringBuffer path;
+    path.append("Software/ThorCluster[@name=\"").append(cluster).append("\"]");
+    IPropertyTree * child = root->queryPropTree(path);
+    if (child)
+        getClusterGroupName(*child, ret);
 
     return ret;
 }
@@ -6936,23 +6926,20 @@ extern WORKUNIT_API StringBuffer &getClusterEclAgentQueueName(StringBuffer &ret,
 extern WORKUNIT_API IStringIterator *getTargetClusters(const char *processType, const char *processName)
 {
     Owned<CStringArrayIterator> ret = new CStringArrayIterator;
-    Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
+    Owned<IEnvironmentFactory> factory = getEnvironmentFactory(true);
     Owned<IConstEnvironment> env = factory->openEnvironment();
-    if (env)
+    Owned<IPropertyTree> root = &env->getPTree();
+    StringBuffer xpath;
+    xpath.appendf("%s", processType ? processType : "*");
+    if (processName && *processName)
+        xpath.appendf("[@process=\"%s\"]", processName);
+    Owned<IPropertyTreeIterator> targets = root->getElements("Software/Topology/Cluster");
+    ForEach(*targets)
     {
-        Owned<IPropertyTree> root = &env->getPTree();
-        StringBuffer xpath;
-        xpath.appendf("%s", processType ? processType : "*");
-        if (processName && *processName)
-            xpath.appendf("[@process=\"%s\"]", processName);
-        Owned<IPropertyTreeIterator> targets = root->getElements("Software/Topology/Cluster");
-        ForEach(*targets)
+        IPropertyTree &target = targets->query();
+        if (target.hasProp(xpath))
         {
-            IPropertyTree &target = targets->query();
-            if (target.hasProp(xpath))
-            {
-                ret->append(target.queryProp("@name"));
-            }
+            ret->append(target.queryProp("@name"));
         }
     }
     return ret.getClear();
@@ -6962,11 +6949,8 @@ extern WORKUNIT_API bool isProcessCluster(const char *process)
 {
     if (!process || !*process)
         return false;
-    Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
+    Owned<IEnvironmentFactory> factory = getEnvironmentFactory(true);
     Owned<IConstEnvironment> env = factory->openEnvironment();
-    if (!env)
-        return false;
-
     Owned<IPropertyTree> root = &env->getPTree();
     VStringBuffer xpath("Software/*Cluster[@name=\"%s\"]", process);
     return root->hasProp(xpath.str());
@@ -7039,11 +7023,8 @@ IPropertyTree* getTopologyCluster(Owned<IPropertyTree> &envRoot, const char *clu
 {
     if (!clustname || !*clustname)
         return NULL;
-    Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
+    Owned<IEnvironmentFactory> factory = getEnvironmentFactory(true);
     Owned<IConstEnvironment> env = factory->openEnvironment();
-    if (!env)
-        return NULL;
-
     envRoot.setown(&env->getPTree());
     StringBuffer xpath;
     xpath.appendf("Software/Topology/Cluster[@name=\"%s\"]", clustname);
@@ -7068,11 +7049,8 @@ IConstWUClusterInfo* getTargetClusterInfo(const char *clustname)
 
 unsigned getEnvironmentClusterInfo(CConstWUClusterInfoArray &clusters)
 {
-    Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
+    Owned<IEnvironmentFactory> factory = getEnvironmentFactory(true);
     Owned<IConstEnvironment> env = factory->openEnvironment();
-    if (!env)
-        return 0;
-
     Owned<IPropertyTree> root = &env->getPTree();
     return getEnvironmentClusterInfo(root, clusters);
 }
@@ -7097,11 +7075,8 @@ const char *getTargetClusterComponentName(const char *clustname, const char *pro
     if (!clustname)
         return NULL;
 
-    Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
+    Owned<IEnvironmentFactory> factory = getEnvironmentFactory(true);
     Owned<IConstEnvironment> env = factory->openEnvironment();
-    if (!env)
-        return NULL;
-
     Owned<IPropertyTree> root = &env->getPTree();
     StringBuffer xpath;
 
@@ -7118,11 +7093,8 @@ const char *getTargetClusterComponentName(const char *clustname, const char *pro
 
 unsigned getEnvironmentThorClusterNames(StringArray &thorNames, StringArray &groupNames, StringArray &targetNames, StringArray &queueNames)
 {
-    Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
+    Owned<IEnvironmentFactory> factory = getEnvironmentFactory(true);
     Owned<IConstEnvironment> env = factory->openEnvironment();
-    if (!env)
-        return 0;
-
     Owned<IPropertyTree> root = &env->getPTree();
     Owned<IPropertyTreeIterator> allTargets = root->getElements("Software/Topology/Cluster");
     ForEach(*allTargets)
@@ -7157,11 +7129,8 @@ unsigned getEnvironmentThorClusterNames(StringArray &thorNames, StringArray &gro
 
 unsigned getEnvironmentHThorClusterNames(StringArray &eclAgentNames, StringArray &groupNames, StringArray &targetNames)
 {
-    Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
+    Owned<IEnvironmentFactory> factory = getEnvironmentFactory(true);
     Owned<IConstEnvironment> env = factory->openEnvironment();
-    if (!env)
-        return 0;
-
     Owned<IPropertyTree> root = &env->getPTree();
     Owned<IPropertyTreeIterator> allEclAgents = root->getElements("Software/EclAgentProcess");
     ForEach(*allEclAgents)

--- a/dali/dfu/dfurun.cpp
+++ b/dali/dfu/dfurun.cpp
@@ -461,37 +461,31 @@ class CDFUengine: public CInterface, implements IDFUengine
         if ((isDotDotString != nullptr) || (isDotString != nullptr))
             throwError3(DFTERR_InvalidFilePath, pfilePath, dotDotString, dotString);
 
-        Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
-        if (factory)
+        Owned<IEnvironmentFactory> factory = getEnvironmentFactory(true);
+        Owned<IConstEnvironment> env = factory->openEnvironment();
+        StringBuffer netaddress;
+        filename.queryIP().getIpText(netaddress);
+
+        Owned<IConstDropZoneInfo> dropZone = env->getDropZoneByAddressPath(netaddress.str(), pfilePath);
+        if (!dropZone)
         {
-            Owned<IConstEnvironment> env = factory->openEnvironment();
-            if (env)
-            {
-                StringBuffer netaddress;
-                filename.queryIP().getIpText(netaddress);
-
-                Owned<IConstDropZoneInfo> dropZone = env->getDropZoneByAddressPath(netaddress.str(), pfilePath);
-                if (!dropZone)
-                {
-                    if (env->isDropZoneRestrictionEnabled())
-                        throwError2(DFTERR_NoMatchingDropzonePath, netaddress.str(), pfilePath);
-                    else
-                        LOG(MCdebugInfo, unknownJob, "No matching drop zone path on '%s' to file path: '%s'", netaddress.str(), pfilePath);
-                }
-#ifdef _DEBUG
-                else
-                {
-                    SCMStringBuffer dropZoneName;
-                    dropZone->getName(dropZoneName);
-
-                    LOG(MCdebugInfo, unknownJob, "Drop zone path '%s' is %svisible in ECLWatch."
-                            , dropZoneName.str()
-                            , (dropZone->isECLWatchVisible() ? "" : "not ")
-                            );
-                }
-#endif
-            }
+            if (env->isDropZoneRestrictionEnabled())
+                throwError2(DFTERR_NoMatchingDropzonePath, netaddress.str(), pfilePath);
+            else
+                LOG(MCdebugInfo, unknownJob, "No matching drop zone path on '%s' to file path: '%s'", netaddress.str(), pfilePath);
         }
+#ifdef _DEBUG
+        else
+        {
+            SCMStringBuffer dropZoneName;
+            dropZone->getName(dropZoneName);
+
+            LOG(MCdebugInfo, unknownJob, "Drop zone path '%s' is %svisible in ECLWatch."
+                , dropZoneName.str()
+                , (dropZone->isECLWatchVisible() ? "" : "not ")
+                );
+        }
+#endif
     }
 
     // Prepare DropZone check for file(s)
@@ -1067,7 +1061,7 @@ public:
                 : running(_running)
             {
                 if (atomic_dec_and_test(&running)) {
-                    Owned<IEnvironmentFactory> envf = getEnvironmentFactory();
+                    Owned<IEnvironmentFactory> envf = getEnvironmentFactory(false);
                     Owned<IConstEnvironment> env = envf->openEnvironment();
                     env->clearCache();
                 }

--- a/dali/ft/filecopy.cpp
+++ b/dali/ft/filecopy.cpp
@@ -924,21 +924,17 @@ void FileSprayer::beforeTransfer()
     throttleNicSpeed = options->getPropInt(ANthrottle, 0);
     if (throttleNicSpeed == 0 && !usePullOperation() && targets.ordinality() == 1 && sources.ordinality() > 1)
     {
-        Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
-        if (factory) {
-            Owned<IConstEnvironment> env = factory->openEnvironment();
-            if (env) {
-                StringBuffer ipText;
-                targets.item(0).filename.queryIP().getIpText(ipText);
-                Owned<IConstMachineInfo> machine = env->getMachineByAddress(ipText.str());
-                if (machine)
-                {
-                    if (machine->getOS() == MachineOsW2K)
-                    {
-                        throttleNicSpeed = machine->getNicSpeedMbitSec();
-                        LOG(MCdebugInfo, job, "Throttle target speed to %dMbit/sec", throttleNicSpeed);
-                    }
-                }
+        Owned<IEnvironmentFactory> factory = getEnvironmentFactory(true);
+        Owned<IConstEnvironment> env = factory->openEnvironment();
+        StringBuffer ipText;
+        targets.item(0).filename.queryIP().getIpText(ipText);
+        Owned<IConstMachineInfo> machine = env->getMachineByAddress(ipText.str());
+        if (machine)
+        {
+            if (machine->getOS() == MachineOsW2K)
+            {
+                throttleNicSpeed = machine->getNicSpeedMbitSec();
+                LOG(MCdebugInfo, job, "Throttle target speed to %dMbit/sec", throttleNicSpeed);
             }
         }
     }

--- a/dali/sasha/saarch.cpp
+++ b/dali/sasha/saarch.cpp
@@ -1183,7 +1183,7 @@ public:
     CSashaArchiverServer()
         : Thread("CSashaArchiverServer")
     {
-        Owned<IEnvironmentFactory> f = getEnvironmentFactory();
+        Owned<IEnvironmentFactory> f = getEnvironmentFactory(true);
         env.setown(f->openEnvironment());
         stopped = false;
     }

--- a/deployment/configgen/main.cpp
+++ b/deployment/configgen/main.cpp
@@ -273,7 +273,7 @@ int processRequest(const char* in_cfgname, const char* out_dirname, const char* 
   StringBuffer envXML;
   toXML(pEnv, envXML);
 
-  Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
+  Owned<IEnvironmentFactory> factory = getEnvironmentFactory(false);
   m_pEnvironment.setown(factory->loadLocalEnvironment(envXML));
   m_pConstEnvironment.set(m_pEnvironment);
 

--- a/deployment/envgen/main.cpp
+++ b/deployment/envgen/main.cpp
@@ -373,7 +373,7 @@ int main(int argc, char** argv)
       env.appendf("<" XML_HEADER ">\n<!-- Generated with envgen on ip %s -->\n", thisip.str());
       env.append(envXml);
       
-      Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
+      Owned<IEnvironmentFactory> factory = getEnvironmentFactory(false);
       Owned<IConstEnvironment>  constEnv = factory->loadLocalEnvironment(env);
       validateEnv(constEnv);
 

--- a/esp/services/WsDeploy/WsDeployEngine.cpp
+++ b/esp/services/WsDeploy/WsDeployEngine.cpp
@@ -206,8 +206,7 @@ void CWsDeployEngine::deploy(CDeployOptions& pOptions)
 {
   try
   {
-    Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
-    factory->validateCache();   
+    Owned<IEnvironmentFactory> factory = getEnvironmentFactory(true);
     Owned<IConstEnvironment> constEnv(factory->openEnvironment());
 
     m_pEnvDepEngine.setown( createEnvDeploymentEngine(*constEnv, *this, m_pDeploy->queryPropTree("SelectedComponents")) );
@@ -360,8 +359,7 @@ void CWsDeployEngine::deploy()
 {
   try
   {
-    Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
-    factory->validateCache();   
+    Owned<IEnvironmentFactory> factory = getEnvironmentFactory(true);
     Owned<IConstEnvironment> constEnv(factory->openEnvironment());
 
     m_pEnvDepEngine.setown( createEnvDeploymentEngine(*constEnv, *this, m_pDeploy->queryPropTree("SelectedComponents")) );

--- a/esp/services/WsDeploy/WsDeployService.cpp
+++ b/esp/services/WsDeploy/WsDeployService.cpp
@@ -598,7 +598,7 @@ bool CWsDeployFileInfo::navMenuEvent(IEspContext &context,
           else
             toXML(&m_constEnvRdOnly->getPTree(), sbxml);
           
-          Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
+          Owned<IEnvironmentFactory> factory = getEnvironmentFactory(false);
           m_Environment.setown(factory->loadLocalEnvironment(sbxml.str()));
           m_userWithLock.clear().append(req.getReqInfo().getUserId());
           context.getPeer(m_userIp.clear());
@@ -2779,7 +2779,7 @@ void CWsDeployFileInfo::setEnvironment(IEspContext &context, IConstWsDeployReqIn
   
   try
   {
-    Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
+    Owned<IEnvironmentFactory> factory = getEnvironmentFactory(false);
     Owned<IConstEnvironment>    constEnv = factory->loadLocalEnvironment(pszEnv);
 
     Owned<IPropertyTree> pEnvRoot = createPTreeFromXMLString(pszEnv);
@@ -5647,7 +5647,7 @@ void CWsDeployFileInfo::updateConfigFromFile()
   Owned <IPropertyTree> pTree = createPTree(*m_pFileIO);
   toXML(pTree, sbxml.clear());
 
-  Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
+  Owned<IEnvironmentFactory> factory = getEnvironmentFactory(false);
 
   m_constEnvRdOnly.clear();
   m_constEnvRdOnly.setown(factory->loadLocalEnvironment(sbxml.str()));
@@ -5894,7 +5894,7 @@ void CWsDeployFileInfo::saveEnvironment(IEspContext* pContext, IConstWsDeployReq
     m_lastSaved.setNow();
 
     //reset the readonly tree
-    Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
+    Owned<IEnvironmentFactory> factory = getEnvironmentFactory(false);
     m_constEnvRdOnly.setown(factory->loadLocalEnvironment(sXML.str()));
 
     if (valerrs.length())
@@ -6069,7 +6069,7 @@ void CWsDeployFileInfo::unlockEnvironment(IEspContext* context, IConstWsDeployRe
 
     m_pSubscription.clear();
     m_pSubscription.setown( new CSdsSubscription(this) );
-    Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
+    Owned<IEnvironmentFactory> factory = getEnvironmentFactory(true);
     m_constEnvRdOnly.setown(factory->openEnvironment());
   }
 
@@ -6136,7 +6136,7 @@ bool CWsDeployFileInfo::updateEnvironment(const char* xml)
   if (!xml || !*xml)
     return false;
 
-  Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
+  Owned<IEnvironmentFactory> factory = getEnvironmentFactory(false);
   m_constEnvRdOnly.setown(factory->loadLocalEnvironment(xml));
   return true;
 }
@@ -6179,7 +6179,7 @@ bool CWsDeployFileInfo::buildEnvironment(IEspContext &context, IEspBuildEnvironm
           {
             m_Environment.clear();
           }
-          Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
+          Owned<IEnvironmentFactory> factory = getEnvironmentFactory(false);
           m_Environment.setown(factory->loadLocalEnvironment(envXml.str()));
         }
         else
@@ -6400,7 +6400,7 @@ void CWsDeployFileInfo::initFileInfo(bool createOrOverwrite, bool bClearEnv)
     }
   }
 
-  Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
+  Owned<IEnvironmentFactory> factory = getEnvironmentFactory(false);
   m_Environment.setown(factory->loadLocalEnvironment(sbxml.str()));
 
   //add env 

--- a/esp/services/WsDeploy/WsDeployService.hpp
+++ b/esp/services/WsDeploy/WsDeployService.hpp
@@ -512,7 +512,7 @@ public:
         m_pGraphXml.clear();
         m_pNavTree.clear();
 
-        Owned<IEnvironmentFactory> factory = getEnvironmentFactory();       
+        Owned<IEnvironmentFactory> factory = getEnvironmentFactory(false);
         m_constEnvRdOnly.set(factory->openEnvironment());
         m_constEnvRdOnly->clearCache();
     }

--- a/esp/services/ws_dfu/ws_dfuService.cpp
+++ b/esp/services/ws_dfu/ws_dfuService.cpp
@@ -81,11 +81,8 @@ short days[12] = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
 
 CThorNodeGroup* CThorNodeGroupCache::readNodeGroup(const char* _groupName)
 {
-    Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
+    Owned<IEnvironmentFactory> factory = getEnvironmentFactory(true);
     Owned<IConstEnvironment> env = factory->openEnvironment();
-    if (!env)
-        throw MakeStringException(ECLWATCH_CANNOT_GET_ENV_INFO, "Failed to get environment information.");
-
     Owned<IPropertyTree> root = &env->getPTree();
     Owned<IPropertyTreeIterator> it= root->getElements("Software/ThorCluster");
     ForEach(*it)
@@ -4926,63 +4923,6 @@ bool CWsDfuEx::onEraseHistory(IEspContext &context, IEspEraseHistoryRequest &req
         FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
     return true;
-}
-
-void CWsDfuEx::getRoxieClusterConfig(char const * clusterType, char const * clusterName, char const * processName, StringBuffer& netAddress, int& port)
-{
-#if 0
-    Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
-    Owned<IConstEnvironment> environment = factory->openEnvironment();
-    Owned<IPropertyTree> pRoot = &environment->getPTree();
-#else
-    CTpWrapper dummy;
-    Owned<IPropertyTree> pRoot = dummy.getEnvironment("");
-    if (!pRoot)
-        throw MakeStringException(ECLWATCH_CANNOT_GET_ENV_INFO,"Failed to get environment information.");
-#endif
-
-    StringBuffer xpath;
-    xpath.appendf("Software/%s[@name='%s']", clusterType, clusterName);
-
-    IPropertyTree* pCluster = pRoot->queryPropTree( xpath.str() );
-    if (!pCluster)
-        throw MakeStringException(ECLWATCH_CLUSTER_NOT_IN_ENV_INFO, "'%s %s' is not defined!", clusterType, clusterName);
-
-    xpath.clear().append(processName);
-    xpath.append("@computer");
-    const char* computer = pCluster->queryProp(xpath.str());
-    if (!computer || strlen(computer) < 1)
-        throw MakeStringException(ECLWATCH_INVALID_CLUSTER_INFO, "'%s %s: %s' is not defined!", clusterType, clusterName, processName);
-
-    xpath.clear().append(processName);
-    xpath.append("@port");
-    const char* portStr = pCluster->queryProp(xpath.str());
-    port = ROXIE_SERVER_PORT;
-    if (portStr && *portStr)
-    {
-        port = atoi(portStr);
-    }
-
-#if 0
-    Owned<IConstMachineInfo> pMachine = environment->getMachine(computer);
-    if (pMachine)
-    {
-        SCMStringBuffer scmNetAddress;
-        pMachine->getNetAddress(scmNetAddress);
-        netAddress = scmNetAddress.str();
-    }
-#else
-    xpath.clear().appendf("Hardware/Computer[@name=\"%s\"]", computer);
-    IPropertyTree* pMachine = pRoot->queryPropTree( xpath.str() );
-    if (pMachine)
-    {
-        const char* addr = pMachine->queryProp("@netAddress");
-        if (addr && *addr)
-            netAddress.append(addr);
-    }
-#endif
-
-    return;
 }
 
 //////////////////////HPCC Browser//////////////////////////

--- a/esp/services/ws_dfu/ws_dfuService.hpp
+++ b/esp/services/ws_dfu/ws_dfuService.hpp
@@ -179,7 +179,6 @@ private:
     void getDefFile(IUserDescriptor* udesc, const char* FileName,StringBuffer& returnStr);
     void xsltTransformer(const char* xsltPath,StringBuffer& source,StringBuffer& returnStr);
     bool checkFileContent(IEspContext &context, IUserDescriptor* udesc, const char * logicalName, const char * cluster);
-    void getRoxieClusterConfig(char const * clusterType, char const * clusterName, char const * processName, StringBuffer& netAddress, int& port);
     bool checkRoxieQueryFilesOnDelete(IEspDFUArrayActionRequest &req, StringArray& roxieQueries);
     bool DFUDeleteFiles(IEspContext &context, IEspDFUArrayActionRequest &req, IEspDFUArrayActionResponse &resp);
 

--- a/esp/services/ws_ecl/ws_ecl_service.cpp
+++ b/esp/services/ws_ecl/ws_ecl_service.cpp
@@ -214,7 +214,7 @@ bool CWsEclService::init(const char * name, const char * type, IPropertyTree * c
             daliAddress.append(*daliServers++);
     }
 
-    Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
+    Owned<IEnvironmentFactory> factory = getEnvironmentFactory(true);
     Owned<IConstEnvironment> environment = factory->openEnvironment();
     Owned<IPropertyTree> pRoot = &environment->getPTree();
 

--- a/esp/services/ws_fileio/ws_fileioservice.cpp
+++ b/esp/services/ws_fileio/ws_fileioservice.cpp
@@ -36,11 +36,9 @@ bool CWsFileIOEx::CheckServerAccess(const char* server, const char* relPath, Str
 {
     if (!server || (server[0] == 0) || !relPath || (relPath[0] == 0))
         return false;
-    Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
 
-    Owned<IConstEnvironment> env;
-    env.setown(factory->openEnvironment());
-
+    Owned<IEnvironmentFactory> factory = getEnvironmentFactory(true);
+    Owned<IConstEnvironment> env = factory->openEnvironment();
     Owned<IPropertyTree> pEnvRoot = &env->getPTree();
     IPropertyTree* pEnvSoftware = pEnvRoot->queryPropTree("Software");
     Owned<IPropertyTree> pRoot = createPTreeFromXMLString("<Environment/>");

--- a/esp/services/ws_fs/ws_fsBinding.cpp
+++ b/esp/services/ws_fs/ws_fsBinding.cpp
@@ -200,9 +200,9 @@ int CFileSpraySoapBindingEx::onGetInstantQuery(IEspContext &context, CHttpReques
 
 IPropertyTree* CFileSpraySoapBindingEx::createPTreeForXslt(double clientVersion, const char* method, const char* dfuwuid)
 {
-    Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
-    Owned<IConstEnvironment> m_constEnv = factory->openEnvironment();
-    Owned<IPropertyTree> pEnvRoot = &m_constEnv->getPTree();
+    Owned<IEnvironmentFactory> factory = getEnvironmentFactory(true);
+    Owned<IConstEnvironment> constEnv = factory->openEnvironment();
+    Owned<IPropertyTree> pEnvRoot = &constEnv->getPTree();
     IPropertyTree* pEnvSoftware = pEnvRoot->queryPropTree("Software");
 
     Owned<IPropertyTree> pRoot = createPTreeFromXMLString("<Environment/>");
@@ -229,7 +229,7 @@ IPropertyTree* CFileSpraySoapBindingEx::createPTreeForXslt(double clientVersion,
             }
         }
 
-        appendDropZones(clientVersion, m_constEnv, dfuwuidSourcePartIP.str(), pSoftware);
+        appendDropZones(clientVersion, constEnv, dfuwuidSourcePartIP.str(), pSoftware);
 
         //For Spray files on Thor Cluster, fetch all the group names for all the thor instances (and dedup them)
         BoolHash uniqueThorClusterGroupNames;

--- a/esp/services/ws_fs/ws_fsService.cpp
+++ b/esp/services/ws_fs/ws_fsService.cpp
@@ -199,11 +199,9 @@ static void DeepAssign(IEspContext &context, IConstDFUWorkUnit *src, IEspDFUWork
     if(src == NULL)
         throw MakeStringException(ECLWATCH_MISSING_PARAMS, "'Source DFU workunit' doesn't exist.");
 
-    Owned<IEnvironmentFactory> envFactory = getEnvironmentFactory();
+    Owned<IEnvironmentFactory> envFactory = getEnvironmentFactory(true);
     Owned<IConstEnvironment> constEnv = envFactory->openEnvironment();
     Owned<IPropertyTree> root = &constEnv->getPTree();
-    if (!root)
-        throw MakeStringException(ECLWATCH_CANNOT_GET_ENV_INFO, "Failed to get environment information.");
 
     double version = context.getClientVersion();
     StringBuffer tmp, encoded;
@@ -561,12 +559,10 @@ bool CFileSprayEx::ParseLogicalPath(const char * pLogicalPath, StringBuffer &tit
 void setRoxieClusterPartDiskMapping(const char *clusterName, const char *defaultFolder, const char *defaultReplicateFolder,
                                bool supercopy, IDFUfileSpec *wuFSpecDest, IDFUoptions *wuOptions)
 {
-    Owned<IEnvironmentFactory> envFactory = getEnvironmentFactory();
-    envFactory->validateCache();
-
-    StringBuffer dirxpath;
-    dirxpath.appendf("Software/RoxieCluster[@name=\"%s\"]",clusterName);
+    Owned<IEnvironmentFactory> envFactory = getEnvironmentFactory(true);
     Owned<IConstEnvironment> constEnv = envFactory->openEnvironment();
+
+    VStringBuffer dirxpath("Software/RoxieCluster[@name=\"%s\"]",clusterName);
     Owned<IPropertyTree> pEnvRoot = &constEnv->getPTree();
     Owned<IPropertyTreeIterator> processes = pEnvRoot->getElements(dirxpath);
     if (!processes->first())
@@ -646,13 +642,11 @@ bool CFileSprayEx::onDFUWUSearch(IEspContext &context, IEspDFUWUSearchRequest & 
         if (!context.validateFeatureAccess(DFU_WU_URL, SecAccess_Read, false))
             throw MakeStringException(ECLWATCH_DFU_WU_ACCESS_DENIED, "Access to DFU workunit is denied.");
 
-        StringArray dfuclusters;
-        Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
+        Owned<IEnvironmentFactory> factory = getEnvironmentFactory(true);
         Owned<IConstEnvironment> environment = factory->openEnvironment();
         Owned<IPropertyTree> root = &environment->getPTree();
-        if (!root)
-            throw MakeStringException(ECLWATCH_CANNOT_GET_ENV_INFO, "Failed to get environment information.");
 
+        StringArray dfuclusters;
         Owned<IPropertyTreeIterator> clusterIterator = root->getElements("Software/Topology/Cluster");
         if (clusterIterator->first())
         {
@@ -933,11 +927,9 @@ bool CFileSprayEx::onGetDFUWorkunits(IEspContext &context, IEspGetDFUWorkunits &
             clusterReq.append(clusterName);
         }
 
-        Owned<IEnvironmentFactory> envFactory = getEnvironmentFactory();
+        Owned<IEnvironmentFactory> envFactory = getEnvironmentFactory(true);
         Owned<IConstEnvironment> constEnv = envFactory->openEnvironment();
         Owned<IPropertyTree> root = &constEnv->getPTree();
-        if (!root)
-            throw MakeStringException(ECLWATCH_CANNOT_GET_ENV_INFO, "Failed to get environment information.");
 
         StringArray targetClusters, clusterProcesses;
         Owned<IPropertyTreeIterator> clusters= root->getElements("Software/Topology/Cluster");
@@ -2229,10 +2221,8 @@ void CFileSprayEx::getDropZoneInfoByIP(double clientVersion, const char* ip, con
     if (!ip || !*ip)
         throw MakeStringExceptionDirect(ECLWATCH_INVALID_IP, "Network address must be specified for a drop zone!");
 
-    Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
+    Owned<IEnvironmentFactory> factory = getEnvironmentFactory(true);
     Owned<IConstEnvironment> constEnv = factory->openEnvironment();
-    if (!constEnv)
-        throw MakeStringException(ECLWATCH_CANNOT_GET_ENV_INFO, "Failed to get environment information.");
 
     StringBuffer destFile;
     if (isAbsolutePath(destFileIn))
@@ -2828,7 +2818,7 @@ bool CFileSprayEx::checkDropZoneIPAndPath(double clientVersion, const char* drop
     if (isEmptyString(netAddr) || isEmptyString(path))
         throw MakeStringException(ECLWATCH_INVALID_INPUT, "NetworkAddress or Path not defined.");
 
-    Owned<IEnvironmentFactory> envFactory = getEnvironmentFactory();
+    Owned<IEnvironmentFactory> envFactory = getEnvironmentFactory(true);
     Owned<IConstEnvironment> constEnv = envFactory->openEnvironment();
     Owned<IConstDropZoneInfoIterator> dropZoneItr = constEnv->getDropZoneIteratorByAddress(netAddr);
     ForEach(*dropZoneItr)
@@ -2942,7 +2932,7 @@ bool CFileSprayEx::onDropZoneFileSearch(IEspContext &context, IEspDropZoneFileSe
         if (isEmptyString(dropZoneName))
             throw MakeStringException(ECLWATCH_INVALID_INPUT, "DropZone not specified.");
 
-        Owned<IEnvironmentFactory> envFactory = getEnvironmentFactory();
+        Owned<IEnvironmentFactory> envFactory = getEnvironmentFactory(true);
         Owned<IConstEnvironment> constEnv = envFactory->openEnvironment();
         Owned<IConstDropZoneInfo> dropZoneInfo = constEnv->getDropZone(dropZoneName);
         if (!dropZoneInfo || (req.getECLWatchVisibleOnly() && !dropZoneInfo->isECLWatchVisible()))
@@ -3153,7 +3143,7 @@ bool CFileSprayEx::onDropZoneFiles(IEspContext &context, IEspDropZoneFilesReques
         bool filesFromALinux = false;
         IArrayOf<IEspDropZone> dropZoneList;
         bool ECLWatchVisibleOnly = req.getECLWatchVisibleOnly();
-        Owned<IEnvironmentFactory> envFactory = getEnvironmentFactory();
+        Owned<IEnvironmentFactory> envFactory = getEnvironmentFactory(true);
         Owned<IConstEnvironment> constEnv = envFactory->openEnvironment();
         Owned<IConstDropZoneInfoIterator> dropZoneItr = constEnv->getDropZoneIterator();
         ForEach(*dropZoneItr)
@@ -3345,11 +3335,9 @@ bool CFileSprayEx::onGetSprayTargets(IEspContext &context, IEspGetSprayTargetsRe
         if (!context.validateFeatureAccess(FILE_SPRAY_URL, SecAccess_Read, false))
             throw MakeStringException(ECLWATCH_FILE_SPRAY_ACCESS_DENIED, "Permission denied.");
 
-        Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
+        Owned<IEnvironmentFactory> factory = getEnvironmentFactory(true);
         Owned<IConstEnvironment> environment = factory->openEnvironment();
         Owned<IPropertyTree> root = &environment->getPTree();
-        if (!root)
-            throw MakeStringException(ECLWATCH_CANNOT_GET_ENV_INFO, "Failed to get environment information.");
 
         IArrayOf<IEspGroupNode> sprayTargets;
         //Fetch all the group names for all the thor instances (and dedup them)

--- a/esp/services/ws_machine/ws_machineService.hpp
+++ b/esp/services/ws_machine/ws_machineService.hpp
@@ -812,7 +812,6 @@ private:
     StringBuffer m_sTestStr2;
     bool m_useDefaultHPCCInit;
 
-    Owned<IEnvironmentFactory>  m_envFactory;
     Owned<IPropertyTree>        m_processFilters;
     Owned<IThreadPool>          m_threadPool;
     int                         m_threadPoolSize;

--- a/esp/services/ws_packageprocess/ws_packageprocessService.cpp
+++ b/esp/services/ws_packageprocess/ws_packageprocessService.cpp
@@ -1185,10 +1185,8 @@ bool CWsPackageProcessEx::onGetPackageMapSelectOptions(IEspContext &context, IEs
         bool includeProcesses = req.getIncludeProcesses();
         if (includeTargets || includeProcesses)
         {
-            Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
+            Owned<IEnvironmentFactory> factory = getEnvironmentFactory(true);
             Owned<IConstEnvironment> env = factory->openEnvironment();
-            if (!env)
-                throw MakeStringException(PKG_DALI_LOOKUP_ERROR,"Failed to get environment information.");
             Owned<IPropertyTree> root = &env->getPTree();
 
             IArrayOf<IConstTargetData> targets;

--- a/esp/services/ws_smc/ws_smcService.cpp
+++ b/esp/services/ws_smc/ws_smcService.cpp
@@ -239,10 +239,8 @@ bool CActivityInfo::isCachedActivityInfoValid(unsigned timeOutSeconds)
 
 void CActivityInfo::createActivityInfo(IEspContext& context)
 {
-    Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
+    Owned<IEnvironmentFactory> factory = getEnvironmentFactory(true);
     Owned<IConstEnvironment> env = factory->openEnvironment();
-    if (!env)
-        throw MakeStringException(ECLWATCH_CANNOT_GET_ENV_INFO,"Failed to get environment information.");
 
     CConstWUClusterInfoArray clusters;
     Owned<IPropertyTree> envRoot= &env->getPTree();
@@ -1847,7 +1845,7 @@ bool CWsSMCEx::onBrowseResources(IEspContext &context, IEspBrowseResourcesReques
 
         double version = context.getClientVersion();
 
-        Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
+        Owned<IEnvironmentFactory> factory = getEnvironmentFactory(true);
         Owned<IConstEnvironment> constEnv = factory->openEnvironment();
 
         //The resource files will be downloaded from the same box of ESP (not dali)

--- a/esp/services/ws_topology/ws_topologyService.cpp
+++ b/esp/services/ws_topology/ws_topologyService.cpp
@@ -54,7 +54,6 @@ void CWsTopologyEx::init(IPropertyTree *cfg, const char *process, const char *se
         ERRLOG("No Dali Connection Active.");
         throw MakeStringException(ECLWATCH_CANNOT_CONNECT_DALI, "No Connection to Dali server is active. Please specify a Dali server in the configuration file.");
     }
-    m_envFactory.setown( getEnvironmentFactory() );
 
     //load threshold values for monitoring cpu load, disk/memory usage
     xpath.clear().appendf("Software/EspProcess[@name=\"%s\"]/EspService[@name=\"%s\"]", process, service);
@@ -150,9 +149,6 @@ bool CWsTopologyEx::onTpSwapNode(IEspContext &context,IEspTpSwapNodeRequest  &re
     {
         if (!context.validateFeatureAccess(FEATURE_URL, SecAccess_Full, false))
             throw MakeStringException(ECLWATCH_TOPOLOGY_ACCESS_DENIED, "Failed to Swap Node. Permission denied.");
-
-        //another client (like configenv) may have updated the constant environment so reload it
-        m_envFactory->validateCache();
 
         bool res = swapNode(req.getCluster(),req.getOldIP(),req.getNewIP());
 
@@ -977,9 +973,6 @@ bool CWsTopologyEx::onTpClusterQuery(IEspContext &context, IEspTpClusterQueryReq
         if (!context.validateFeatureAccess(FEATURE_URL, SecAccess_Read, false))
             throw MakeStringException(ECLWATCH_TOPOLOGY_ACCESS_DENIED, "Failed to do Cluster Query. Permission denied.");
 
-        //another client (like configenv) may have updated the constant environment so reload it
-        m_envFactory->validateCache();
-
         IArrayOf<IEspTpCluster> clusters;
         const char* type = req.getType();
         if (!type || !*type || (strcmp(eqRootNode,type) == 0) || (strcmp(eqAllClusters,type) == 0))
@@ -1019,14 +1012,8 @@ bool CWsTopologyEx::onTpListTargetClusters(IEspContext &context, IEspTpListTarge
         if (!context.validateFeatureAccess(FEATURE_URL, SecAccess_Read, false))
             throw MakeStringException(ECLWATCH_TOPOLOGY_ACCESS_DENIED, "Failed to do Cluster Query. Permission denied.");
 
-        //another client (like configenv) may have updated the constant environment so reload it
-        m_envFactory->validateCache();
-
-        Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
+        Owned<IEnvironmentFactory> factory = getEnvironmentFactory(true);
         Owned<IConstEnvironment> env = factory->openEnvironment();
-        if (!env)
-            return false;
-
         Owned<IPropertyTree> root = &env->getPTree();
         bool foundDefault = false;
         bool hasHThor = false;
@@ -1114,9 +1101,6 @@ bool CWsTopologyEx::onTpTargetClusterQuery(IEspContext &context, IEspTpTargetClu
     {
         if (!context.validateFeatureAccess(FEATURE_URL, SecAccess_Read, false))
             throw MakeStringException(ECLWATCH_TOPOLOGY_ACCESS_DENIED, "Failed to do Cluster Query. Permission denied.");
-
-        //another client (like configenv) may have updated the constant environment so reload it
-        m_envFactory->validateCache();
 
         double version = context.getClientVersion();
 
@@ -1273,9 +1257,6 @@ bool CWsTopologyEx::onTpServiceQuery(IEspContext &context, IEspTpServiceQueryReq
         const char* type = req.getType();
         if (!type || !*type || (strcmp(eqAllServices,type) == 0))
         {
-            //another client (like configenv) may have updated the constant environment so reload it
-            m_envFactory->validateCache();
-
             IEspTpServices& ServiceList = resp.updateServiceList();
 
             m_TpWrapper.getTpDaliServers( ServiceList.getTpDalis() );
@@ -1332,9 +1313,6 @@ bool CWsTopologyEx::onTpMachineQuery(IEspContext &context, IEspTpMachineQueryReq
 { 
     try
     {
-        //another client (like configenv) may have updated the constant environment so reload it
-        m_envFactory->validateCache();
-
         if (!context.validateFeatureAccess(FEATURE_URL, SecAccess_Read, false))
             throw MakeStringException(ECLWATCH_TOPOLOGY_ACCESS_DENIED, "Failed to do Machine Query. Permission denied.");
         
@@ -1403,9 +1381,6 @@ bool CWsTopologyEx::onTpMachineInfo(IEspContext &context, IEspTpMachineInfoReque
 {
     try
     {
-        //another client (like configenv) may have updated the constant environment so reload it
-        m_envFactory->validateCache();
-
         if (!context.validateFeatureAccess(FEATURE_URL, SecAccess_Read, false))
             throw MakeStringException(ECLWATCH_TOPOLOGY_ACCESS_DENIED, "Failed to do Machine Info. Permission denied.");
 
@@ -1498,9 +1473,8 @@ bool CWsTopologyEx::onTpGetComponentFile(IEspContext &context,
         StringAttr      sDirectory;
         if (bCluster && !(netAddress && *netAddress))
         {
-            //another client (like configenv) may have updated the constant environment so reload it
-            m_envFactory->validateCache();
-            Owned<IConstEnvironment> constEnv = m_envFactory->openEnvironment();
+            Owned<IEnvironmentFactory> factory = getEnvironmentFactory(true);
+            Owned<IConstEnvironment> constEnv = factory->openEnvironment();
             Owned<IPropertyTree> pRoot = &constEnv->getPTree();
 
             StringBuffer xpath;

--- a/esp/services/ws_topology/ws_topologyService.hpp
+++ b/esp/services/ws_topology/ws_topologyService.hpp
@@ -78,7 +78,6 @@ private:
 
     CTpWrapper m_TpWrapper;
     bool         m_displayRoxieCluster;
-    Owned<IEnvironmentFactory> m_envFactory;
     StringBuffer                    m_preflightProcessFilter;
     unsigned int                    m_cpuThreshold;
     unsigned int                    m_memThreshold;

--- a/esp/services/ws_workunits/ws_workunitsHelpers.cpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.cpp
@@ -184,10 +184,8 @@ WsWUExceptions::WsWUExceptions(IConstWorkUnit& wu): numerr(0), numwrn(0), numinf
 
 void getSashaNode(SocketEndpoint &ep)
 {
-    Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
+    Owned<IEnvironmentFactory> factory = getEnvironmentFactory(true);
     Owned<IConstEnvironment> env = factory->openEnvironment();
-    if (!env)
-        throw MakeStringException(ECLWATCH_CANNOT_GET_ENV_INFO,"Cannot get environment information.");
     Owned<IPropertyTree> root = &env->getPTree();
     IPropertyTree *pt = root->queryPropTree("Software/SashaServerProcess[1]/Instance[1]");
     if (!pt)
@@ -1156,7 +1154,7 @@ unsigned WsWuInfo::getWorkunitThorLogInfo(IArrayOf<IEspECLHelpFile>& helpers, IE
         }
 
         StringBuffer logDir;
-        Owned<IEnvironmentFactory> envFactory = getEnvironmentFactory();
+        Owned<IEnvironmentFactory> envFactory = getEnvironmentFactory(true);
         Owned<IConstEnvironment> constEnv = envFactory->openEnvironment();
         Owned<IPropertyTree> logTree = &constEnv->getPTree();
         if (logTree)
@@ -1247,11 +1245,9 @@ bool WsWuInfo::getClusterInfo(IEspECLWorkunit &info, unsigned long flags)
     {
         int clusterTypeFlag = 0;
 
-        Owned<IEnvironmentFactory> envFactory = getEnvironmentFactory();
+        Owned<IEnvironmentFactory> envFactory = getEnvironmentFactory(true);
         Owned<IConstEnvironment> constEnv = envFactory->openEnvironment();
         Owned<IPropertyTree> root = &constEnv->getPTree();
-        if (!root)
-            throw MakeStringException(ECLWATCH_CANNOT_CONNECT_DALI,"Cannot connect to DALI server.");
 
         Owned<IConstWUClusterInfo> clusterInfo = getTargetClusterInfo(clusterName.str());
         if (clusterInfo.get())

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -3741,11 +3741,9 @@ bool CWsWorkunitsEx::onWUShowScheduled(IEspContext &context, IEspWUShowScheduled
         if(notEmpty(req.getPushEventText()))
             resp.setPushEventText(req.getPushEventText());
 
-        Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
+        Owned<IEnvironmentFactory> factory = getEnvironmentFactory(true);
         Owned<IConstEnvironment> environment = factory->openEnvironment();
         Owned<IPropertyTree> root = &environment->getPTree();
-        if (!root)
-            throw MakeStringException(ECLWATCH_CANNOT_GET_ENV_INFO, "Failed to get environment information.");
 
         unsigned i = 0;
         Owned<IPropertyTreeIterator> ic = root->getElements("Software/Topology/Cluster");
@@ -4009,37 +4007,6 @@ bool CWsWorkunitsEx::onWUAddLocalFileToWorkunit(IEspContext& context, IEspWUAddL
         FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
    return true;
-}
-
-void getClusterConfig(char const * clusterType, char const * clusterName, char const * processName, StringBuffer& netAddress)
-{
-    Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
-    Owned<IConstEnvironment> environment = factory->openEnvironment();
-    Owned<IPropertyTree> pRoot = &environment->getPTree();
-
-    VStringBuffer xpath("Software/%s[@name='%s']", clusterType, clusterName);
-    IPropertyTree* pCluster = pRoot->queryPropTree(xpath.str());
-    if (!pCluster)
-        throw MakeStringException(ECLWATCH_CLUSTER_NOT_IN_ENV_INFO, "'%s %s' is not defined.", clusterType, clusterName);
-
-    const char* port = pCluster->queryProp(xpath.set(processName).append("@port").str());
-    const char* computer = pCluster->queryProp(xpath.set(processName).append("@computer").str());
-    if (isEmpty(computer))
-        throw MakeStringException(ECLWATCH_INVALID_CLUSTER_INFO, "'%s %s: %s' is not defined.", clusterType, clusterName, processName);
-
-    Owned<IConstMachineInfo> pMachine = environment->getMachine(computer);
-    if (pMachine)
-    {
-        StringBufferAdaptor s(netAddress);
-        pMachine->getNetAddress(s);
-#ifdef MACHINE_IP
-        if (streq(netAddress.str(), "."))
-            netAddress = MACHINE_IP;
-#endif
-        netAddress.append(':').append(port);
-    }
-
-    return;
 }
 
 bool CWsWorkunitsEx::onWUGetGraphNameAndTypes(IEspContext &context,IEspWUGetGraphNameAndTypesRequest &req, IEspWUGetGraphNameAndTypesResponse &resp)
@@ -4332,11 +4299,9 @@ int CWsWorkunitsSoapBindingEx::onGetForm(IEspContext &context, CHttpRequest* req
         StringBuffer xslt;
         if(strieq(method,"WUQuery") || strieq(method,"WUJobList"))
         {
-            Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
+            Owned<IEnvironmentFactory> factory = getEnvironmentFactory(true);
             Owned<IConstEnvironment> environment = factory->openEnvironment();
             Owned<IPropertyTree> root = &environment->getPTree();
-            if (!root)
-                throw MakeStringException(ECLWATCH_CANNOT_GET_ENV_INFO, "Failed to get environment information.");
             if(strieq(method,"WUQuery"))
             {
                 SecAccessFlags accessOwn;

--- a/esp/smc/SMCLib/TpWrapper.cpp
+++ b/esp/smc/SMCLib/TpWrapper.cpp
@@ -33,22 +33,14 @@ const char* MSG_FAILED_GET_ENVIRONMENT_INFO = "Failed to get environment informa
 
 IPropertyTree* CTpWrapper::getEnvironment(const char* xpath)
 {
-    Owned<IEnvironmentFactory> envFactory = getEnvironmentFactory();
+    Owned<IEnvironmentFactory> envFactory = getEnvironmentFactory(true);
     Owned<IConstEnvironment> constEnv = envFactory->openEnvironment();
     Owned<IPropertyTree> root = &constEnv->getPTree();
-    if (root)
-    {
-        if (!xpath || !*xpath)
-        {
-            return LINK(root);
-        }
-        else
-        {
-            IPropertyTree* pSubTree = root->queryPropTree( xpath );
-            if (pSubTree)
-                return LINK(pSubTree);
-        }
-    }
+    if (!xpath || !*xpath)
+        return LINK(root);
+    IPropertyTree* pSubTree = root->queryPropTree( xpath );
+    if (pSubTree)
+        return LINK(pSubTree);
 
     return NULL;
 }
@@ -59,17 +51,9 @@ bool CTpWrapper::getClusterLCR(const char* clusterType, const char* clusterName)
     if (!clusterType || !*clusterType || !clusterName || !*clusterName)
         return bLCR;
 
-    Owned<IEnvironmentFactory> envFactory = getEnvironmentFactory();
-    if (!envFactory)
-        throw MakeStringExceptionDirect(ECLWATCH_CANNOT_GET_ENV_INFO, MSG_FAILED_GET_ENVIRONMENT_INFO);
-    
+    Owned<IEnvironmentFactory> envFactory = getEnvironmentFactory(true);
     Owned<IConstEnvironment> constEnv = envFactory->openEnvironment();
-    if (!constEnv)
-        throw MakeStringExceptionDirect(ECLWATCH_CANNOT_GET_ENV_INFO, MSG_FAILED_GET_ENVIRONMENT_INFO);
-
     Owned<IPropertyTree> root = &constEnv->getPTree();
-    if (!root)
-        throw MakeStringExceptionDirect(ECLWATCH_CANNOT_GET_ENV_INFO, MSG_FAILED_GET_ENVIRONMENT_INFO);
 
     StringBuffer xpath;
     xpath.appendf("Software/%s[@name='%s']", clusterType, clusterName);
@@ -734,11 +718,9 @@ void CTpWrapper::getTargetClusterList(IArrayOf<IEspTpLogicalCluster>& clusters, 
 
 void CTpWrapper::queryTargetClusterProcess(double version, const char* processName, const char* clusterType, IArrayOf<IConstTpCluster>& clusterList)
 {
-    Owned<IEnvironmentFactory> envFactory = getEnvironmentFactory();
+    Owned<IEnvironmentFactory> envFactory = getEnvironmentFactory(true);
     Owned<IConstEnvironment> constEnv = envFactory->openEnvironment();
     Owned<IPropertyTree> root = &constEnv->getPTree();
-    if (!root)
-        throw MakeStringExceptionDirect(ECLWATCH_CANNOT_GET_ENV_INFO, MSG_FAILED_GET_ENVIRONMENT_INFO);
 
     StringBuffer xpath;
     xpath.appendf("Software/%s[@name='%s']", clusterType, processName);
@@ -864,11 +846,9 @@ void CTpWrapper::queryTargetClusters(double version, const char* clusterType, co
 {
     try
     {
-        Owned<IEnvironmentFactory> envFactory = getEnvironmentFactory();
+        Owned<IEnvironmentFactory> envFactory = getEnvironmentFactory(true);
         Owned<IConstEnvironment> constEnv = envFactory->openEnvironment();
         Owned<IPropertyTree> root = &constEnv->getPTree();
-        if (!root)
-            throw MakeStringExceptionDirect(ECLWATCH_CANNOT_GET_ENV_INFO, MSG_FAILED_GET_ENVIRONMENT_INFO);
 
         Owned<IPropertyTreeIterator> clusters= root->getElements("Software/Topology/Cluster");
         if (!clusters->first())
@@ -1001,152 +981,149 @@ void CTpWrapper::getClusterProcessList(const char* ClusterType, IArrayOf<IEspTpC
 {
     try
     {
-        Owned<IEnvironmentFactory> envFactory = getEnvironmentFactory();
+        Owned<IEnvironmentFactory> envFactory = getEnvironmentFactory(true);
         Owned<IConstEnvironment> constEnv = envFactory->openEnvironment();
         Owned<IPropertyTree> root = &constEnv->getPTree();
-        if (root)
-        {
-            IPropertyTree* pSoftware = root->queryPropTree("Software");
-            if (!pSoftware)
-                throw MakeStringExceptionDirect(ECLWATCH_CANNOT_GET_ENV_INFO, MSG_FAILED_GET_ENVIRONMENT_INFO);
+        IPropertyTree* pSoftware = root->queryPropTree("Software");
+        if (!pSoftware)
+            throw MakeStringExceptionDirect(ECLWATCH_CANNOT_GET_ENV_INFO, MSG_FAILED_GET_ENVIRONMENT_INFO);
 
-            StringArray queuesdone;
-            StringArray groupsdone;
-            Owned<IPropertyTreeIterator> clusters= pSoftware->getElements(ClusterType);
-            if (clusters->first()) {
-                do {
-                    IPropertyTree &cluster = clusters->query();                 
-                    const char* name = cluster.queryProp("@name");
-                    if (!name||!*name)
-                        continue;
-                    const char* queueName = NULL;
-                    const char* groupName = NULL;
-                    if (name&&(stricmp(ClusterType,eqThorCluster)==0)) 
-                    {   
-                        // only for multi-thor
-                        // only list first thor cluster on queue
-                        queueName = cluster.queryProp("@queueName");
-                        if (!queueName||!*queueName)
-                            queueName = name;
-                        if (ignoreduplicatqueues) 
+        StringArray queuesdone;
+        StringArray groupsdone;
+        Owned<IPropertyTreeIterator> clusters= pSoftware->getElements(ClusterType);
+        if (clusters->first()) {
+            do {
+                IPropertyTree &cluster = clusters->query();
+                const char* name = cluster.queryProp("@name");
+                if (!name||!*name)
+                    continue;
+                const char* queueName = NULL;
+                const char* groupName = NULL;
+                if (name&&(stricmp(ClusterType,eqThorCluster)==0))
+                {
+                    // only for multi-thor
+                    // only list first thor cluster on queue
+                    queueName = cluster.queryProp("@queueName");
+                    if (!queueName||!*queueName)
+                        queueName = name;
+                    if (ignoreduplicatqueues)
+                    {
+                        bool done=false;
+                        ForEachItemIn(i,queuesdone)
                         {
-                            bool done=false;
-                            ForEachItemIn(i,queuesdone) 
+                            if (strcmp(queuesdone.item(i),queueName)==0)
                             {
-                                if (strcmp(queuesdone.item(i),queueName)==0) 
-                                {
-                                    done = true;
-                                    break;
-                                }
+                                done = true;
+                                break;
                             }
-                            if (done)
-                                continue;
-                            queuesdone.append(queueName);
                         }
-                        groupName = cluster.queryProp("@nodeGroup");
-                        if (!groupName||!*groupName)
-                            groupName = name;
-                        if (ignoreduplicategroups) 
+                        if (done)
+                            continue;
+                        queuesdone.append(queueName);
+                    }
+                    groupName = cluster.queryProp("@nodeGroup");
+                    if (!groupName||!*groupName)
+                        groupName = name;
+                    if (ignoreduplicategroups)
+                    {
+                        bool done=false;
+                        ForEachItemIn(i,groupsdone)
                         {
-                            bool done=false;
-                            ForEachItemIn(i,groupsdone) 
+                            if (strcmp(groupsdone.item(i),groupName)==0)
                             {
-                                if (strcmp(groupsdone.item(i),groupName)==0) 
-                                {
-                                    done = true;
-                                    break;
-                                }
+                                done = true;
+                                break;
                             }
-                            if (done)
-                                continue;
-                            groupsdone.append(groupName);
                         }
-
+                        if (done)
+                            continue;
+                        groupsdone.append(groupName);
                     }
 
-                    IEspTpCluster* clusterInfo = createTpCluster("","");                    
-                    clusterInfo->setName(name);
-                    if (queueName && *queueName)
-                        clusterInfo->setQueueName(queueName);
+                }
+
+                IEspTpCluster* clusterInfo = createTpCluster("","");
+                clusterInfo->setName(name);
+                if (queueName && *queueName)
+                    clusterInfo->setQueueName(queueName);
+                else
+                    clusterInfo->setQueueName(name);
+                clusterInfo->setDesc(name);
+                clusterInfo->setBuild( cluster.queryProp("@build") );
+
+                StringBuffer path("/Environment/Software");
+                StringBuffer tmpPath;
+                setAttPath(path, ClusterType, "name", name, tmpPath);
+
+                clusterInfo->setType(ClusterType);
+
+                StringBuffer tmpDir;
+                if (getConfigurationDirectory(root->queryPropTree("Software/Directories"), "run", ClusterType, name, tmpDir))
+                {
+                    clusterInfo->setDirectory(tmpDir.str());
+                }
+                else
+                {
+                    clusterInfo->setDirectory(cluster.queryProp("@directory"));
+                }
+
+                tmpDir.clear();
+                if (getConfigurationDirectory(root->queryPropTree("Software/Directories"), "log", ClusterType, name, tmpDir))
+                {
+                    clusterInfo->setLogDirectory( tmpDir.str() );
+                }
+                else
+                {
+                    const char* logDir = cluster.queryProp("@logDir");
+                    if (logDir)
+                        clusterInfo->setLogDirectory( logDir );
+                }
+
+                clusterInfo->setPath(tmpPath.str());
+                clusterInfo->setPrefix("");
+                if(cluster.hasProp("@dataBuild"))
+                    clusterInfo->setDataModel(cluster.queryProp("@dataBuild"));
+
+                clusterList.append(*clusterInfo);
+
+                //find out OS
+                OS_TYPE os = OS_WINDOWS;
+                unsigned int clusterTypeLen = strlen(ClusterType);
+                const char* childType = NULL;
+                if (clusterTypeLen > 4)
+                {
+                    if (!strnicmp(ClusterType, "roxie", 4))
+                        childType = "RoxieServerProcess[1]";
+                    else if (!strnicmp(ClusterType, "thor", 4))
+                        childType = "ThorMasterProcess";
                     else
-                        clusterInfo->setQueueName(name);
-                    clusterInfo->setDesc(name);
-                    clusterInfo->setBuild( cluster.queryProp("@build") );
-
-                    StringBuffer path("/Environment/Software");
-                    StringBuffer tmpPath;
-                    setAttPath(path, ClusterType, "name", name, tmpPath);
-
-                    clusterInfo->setType(ClusterType);
-
-                    StringBuffer tmpDir;
-                    if (getConfigurationDirectory(root->queryPropTree("Software/Directories"), "run", ClusterType, name, tmpDir))
+                        childType = "HoleControlProcess";
+                }
+                if (childType)
+                {
+                    IPropertyTree* pChild = cluster.queryPropTree(childType);
+                    if (pChild)
                     {
-                        clusterInfo->setDirectory(tmpDir.str());
-                    }
-                    else
-                    {
-                        clusterInfo->setDirectory(cluster.queryProp("@directory"));
-                    }
-
-                    tmpDir.clear();
-                    if (getConfigurationDirectory(root->queryPropTree("Software/Directories"), "log", ClusterType, name, tmpDir))
-                    {
-                        clusterInfo->setLogDirectory( tmpDir.str() );
-                    }
-                    else
-                    {
-                        const char* logDir = cluster.queryProp("@logDir");
-                        if (logDir)
-                            clusterInfo->setLogDirectory( logDir );
-                    }
-
-                    clusterInfo->setPath(tmpPath.str());
-                    clusterInfo->setPrefix("");
-                    if(cluster.hasProp("@dataBuild"))
-                        clusterInfo->setDataModel(cluster.queryProp("@dataBuild"));
-
-                    clusterList.append(*clusterInfo);
-
-                    //find out OS
-                    OS_TYPE os = OS_WINDOWS;
-                    unsigned int clusterTypeLen = strlen(ClusterType);
-                    const char* childType = NULL;
-                    if (clusterTypeLen > 4)
-                    {
-                        if (!strnicmp(ClusterType, "roxie", 4))
-                            childType = "RoxieServerProcess[1]";
-                        else if (!strnicmp(ClusterType, "thor", 4))
-                            childType = "ThorMasterProcess";
-                        else
-                            childType = "HoleControlProcess";
-                    }
-                    if (childType)
-                    {
-                        IPropertyTree* pChild = cluster.queryPropTree(childType);
-                        if (pChild)
+                        const char* computer = pChild->queryProp("@computer");
+                        IPropertyTree* pHardware = root->queryPropTree("Hardware");
+                        if (computer && *computer && pHardware)
                         {
-                            const char* computer = pChild->queryProp("@computer");
-                            IPropertyTree* pHardware = root->queryPropTree("Hardware");
-                            if (computer && *computer && pHardware)
+                            StringBuffer xpath;
+                            xpath.appendf("Computer[@name='%s']/@computerType", computer);
+                            const char* computerType = pHardware->queryProp( xpath.str() );
+                            if (computerType && *computerType)
                             {
-                                StringBuffer xpath;
-                                xpath.appendf("Computer[@name='%s']/@computerType", computer);
-                                const char* computerType = pHardware->queryProp( xpath.str() );
-                                if (computerType && *computerType)
-                                {
-                                    xpath.clear().appendf("ComputerType[@name='%s']/@opSys", computerType);
-                                    const char* opSys = pHardware->queryProp( xpath.str() );
-                                    if (!stricmp(opSys, "linux") || !stricmp( opSys, "solaris"))
-                                        os = OS_LINUX;
-                                }
+                                xpath.clear().appendf("ComputerType[@name='%s']/@opSys", computerType);
+                                const char* opSys = pHardware->queryProp( xpath.str() );
+                                if (!stricmp(opSys, "linux") || !stricmp( opSys, "solaris"))
+                                    os = OS_LINUX;
                             }
                         }
                     }
-                    clusterInfo->setOS(os);
+                }
+                clusterInfo->setOS(os);
 
-                } while (clusters->next());
-            }
+            } while (clusters->next());
         }
     }
     catch(IException* e){   
@@ -1164,84 +1141,81 @@ void CTpWrapper::getHthorClusterList(IArrayOf<IEspTpCluster>& clusterList)
 {
     try
     {
-        Owned<IEnvironmentFactory> envFactory = getEnvironmentFactory();
+        Owned<IEnvironmentFactory> envFactory = getEnvironmentFactory(true);
         Owned<IConstEnvironment> constEnv = envFactory->openEnvironment();
         Owned<IPropertyTree> root = &constEnv->getPTree();
-        if (root)
+        IPropertyTree* pSoftware = root->queryPropTree("Software");
+
+        const char * ClusterType = "EclAgentProcess";
+        Owned<IPropertyTreeIterator> clusters(pSoftware->getElements(ClusterType));
+        ForEach(*clusters)
         {
-            IPropertyTree* pSoftware = root->queryPropTree("Software");
-
-            const char * ClusterType = "EclAgentProcess";
-            Owned<IPropertyTreeIterator> clusters(pSoftware->getElements(ClusterType));
-            ForEach(*clusters) 
+            IPropertyTree &cluster = clusters->query();
+            const char* name = cluster.queryProp("@name");
+            if (!name||!*name)
+                continue;
+            unsigned ins = 0;
+            Owned<IPropertyTreeIterator> insts = clusters->query().getElements("Instance");
+            ForEach(*insts)
             {
-                IPropertyTree &cluster = clusters->query();                 
-                const char* name = cluster.queryProp("@name");
-                if (!name||!*name)
-                    continue;
-                unsigned ins = 0;
-                Owned<IPropertyTreeIterator> insts = clusters->query().getElements("Instance");
-                ForEach(*insts) 
+                const char *na = insts->query().queryProp("@netAddress");
+                if (na&&*na)
                 {
-                    const char *na = insts->query().queryProp("@netAddress");
-                    if (na&&*na) 
+                    SocketEndpoint ep(na);
+                    if (!ep.isNull())
                     {
-                        SocketEndpoint ep(na);
-                        if (!ep.isNull()) 
+                        ins++;
+                        StringBuffer gname("hthor__");
+                        gname.append(name);
+                        if (ins>1)
+                            gname.append('_').append(ins);
+
+                        IEspTpCluster* clusterInfo = createTpCluster("","");
+
+                        clusterInfo->setName(gname.str());
+                        clusterInfo->setQueueName(name);
+                        clusterInfo->setDesc(cluster.queryProp("@build"));
+
+                        clusterInfo->setBuild( cluster.queryProp("@description") );
+
+                        StringBuffer path("/Environment/Software");
+                        StringBuffer tmpPath;
+                        setAttPath(path, ClusterType, "name", name, tmpPath);
+
+                        clusterInfo->setType(ClusterType);
+                        clusterInfo->setDirectory(insts->query().queryProp("@directory"));
+
+                        StringBuffer tmpDir;
+                        if (getConfigurationDirectory(root->queryPropTree("Software/Directories"), "run", ClusterType, name, tmpDir))
                         {
-                            ins++;
-                            StringBuffer gname("hthor__");
-                            gname.append(name);
-                            if (ins>1)
-                                gname.append('_').append(ins);
-
-                            IEspTpCluster* clusterInfo = createTpCluster("","");    
-                    
-                            clusterInfo->setName(gname.str());
-                            clusterInfo->setQueueName(name);
-                            clusterInfo->setDesc(cluster.queryProp("@build"));
-
-                            clusterInfo->setBuild( cluster.queryProp("@description") );
-
-                            StringBuffer path("/Environment/Software");
-                            StringBuffer tmpPath;
-                            setAttPath(path, ClusterType, "name", name, tmpPath);
-
-                            clusterInfo->setType(ClusterType);
-                            clusterInfo->setDirectory(insts->query().queryProp("@directory"));
-
-                            StringBuffer tmpDir;
-                            if (getConfigurationDirectory(root->queryPropTree("Software/Directories"), "run", ClusterType, name, tmpDir))
-                            {
-                                clusterInfo->setDirectory(tmpDir.str());
-                            }
-                            else
-                            {
-                                clusterInfo->setDirectory(insts->query().queryProp("@directory"));
-                            }
-
-                            clusterInfo->setPath(tmpPath.str());
-                            clusterList.append(*clusterInfo);
-
-                            //find out OS
-                            OS_TYPE os = OS_WINDOWS;
-                            const char* computer = insts->query().queryProp("@computer");
-                            IPropertyTree* pHardware = root->queryPropTree("Hardware");
-                            if (computer && *computer && pHardware)
-                            {
-                                StringBuffer xpath;
-                                xpath.appendf("Computer[@name='%s']/@computerType", computer);
-                                const char* computerType = pHardware->queryProp( xpath.str() );
-                                if (computerType && *computerType)
-                                {
-                                    xpath.clear().appendf("ComputerType[@name='%s']/@opSys", computerType);
-                                    const char* opSys = pHardware->queryProp( xpath.str() );
-                                    if (!stricmp(opSys, "linux") || !stricmp( opSys, "solaris"))
-                                        os = OS_LINUX;
-                                }
-                            }
-                            clusterInfo->setOS(os);
+                            clusterInfo->setDirectory(tmpDir.str());
                         }
+                        else
+                        {
+                            clusterInfo->setDirectory(insts->query().queryProp("@directory"));
+                        }
+
+                        clusterInfo->setPath(tmpPath.str());
+                        clusterList.append(*clusterInfo);
+
+                        //find out OS
+                        OS_TYPE os = OS_WINDOWS;
+                        const char* computer = insts->query().queryProp("@computer");
+                        IPropertyTree* pHardware = root->queryPropTree("Hardware");
+                        if (computer && *computer && pHardware)
+                        {
+                            StringBuffer xpath;
+                            xpath.appendf("Computer[@name='%s']/@computerType", computer);
+                            const char* computerType = pHardware->queryProp( xpath.str() );
+                            if (computerType && *computerType)
+                            {
+                                xpath.clear().appendf("ComputerType[@name='%s']/@opSys", computerType);
+                                const char* opSys = pHardware->queryProp( xpath.str() );
+                                if (!stricmp(opSys, "linux") || !stricmp( opSys, "solaris"))
+                                    os = OS_LINUX;
+                            }
+                        }
+                        clusterInfo->setOS(os);
                     }
                 }
             }
@@ -1304,13 +1278,9 @@ bool CTpWrapper::checkGroupReplicateOutputs(const char* groupName, const char* k
     if (strieq(kind, "Roxie") || strieq(kind, "hthor"))
         return false;
 
-    Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
+    Owned<IEnvironmentFactory> factory = getEnvironmentFactory(true);
     Owned<IConstEnvironment> environment = factory->openEnvironment();
-    if (!environment)
-        throw MakeStringException(ECLWATCH_CANNOT_GET_ENV_INFO, "Failed to get environment information.");
     Owned<IPropertyTree> root = &environment->getPTree();
-    if (!root)
-        throw MakeStringException(ECLWATCH_CANNOT_GET_ENV_INFO, "Failed to get environment information.");
 
     Owned<IPropertyTreeIterator> it= root->getElements("Software/ThorCluster");
     ForEach(*it)
@@ -1384,7 +1354,7 @@ bool CTpWrapper::ContainsProcessDefinition(IPropertyTree& clusterNode,const char
 
 void CTpWrapper::getMachineInfo(double clientVersion, const char* name, const char* netAddress, IEspTpMachine& machineInfo)
 {
-    Owned<IEnvironmentFactory> envFactory = getEnvironmentFactory();
+    Owned<IEnvironmentFactory> envFactory = getEnvironmentFactory(true);
     Owned<IConstEnvironment> constEnv = envFactory->openEnvironment();
     Owned<IConstMachineInfo> pMachineInfo;
     if (name && *name)
@@ -1446,11 +1416,9 @@ void CTpWrapper::getMachineInfo(IEspTpMachine& machineInfo,IPropertyTree& machin
 
 bool CTpWrapper::checkMultiSlavesFlag(const char* clusterName)
 {
-    Owned<IEnvironmentFactory> envFactory = getEnvironmentFactory();
+    Owned<IEnvironmentFactory> envFactory = getEnvironmentFactory(true);
     Owned<IConstEnvironment> constEnv = envFactory->openEnvironment();
     Owned<IPropertyTree> root = &constEnv->getPTree();
-    if (!root)
-        throw MakeStringExceptionDirect(ECLWATCH_CANNOT_GET_ENV_INFO, MSG_FAILED_GET_ENVIRONMENT_INFO);
 
     VStringBuffer path("Software/ThorCluster[@name=\"%s\"]", clusterName);
     Owned<IPropertyTree> cluster= root->getPropTree(path.str());
@@ -1504,7 +1472,7 @@ void CTpWrapper::getThorSlaveMachineList(double clientVersion, const char* clust
 {
     try
     {
-        Owned<IEnvironmentFactory> envFactory = getEnvironmentFactory();
+        Owned<IEnvironmentFactory> envFactory = getEnvironmentFactory(true);
         Owned<IConstEnvironment> constEnv = envFactory->openEnvironment();
         Owned<IGroup> nodeGroup = getClusterProcessNodeGroup(clusterName, "ThorCluster");
         if (!nodeGroup || (nodeGroup->ordinality() == 0))
@@ -1534,11 +1502,9 @@ void CTpWrapper::getThorSpareMachineList(double clientVersion, const char* clust
 {
     try
     {
-        Owned<IEnvironmentFactory> envFactory = getEnvironmentFactory();
+        Owned<IEnvironmentFactory> envFactory = getEnvironmentFactory(true);
         Owned<IConstEnvironment> constEnv = envFactory->openEnvironment();
         Owned<IPropertyTree> root = &constEnv->getPTree();
-        if (!root)
-            throw MakeStringExceptionDirect(ECLWATCH_CANNOT_GET_ENV_INFO, MSG_FAILED_GET_ENVIRONMENT_INFO);
 
         VStringBuffer path("Software/ThorCluster[@name=\"%s\"]", clusterName);
         Owned<IPropertyTree> cluster= root->getPropTree(path.str());
@@ -1584,11 +1550,9 @@ void CTpWrapper::getMachineList(const char* MachineType,
     try
     {
         //ParentPath=Path to parent node... normally a cluster
-        Owned<IEnvironmentFactory> envFactory = getEnvironmentFactory();
+        Owned<IEnvironmentFactory> envFactory = getEnvironmentFactory(true);
         Owned<IConstEnvironment> constEnv = envFactory->openEnvironment();
         Owned<IPropertyTree> root0 = &constEnv->getPTree();
-        if (!root0)
-            throw MakeStringExceptionDirect(ECLWATCH_CANNOT_GET_ENV_INFO, MSG_FAILED_GET_ENVIRONMENT_INFO);
     
         char* xpath = (char*)ParentPath;
         if (!strnicmp(xpath, "/Environment/", 13))
@@ -1689,7 +1653,7 @@ void CTpWrapper::getDropZoneMachineList(double clientVersion, bool ECLWatchVisib
 
 void CTpWrapper::getTpDropZones(double clientVersion, const char* name, bool ECLWatchVisibleOnly, IArrayOf<IConstTpDropZone>& list)
 {
-    Owned<IEnvironmentFactory> envFactory = getEnvironmentFactory();
+    Owned<IEnvironmentFactory> envFactory = getEnvironmentFactory(true);
     Owned<IConstEnvironment> constEnv = envFactory->openEnvironment();
     if (!isEmptyString(name))
     {
@@ -1811,9 +1775,9 @@ IEspTpMachine* CTpWrapper::createTpMachineEx(const char* name, const char* type,
 void CTpWrapper::setMachineInfo(const char* name,const char* type,IEspTpMachine& machine)
 {
     try{
-        Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
-        Owned<IConstEnvironment> m_pConstEnvironment = factory->openEnvironment();
-        Owned<IConstMachineInfo> pMachineInfo =  m_pConstEnvironment->getMachine(name);
+        Owned<IEnvironmentFactory> factory = getEnvironmentFactory(true);
+        Owned<IConstEnvironment> constEnv = factory->openEnvironment();
+        Owned<IConstMachineInfo> pMachineInfo =  constEnv->getMachine(name);
         if (pMachineInfo.get())
         {
             SCMStringBuffer ep;

--- a/plugins/fileservices/fileservices.cpp
+++ b/plugins/fileservices/fileservices.cpp
@@ -187,7 +187,7 @@ static IConstEnvironment * openDaliEnvironment()
 {
     if (daliClientActive())
     {
-        Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
+        Owned<IEnvironmentFactory> factory = getEnvironmentFactory(true);
         return factory->openEnvironment();
     }
     return NULL;

--- a/plugins/workunitservices/workunitservices.cpp
+++ b/plugins/workunitservices/workunitservices.cpp
@@ -180,14 +180,8 @@ IPluginContext * parentCtx = NULL;
 
 static void getSashaNodes(SocketEndpointArray &epa)
 {
-    Owned<IEnvironmentFactory> factory = getEnvironmentFactory();
+    Owned<IEnvironmentFactory> factory = getEnvironmentFactory(true);
     Owned<IConstEnvironment> env = factory->openEnvironment();
-    if (!env)
-    {
-        ERRLOG("getSashaNodes: cannot connect to /Environment!");
-        return;
-    }
-
     Owned<IPropertyTree> root = &env->getPTree();
     StringBuffer tmp;
     Owned<IPropertyTreeIterator> siter = root->getElements("Software/SashaServerProcess/Instance");


### PR DESCRIPTION
1. add a default update=false param into getEnvironmentFactory(); If
   the update=true, call validateCache();
2. in ESP services, remove ESP direct calls to IEnvironmentFactory::
   validateCache(); also change getEnvironmentFactory() calls to
   getEnvironmentFactory(true);
3. add more error checks; Remove old code (not used):
   getClusterConfig() and CWsDfuEx::getRoxieClusterConfig().

Signed-off-by: wangkx <kevin.wang@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [x] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->
Start an EclWatch. Click Operation icon. Select System Servers tab. Check whether all of the system servers are displayed or not.

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
