### PR TITLE
HPCC-18720 Fix a race condition in dali subscription unit test

### DIFF
--- a/testing/unittests/dalitests.cpp
+++ b/testing/unittests/dalitests.cpp
@@ -1107,31 +1107,73 @@ public:
     }
     void testSDSSubs2()
     {
+        class CResult
+        {
+            Semaphore sem;
+            StringBuffer resultString;
+            CriticalSection crit;
+        public:
+            CResult()
+            {
+            }
+            void add(const char *message)
+            {
+                CriticalBlock b(crit);
+                if (resultString.length())
+                    resultString.append("|");
+                resultString.append(message);
+                sem.signal();
+            }
+            Semaphore &querySem() { return sem; }
+            void clear() { resultString.clear(); }
+            bool wait(unsigned numExpected)
+            {
+                for (unsigned t=0; t<numExpected; t++)
+                {
+                    if (!sem.wait(5000))
+                        return false;
+                }
+                return true;
+            }
+            StringBuffer &getResultsClear(StringBuffer &ret)
+            {
+                StringArray array;
+                array.appendList(resultString, "|");
+                resultString.clear();
+                array.sortAscii();
+                ForEachItemIn(r, array)
+                {
+                    if (ret.length())
+                        ret.append("|");
+                    ret.append(array.item(r));
+                }
+                return ret;
+            }
+        } result;
         class CSubscriberContainer : public CInterface
         {
             class CSubscriber : public CSimpleInterfaceOf<ISDSSubscription>
             {
                 StringAttr xpath;
                 bool sub;
-                StringBuffer &result;
+                CResult &result;
             public:
-                CSubscriber(StringBuffer &_result, const char *_xpath, bool _sub) : result(_result), xpath(_xpath), sub(_sub)
+                CSubscriber(CResult &_result, const char *_xpath, bool _sub) : result(_result), xpath(_xpath), sub(_sub)
                 {
                 }
                 virtual void notify(SubscriptionId id, const char *_xpath, SDSNotifyFlags flags, unsigned valueLen, const void *valueData)
                 {
                     PROGLOG("CSubscriber notified path=%s for subscriber=%s, sub=%s", _xpath, xpath.get(), sub?"true":"false");
-                    if (result.length())
-                        result.append("|");
-                    result.append(xpath);
+                    StringBuffer message(xpath);
                     if (!sub && valueLen)
-                        result.append(",").append(valueLen, (const char *)valueData);
+                        message.append(",").append(valueLen, (const char *)valueData);
+                    result.add(message);
                 }
             };
             Owned<CSubscriber> subscriber;
             SubscriptionId id;
         public:
-            CSubscriberContainer(StringBuffer &result, const char *xpath, bool sub)
+            CSubscriberContainer(CResult &result, const char *xpath, bool sub)
             {
                 subscriber.setown(new CSubscriber(result, xpath, sub));
                 id = querySDS().subscribe(xpath, *subscriber, sub, !sub);
@@ -1149,7 +1191,6 @@ public:
         daRegress->setPropTree("TestSub2", tree.getClear());
         conn->commit();
 
-        StringBuffer result;
         Owned<CSubscriberContainer> sub1 = new CSubscriberContainer(result, "/DAREGRESS/TestSub2/a", true);
         Owned<CSubscriberContainer> sub2 = new CSubscriberContainer(result, "/DAREGRESS/TestSub2/a/b1", false);
         Owned<CSubscriberContainer> sub3 = new CSubscriberContainer(result, "/DAREGRESS/TestSub2/a/b2", false);
@@ -1157,8 +1198,6 @@ public:
         Owned<CSubscriberContainer> sub5 = new CSubscriberContainer(result, "/DAREGRESS/TestSub2/a/b3", true);
         Owned<CSubscriberContainer> sub6 = new CSubscriberContainer(result, "/DAREGRESS/TestSub2/a/b4", false);
         Owned<CSubscriberContainer> sub7 = new CSubscriberContainer(result, "/DAREGRESS/TestSub2/a/b4/sub", false);
-
-        MilliSleep(1000);
 
         StringArray expectedResults;
         expectedResults.append("/DAREGRESS/TestSub2/a");
@@ -1179,7 +1218,6 @@ public:
 
         ForEachItemIn(p, props)
         {
-            result.clear(); // filled by subscriber notifications
             const char *cmd = props.item(p);
             const char *propPath=cmd+2;
             switch (*cmd)
@@ -1208,27 +1246,24 @@ public:
             }
             conn->commit();
 
-            MilliSleep(100); // time for notifications to come through
-
-            PROGLOG("Checking results");
-            StringArray resultArray;
-            resultArray.appendList(result, "|");
-            result.clear();
-            resultArray.sortAscii();
-            ForEachItemIn(r, resultArray)
-            {
-                if (result.length())
-                    result.append("|");
-                result.append(resultArray.item(r));
-            }
             const char *expectedResult = expectedResults.item(p);
-            if (0 == strcmp(expectedResult, result))
+            StringArray expectedResultArray;
+            expectedResultArray.appendList(expectedResult, "|"); // just to get #
+            if (!result.wait(expectedResultArray.ordinality()))
+            {
+                VStringBuffer errMsg("Timeout waiting for subcription notificaitons, where expected result = '%s',", expectedResult);
+                CPPUNIT_ASSERT_MESSAGE(errMsg.str(), 0);
+            }
+            StringBuffer results;
+            result.getResultsClear(results);
+            PROGLOG("Checking results");
+            if (0 == strcmp(expectedResult, results))
                 PROGLOG("testSDSSubs2 [ %s ]: MATCH", cmd);
             else
             {
                 VStringBuffer errMsg("testSDSSubs2 [ %s ]: MISMATCH", cmd);
                 errMsg.newline().append("Expected: ").append(expectedResult);
-                errMsg.newline().append("Got: ").append(result);
+                errMsg.newline().append("Got: ").append(results);
                 PROGLOG("%s", errMsg.str());
                 CPPUNIT_ASSERT_MESSAGE(errMsg.str(), 0);
             }


### PR DESCRIPTION
One of the subscription unit tests could fail if a subscription
message was not received quickly.
Refactor to count expected notifications and wait for them on
a semaphore, timeout only if not heard from any for a while.

Signed-off-by: Jake Smith <jake.smith@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

tested failing test in tight loop

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
