### PR TITLE
HPCC-18780 Generate projected as well as expected disk meta functions

### DIFF
--- a/common/thorhelper/thorfile.cpp
+++ b/common/thorhelper/thorfile.cpp
@@ -53,6 +53,10 @@ public:
     {
         return (IOutputMetaData *)recordSize;
     }
+    virtual IOutputMetaData * queryProjectedDiskRecordSize()
+    {
+        return (IOutputMetaData *)recordSize;
+    }
     virtual unsigned getFormatCrc()
     {
         return 0;

--- a/ecl/hqlcpp/hqlckey.cpp
+++ b/ecl/hqlcpp/hqlckey.cpp
@@ -1260,9 +1260,12 @@ void KeyedJoinInfo::splitFilter(IHqlExpression * filter, SharedHqlExpr & keyTarg
 void HqlCppTranslator::buildKeyedJoinExtra(ActivityInstance & instance, IHqlExpression * expr, KeyedJoinInfo * info)
 {
     //virtual IOutputMetaData * queryDiskRecordSize() = 0;
+    //virtual IOutputMetaData * queryProjectedDiskRecordSize() = 0;
     if (info->isFullJoin())
+    {
         buildMetaMember(instance.classctx, info->queryRawRhs(), false, "queryDiskRecordSize");
-
+        buildMetaMember(instance.classctx, info->queryRawRhs(), false, "queryProjectedDiskRecordSize");
+    }
     //virtual unsigned __int64 extractPosition(const void * _right) = 0;  // Gets file position value from rhs row
     if (info->isFullJoin())
     {
@@ -1328,6 +1331,7 @@ void HqlCppTranslator::buildKeyJoinIndexReadHelper(ActivityInstance & instance, 
     bool hasFilePosition = getBoolAttribute(indexExpr, filepositionAtom, true);
     serializedRecord.setown(createMetadataIndexRecord(serializedRecord, hasFilePosition));
     buildMetaMember(instance.classctx, serializedRecord, false, "queryIndexRecordSize");
+    buildMetaMember(instance.classctx, serializedRecord, false, "queryProjectedIndexRecordSize");
 
     //virtual void createSegmentMonitors(IIndexReadContext *ctx, const void *lhs) = 0;
     info->buildMonitors(instance.startctx);

--- a/ecl/hqlcpp/hqlsource.cpp
+++ b/ecl/hqlcpp/hqlsource.cpp
@@ -2023,6 +2023,7 @@ ABoundActivity * SourceBuilder::buildActivity(BuildCtx & ctx, IHqlExpression * e
                 bool hasFilePosition = getBoolAttribute(indexExpr, filepositionAtom, true);
                 serializedRecord.setown(createMetadataIndexRecord(serializedRecord, hasFilePosition));
                 translator.buildMetaMember(instance->classctx, serializedRecord, false, "queryDiskRecordSize");
+                translator.buildMetaMember(instance->classctx, serializedRecord, false, "queryProjectedDiskRecordSize");
                 break;
             }
             default:
@@ -2030,10 +2031,14 @@ ABoundActivity * SourceBuilder::buildActivity(BuildCtx & ctx, IHqlExpression * e
                 {
                     OwnedHqlExpr diskTable = createDataset(no_anon, LINK(physicalRecord));
                     translator.buildMetaMember(instance->classctx, diskTable, false, "queryDiskRecordSize");
+                    if (activityKind != TAKpiperead)
+                        translator.buildMetaMember(instance->classctx, diskTable, false, "queryProjectedDiskRecordSize");
                 }
                 else
                 {
                     translator.buildMetaMember(instance->classctx, tableExpr, isGrouped(tableExpr), "queryDiskRecordSize");
+                    if (activityKind != TAKpiperead)
+                        translator.buildMetaMember(instance->classctx, tableExpr, isGrouped(tableExpr), "queryProjectedDiskRecordSize");
                 }
             }
         }
@@ -6973,6 +6978,7 @@ ABoundActivity * HqlCppTranslator::doBuildActivityXmlRead(BuildCtx & ctx, IHqlEx
     doBuildVarStringFunction(instance->classctx, "getXmlIteratorPath", queryRealChild(mode, 0));
 
     buildMetaMember(instance->classctx, tableExpr, false, "queryDiskRecordSize");  // A lie, but I don't care....
+    buildMetaMember(instance->classctx, tableExpr, false, "queryProjectedDiskRecordSize");  // A lie, but I don't care....
 
     //virtual unsigned getFlags() = 0;
     StringBuffer flags;

--- a/rtl/eclrtl/eclhelper_base.cpp
+++ b/rtl/eclrtl/eclhelper_base.cpp
@@ -329,6 +329,7 @@ ICompare * CThorSubSortArg::queryCompareSerializedRow() { return NULL; }
 bool CThorKeyedJoinArg::diskAccessRequired() { return false; }
 const char * CThorKeyedJoinArg::getFileName() { return NULL; }
 IOutputMetaData * CThorKeyedJoinArg::queryDiskRecordSize() { return NULL; }
+IOutputMetaData * CThorKeyedJoinArg::queryProjectedDiskRecordSize() { return NULL; }
 unsigned __int64 CThorKeyedJoinArg::extractPosition(const void * _right) { return 0; }
 
 bool CThorKeyedJoinArg::leftCanMatch(const void * inputRow) { return true; }

--- a/rtl/eclrtl/eclhelper_dyn.cpp
+++ b/rtl/eclrtl/eclhelper_dyn.cpp
@@ -232,6 +232,10 @@ public:
     {
         return in;
     }
+    virtual IOutputMetaData * queryProjectedDiskRecordSize() override final
+    {
+        return in;
+    }
     virtual unsigned getFormatCrc() override
     {
         return 0;  // engines should treat 0 as 'ignore'
@@ -294,6 +298,10 @@ public:
         return fileName;
     }
     virtual IOutputMetaData * queryDiskRecordSize() override final
+    {
+        return in;
+    }
+    virtual IOutputMetaData * queryProjectedDiskRecordSize() override final
     {
         return in;
     }

--- a/rtl/include/eclhelper.hpp
+++ b/rtl/include/eclhelper.hpp
@@ -1679,7 +1679,8 @@ struct IHThorFetchContext
 {
     virtual unsigned __int64 extractPosition(const void * _right) = 0;  // Gets file position value from rhs row
     virtual const char * getFileName() = 0;                 // Returns filename of raw file fpos'es refer into
-    virtual IOutputMetaData * queryDiskRecordSize() = 0;        // Returns record size of raw file fpos'es refer into
+    virtual IOutputMetaData * queryDiskRecordSize() = 0;            // Expected layout
+    virtual IOutputMetaData * queryProjectedDiskRecordSize() = 0;   // Projected layout
     virtual unsigned getFetchFlags() { return 0; }              
     virtual unsigned getDiskFormatCrc() { return 0; }
     virtual void getFileEncryptKey(size32_t & keyLen, void * & key) { keyLen = 0; key = 0; }
@@ -1694,7 +1695,8 @@ struct IHThorKeyedJoinBaseArg : public IHThorArg
 
     // Inside the indexRead remote activity:
     virtual const char * getIndexFileName() = 0;
-    virtual IOutputMetaData * queryIndexRecordSize() = 0;
+    virtual IOutputMetaData * queryIndexRecordSize() = 0;            // Expected layout
+    virtual IOutputMetaData * queryProjectedIndexRecordSize() = 0;   // Projected layout
     virtual void createSegmentMonitors(IIndexReadContext *ctx, const void *lhs) = 0;
     virtual bool indexReadMatch(const void * indexRow, const void * inputRow, unsigned __int64 keyedFpos, IBlobProvider * blobs) = 0;
     virtual unsigned getJoinLimit() = 0;                                        // if a key joins more than this limit no records are output (0 = no limit)
@@ -2276,7 +2278,8 @@ struct IHThorCompoundBaseArg : public IHThorArg
 struct IHThorIndexReadBaseArg : extends IHThorCompoundBaseArg
 {
     virtual const char * getFileName() = 0;
-    virtual IOutputMetaData * queryDiskRecordSize() = 0;                // size of records on disk may differ if records are transformed on read
+    virtual IOutputMetaData * queryDiskRecordSize() = 0;            // Expected layout
+    virtual IOutputMetaData * queryProjectedDiskRecordSize() = 0;   // Projected layout
     virtual unsigned getFlags() = 0;
     virtual unsigned getFormatCrc() = 0;
     virtual void setCallback(IThorIndexCallback * callback) = 0;
@@ -2289,7 +2292,8 @@ struct IHThorIndexReadBaseArg : extends IHThorCompoundBaseArg
 struct IHThorDiskReadBaseArg : extends IHThorCompoundBaseArg
 {
     virtual const char * getFileName() = 0;
-    virtual IOutputMetaData * queryDiskRecordSize() = 0;                // size of records on disk may differ if records are transformed on read
+    virtual IOutputMetaData * queryDiskRecordSize() = 0;            // Expected layout
+    virtual IOutputMetaData * queryProjectedDiskRecordSize() = 0;   // Projected layout
     virtual unsigned getFlags() = 0;
     virtual unsigned getFormatCrc() = 0;
     virtual void getEncryptKey(size32_t & keyLen, void * & key) { keyLen = 0; key = 0; }

--- a/rtl/include/eclhelper_base.hpp
+++ b/rtl/include/eclhelper_base.hpp
@@ -441,6 +441,7 @@ class ECLRTL_API CThorKeyedJoinArg : public CThorArgOf<IHThorKeyedJoinArg>
     virtual bool diskAccessRequired() override;
     virtual const char * getFileName() override;
     virtual IOutputMetaData * queryDiskRecordSize() override;
+    virtual IOutputMetaData * queryProjectedDiskRecordSize() override;
     virtual unsigned __int64 extractPosition(const void * _right) override;
     
     // For the data going to the indexRead remote activity:
@@ -1228,7 +1229,8 @@ public:
 
     virtual unsigned getFlags()                             { return TDXtemporary|TDXcompress; }
     virtual unsigned getFormatCrc()                         { rtlFailUnexpected(); return 0; }
-    virtual IOutputMetaData * queryDiskRecordSize()             { return meta; }
+    virtual IOutputMetaData * queryDiskRecordSize()         { return meta; }
+    virtual IOutputMetaData * queryProjectedDiskRecordSize() { return meta; }
     virtual IOutputMetaData * queryOutputMeta()             { return meta; }
     virtual const char * getFileName()                      { return filename; }
     virtual size32_t transform(ARowBuilder & rowBuilder, const void * _left) { rtlFailUnexpected(); return 0; }

--- a/thorlcr/activities/csvread/thcsvrslave.cpp
+++ b/thorlcr/activities/csvread/thcsvrslave.cpp
@@ -299,7 +299,7 @@ class CCsvReadSlaveActivity : public CDiskReadSlaveActivityBase
         }
     }
 public:
-    CCsvReadSlaveActivity(CGraphElementBase *_container) : CDiskReadSlaveActivityBase(_container)
+    CCsvReadSlaveActivity(CGraphElementBase *_container) : CDiskReadSlaveActivityBase(_container, nullptr)
     {
         helper = static_cast <IHThorCsvReadArg *> (queryHelper());
         stopAfter = (rowcount_t)helper->getChooseNLimit();

--- a/thorlcr/activities/diskread/thdiskreadslave.cpp
+++ b/thorlcr/activities/diskread/thdiskreadslave.cpp
@@ -74,10 +74,8 @@ protected:
 
 public:
     CDiskReadSlaveActivityRecord(CGraphElementBase *_container, IHThorArg *_helper=NULL) 
-        : CDiskReadSlaveActivityBase(_container)
+        : CDiskReadSlaveActivityBase(_container, _helper)
     {
-        if (_helper)
-            baseHelper.set(_helper);
         helper = (IHThorDiskReadArg *)queryHelper();
         IOutputMetaData *diskRowMeta = queryDiskRowInterfaces()->queryRowMetaData()->querySerializedDiskMeta();
         isFixedDiskWidth = diskRowMeta->isFixedSize();

--- a/thorlcr/activities/thdiskbaseslave.cpp
+++ b/thorlcr/activities/thdiskbaseslave.cpp
@@ -202,8 +202,10 @@ const char * CDiskPartHandlerBase::queryLogicalFilename(const void * row)
 
 //////////////////////////////////////////////
 
-CDiskReadSlaveActivityBase::CDiskReadSlaveActivityBase(CGraphElementBase *_container) : CSlaveActivity(_container)
+CDiskReadSlaveActivityBase::CDiskReadSlaveActivityBase(CGraphElementBase *_container, IHThorArg *_helper) : CSlaveActivity(_container)
 {
+    if (_helper)
+        baseHelper.set(_helper);
     helper = (IHThorDiskReadBaseArg *)queryHelper();
     reInit = 0 != (helper->getFlags() & (TDXvarfilename|TDXdynamicfilename));
     crcCheckCompressed = getOptBool(THOROPT_READCOMPRESSED_CRC, false);

--- a/thorlcr/activities/thdiskbaseslave.ipp
+++ b/thorlcr/activities/thdiskbaseslave.ipp
@@ -91,7 +91,7 @@ protected:
     rowcount_t diskProgress = 0;
 
 public:
-    CDiskReadSlaveActivityBase(CGraphElementBase *_container);
+    CDiskReadSlaveActivityBase(CGraphElementBase *_container, IHThorArg *_helper);
     const char *queryLogicalFilename(unsigned index);
     IThorRowInterfaces * queryDiskRowInterfaces();
     virtual void start() override;

--- a/thorlcr/activities/xmlread/thxmlreadslave.cpp
+++ b/thorlcr/activities/xmlread/thxmlreadslave.cpp
@@ -204,7 +204,7 @@ class CXmlReadSlaveActivity : public CDiskReadSlaveActivityBase
         }
     };
 public:
-    CXmlReadSlaveActivity(CGraphElementBase *_container) : CDiskReadSlaveActivityBase(_container)
+    CXmlReadSlaveActivity(CGraphElementBase *_container) : CDiskReadSlaveActivityBase(_container, nullptr)
     {
         out = NULL;
         helper = (IHThorXmlReadArg *)queryHelper();


### PR DESCRIPTION
Signed-off-by: Richard Chapman <rchapman@hpccsystems.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [ ] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
Compiled
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
