### PR TITLE
HPCC-18004 Remote file open use file sharing flag if set

### DIFF
--- a/common/remote/sockfile.cpp
+++ b/common/remote/sockfile.cpp
@@ -1700,12 +1700,14 @@ class CRemoteFile : public CRemoteBase, implements IFile
 {
     StringAttr remotefilename;
     unsigned flags;
+    bool isShareSet;
 public:
     IMPLEMENT_IINTERFACE
     CRemoteFile(const SocketEndpoint &_ep, const char * _filename)
         : CRemoteBase(_ep, _filename)
     {
         flags = ((unsigned)IFSHread)|((S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP|S_IROTH|S_IWOTH)<<16);
+        isShareSet = false;
         if (filename.length()>2 && isPathSepChar(filename[0]) && isShareChar(filename[2]))
         {
             VStringBuffer winDriveFilename("%c:%s", filename[1], filename+3);
@@ -2134,12 +2136,17 @@ public:
     {
         flags &= ~(IFSHfull|IFSHread);
         flags |= (unsigned)(shmode&(IFSHfull|IFSHread));
-        flags |= IFSHset;
+        isShareSet = true;
     }
 
     unsigned short getShareMode()
     {
         return (unsigned short)(flags&0xffff);
+    }
+
+    bool getIsShareSet()
+    {
+        return isShareSet;
     }
 
     void remoteExtractBlobElements(const char * prefix, ExtractedBlobArray & extracted)
@@ -2325,7 +2332,7 @@ public:
         // then also send sMode, cFlags
         unsigned short sMode = parent->getShareMode();
         unsigned short cFlags = parent->getCreateFlags();
-        if (!(sMode & IFSHset))
+        if (parent->getIsShareSet())
         {
             // share mode not explicitly set, match backward compatibility ...
             switch ((compatIFSHmode)_compatmode)
@@ -2343,10 +2350,6 @@ public:
                     sMode = IFSHfull;
                     break;
             }
-        }
-        else
-        {
-            sMode &= ~IFSHset;
         }
         sendBuffer.append((RemoteFileCommandType)RFCopenIO).append(localname).append((byte)_mode).append((byte)_compatmode).append((byte)_extraFlags).append(sMode).append(cFlags);
         parent->sendRemoteCommand(sendBuffer, replyBuffer);
@@ -2605,6 +2608,9 @@ void clientDisconnectRemoteIoOnExit(IFileIO *fileio,bool set)
 
 IFileIO * CRemoteFile::openShared(IFOmode mode,IFSHmode shmode,IFEflags extraFlags)
 {
+    // 0x8, 0x10 and 0x20 are only share modes supported
+    // currently only 0x8 (IFSHread) and 0x10 (IFSHfull) are used so this could be 0xffffffe7
+    // note: IFSHfull also includes read sharing on Windows
     assertex(((unsigned)shmode&0xffffffc7)==0);
     compatIFSHmode compatmode;
     unsigned fileflags = (flags>>16) &  (S_IRUSR|S_IWUSR|S_IXUSR|S_IRGRP|S_IWGRP|S_IXGRP|S_IROTH|S_IWOTH|S_IXOTH);

--- a/system/jlib/jfile.hpp
+++ b/system/jlib/jfile.hpp
@@ -37,7 +37,7 @@ class MemoryBuffer;
 class Semaphore;
 
 enum IFOmode { IFOcreate, IFOread, IFOwrite, IFOreadwrite, IFOcreaterw };    // modes for open
-enum IFSHmode { IFSHnone, IFSHread=0x8, IFSHfull=0x10};   // sharing modes
+enum IFSHmode { IFSHnone, IFSHset=0x1, IFSHread=0x8, IFSHfull=0x10};   // sharing modes
 enum IFSmode { IFScurrent = FILE_CURRENT, IFSend = FILE_END, IFSbegin = FILE_BEGIN };    // seek mode
 enum CFPmode { CFPcontinue, CFPcancel, CFPstop };    // modes for ICopyFileProgress::onProgress return
 enum IFEflags { IFEnone=0x0, IFEnocache=0x1, IFEcache=0x2 };    // mask

--- a/system/jlib/jfile.hpp
+++ b/system/jlib/jfile.hpp
@@ -37,7 +37,7 @@ class MemoryBuffer;
 class Semaphore;
 
 enum IFOmode { IFOcreate, IFOread, IFOwrite, IFOreadwrite, IFOcreaterw };    // modes for open
-enum IFSHmode { IFSHnone, IFSHset=0x1, IFSHread=0x8, IFSHfull=0x10};   // sharing modes
+enum IFSHmode { IFSHnone, IFSHread=0x8, IFSHfull=0x10};   // sharing modes
 enum IFSmode { IFScurrent = FILE_CURRENT, IFSend = FILE_END, IFSbegin = FILE_BEGIN };    // seek mode
 enum CFPmode { CFPcontinue, CFPcancel, CFPstop };    // modes for ICopyFileProgress::onProgress return
 enum IFEflags { IFEnone=0x0, IFEnocache=0x1, IFEcache=0x2 };    // mask

--- a/testing/unittests/jlibtests.cpp
+++ b/testing/unittests/jlibtests.cpp
@@ -499,9 +499,9 @@ protected:
                 extraFlags = IFEnocache;
             ifileio = ifile->open(IFOcreate, extraFlags);
 
-#if 0
+#if 0 // for testing default and explicitly set share mode to Windows dafilesrv
             if (server != NULL)
-                ifile->setShareMode((IFSHmode)IFSHfull);
+                ifile->setShareMode((IFSHmode)IFSHread);
 #endif
 
             try

--- a/testing/unittests/jlibtests.cpp
+++ b/testing/unittests/jlibtests.cpp
@@ -499,6 +499,11 @@ protected:
                 extraFlags = IFEnocache;
             ifileio = ifile->open(IFOcreate, extraFlags);
 
+#if 0
+            if (server != NULL)
+                ifile->setShareMode((IFSHmode)IFSHfull);
+#endif
+
             try
             {
                 ifile->setFilePermissions(0666);
@@ -509,6 +514,8 @@ protected:
             }
 
             unsigned iter = nr / 40;
+            if (iter < 1)
+                iter = 1;
 
             __int64 pos = 0;
             for (unsigned i=0;i<nr;i++)


### PR DESCRIPTION
If IFile->setShareMode() is called then use that value for remote file share setting, otherwise use existing value (for backward compatibility).

Signed-off-by: Mark Kelly <mark.kelly@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [x] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [x] I have added tests to cover my changes.
  - [x] All new and existing tests passed.
  - [x] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [x] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

Full QA suite passed and jlib unittests to a Windows dafilesrv verified file share value.

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
