### PR TITLE
HPCC-18504 Make WsEcl libxslt max complexity parameters configurable

### DIFF
--- a/common/wuwebview/wuwebview.hpp
+++ b/common/wuwebview/wuwebview.hpp
@@ -58,8 +58,8 @@ interface IWuWebView : extends IInterface
 
 };
 
-extern WUWEBVIEW_API IWuWebView *createWuWebView(IConstWorkUnit &wu, const char *target, const char *queryname, const char*dir, bool mapEspDir);
-extern WUWEBVIEW_API IWuWebView *createWuWebView(const char *wuid, const char *target, const char *queryname, const char*dir, bool mapEspDir);
+extern WUWEBVIEW_API IWuWebView *createWuWebView(IConstWorkUnit &wu, const char *target, const char *queryname, const char*dir, bool mapEspDir, IPropertyTree *xsltcfg);
+extern WUWEBVIEW_API IWuWebView *createWuWebView(const char *wuid, const char *target, const char *queryname, const char*dir, bool mapEspDir, IPropertyTree *xsltcfg);
 
 extern WUWEBVIEW_API void getWuResourceUrlListByPath(const char *path, StringBuffer &fmt, StringBuffer &content, const char *prefix);
 extern WUWEBVIEW_API void getWuManifestByPath(const char *path, StringBuffer &mf);

