### PR TITLE
HPCC-18645 Normalize logical filenames

### DIFF
--- a/dali/base/dautils.cpp
+++ b/dali/base/dautils.cpp
@@ -41,6 +41,7 @@
 
 #define EXTERNAL_SCOPE      "file"
 #define FOREIGN_SCOPE       "foreign"
+#define SELF_SCOPE          "."
 #define SDS_DFS_ROOT        "Files" // followed by scope/name
 #define SDS_RELATIONSHIPS_ROOT  "Files/Relationships"
 #define SDS_CONNECT_TIMEOUT  (1000*60*60*2)     // better than infinite
@@ -402,7 +403,6 @@ void normalizeNodeName(const char *node, unsigned len, SocketEndpoint &ep, bool 
 void CDfsLogicalFileName::normalizeName(const char *name, StringAttr &res, bool strict)
 {
     // NB: If !strict(default) allows spaces to exist either side of scopes (no idea why would want to permit that, but preserving for bwrd compat.)
-    StringBuffer str;
     StringBuffer nametmp;
     const char *ct = nullptr;
     bool wilddetected = false;
@@ -457,55 +457,76 @@ void CDfsLogicalFileName::normalizeName(const char *name, StringAttr &res, bool 
         }
     }
     if (!*name)
-        name = ".::_blank_";
-    s=strstr(name,"::");
-    if (s)
     {
-        if (s==name) // JCS: meaning name leads with "::", would have thought should be treated as invalid
-            str.append('.');
-        else
-        {
-            normalizeScope(name, name, s-name, str, strict);
-            bool isForeign = 0 == stricmp(str.str(),FOREIGN_SCOPE);
-            if (isForeign) // normalize node
-            {
-                const char *s1 = s+2;
-                const char *ns1 = strstr(s1,"::");
-                if (ns1)
-                {
-                    normalizeNodeName(s1, ns1-s1, foreignep, strict);
-                    if (!foreignep.isNull())
-                    {
-                        foreignep.getUrlStr(str.append("::"));
-                        s = ns1;
-                        localpos = str.length()+2;
-                    }
-                }
-            }
-        }
-        for (;;)
-        {
-            s+=2;
-            const char *ns = strstr(s,"::");
-            if (!ns)
-                break;
-            str.append("::");
-            normalizeScope(name, s, ns-s, str, strict);
-            s = ns;
-        }
+        name = ".::_blank_";
+        tailpos = 3;
+        res.set(name);
     }
     else
     {
-        s = name;
-        str.append(".");
+        StringBuffer str;
+        s=strstr(name,"::");
+        if (s)
+        {
+            bool skipScope = false;
+            unsigned scopeStart = 0;
+            if (s==name) // JCS: meaning name leads with "::", would have thought should be treated as invalid
+                str.append('.');
+            else
+            {
+                normalizeScope(name, name, s-name, str, strict);
+                if (strieq(FOREIGN_SCOPE, str)) // normalize node
+                {
+                    const char *s1 = s+2;
+                    const char *ns1 = strstr(s1,"::");
+                    if (ns1)
+                    {
+                        normalizeNodeName(s1, ns1-s1, foreignep, strict);
+                        if (!foreignep.isNull())
+                        {
+                            foreignep.getUrlStr(str.append("::"));
+                            s = ns1;
+                            localpos = str.length()+2;
+                        }
+                    }
+                }
+                else if (streq(SELF_SCOPE, str) && selfScopeTranslation)
+                    skipScope = true;
+            }
+            for (;;)
+            {
+                s+=2;
+                const char *ns = strstr(s,"::");
+                if ((ns || str.length()>1) && skipScope && selfScopeTranslation)
+                {
+                    str.setLength(scopeStart);
+                    skipScope = false;
+                }
+                else
+                    str.append("::");
+                if (!ns)
+                    break;
+                scopeStart = str.length();
+                normalizeScope(name, s, ns-s, str, strict);
+                unsigned scopeLen = str.length()-scopeStart;
+                if ((1 == scopeLen) && (*SELF_SCOPE == str.charAt(str.length()-1)) && selfScopeTranslation)
+                    skipScope = true;
+                s = ns;
+            }
+        }
+        else
+        {
+            s = name;
+            str.append(".::");
+        }
+        tailpos = str.length();
+        normalizeScope(name, s, strlen(name)-(s-name), str, strict);
+        unsigned scopeLen = str.length()-tailpos;
+        if ((1 == scopeLen) && (*SELF_SCOPE == str.charAt(str.length()-1)))
+            throw MakeStringException(-1, "Logical filename cannot end with scope \".\"");
+        str.toLowerCase();
+        res.set(str);
     }
-    str.append("::");
-    tailpos = str.length();
-    if (strstr(s,"::")!=nullptr)
-        ERRLOG("Tail contains '::'!");
-    normalizeScope(name, s, strlen(name)-(s-name), str, strict);
-    str.toLowerCase();
-    res.set(str);
 }
 
 bool CDfsLogicalFileName::normalizeExternal(const char * name, StringAttr &res, bool strict)

--- a/dali/base/dautils.hpp
+++ b/dali/base/dautils.hpp
@@ -61,6 +61,7 @@ class da_decl CDfsLogicalFileName
     bool allowospath;
     bool allowWild;
     SocketEndpoint foreignep;
