### PR TITLE
HPCC-18784 Ensure windows share translated

### DIFF
--- a/common/remote/sockfile.cpp
+++ b/common/remote/sockfile.cpp
@@ -6340,6 +6340,7 @@ static Owned<CSimpleInterface> serverThread;
 class RemoteFileTest : public CppUnit::TestFixture
 {
     CPPUNIT_TEST_SUITE(RemoteFileTest);
+        CPPUNIT_TEST(testRemoteFilename);
         CPPUNIT_TEST(testStartServer);
         CPPUNIT_TEST(testBasicFunctionality);
         CPPUNIT_TEST(testCopy);
@@ -6352,6 +6353,37 @@ class RemoteFileTest : public CppUnit::TestFixture
     size32_t testLen = 1024;
 
 protected:
+    void testRemoteFilename()
+    {
+        const char *rfns = "//1.2.3.4/dir1/file1|//1.2.3.4:7100/dir1/file1,"
+                           "//1.2.3.4:7100/dir1/file1|//1.2.3.4:7100/dir1/file1,"
+                           "//1.2.3.4/c$/dir1/file1|//1.2.3.4:7100/c$/dir1/file1,"
+                           "//1.2.3.4:7100/c$/dir1/file1|//1.2.3.4:7100/c$/dir1/file1,"
+                           "//1.2.3.4:7100/d$/dir1/file1|//1.2.3.4:7100/d$/dir1/file1";
+        StringArray tests;
+        tests.appendList(rfns, ",");
+
+        ForEachItemIn(i, tests)
+        {
+            StringArray inOut;
+            const char *pair = tests.item(i);
+            inOut.appendList(pair, "|");
+            const char *rfn = inOut.item(0);
+            const char *expected = inOut.item(1);
+            Owned<IFile> iFile = createIFile(rfn);
+            const char *res = iFile->queryFilename();
+            if (!streq(expected, res))
+            {
+                StringBuffer errMsg("testRemoteFilename MISMATCH");
+                errMsg.newline().append("Expected: ").append(expected);
+                errMsg.newline().append("Got: ").append(res);
+                PROGLOG("%s", errMsg.str());
+                CPPUNIT_ASSERT_MESSAGE(errMsg.str(), 0);
+            }
+            else
+                PROGLOG("MATCH: %s", res);
+        }
+    }
     void testStartServer()
     {
         Owned<ISocket> socket;

--- a/system/jlib/jfile.cpp
+++ b/system/jlib/jfile.cpp
@@ -4471,7 +4471,7 @@ StringBuffer & RemoteFilename::getRemotePath(StringBuffer & out) const
         fn = loc.append(sharehead).append(tailpath).str();
     else // try and guess from just tail (may likely fail other than for windows) 
         fn=getLocalPath(loc).str();
-    if ((c=='\\')&&(fn[1]==':')) {  // windows \\d$
+    if ((fn[1]==':') && (fn[2]=='/' || fn[2]=='\\')) {  // windows \\d$
         out.append((char)tolower(c)).append(*fn).append(getShareChar());
         fn+=2;
     }


### PR DESCRIPTION
HPCC-18556 ensured that URL's with a windows share were
translated to Windows format so that dafilesrv's would read/write
to the correct locations.
However, remote filenames of this type also needed to translate
the URL for the purposes of IFile->queryFilename()
This was noticed as a bug in backupnode, which generated lists
of filenames based on queryFilename() and on legacy systems that
used windows share paths, a corruption was noticed.

Signed-off-by: Jake Smith <jake.smith@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

Add unit tests to validate RemoteFilename usage in remote file.

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