--- a/esp/services/ecldirect/EclDirectService.cpp
+++ b/esp/services/ecldirect/EclDirectService.cpp
@@ -314,7 +314,7 @@ bool CEclDirectEx::onRunEclEx(IEspContext &context, IEspRunEclExRequest & req, I
     {
         StringBuffer results;
         CRunEclExFormat outputFormat = req.getFormat();
-        Owned<IWuWebView> web = createWuWebView(wuid.str(), NULL, NULL, getCFD(), true);
+        Owned<IWuWebView> web = createWuWebView(wuid.str(), NULL, NULL, getCFD(), true, nullptr);
         if (!web)
             results.appendf("<Exception><Source>ESP</Source><Message>Failed loading result workunit %s</Message></Exception>", wuid.str());
         else if (outputFormat == CRunEclExFormat_Table)

--- a/esp/services/ws_ecl/ws_ecl_service.hpp
+++ b/esp/services/ws_ecl/ws_ecl_service.hpp
@@ -103,6 +103,7 @@ class CWsEclService : public CInterface,
 {
 public:
     MapStringToMyClass<ISmartSocketFactory> connMap;
+    Owned<IPropertyTree> xsltConfig = createPTree("XsltConfig");
     StringArray targets;
     StringAttr auth_method;
     StringAttr portal_URL;
@@ -145,7 +146,8 @@ public:
     }
     
     virtual void setXslProcessor(IInterface * xslp){}
-    
+    inline IPropertyTree *queryXsltConfig(){return wsecl ? wsecl->xsltConfig : nullptr;}
+
     StringBuffer &generateNamespace(IEspContext &context, CHttpRequest* request, const char *serv, const char *method, StringBuffer &ns);
 
     virtual int getQualifiedNames(IEspContext& ctx, MethodInfoArray & methods){return 0;}

--- a/esp/services/ws_workunits/ws_workunitsHelpers.cpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.cpp
@@ -1812,7 +1812,7 @@ bool WsWuInfo::getResourceInfo(StringArray &viewnames, StringArray &urls, unsign
         return true;
     try
     {
-        Owned<IWuWebView> wv = createWuWebView(*cw, NULL, NULL, NULL, false);
+        Owned<IWuWebView> wv = createWuWebView(*cw, NULL, NULL, NULL, false, nullptr);
         if (wv)
         {
             if (flags & WUINFO_IncludeResultsViewNames)
@@ -1836,7 +1836,7 @@ unsigned WsWuInfo::getResourceURLCount()
 {
     try
     {
-        Owned<IWuWebView> wv = createWuWebView(*cw, NULL, NULL, NULL, false);
+        Owned<IWuWebView> wv = createWuWebView(*cw, NULL, NULL, NULL, false, nullptr);
         if (wv)
             return wv->getResourceURLCount();
     }
@@ -2125,7 +2125,7 @@ void WsWuInfo::getWorkunitResTxt(MemoryBuffer& buf)
 
 IConstWUQuery* WsWuInfo::getEmbeddedQuery()
 {
-    Owned<IWuWebView> wv = createWuWebView(*cw, NULL, NULL, NULL, false);
+    Owned<IWuWebView> wv = createWuWebView(*cw, NULL, NULL, NULL, false, nullptr);
     if (wv)
         return wv->getEmbeddedQuery();
 

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -1617,7 +1617,7 @@ bool CWsWorkunitsEx::onWUResultView(IEspContext &context, IEspWUResultViewReques
     ensureWsWorkunitAccess(context, wuid.str(), SecAccess_Read);
     PROGLOG("WUResultView: %s", wuid.str());
 
-    Owned<IWuWebView> wv = createWuWebView(wuid.str(), NULL, NULL, getCFD(), true);
+    Owned<IWuWebView> wv = createWuWebView(wuid.str(), NULL, NULL, getCFD(), true, nullptr);
     StringBuffer html;
     wv->renderSingleResult(req.getViewName(), req.getResultName(), html);
     resp.setResult(html.str());

--- a/initfiles/componentfiles/configxml/@temp/esp_service.xsl
+++ b/initfiles/componentfiles/configxml/@temp/esp_service.xsl
@@ -907,6 +907,12 @@ xmlns:seisint="http://seisint.com"  xmlns:set="http://exslt.org/sets" exclude-re
                     <WorkunitTimeout><xsl:value-of select="@workunitTimeout"/></WorkunitTimeout>
                 </xsl:if>
                 <WorkunitTimeout><xsl:value-of select="@workunitTimeout"/></WorkunitTimeout>
+                <xsl:if test="string(@xsltMaxDepth)!=''">
+                    <xsltMaxDepth><xsl:value-of select="@xsltMaxDepth"/></xsltMaxDepth>
+                </xsl:if>
+                <xsl:if test="string(@xsltMaxVars)!=''">
+                    <xsltMaxVars><xsl:value-of select="@xsltMaxVars"/></xsltMaxVars>
+                </xsl:if>
                 <VIPS>
                     <xsl:for-each select="ProcessCluster">
                         <xsl:if test="string(@roxie) != '' and string(@vip) != ''">

--- a/initfiles/componentfiles/configxml/esp_service_wsecl2.xsd
+++ b/initfiles/componentfiles/configxml/esp_service_wsecl2.xsd
@@ -157,6 +157,20 @@
                     </xs:appinfo>
                 </xs:annotation>
             </xs:attribute>
+            <xs:attribute name="xsltMaxDepth" type="xs:unsignedInt" use="optional" default="100000">
+                <xs:annotation>
+                    <xs:appinfo>
+                        <tooltip>Maximum libxslt stylesheet template depth (affects size and complexity of dataset that can be rendered)</tooltip>
+                    </xs:appinfo>
+                </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="xsltMaxVars" type="xs:unsignedInt" use="optional" default="1000000">
+                <xs:annotation>
+                    <xs:appinfo>
+                        <tooltip>Maximum libxslt stylesheet template variables (affects size and complexity of dataset that can be rendered)</tooltip>
+                    </xs:appinfo>
+                </xs:annotation>
+            </xs:attribute>
         </xs:complexType>
     </xs:element>
 </xs:schema>

--- a/system/xmllib/libxslt_processor.cpp
+++ b/system/xmllib/libxslt_processor.cpp
@@ -330,7 +330,7 @@ class CLibXslTransform : public CInterface, implements IXslTransform
 public:
     IMPLEMENT_IINTERFACE;
 
-    CLibXslTransform();
+    CLibXslTransform(IPropertyTree *cfg);
     ~CLibXslTransform();
     virtual int transform();
     virtual int transform(StringBuffer &s);
@@ -406,6 +406,7 @@ public:
     void clearMessages(){messages.clear();}
 
 public:
+    Owned<IPropertyTree> xslConfig;
     Owned<IProperties> xslParameters;
     Owned<CLibXsltSource> xslSrc;
     Owned<CLibXmlSource> xmlSrc;
@@ -418,11 +419,13 @@ public:
     void *userData;
 };
 
-CLibXslTransform::CLibXslTransform()
+CLibXslTransform::CLibXslTransform(IPropertyTree *cfg)
 {
     userData = NULL;
     msgfn.setown(createExternalFunction("message", libxsltCustomMessageHandler));
     setExternalFunction(SEISINT_XSLTEXT_NAMESPACE, msgfn, true);
+    if (cfg)
+        xslConfig.set(cfg);
 }
 
 CLibXslTransform::~CLibXslTransform()
@@ -529,6 +532,16 @@ int CLibXslTransform::transform(xmlChar **xmlbuff, int &len)
     if (!ctxt)
         throw MakeStringException(XSLERR_CouldNotCreateTransform, "Failed creating libxslt Transform Context");
     ctxt->_private = this;
+    if (xslConfig)
+    {
+        ctxt->maxTemplateDepth = xslConfig->getPropInt("xsltMaxDepth", 100000);
+        ctxt->maxTemplateVars = xslConfig->getPropInt("xsltMaxVars", 1000000);
+    }
+    else
+    {
+        ctxt->maxTemplateDepth = 100000; //we use some very highly nested stylesheets
+        ctxt->maxTemplateVars = 1000000;
+    }
 
     HashIterator h(functions);
     ForEach (h)
@@ -696,7 +709,7 @@ public:
 
     CLibXslProcessor();
     ~CLibXslProcessor();
-    virtual IXslTransform *createXslTransform();
+    virtual IXslTransform *createXslTransform(IPropertyTree *cfg);
     virtual int execute(IXslTransform *pITransform);
 
     virtual int setDefIncludeHandler(IIncludeHandler* handler){includeHandler.set(handler); return 0;}
@@ -741,9 +754,9 @@ extern IXslProcessor* getXslProcessor()
     return LINK(&xslProcessor);
 }
 
-IXslTransform *CLibXslProcessor::createXslTransform()
+IXslTransform *CLibXslProcessor::createXslTransform(IPropertyTree *cfg)
 {
-    return new CLibXslTransform();
+    return new CLibXslTransform(cfg);
 }
 
 int CLibXslProcessor::execute(IXslTransform *pITransform)

--- a/system/xmllib/xalan_processor.cpp
+++ b/system/xmllib/xalan_processor.cpp
@@ -269,7 +269,7 @@ CXslProcessor::~CXslProcessor()
 {
 }
 
-IXslTransform *CXslProcessor::createXslTransform()
+IXslTransform *CXslProcessor::createXslTransform(IPropertyTree *cfg)
 {
     return new CXslTransform(inch.get());
 }

--- a/system/xmllib/xalan_processor.ipp
+++ b/system/xmllib/xalan_processor.ipp
@@ -590,7 +590,7 @@ public:
 
     CXslProcessor();
     ~CXslProcessor();
-    virtual IXslTransform *createXslTransform();
+    virtual IXslTransform *createXslTransform(IPropertyTree *cfg = nullptr);
     virtual int execute(IXslTransform *pITransform);
 
     virtual int setDefIncludeHandler(IIncludeHandler* handler){inch.set(handler); return 0;}

--- a/system/xmllib/xslprocessor.hpp
+++ b/system/xmllib/xslprocessor.hpp
@@ -112,7 +112,7 @@ public:
 
 interface XMLLIB_API IXslProcessor : public IInterface
 {
-    virtual IXslTransform *createXslTransform() = 0;
+    virtual IXslTransform *createXslTransform(IPropertyTree *cfg = nullptr) = 0;
  
     // execute - runs the transformation placing the results in the specified output location
     //


### PR DESCRIPTION
The WsEcl result stylesheet is recursive and can fail for large complex
datasets.  Raise libxslt maxTeplateVars and maxTemplateDepth
default values and allow the service to configure them.

Also add a generic mechanism for adding xslt configuration values to
the ws_ecl config.  Any ws_ecl configuration element starting with
"xslt" will be passed as configuration to the xslt processor.

Signed-off-by: Anthony Fishbeck <anthony.fishbeck@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