+    bool selfScopeTranslation = true; // default behaviour is to translate self scopes, e.g. .::.::scope::.::name -> scope::name
 
 public:
     CDfsLogicalFileName();
@@ -75,6 +76,7 @@ public:
     bool setFromXPath(const char *xpath);
     void clear();
     bool isSet() const;
+    void enableSelfScopeTranslation(bool onOff) { selfScopeTranslation = onOff; }
     /*
      * Foreign files are distributed files whose meta data is stored on a foreign
      * Dali Server, so their names are resolved externally.

--- a/testing/unittests/dalitests.cpp
+++ b/testing/unittests/dalitests.cpp
@@ -2402,6 +2402,20 @@ public:
                                ".:: scope1::file*",
                                NULL                                             // terminator
                              };
+
+        const char *translatedLfns[][2] = {
+                               { ".::fname", ".::fname" },
+                               { "fname", ".::fname" },
+                               { "~.::fname", ".::fname" },
+                               { ".::.::.::fname", ".::fname" },
+                               { ".::.::.::sname::.::.::fname", "sname::fname" },
+                               { "~.::.::scope2::.::.::.::fname", "scope2::fname" },
+                               { "{.::.::multitest1f1, .::.::multitest1f2}", "{.::multitest1f1,.::multitest1f2}" },
+                               { ".::.::.::.sname.::.::.fname.", ".sname.::.fname." },
+                               { "~foreign::192.168.16.1::.::scope1::file1", "foreign::192.168.16.1::scope1::file1" },
+                               { "{~foreign::192.168.16.1::.::.::multi1, ~foreign::192.168.16.2::multi2::.::fname}", "{foreign::192.168.16.1::multi1,foreign::192.168.16.2::multi2::fname}" },
+                               { nullptr, nullptr }                             // terminator
+                             };
         PROGLOG("Checking valid logical filenames");
         unsigned nlfn=0;
         for (;;)
@@ -2419,30 +2433,39 @@ public:
             {
                 VStringBuffer err("Logical filename '%s' failed.", lfn);
                 EXCLOG(e, err.str());
-                CPPUNIT_FAIL(err.str());
                 e->Release();
+                CPPUNIT_FAIL(err.str());
             }
         }
-        PROGLOG("Checking invalid logical filenames");
+        PROGLOG("Checking translations");
         nlfn = 0;
         for (;;)
         {
-            const char *lfn = invalidLfns[nlfn++];
-            if (NULL == lfn)
+            const char **entry = translatedLfns[nlfn++];
+            if (nullptr == entry[0])
                 break;
-            PROGLOG("lfn = %s", lfn);
+            const char *lfn = entry[0];
+            const char *expected = entry[1];
+            PROGLOG("lfn = %s, expect = %s", lfn, expected);
             CDfsLogicalFileName dlfn;
+            StringBuffer err;
             try
             {
                 dlfn.set(lfn);
-                VStringBuffer err("Logical filename '%s' passed and should have failed.", lfn);
-                ERRLOG("%s", err.str());
-                CPPUNIT_FAIL(err.str());
+                const char *result = dlfn.get();
+                if (!streq(result, expected))
+                    err.appendf("Logical filename '%s' should have translated to '%s', but result was '%s'.", lfn, expected, result);
             }
             catch (IException *e)
             {
-                EXCLOG(e, "Expected error:");
+                err.appendf("Logical filename '%s' failed: ", lfn);
+                e->errorMessage(err);
                 e->Release();
+            }
+            if (err.length())
+            {
+                ERRLOG("%s", err.str());
+                CPPUNIT_FAIL(err.str());
             }
         }
     }
@@ -2479,15 +2502,15 @@ public:
          const char *validInternalLfns[][2] = {
                  //     input file name                    expected normalized file name
                  {"~foreign::192.168.16.1::scope1::file1", "foreign::192.168.16.1::scope1::file1"},
-                 {".::scope1::file",                       ".::scope1::file"},
+                 {".::scope1::file",                       "scope1::file"},
                  {"~ scope1 :: scope2 :: file  ",          "scope1::scope2::file"},
-                 {". :: scope1 :: file nine",              ".::scope1::file nine"},
-                 {". :: scope1 :: file ten  ",             ".::scope1::file ten"},
-                 {". :: scope1 :: file",                   ".::scope1::file"},
+                 {". :: scope1 :: file nine",              "scope1::file nine"},
+                 {". :: scope1 :: file ten  ",             "scope1::file ten"},
+                 {". :: scope1 :: file",                   "scope1::file"},
                  {"~scope1::file@cluster1",                "scope1::file"},
                  {"~scope::^C^a^S^e^d",                    "scope::^c^a^s^e^d"},
                  {"~scope::CaSed",                         "scope::cased"},
-                 {"~scope::^CaSed",                         "scope::^cased"},
+                 {"~scope::^CaSed",                        "scope::^cased"},
                  {nullptr,                                 nullptr}   // terminator
                  };
 


### PR DESCRIPTION
Avoid publishing filesnames with inline "." scopes in them.
e.g. translate ".::.::scope::.::name" to "scope::name" etc.

Also provide a tool (option in daliadmin) to normalize existing
published filenames.

Signed-off-by: Jake Smith <jake.smith@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

Added unit tests
Regression suite run/passed.

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
