### PR TITLE
HPCC-18805 Ensure the LHS of a FETCH is in the serialized format

### DIFF
--- a/ecl/hql/hqlopt.cpp
+++ b/ecl/hql/hqlopt.cpp
@@ -3786,6 +3786,18 @@ IHqlExpression * CTreeOptimizer::doCreateTransformed(IHqlExpression * transforme
             node_operator childOp = child->getOperator();
             switch(childOp)
             {
+            //None of the following change the format of the left hand side, and since the fetch is on the underlying
+            //dataset they can all be removed.  If they remain the disk file can be treated as if it is in memory format.
+            case no_preload:
+            case no_nofold:
+            case no_nocombine:
+            case no_dedup:
+            case no_group:
+            case no_compound_diskread:
+            case no_filter:
+            case no_sort:
+            case no_sorted:
+                return replaceChild(transformed, child->queryChild(0));
             case no_newusertable:
                 if (isAggregateDataset(child))
                     break;

--- a/ecl/hqlcpp/hqlcerrors.hpp
+++ b/ecl/hqlcpp/hqlcerrors.hpp
@@ -225,6 +225,7 @@
 #define HQLERR_DedupBestWithKeepn               4206
 #define HQLERR_HashStoredDuplication            4207
 #define HQLERR_DatafileRequiresSigned           4208
+#define HQLERR_ExpectedFileLhsFetch             4209
 
 //Warnings....
 #define HQLWRN_PersistDataNotLikely             4500
@@ -529,6 +530,7 @@
 #define HQLERR_DedupBestWithKeepn_Text          "DEDUP with BEST does not support KEEP"
 #define HQLERR_HashStoredDuplication_Text       "Inconsistent #%s(%s, %s) and #%s(%s, %s)"
 #define HQLERR_DatafileRequiresSigned_Text      "Insufficient access rights to use datafiles"
+#define HQLERR_ExpectedFileLhsFetch_Text        "The first argument of FETCH must be a disk file (had %s)"
 
 //Warnings.
 #define HQLWRN_CannotRecreateDistribution_Text  "Cannot recreate the distribution for a persistent dataset"

--- a/ecl/hqlcpp/hqlsource.cpp
+++ b/ecl/hqlcpp/hqlsource.cpp
@@ -7253,6 +7253,12 @@ ABoundActivity * HqlCppTranslator::doBuildActivityFetch(BuildCtx & ctx, IHqlExpr
         OwnedHqlExpr simple = replaceFetchInput(expr, null, no_right);
         OwnedHqlExpr transformed = replaceExpression(simple, tableExpr, projected);
         OwnedHqlExpr optSimple = optimizeHqlExpression(queryErrorProcessor(), transformed, optFlags);
+        IHqlExpression * newFetch = queryFetch(optSimple);
+        assertex(newFetch);
+        IHqlExpression * lhs = newFetch->queryChild(0);
+        if (lhs->getOperator() != no_table)
+            throwError1(HQLERR_ExpectedFileLhsFetch, getOpString(lhs->getOperator()));
+
         OwnedHqlExpr optimized = replaceFetchInput(optSimple, fetchRhs, no_right);
         return doBuildActivityFetch(ctx, optimized);
     }


### PR DESCRIPTION
Signed-off-by: Gavin Halliday <gavin.halliday@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [ ] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [x] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->
Ran full compiler regression suite and checked output.  Checked that the problem fixed Richard's initial issue.  (His test will be released in a separate PR.)
Note ecl/regress/fetch11.ecl changes as a result of this - the previous code was incorrect.

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
