### PR TITLE
HPCC-18362 ESDL/ESP service no longer render main page

### DIFF
--- a/esp/bindings/http/platform/httpservice.cpp
+++ b/esp/bindings/http/platform/httpservice.cpp
@@ -987,17 +987,18 @@ EspHttpBinding* CEspHttpServer::getEspHttpBinding(EspAuthRequest& authReq)
         //is set to nullptr only if !authReq.isSoapPost.
         if (!authReq.isSoapPost && espHttpBinding && !espHttpBinding->isValidServiceName(*authReq.ctx, authReq.serviceName.str()))
             espHttpBinding=nullptr;
-        return espHttpBinding;
     }
-
-    for (unsigned index=0; index<ordinality; index++)
+    else
     {
-        CEspBindingEntry *entry = m_apport->queryBindingItem(index);
-        EspHttpBinding* lbind = (entry) ? dynamic_cast<EspHttpBinding*>(entry->queryBinding()) : nullptr;
-        if (lbind && lbind->isValidServiceName(*authReq.ctx, authReq.serviceName.str()))
+        for (unsigned index=0; index<ordinality; index++)
         {
-            espHttpBinding=lbind;
-            break;
+            CEspBindingEntry *entry = m_apport->queryBindingItem(index);
+            EspHttpBinding* lbind = (entry) ? dynamic_cast<EspHttpBinding*>(entry->queryBinding()) : nullptr;
+            if (lbind && lbind->isValidServiceName(*authReq.ctx, authReq.serviceName.str()))
+            {
+                espHttpBinding=lbind;
+                break;
+            }
         }
     }
 

