### PR TITLE
HPCC-18706 Sometimes file access calls to Dali don't provide creds

### DIFF
--- a/roxie/ccd/ccdcontext.cpp
+++ b/roxie/ccd/ccdcontext.cpp
@@ -429,7 +429,7 @@ private:
 
     inline bool fileExists(const char *lfn)
     {
-        Owned<IDistributedFile> f = queryDistributedFileDirectory().lookup(lfn, NULL);  // MORE - need a userdescriptor from workunit
+        Owned<IDistributedFile> f = queryDistributedFileDirectory().lookup(lfn, queryUserDescriptor());
         if (f)
             return true;
         return false;
@@ -437,7 +437,15 @@ private:
 
     inline IUserDescriptor *queryUserDescriptor()
     {
-        return workunit->queryUserDescriptor();
+        if (workunit)
+            return workunit->queryUserDescriptor();//ad-hoc mode
+        else
+        {
+            Owned<IRoxieDaliHelper> daliHelper = connectToDali(false);
+            if (daliHelper)
+                return daliHelper->queryUserDescriptor();//predeployed query mode
+        }
+        return NULL;
     }
 
     bool checkPersistUptoDate(IRuntimeWorkflowItem & item, const char * logicalName, unsigned eclCRC, unsigned __int64 allCRC, bool isFile, StringBuffer &errText)
@@ -3666,7 +3674,15 @@ public:
     }
     IUserDescriptor *queryUserDescriptor()
     {
-        return NULL; // TBD - Richard, where do user credentials for a roxie query come from
+        if (workUnit)
+            return workUnit->queryUserDescriptor();//ad-hoc mode
+        else
+        {
+            Owned<IRoxieDaliHelper> daliHelper = connectToDali(false);
+            if (daliHelper)
+                return daliHelper->queryUserDescriptor();//predeployed query mode
+        }
+        return NULL;
     }
 
     virtual bool isResult(const char * name, unsigned sequence)

--- a/roxie/ccd/ccddali.cpp
+++ b/roxie/ccd/ccddali.cpp
@@ -431,6 +431,11 @@ public:
             initMyNode(1); // Hack
     }
 
+    virtual IUserDescriptor *queryUserDescriptor()
+    {
+        return userdesc;
+    }
+
     static const char *getQuerySetPath(StringBuffer &buf, const char *id)
     {
         buf.appendf("QuerySets/QuerySet[@id='%s']", id);

--- a/roxie/ccd/ccddali.hpp
+++ b/roxie/ccd/ccddali.hpp
@@ -56,6 +56,7 @@ interface IRoxieDaliHelper : extends IInterface
     virtual void noteQueuesRunning(const char *queueNames) = 0;
     virtual void noteWorkunitRunning(const char *wu, bool running) = 0;
     virtual StringBuffer &getDaliIp(StringBuffer &ip) const = 0;
+    virtual IUserDescriptor *queryUserDescriptor() = 0;
 };
 
 

--- a/roxie/ccd/ccdfile.cpp
+++ b/roxie/ccd/ccdfile.cpp
@@ -2646,7 +2646,17 @@ private:
 
             Owned<IDistributedFile> publishFile = queryDistributedFileDirectory().createNew(desc); // MORE - we'll create this earlier if we change the locking paradigm
             publishFile->setAccessedTime(modifiedTime);
-            publishFile->attach(dFile->queryLogicalName(), activity ? activity->queryUserDescriptor() : UNKNOWN_USER);
+            IUserDescriptor * userdesc = NULL;
+            if (activity)
+                userdesc = activity->queryUserDescriptor();
+            else
+            {
+                Owned<IRoxieDaliHelper> daliHelper = connectToDali(false);
+                if (daliHelper)
+                    userdesc = daliHelper->queryUserDescriptor();//predeployed query mode
+            }
+
+            publishFile->attach(dFile->queryLogicalName(), userdesc);
             // MORE should probably write to the roxielocalstate too in case Dali is down next time I look...
         }
     }

--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -11625,9 +11625,14 @@ public:
     {
         IConstWorkUnit *workUnit = ctx->queryWorkUnit();
         if (workUnit)
-            return workUnit->queryUserDescriptor();
+            return workUnit->queryUserDescriptor();//ad-hoc mode
         else
-            return NULL;
+        {
+            Owned<IRoxieDaliHelper> daliHelper = connectToDali(false);
+            if (daliHelper)
+                return daliHelper->queryUserDescriptor();//predeployed query mode
+        }
+        return NULL;
     }
 
     virtual bool isOutputTransformed() const { return false; }
@@ -12168,9 +12173,14 @@ public:
     {
         IConstWorkUnit *workUnit = ctx->queryWorkUnit();
         if (workUnit)
-            return workUnit->queryUserDescriptor();
+            return workUnit->queryUserDescriptor();//ad-hoc mode
         else
-            return NULL;
+        {
+            Owned<IRoxieDaliHelper> daliHelper = connectToDali(false);
+            if (daliHelper)
+                return daliHelper->queryUserDescriptor();//predeployed query mode
+        }
+        return NULL;
     }
 };
 

--- a/roxie/ccd/ccdstate.cpp
+++ b/roxie/ccd/ccdstate.cpp
@@ -724,7 +724,14 @@ public:
         Owned<IRoxieDaliHelper> daliHelper = connectToDali();
         bool onlyLocal = fileNameServiceDali.isEmpty();
         bool onlyDFS = !resolveLocally() && !onlyLocal;
-        Owned<ILocalOrDistributedFile> ldFile = createLocalOrDistributedFile(fileName, NULL, onlyLocal, onlyDFS, true);
+
+        IUserDescriptor *user = NULL;
+        if (wu)
+            user = wu->queryUserDescriptor();//ad-hoc mode
+        else if (daliHelper)
+            user = daliHelper->queryUserDescriptor();//predeployed query mode
+
+        Owned<ILocalOrDistributedFile> ldFile = createLocalOrDistributedFile(fileName, user, onlyLocal, onlyDFS, true);
         if (!ldFile)
             throw MakeStringException(ROXIE_FILE_ERROR, "Cannot write %s", fileName.str());
         return createRoxieWriteHandler(daliHelper, ldFile.getClear(), clusters);


### PR DESCRIPTION
In several places Roxie is not sending credentials in calls to Dali. This
PR fixes all known instances of this omission

Signed-off-by: Russ Whitehead <william.whitehead@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [ ] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [x] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [x] This change fixes the problem, not just the symptom
  - [x] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [x] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