--- a/esp/services/esdl_svc_engine/CMakeLists.txt
+++ b/esp/services/esdl_svc_engine/CMakeLists.txt
@@ -28,6 +28,7 @@ set (   SRCS
         esdl_binding.cpp
         esdl_svc_engine_plugin.cpp
         esdl_svc_engine.cpp
+        esdl_store.cpp
     )
 
 include_directories (

--- a/esp/services/esdl_svc_engine/esdl_binding.cpp
+++ b/esp/services/esdl_svc_engine/esdl_binding.cpp
@@ -67,75 +67,6 @@ bool trimXPathToParentSDSElement(const char *element, const char * xpath, String
     return false;
 }
 
-void fetchESDLDefinitionFromDaliById(const char *id, StringBuffer & exsdl)
-{
-    if (!id || !*id)
-        throw MakeStringException(-1, "Unable to fetch ESDL Service definition information, service id is not available");
-
-    //There shouldn't be multiple entries here, but if so, we'll use the first one
-    VStringBuffer xpath("%s[@id='%s'][1]", ESDL_DEF_ENTRY, id);
-
-    ESPLOG(LogNormal, "ESDL Binding: Fetching ESDL Definition from Dali: %s ", id);
-
-    Owned<IRemoteConnection> conn = querySDS().connect(ESDL_DEFS_ROOT_PATH, myProcessSession(), RTM_LOCK_READ, SDS_LOCK_TIMEOUT_DESDL);
-    if (!conn)
-       throw MakeStringException(-1, "Unable to connect to ESDL Service definition information in dali '%s'", ESDL_DEFS_ROOT_PATH);
-
-    IPropertyTree * esdlDefinitions = conn->queryRoot();
-
-    toXML(esdlDefinitions->queryPropTree(xpath), exsdl);
-}
-
-void fetchESDLDefinitionFromDali(const char *esdlServiceName, unsigned targetVersion, StringBuffer & exsdl)
-{
-    if (!esdlServiceName || !*esdlServiceName)
-        throw MakeStringException(-1, "Unable to fetch ESDL Service definition information, service name is not available");
-    if (targetVersion == 0 )
-        throw MakeStringException(-1, "Unable to fetch ESDL Service definition information, target version number is invalid: '%s.%d", esdlServiceName, targetVersion);
-
-    DBGLOG("ESDL Binding: Fetching ESDL Definition from Dali: %s.%d ", esdlServiceName, targetVersion);
-
-    StringBuffer id(esdlServiceName);
-    id.toLowerCase().append(".").append(targetVersion);
-
-    return fetchESDLDefinitionFromDaliById(id, exsdl);
-}
-
-IPropertyTree * fetchESDLBindingFromDali(const char *process, const char *bindingName)
-{
-    try
-    {
-        //There shouldn't be multiple entries here, but if so, we'll use the first one
-        VStringBuffer xpath("%s[@id='%s.%s'][1]", ESDL_BINDING_ENTRY, process, bindingName);
-
-        Owned<IRemoteConnection> conn = querySDS().connect(ESDL_BINDINGS_ROOT_PATH, myProcessSession(), RTM_LOCK_READ, SDS_LOCK_TIMEOUT_DESDL);
-        if (!conn)
-        {
-            ESPLOG(LogMin, "Unable to connect to ESDL Service binding information in dali %s", ESDL_BINDINGS_ROOT_PATH);
-            return nullptr;
-        }
-
-        ESPLOG(LogNormal, "ESDL Binding: Fetching ESDL Binding from Dali %s[@EspProcess='%s'][@EspBinding='%s'][1]", ESDL_BINDING_ENTRY, process, bindingName);
-
-        if (conn->queryRoot()->hasProp(xpath))
-            return createPTreeFromIPT(conn->queryRoot()->queryPropTree(xpath));
-        else
-            return nullptr;
-    }
-    catch (IException *E)
-    {
-        VStringBuffer message("ESDL Binding: Error fetching ESDL Binding %s[@EspProcess='%s'][@EspBinding='%s'][1] from Dali.", ESDL_BINDING_ENTRY, process, bindingName);
-        EXCLOG(E, message);
-        E->Release();
-    }
-    catch(...)
-    {
-        ESPLOG(LogMin, "ESDL Binding: Unknown error encountered while fetching ESDL Binding from Dali %s[@EspProcess='%s'][@EspBinding='%s'][1]", ESDL_BINDING_ENTRY, process, bindingName);
-    }
-
-    return NULL;
-}
-
 IPropertyTree * fetchESDLBindingFromStateFile(const char *process, const char *bindingName, const char * stateFileName)
 {
     try
@@ -158,17 +89,6 @@ IPropertyTree * fetchESDLBindingFromStateFile(const char *process, const char *b
     }
 
     return nullptr;
-}
-
-IPropertyTree * fetchESDLBinding(const char *process, const char *bindingName, const char * stateFileName)
-{
-    Owned<IPropertyTree> esdlBinding = fetchESDLBindingFromDali(process, bindingName);
-    if (!esdlBinding)
-    {
-        return fetchESDLBindingFromStateFile(process, bindingName, stateFileName);
-    }
-
-    return esdlBinding.getClear();
 }
 
 void saveState(const char * esdlDefinition, IPropertyTree * esdlBinding, const char * stateFileFullPath)
@@ -201,89 +121,6 @@ void clearState(const char * stateFileFullPath)
 {
     saveState("", NULL, stateFileFullPath);
 }
-/* if the target ESDL binding contains an ESDL service definition matching this espServiceName, load it.
- * Otherwise, load the first definition available, and report it via the loadedServiceName
- */
-bool loadDefinitions(const char * espServiceName, IEsdlDefinition * esdl, IPropertyTree * config, StringBuffer & loadedServiceName, const char * stateFileName)
-{
-    if (!esdl || !config)
-        return false;
-
-    //Loading first ESDL definition encountered, informed that espServiceName is to be treated as arbitrary
-    IPropertyTree * esdlDefinitionConfig = config->queryPropTree("Definition[1]");
-
-    bool stateRestored = false;
-    if (esdlDefinitionConfig)
-    {
-        try
-        {
-            const char * id = esdlDefinitionConfig->queryProp("@id");
-            StringBuffer esdlXML;
-            fetchESDLDefinitionFromDaliById(id, esdlXML);
-            if (!esdlXML.length())
-            {
-                Owned<IPropertyTree> esdlDefintion;
-                DBGLOG("ESDL Binding: Could not load ESDL definition: '%s' from Dali, attempting to load from local state store", id);
-                Owned<IPTree> pt = createPTreeFromXMLFile(stateFileName);
-
-                if (pt)
-                    esdlDefintion.set(pt->queryPropTree("EsdlDefinition"));
-
-                if (!esdlDefintion)
-                    throw MakeStringException(-1, "Could not load ESDL definition: '%s' assigned to esp service name '%s'", id, espServiceName);
-
-                stateRestored = true;
-                toXML(esdlDefintion, esdlXML);
-            }
-
-#ifdef _DEBUG
-            DBGLOG("\nESDL Definition to be loaded:\n%s", esdlXML.str());
-#endif
-
-            esdl->addDefinitionFromXML(esdlXML, id);
-            loadedServiceName.set(esdlDefinitionConfig->queryProp("@name"));
-
-            if (strcmp(loadedServiceName.str(), espServiceName)!=0)
-                DBGLOG("ESDL Binding: ESP service %s now based off of ESDL Service def: %s", espServiceName, loadedServiceName.str());
-
-            if (!stateRestored)
-            {
-                try
-                {
-                    saveState(esdlXML.str(), config, stateFileName);
-                }
-                catch (IException *E)
-                {
-                    StringBuffer message;
-                    message.setf("Error saving DESDL state file for ESP service %s", espServiceName);
-                    // If we can't save the DESDL state for this binding, then tough. Carry on without it. Changes will not survive an unexpected roxie restart
-                    EXCLOG(E, message);
-                    E->Release();
-                }
-                catch (...)
-                {
-                    // If we can't save the DESDL state for this binding, then tough. Carry on without it. Changes will not survive an unexpected roxie restart
-                    DBGLOG("Error saving DESDL state file for ESP service %s", espServiceName);
-                }
-            }
-        }
-        catch (IException * e)
-        {
-            StringBuffer msg;
-            e->errorMessage(msg);
-            DBGLOG("Error while loading ESDL definitions: %s", msg.str());
-            e->Release();
-        }
-    }
-    else
-    {
-        DBGLOG("ESDL Binding: Could not find any ESDL definition while loading ESDL Binding: %s", config->queryProp("@id"));
-        return false;
-    }
-
-    return true;
-}
-
 
 bool EsdlServiceImpl::loadLogggingManager()
 {
@@ -1069,6 +906,7 @@ EsdlBindingImpl::EsdlBindingImpl()
 
 EsdlBindingImpl::EsdlBindingImpl(IPropertyTree* cfg, const char *binding,  const char *process) : CHttpSoapBinding(cfg, binding, process)
 {
+    m_pCentralStore.setown(createEsdlCentralStore());
     m_bindingName.set(binding);
     m_processName.set(process);
 
@@ -1090,25 +928,14 @@ EsdlBindingImpl::EsdlBindingImpl(IPropertyTree* cfg, const char *binding,  const
 
     try
     {
-
-        ensureSDSPath(ESDL_DEFS_ROOT_PATH);
-        ensureSDSPath(ESDL_BINDINGS_ROOT_PATH);
-
         m_esdlBndCfg.set(fetchESDLBinding(process, binding, m_esdlStateFilesLocation));
 
         if (!m_esdlBndCfg.get())
             DBGLOG("ESDL Binding: Could not fetch ESDL binding %s for ESP Process %s", binding, process);
 
-        //Subscribe to Dali anyway
         DBGLOG("ESDL Binding %s is subscribing to all /ESDL/Bindings/Binding dali changes", binding);
-        //Since it seems we cannot subscribe to a specific /ESDL/Bindings/Binding, all bindings have to subscribe to the /ESDL/Bindings branch
-        m_pBindingSubscription.clear();
-        m_pBindingSubscription.setown( new CESDLBindingSubscription(this));
-
         DBGLOG("ESDL Binding %s is subscribing to all /ESDL/Bindings/Definition dali changes", binding);
-        //Since it seems we cannot subscribe to a specific /ESDL/Definitions/Definition, all bindings have to subscribe to the /ESDL/Definitions branch
-        m_pDefinitionSubscription.clear();
-        m_pDefinitionSubscription.setown( new CESDLDefinitionSubscription(this));
+        m_pSubscription.setown(createEsdlSubscription(this, process, binding));
 
         StringBuffer xpath;
         xpath.appendf("Software/EspProcess[@name=\"%s\"]/EspBinding[@name=\"%s\"]", process, binding);
@@ -1130,6 +957,100 @@ EsdlBindingImpl::EsdlBindingImpl(IPropertyTree* cfg, const char *binding,  const
     {
         DBGLOG("Exception caught in EsdlBindingImpl::EsdlBindingImpl: Could Not load Binding %s information from Dali!", binding);
     }
+}
+
+IPropertyTree* EsdlBindingImpl::fetchESDLBinding(const char *process, const char *bindingName, const char * stateFileName)
+{
+    Owned<IPropertyTree> esdlBinding = m_pCentralStore->fetchBinding(process, bindingName);
+    if (!esdlBinding)
+    {
+        return fetchESDLBindingFromStateFile(process, bindingName, stateFileName);
+    }
+
+    return esdlBinding.getClear();
+}
+
+/* if the target ESDL binding contains an ESDL service definition matching this espServiceName, load it.
+ * Otherwise, load the first definition available, and report it via the loadedServiceName
+ */
+bool EsdlBindingImpl::loadDefinitions(const char * espServiceName, IEsdlDefinition * esdl, IPropertyTree * config, StringBuffer & loadedServiceName, const char * stateFileName)
+{
+    if (!esdl || !config)
+        return false;
+
+    //Loading first ESDL definition encountered, informed that espServiceName is to be treated as arbitrary
+    IPropertyTree * esdlDefinitionConfig = config->queryPropTree("Definition[1]");
+
+    bool stateRestored = false;
+    if (esdlDefinitionConfig)
+    {
+        try
+        {
+            const char * id = esdlDefinitionConfig->queryProp("@id");
+            StringBuffer esdlXML;
+            m_pCentralStore->fetchDefinition(id, esdlXML);
+            if (!esdlXML.length())
+            {
+                Owned<IPropertyTree> esdlDefintion;
+                DBGLOG("ESDL Binding: Could not load ESDL definition: '%s' from Dali, attempting to load from local state store", id);
+                Owned<IPTree> pt = createPTreeFromXMLFile(stateFileName);
+
+                if (pt)
+                    esdlDefintion.set(pt->queryPropTree("EsdlDefinition"));
+
+                if (!esdlDefintion)
+                    throw MakeStringException(-1, "Could not load ESDL definition: '%s' assigned to esp service name '%s'", id, espServiceName);
+
+                stateRestored = true;
+                toXML(esdlDefintion, esdlXML);
+            }
+
+#ifdef _DEBUG
+            DBGLOG("\nESDL Definition to be loaded:\n%s", esdlXML.str());
+#endif
+
+            esdl->addDefinitionFromXML(esdlXML, id);
+            loadedServiceName.set(esdlDefinitionConfig->queryProp("@name"));
+
+            if (strcmp(loadedServiceName.str(), espServiceName)!=0)
+                DBGLOG("ESDL Binding: ESP service %s now based off of ESDL Service def: %s", espServiceName, loadedServiceName.str());
+
+            if (!stateRestored)
+            {
+                try
+                {
+                    saveState(esdlXML.str(), config, stateFileName);
+                }
+                catch (IException *E)
+                {
+                    StringBuffer message;
+                    message.setf("Error saving DESDL state file for ESP service %s", espServiceName);
+                    // If we can't save the DESDL state for this binding, then tough. Carry on without it. Changes will not survive an unexpected roxie restart
+                    EXCLOG(E, message);
+                    E->Release();
+                }
+                catch (...)
+                {
+                    // If we can't save the DESDL state for this binding, then tough. Carry on without it. Changes will not survive an unexpected roxie restart
+                    DBGLOG("Error saving DESDL state file for ESP service %s", espServiceName);
+                }
+            }
+        }
+        catch (IException * e)
+        {
+            StringBuffer msg;
+            e->errorMessage(msg);
+            DBGLOG("Error while loading ESDL definitions: %s", msg.str());
+            e->Release();
+        }
+    }
+    else
+    {
+        DBGLOG("ESDL Binding: Could not find any ESDL definition while loading ESDL Binding: %s", config->queryProp("@id"));
+        return false;
+    }
+
+    return true;
 }
 
 void EsdlBindingImpl::saveDESDLState()
@@ -1160,7 +1081,23 @@ void EsdlBindingImpl::saveDESDLState()
     }
 }
 
-bool EsdlBindingImpl::reloadDefinitionsFromDali(IPropertyTree * esdlBndCng, StringBuffer & loadedname)
+bool EsdlBindingImpl::reloadDefinitionsFromCentralStore(const char* binding, const char* process, StringBuffer & loadedname)
+{
+    if (strcmp(m_bindingName.get(), binding)==0 && strcmp(m_processName.get(), process) == 0)
+    {
+        if ( m_pESDLService)
+        {
+            Owned<IPropertyTree> tempEsdlBndCfg;
+            DBGLOG("Fetching ESDL binding information from dali based on ESP binding (%s.%s)", process, binding);
+            tempEsdlBndCfg.set(m_pCentralStore->fetchBinding(process, binding));
+            if(tempEsdlBndCfg.get() != nullptr)
+                return reloadDefinitionsFromCentralStore(tempEsdlBndCfg.get(), loadedname);
+        }
+    }
+    return false;
+}
+
+bool EsdlBindingImpl::reloadDefinitionsFromCentralStore(IPropertyTree * esdlBndCng, StringBuffer & loadedname)
 {
     if ( m_pESDLService )
     {
@@ -1183,7 +1120,7 @@ bool EsdlBindingImpl::reloadDefinitionsFromDali(IPropertyTree * esdlBndCng, Stri
 }
 
 
-bool EsdlBindingImpl::reloadBindingFromDali(const char *binding, const char *process)
+bool EsdlBindingImpl::reloadBindingFromCentralStore(const char *binding, const char *process)
 {
     if (strcmp(m_bindingName.get(), binding)==0)
     {
@@ -1194,7 +1131,7 @@ bool EsdlBindingImpl::reloadBindingFromDali(const char *binding, const char *pro
             {
                 Owned<IPropertyTree> tempEsdlBndCfg;
                 DBGLOG("Fetching ESDL binding information from dali based on ESP binding (%s.%s)", m_processName.get(), m_bindingName.get());
-                tempEsdlBndCfg.set(fetchESDLBindingFromDali(process, binding));
+                tempEsdlBndCfg.set(m_pCentralStore->fetchBinding(process, binding));
 
                 if (!tempEsdlBndCfg.get())
                 {
@@ -1204,7 +1141,7 @@ bool EsdlBindingImpl::reloadBindingFromDali(const char *binding, const char *pro
                 }
 
                 StringBuffer loadedname;
-                if (!reloadDefinitionsFromDali(tempEsdlBndCfg.get(), loadedname))
+                if (!reloadDefinitionsFromCentralStore(tempEsdlBndCfg.get(), loadedname))
                     return false;
 
                 IEsdlDefService *srvdef = m_esdl->queryService(loadedname);
@@ -2871,94 +2808,24 @@ bool EsdlBindingImpl::makeURL( StringBuffer& url, IPropertyTree& cfg )
     return result;
 }
 
-void EsdlBindingImpl::CESDLBindingSubscription::notify(SubscriptionId id, const char *xpath, SDSNotifyFlags flags, unsigned valueLen, const void *valueData)
+void EsdlBindingImpl::onNotify(EsdlNotifyData* data)
 {
-    if (!thisBinding)
+    if(!data)
         return;
-
-    if (id != sub_id)
+    CriticalBlock b(configurationLoadCritSec);
+    if(data->type == EsdlNotifyType::DefinitionUpdate)
     {
-        DBGLOG("ESDL Binding %s.%s (Dali subscription (%" I64F "d)) received notification for unrecognized dali subscription id: (%" I64F "d)", thisBinding->m_processName.get(), thisBinding->m_bindingName.get(), (__int64) sub_id, (__int64) id);
-        return;
-    }
-
-    DBGLOG("ESDL binding change reported to %s.%s binding: (%" I64F "d) of %s - flags = %d", thisBinding->m_processName.get(), thisBinding->m_bindingName.get(), (__int64) id, xpath, flags);
-
-    StringBuffer parentElementXPath;
-    //path is reported with sibbling number annotation ie /ESDL/Bindings/Binding[2]/...
-    if(!trimXPathToParentSDSElement("Binding[", xpath, parentElementXPath))
-        return;
-
-    StringBuffer bindingName;
-    StringBuffer processName;
-    {
-        Owned<IRemoteConnection> conn = querySDS().connect(parentElementXPath.str(), myProcessSession(), RTM_LOCK_READ, SDS_LOCK_TIMEOUT_DESDL);
-        if (!conn)
+        if (usesESDLDefinition(data->id.str()))
         {
-            //Can't find this path, is this a delete?
-            if (flags == SDSNotify_Deleted)
-            {
-                bindingName.set(thisBinding->m_bindingName);
-                processName.set(thisBinding->m_processName);
-            }
-            else
-                return;
-        }
-        else
-        {
-            IPropertyTree * bindingSubscription = conn->queryRoot();
-
-            bindingName = bindingSubscription->queryProp("@espbinding");
-            if (bindingName.length() == 0)
-                return;
-
-            processName = bindingSubscription->queryProp("@espprocess");
-            if (processName.length() == 0)
-                return;
+            DBGLOG("Requesting reload of ESDL definitions for %s.%s binding...", m_processName.get(), m_bindingName.get() );
+            StringBuffer loaded;
+            reloadDefinitionsFromCentralStore(m_bindingName.str(), m_processName.str(), loaded);
         }
     }
-
-    DBGLOG("Requesting reload of %s.%s binding...", processName.str(), bindingName.str() );
-    CriticalBlock b(daliSubscriptionCritSec);
-    thisBinding->reloadBindingFromDali(bindingName.str(), processName.str());
-}
-
-void EsdlBindingImpl::CESDLDefinitionSubscription::notify(SubscriptionId id, const char *xpath, SDSNotifyFlags flags, unsigned valueLen, const void *valueData)
-{
-    if (!thisBinding)
-        return;
-
-    if (id != sub_id)
+    else
     {
-        DBGLOG("ESDL Binding %s.%s (Dali subscription (%" I64F "d)) received notification for unrecognized dali subscription id: (%" I64F "d)", thisBinding->m_processName.get(), thisBinding->m_bindingName.get(), (__int64) sub_id, (__int64) id);
-        return;
-    }
-
-    DBGLOG("ESDL definition change reported to %s.%s binding: (%" I64F "d) of %s - flags = %d", thisBinding->m_processName.get(), thisBinding->m_bindingName.get(), (__int64) id, xpath, flags);
-
-    StringBuffer parentElementXPath;
-    //path is reported with sibbling number annotation ie /ESDL/Definitions/Definition[2]/...
-    if(!trimXPathToParentSDSElement("Definition[", xpath, parentElementXPath))
-        return;
-
-    Owned<IRemoteConnection> conn = querySDS().connect(parentElementXPath.str(), myProcessSession(), RTM_LOCK_READ, SDS_LOCK_TIMEOUT_DESDL);
-    if (!conn)
-        return;
-
-    IPropertyTree * definitionSubscription = conn->queryRoot();
-
-    const char * definitionId = definitionSubscription->queryProp("@id");
-    if (!definitionId || !*definitionId)
-        return;
-
-    CriticalBlock b(daliSubscriptionCritSec);
-    //we reload all definitions used by this binding because the
-    //ESDL object intermingles all nodes of all definitions used.
-    if (thisBinding->usesESDLDefinition(definitionId))
-    {
-        DBGLOG("Requesting reload of ESDL definitions for %s.%s binding...", thisBinding->m_processName.get(), thisBinding->m_bindingName.get() );
-        StringBuffer loaded;
-        thisBinding->reloadDefinitionsFromDali( thisBinding->m_bndCfg.get(), loaded);
+        DBGLOG("Requesting reload of %s.%s binding...", data->espProcess.str(), data->espBinding.str() );
+        reloadBindingFromCentralStore(data->espBinding.str(), data->espProcess.str());
     }
 }
 

--- a/esp/services/esdl_svc_engine/esdl_binding.hpp
+++ b/esp/services/esdl_svc_engine/esdl_binding.hpp
@@ -28,17 +28,17 @@
 #include "thorplugin.hpp"
 #include "eclrtl.hpp"
 #include "dautils.hpp"
+#include "esdl_store.hpp"
 
+//Yanrui TODO: remove those later after changing ws_esdlconfig
 static const char* ESDL_DEFS_ROOT_PATH="/ESDL/Definitions/";
 static const char* ESDL_DEF_PATH="/ESDL/Definitions/Definition";
 static const char* ESDL_DEF_ENTRY="Definition";
-
 static const char* ESDL_BINDINGS_ROOT_PATH="/ESDL/Bindings/";
 static const char* ESDL_BINDING_PATH="/ESDL/Bindings/Binding";
 static const char* ESDL_BINDING_ENTRY="Binding";
 static const char* ESDL_METHOD_DESCRIPTION="description";
 static const char* ESDL_METHOD_HELP="help";
-
 #define SDS_LOCK_TIMEOUT_DESDL (30*1000)
 
 #include "SOAP/Platform/soapbind.hpp"
@@ -175,119 +175,9 @@ public:
 
 #define DEFAULT_ESDLBINDING_URN_BASE "urn:hpccsystems:ws"
 
-class EsdlBindingImpl : public CHttpSoapBinding
+class EsdlBindingImpl : public CHttpSoapBinding, implements IEsdlListener
 {
 private:
-    //==========================================================================================
-    // the following class implements notification handler for subscription to dali for environment
-    // updates by other clients.
-    //==========================================================================================
-    class CESDLBindingSubscription : public CInterface, implements ISDSSubscription
-    {
-    private :
-        CriticalSection daliSubscriptionCritSec;
-        SubscriptionId sub_id;
-        EsdlBindingImpl * thisBinding;
-
-    public:
-        CESDLBindingSubscription(EsdlBindingImpl * binding)
-        {
-            thisBinding = binding;
-            VStringBuffer fullBindingPath("/ESDL/Bindings/Binding[@id=\'%s.%s\']",thisBinding->m_processName.get(),thisBinding->m_bindingName.get());
-            CriticalBlock b(daliSubscriptionCritSec);
-            try
-            {
-                sub_id = querySDS().subscribe(fullBindingPath.str(), *this, true);
-            }
-            catch (IException *E)
-            {
-                DBGLOG("ESDL Binding %s.%s failed to subscribe to DALI (%s)", thisBinding->m_processName.get(),thisBinding->m_bindingName.get(), fullBindingPath.str());
-                // failure to subscribe implies dali is down... is this ok??
-                // Is this bad enough to halt the esp load process??
-                E->Release();
-            }
-        }
-
-        virtual ~CESDLBindingSubscription()
-        {
-            unsubscribe();
-        }
-
-        void unsubscribe()
-        {
-            CriticalBlock b(daliSubscriptionCritSec);
-            try
-            {
-                if (sub_id)
-                {
-                    querySDS().unsubscribe(sub_id);
-                    sub_id = 0;
-                }
-            }
-            catch (IException *E)
-            {
-                E->Release();
-            }
-            sub_id = 0;
-        }
-
-        IMPLEMENT_IINTERFACE;
-        void notify(SubscriptionId id, const char *xpath, SDSNotifyFlags flags, unsigned valueLen=0, const void *valueData=NULL);
-    };
-
-    class CESDLDefinitionSubscription : public CInterface, implements ISDSSubscription
-    {
-    private :
-        CriticalSection daliSubscriptionCritSec;
-        SubscriptionId sub_id;
-        EsdlBindingImpl * thisBinding;
-
-        public:
-        CESDLDefinitionSubscription(EsdlBindingImpl * binding)
-        {
-            thisBinding = binding;
-            //for some reason subscriptions based on xpaths with attributes don't seem to work correctly
-            //fullBindingPath.set("/ESDL/Bindings/Binding[@EspBinding=\'WsAccurint\'][@EspProcess=\'myesp\']");
-            CriticalBlock b(daliSubscriptionCritSec);
-            try
-            {
-                sub_id = querySDS().subscribe(ESDL_DEF_PATH, *this, true);
-            }
-            catch (IException *E)
-            {
-                // failure to subscribe implies dali is down... is this ok??
-                // Is this bad enough to halt the esp load process??
-                E->Release();
-            }
-        }
-
-        virtual ~CESDLDefinitionSubscription()
-        {
-            unsubscribe();
-        }
-
-        void unsubscribe()
-        {
-            CriticalBlock b(daliSubscriptionCritSec);
-            try
-            {
-                if (sub_id)
-                {
-                    querySDS().unsubscribe(sub_id);
-                    sub_id = 0;
-                }
-            }
-            catch (IException *E)
-            {
-                E->Release();
-            }
-            sub_id = 0;
-        }
-
-        IMPLEMENT_IINTERFACE;
-        void notify(SubscriptionId id, const char *xpath, SDSNotifyFlags flags, unsigned valueLen=0, const void *valueData=NULL);
-    };
-
     Owned<IPropertyTree>                    m_bndCfg;
     Owned<IPropertyTree>                    m_esdlBndCfg;
 
@@ -299,8 +189,8 @@ private:
     StringAttr                              m_processName;
     StringAttr                              m_espServiceName; //previously held the esdl service name, we are now
                                                               //supporting mismatched ESP Service name assigned to a different named ESDL service definition
-    Owned<CESDLBindingSubscription>         m_pBindingSubscription;
-    Owned<CESDLDefinitionSubscription>      m_pDefinitionSubscription;
+    Owned<IEsdlSubscription>                m_pSubscription;
+    Owned<IEsdlStore>                       m_pCentralStore;
     CriticalSection                         configurationLoadCritSec;
     StringBuffer                            m_esdlStateFilesLocation;
     MapStringTo<SecAccessFlags>             m_accessmap;
@@ -326,7 +216,12 @@ public:
     EsdlBindingImpl();
     EsdlBindingImpl(IPropertyTree* cfg, const char *bindname=NULL, const char *procname=NULL);
 
-    virtual ~EsdlBindingImpl(){}
+    virtual ~EsdlBindingImpl()
+    {
+        //Unsubscribe early to avoid a segfault due to closed dali connection
+        if(m_pSubscription)
+            m_pSubscription->unsubscribe();
+    }
 
     virtual int onGet(CHttpRequest* request, CHttpResponse* response);
 
@@ -379,15 +274,19 @@ public:
     bool usesESDLDefinition(const char * id);
     virtual bool isDynamicBinding() const override { return true; }
     virtual unsigned getCacheMethodCount(){return 0;}
+    virtual void onNotify(EsdlNotifyData* data);
 
 private:
     int onGetRoxieBuilder(CHttpRequest* request, CHttpResponse* response, const char *serv, const char *method);
     int onRoxieRequest(CHttpRequest* request, CHttpResponse* response, const char *  method);
     void getSoapMessage(StringBuffer& out,StringBuffer& soapresp,const char * starttxt,const char * endtxt);
 
-    bool reloadBindingFromDali(const char *binding, const char *process);
-    bool reloadDefinitionsFromDali(IPropertyTree * esdlBndCng, StringBuffer & loadedname);
+    bool reloadBindingFromCentralStore(const char *binding, const char *process);
+    bool reloadDefinitionsFromCentralStore(IPropertyTree * esdlBndCng, StringBuffer & loadedname);
+    bool reloadDefinitionsFromCentralStore(const char* binding, const char* process, StringBuffer & loadedname);
     void saveDESDLState();
+    IPropertyTree * fetchESDLBinding(const char *process, const char *bindingName, const char * stateFileName);
+    bool loadDefinitions(const char * espServiceName, IEsdlDefinition * esdl, IPropertyTree * config, StringBuffer & loadedServiceName, const char * stateFileName);
 };
 
 #endif //_EsdlBinding_HPP__

--- a/esp/services/esdl_svc_engine/esdl_store.cpp
+++ b/esp/services/esdl_svc_engine/esdl_store.cpp
@@ -1,0 +1,297 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2013 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include "jexcept.hpp"
+#include "jsmartsock.hpp"
+#include "dasds.hpp"
+#include "daclient.hpp"
+#include "dalienv.hpp"
+#include "dadfs.hpp"
+#include "dasess.hpp"
+#include "dautils.hpp"
+#include "wsexcept.hpp"
+#include "httpclient.hpp"
+#include "espcontext.hpp"
+#include "esdl_store.hpp"
+#include <memory>
+
+static const char* ESDL_DEFS_ROOT_PATH="/ESDL/Definitions/";
+static const char* ESDL_DEF_PATH="/ESDL/Definitions/Definition";
+static const char* ESDL_DEF_ENTRY="Definition";
+
+static const char* ESDL_BINDINGS_ROOT_PATH="/ESDL/Bindings/";
+static const char* ESDL_BINDING_PATH="/ESDL/Bindings/Binding";
+static const char* ESDL_BINDING_ENTRY="Binding";
+static const char* ESDL_METHOD_DESCRIPTION="description";
+static const char* ESDL_METHOD_HELP="help";
+
+#define SDS_LOCK_TIMEOUT_DESDL (30*1000)
+
+extern bool trimXPathToParentSDSElement(const char *element, const char * xpath, StringBuffer & parentNodeXPath);
+
+class CEsdlSDSStore : implements IEsdlStore, public CInterface
+{
+public:
+    IMPLEMENT_IINTERFACE;
+
+    CEsdlSDSStore()
+    {
+        ensureSDSPath(ESDL_DEFS_ROOT_PATH);
+        ensureSDSPath(ESDL_BINDINGS_ROOT_PATH);
+    }
+    virtual ~CEsdlSDSStore() { }
+
+    virtual void fetchDefinition(const char* id, StringBuffer& exsdl)
+    {
+        if (!id || !*id)
+            throw MakeStringException(-1, "Unable to fetch ESDL Service definition information, service id is not available");
+
+        //There shouldn't be multiple entries here, but if so, we'll use the first one
+        VStringBuffer xpath("%s[@id='%s'][1]", ESDL_DEF_ENTRY, id);
+
+        ESPLOG(LogNormal, "ESDL Binding: Fetching ESDL Definition from Dali: %s ", id);
+
+        Owned<IRemoteConnection> conn = querySDS().connect(ESDL_DEFS_ROOT_PATH, myProcessSession(), RTM_LOCK_READ, SDS_LOCK_TIMEOUT_DESDL);
+        if (!conn)
+           throw MakeStringException(-1, "Unable to connect to ESDL Service definition information in dali '%s'", ESDL_DEFS_ROOT_PATH);
+
+        IPropertyTree * esdlDefinitions = conn->queryRoot();
+
+        toXML(esdlDefinitions->queryPropTree(xpath), exsdl);
+    }
+    virtual void fetchDefinition(const char* esdlServiceName, unsigned targetVersion, StringBuffer& exsdl)
+    {
+        if (!esdlServiceName || !*esdlServiceName)
+            throw MakeStringException(-1, "Unable to fetch ESDL Service definition information, service name is not available");
+        if (targetVersion == 0 )
+            throw MakeStringException(-1, "Unable to fetch ESDL Service definition information, target version number is invalid: '%s.%d", esdlServiceName, targetVersion);
+
+        DBGLOG("ESDL Binding: Fetching ESDL Definition from Dali: %s.%d ", esdlServiceName, targetVersion);
+
+        StringBuffer id(esdlServiceName);
+        id.toLowerCase().append(".").append(targetVersion);
+
+        return fetchDefinition(id, exsdl);
+    }
+    virtual IPropertyTree* fetchBinding(const char* espProcess, const char* bindingName)
+    {
+        try
+        {
+            //There shouldn't be multiple entries here, but if so, we'll use the first one
+            VStringBuffer xpath("%s[@id='%s.%s'][1]", ESDL_BINDING_ENTRY, espProcess, bindingName);
+
+            Owned<IRemoteConnection> conn = querySDS().connect(ESDL_BINDINGS_ROOT_PATH, myProcessSession(), RTM_LOCK_READ, SDS_LOCK_TIMEOUT_DESDL);
+            if (!conn)
+            {
+                ESPLOG(LogMin, "Unable to connect to ESDL Service binding information in dali %s", ESDL_BINDINGS_ROOT_PATH);
+                return nullptr;
+            }
+
+            ESPLOG(LogNormal, "ESDL Binding: Fetching ESDL Binding from Dali %s[@EspProcess='%s'][@EspBinding='%s'][1]", ESDL_BINDING_ENTRY, espProcess, bindingName);
+
+            if (conn->queryRoot()->hasProp(xpath))
+                return createPTreeFromIPT(conn->queryRoot()->queryPropTree(xpath));
+            else
+                return nullptr;
+        }
+        catch (IException *E)
+        {
+            VStringBuffer message("ESDL Binding: Error fetching ESDL Binding %s[@EspProcess='%s'][@EspBinding='%s'][1] from Dali.", ESDL_BINDING_ENTRY, espProcess, bindingName);
+            EXCLOG(E, message);
+            E->Release();
+        }
+        catch(...)
+        {
+            ESPLOG(LogMin, "ESDL Binding: Unknown error encountered while fetching ESDL Binding from Dali %s[@EspProcess='%s'][@EspBinding='%s'][1]", ESDL_BINDING_ENTRY, espProcess, bindingName);
+        }
+
+        return nullptr;
+    }
+};
+
+class CEsdlSDSSubscription : implements IEsdlSubscription, public CInterface, implements ISDSSubscription
+{
+protected:
+    IEsdlListener* mListener;
+    CriticalSection daliSubscriptionCritSec;
+    SubscriptionId binding_sub_id;
+    SubscriptionId definition_sub_id;
+    StringBuffer mProcessName, mBindingName;
+    bool subscribed;
+public:
+    IMPLEMENT_IINTERFACE;
+    CEsdlSDSSubscription(IEsdlListener* listener, const char* process, const char* binding)
+    {
+        mListener = listener;
+        mProcessName.set(process);
+        mBindingName.set(binding);
+        binding_sub_id = 0;
+        definition_sub_id = 0;
+        subscribed = false;
+        subscribe();
+    }
+
+    virtual ~CEsdlSDSSubscription()
+    {
+        unsubscribe();
+    }
+
+    virtual void unsubscribe()
+    {
+        CriticalBlock b(daliSubscriptionCritSec);
+        if(!subscribed)
+            return;
+        try
+        {
+            if (binding_sub_id)
+                querySDS().unsubscribe(binding_sub_id);
+            if (definition_sub_id)
+                querySDS().unsubscribe(definition_sub_id);
+            DBGLOG("Esdl SDS subscription successfully unsubscribed.");
+        }
+        catch (IException *E)
+        {
+            StringBuffer msg;
+            E->errorMessage(msg);
+            DBGLOG("Error unsubscribing: %s", msg.str());
+            E->Release();
+        }
+        binding_sub_id = 0;
+        definition_sub_id = 0;
+        subscribed = false;
+    }
+
+    void notify(SubscriptionId id, const char *xpath, SDSNotifyFlags flags, unsigned valueLen, const void *valueData)
+    {
+        if(!mListener)
+        {
+            DBGLOG("Can't handle subscription notification because the listener is NULL");
+            return;
+        }
+        EsdlNotifyType ntype = EsdlNotifyType::BindingUpdate;
+        bool isBindingNotify = false;
+        if (id != binding_sub_id && id != definition_sub_id)
+        {
+            DBGLOG("ESDL Binding %s.%s Dali subscription received notification for unrecognized dali subscription id: (%" I64F "d)", mProcessName.str(), mBindingName.str(),  (__int64) id);
+            return;
+        }
+        else if(id == binding_sub_id)
+            isBindingNotify = true;
+        else
+            ntype = EsdlNotifyType::DefinitionUpdate;
+
+        DBGLOG("ESDL %s change reported to %s.%s: (%" I64F "d) of %s - flags = %d",
+                isBindingNotify?"binding":"definition", mProcessName.str(), mBindingName.str(), (__int64) id, xpath, flags);
+
+        StringBuffer parentElementXPath;
+        //path is reported with sibbling number annotation ie /ESDL/Bindings/Binding[2]/...
+        if(!trimXPathToParentSDSElement(isBindingNotify?"Binding[":"Definition[", xpath, parentElementXPath))
+            return;
+
+        StringBuffer bindingName;
+        StringBuffer processName;
+        StringBuffer definitionId;
+        {
+            Owned<IRemoteConnection> conn = querySDS().connect(parentElementXPath.str(), myProcessSession(), RTM_LOCK_READ, SDS_LOCK_TIMEOUT_DESDL);
+            if (!conn)
+            {
+                //Can't find this path, is this a delete?
+                if (flags == SDSNotify_Deleted && isBindingNotify)
+                {
+                    bindingName.set(mBindingName);
+                    processName.set(mProcessName);
+                    ntype = EsdlNotifyType::BindingDelete;
+                }
+                else
+                    return;
+            }
+            else
+            {
+                if(isBindingNotify)
+                {
+                    IPropertyTree * bindingSubscription = conn->queryRoot();
+
+                    bindingName = bindingSubscription->queryProp("@espbinding");
+                    if (bindingName.length() == 0)
+                        return;
+
+                    processName = bindingSubscription->queryProp("@espprocess");
+                    if (processName.length() == 0)
+                        return;
+                }
+                else
+                {
+                    IPropertyTree * definitionSubscription = conn->queryRoot();
+
+                    definitionId.set(definitionSubscription->queryProp("@id"));
+                    if (definitionId.length() == 0)
+                        return;
+                }
+            }
+        }
+        std::unique_ptr<EsdlNotifyData> dataptr(new EsdlNotifyData);
+        dataptr->type = ntype;
+        if(isBindingNotify)
+        {
+            dataptr->espBinding.set(bindingName);
+            dataptr->espProcess.set(processName);
+        }
+        else
+            dataptr->id.set(definitionId);
+
+        mListener->onNotify(dataptr.get());
+    }
+
+protected:
+    virtual void subscribe()
+    {
+        VStringBuffer fullBindingPath("/ESDL/Bindings/Binding[@id=\'%s.%s\']",mProcessName.str(), mBindingName.str());
+        CriticalBlock b(daliSubscriptionCritSec);
+        if(subscribed)
+            return;
+        try
+        {
+            binding_sub_id = querySDS().subscribe(fullBindingPath.str(), *this, true);
+            subscribed = true;
+            DBGLOG("Esdl SDS subscription successfully subscribed.");
+        }
+        catch (IException *E)
+        {
+            DBGLOG("ESDL Binding %s.%s failed to subscribe to DALI (%s)", mProcessName.str(), mBindingName.str(), fullBindingPath.str());
+            E->Release();
+        }
+        try
+        {
+            definition_sub_id = querySDS().subscribe(ESDL_DEF_PATH, *this, true);
+        }
+        catch (IException *E)
+        {
+            DBGLOG("ESDL failed to subscribe to DALI (%s)", ESDL_DEF_PATH);
+            E->Release();
+        }
+    }
+};
+
+IEsdlStore* createEsdlCentralStore()
+{
+    return new CEsdlSDSStore;
+}
+
+IEsdlSubscription* createEsdlSubscription(IEsdlListener* listener, const char* process, const char* binding)
+{
+    return new CEsdlSDSSubscription(listener, process, binding);
+}

--- a/esp/services/esdl_svc_engine/esdl_store.hpp
+++ b/esp/services/esdl_svc_engine/esdl_store.hpp
@@ -1,0 +1,59 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2013 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef _ESDL_STORE_HPP__
+#define _ESDL_REGISTRY_HPP__
+#include "jlib.hpp"
+#include "jstring.hpp"
+#include "jptree.hpp"
+
+interface IEsdlStore : public IInterface
+{
+    virtual void fetchDefinition(const char* id, StringBuffer& exsdl) = 0;
+    virtual void fetchDefinition(const char* esdlServiceName, unsigned targetVersion, StringBuffer& exsdl) = 0;
+    virtual IPropertyTree* fetchBinding(const char* espProcess, const char* bindingName) = 0;
+};
+
+enum EsdlNotifyType
+{
+    BindingUpdate = 1,
+    BindingDelete = 2,
+    DefinitionUpdate = 3,
+};
+
+struct EsdlNotifyData
+{
+    EsdlNotifyType type;
+    StringBuffer id;
+    StringBuffer espBinding;
+    StringBuffer espProcess;
+};
+
+interface IEsdlListener
+{
+    virtual void onNotify(EsdlNotifyData* data) = 0;
+};
+
+interface IEsdlSubscription : public IInterface
+{
+    virtual void unsubscribe() = 0;
+};
+
+IEsdlStore* createEsdlCentralStore();
+IEsdlSubscription* createEsdlSubscription(IEsdlListener* listener, const char* process, const char* binding);
+
+#endif // _ESDL_STORE_HPP__


### PR DESCRIPTION
- Problem was caused by not using the default binding when there's no
  exact match for the case when there's only 1 binding for the port.
- Fixed by returning the default binding for this case
- When there's 1 binding on the port, currently it's automatically
  treated as the default binding. So we could simply return it
  without any checking. But I'm keeping the check for consistency.
- The issue applies to regular ESP services as well, not just ESDL service

Signed-off-by: mayx <yanrui.ma@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [x] All new and existing tests passed.
  - [x] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [x] Scalability
  - [x] Performance
  - [x] Security
  - [x] Thread-safety
  - [x] Premature optimization
  - [x] Existing deployed queries will not be broken
  - [x] This change fixes the problem, not just the symptom
  - [x] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [x] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
