### PR TITLE
HPCC-18658 Refactor ESP sessionID and digital signature data types

### DIFF
--- a/dali/base/dasess.cpp
+++ b/dali/base/dasess.cpp
@@ -2010,8 +2010,8 @@ class CUserDescriptor: implements IUserDescriptor, public CInterface
 {
     StringAttr username;
     StringAttr passwordenc;
-    MemoryBuffer sessionToken;//ESP session token
-    MemoryBuffer signature;//user's digital Signature
+    unsigned sessionToken;//ESP session token
+    StringBuffer signature;//user's digital Signature
 public:
     IMPLEMENT_IINTERFACE;
     StringBuffer &getUserName(StringBuffer &buf)
@@ -2023,13 +2023,13 @@ public:
         decrypt(buf,passwordenc);
         return buf;
     }
-    const MemoryBuffer *querySessionToken()
+    unsigned querySessionToken()
     {
-        return &sessionToken;
+        return sessionToken;
     }
-    const MemoryBuffer *querySignature()
+    const char * querySignature()
     {
-        return &signature;
+        return signature.str();
     }
     virtual void set(const char *name,const char *password)
     {
@@ -2038,17 +2038,17 @@ public:
         encrypt(buf,password);
         passwordenc.set(buf.str());
     }
-    void set(const char *_name, const char *_password, const MemoryBuffer *_sessionToken, const MemoryBuffer *_signature)
+    void set(const char *_name, const char *_password, unsigned _sessionToken, const char  *_signature)
     {
         set(_name, _password);
-        sessionToken.clear().append(_sessionToken);
+        sessionToken = _sessionToken;
         signature.clear().append(_signature);
     }
     virtual void clear()
     {
         username.clear();
         passwordenc.clear();
-        sessionToken.clear();
+        sessionToken = 0;
         signature.clear();
     }
     void serialize(MemoryBuffer &mb)
@@ -2058,7 +2058,7 @@ public:
     void serializeExtra(MemoryBuffer &mb)
     {
         if (queryDaliServerVersion().compare("3.14") >= 0)
-            mb.append(sessionToken.length()).append(sessionToken).append(signature.length()).append(signature);
+            mb.append(sessionToken).append(signature.length()).append(signature);
     }
     void deserialize(MemoryBuffer &mb)
     {
@@ -2066,18 +2066,17 @@ public:
     }
     void deserializeExtra(MemoryBuffer &mb)
     {
+        signature.clear();
+        sessionToken = 0;
         if (mb.remaining() > 0)
         {
-            size32_t len = 0;
-            mb.read(len);
-            if (len)
-                sessionToken.append(len, mb.readDirect(len));
-
+            mb.read((unsigned &)sessionToken);
             if (mb.remaining() > 0)
             {
+                unsigned len = 0;
                 mb.read(len);
                 if (len)
-                    signature.append(len, mb.readDirect(len));
+                    signature.append(len, (const char *)mb.readDirect(len));
             }
         }
     }

--- a/dali/base/dasess.hpp
+++ b/dali/base/dasess.hpp
@@ -75,10 +75,10 @@ interface IUserDescriptor: extends serializable
 {
     virtual StringBuffer &getUserName(StringBuffer &buf)=0;
     virtual StringBuffer &getPassword(StringBuffer &buf)=0;
-    virtual const MemoryBuffer *querySignature()=0;//user's digital signature
-    virtual const MemoryBuffer *querySessionToken()=0;//ESP session token
+    virtual const char *querySignature()=0;//user's digital signature
+    virtual unsigned querySessionToken()=0;//ESP session token
     virtual void set(const char *name,const char *password)=0;
-    virtual void set(const char *name,const char *password, const MemoryBuffer *_sessionToken, const MemoryBuffer *_signature)=0;
+    virtual void set(const char *name,const char *password, unsigned sessionToken, const char * signature)=0;
     virtual void clear()=0;
     virtual void serializeExtra(MemoryBuffer &tgt)=0;
     virtual void deserializeExtra(MemoryBuffer &src)=0;

--- a/esp/platform/espcontext.cpp
+++ b/esp/platform/espcontext.cpp
@@ -171,23 +171,23 @@ public:
     {
         return m_password.get();
     }
-    virtual void setSessionToken(const MemoryBuffer & token)
+    virtual void setSessionToken(unsigned token)
     {
         if (m_user)
-            m_user->credentials().setSessionToken(&token);
+            m_user->credentials().setSessionToken(token);
     }
-    virtual const MemoryBuffer * querySessionToken()
+    virtual unsigned querySessionToken()
     {
-        return m_user ? &m_user->credentials().getSessionToken() : nullptr;
+        return m_user ? m_user->credentials().getSessionToken() : 0;
     }
-    virtual void setSignature(const MemoryBuffer & signature)
+    virtual void setSignature(const char * signature)
     {
         if (m_user)
-            m_user->credentials().setSignature(&signature);
+            m_user->credentials().setSignature(signature);
     }
-    virtual const MemoryBuffer * querySignature()
+    virtual const char * querySignature()
     {
-        return m_user ? &m_user->credentials().getSignature() : nullptr;
+        return m_user ? m_user->credentials().getSignature() : 0;
     }
     virtual void setRealm(const char* realm)
     {

--- a/esp/scm/esp.ecm
+++ b/esp/scm/esp.ecm
@@ -86,10 +86,10 @@ interface IEspContext : extends IInterface
     virtual const char * queryRealm() = 0;
     virtual void setUser(ISecUser * user) = 0;
     virtual ISecUser * queryUser() = 0;
-    virtual void setSessionToken(const MemoryBuffer & token) = 0;
-    virtual const MemoryBuffer * querySessionToken() = 0;
-    virtual void setSignature(const MemoryBuffer & signature) = 0;
-    virtual const MemoryBuffer * querySignature() = 0;
+    virtual void setSessionToken(unsigned token) = 0;
+    virtual unsigned querySessionToken() = 0;
+    virtual void setSignature(const char * signature) = 0;
+    virtual const char * querySignature() = 0;
     virtual void setResources(ISecResourceList * rlist) = 0;
     virtual ISecResourceList * queryResources() = 0;
     virtual void setSecManger(ISecManager * mgr) = 0;

--- a/system/security/LdapSecurity/ldapsecurity.cpp
+++ b/system/security/LdapSecurity/ldapsecurity.cpp
@@ -202,24 +202,24 @@ bool CLdapSecUser::setEncodedPassword(SecPasswordEncoding enc, void * pw, unsign
     return FALSE;  //not supported yet
 }
 
-void CLdapSecUser::setSessionToken(const MemoryBuffer * const token)
+void CLdapSecUser::setSessionToken(unsigned token)
 {
-    m_sessionToken.clear().append(token);
+    m_sessionToken = token;
 }
 
-const MemoryBuffer & CLdapSecUser::getSessionToken()
+unsigned CLdapSecUser::getSessionToken()
 {
     return m_sessionToken;
 }
 
-void CLdapSecUser::setSignature(const MemoryBuffer * const signature)
+void CLdapSecUser::setSignature(const char * signature)
 {
-    m_signature.clear().append(*signature);
+    m_signature.set(signature);
 }
 
-const MemoryBuffer & CLdapSecUser::getSignature()
+const char * CLdapSecUser::getSignature()
 {
-    return m_signature;
+    return m_signature.str();
 }
 
 void CLdapSecUser::copyTo(ISecUser& destination)
@@ -243,8 +243,8 @@ void CLdapSecUser::copyTo(ISecUser& destination)
     dest->setUserID(m_userid);
     dest->setPasswordExpiration(m_passwordExpiration);
     dest->setDistinguishedName(m_distinguishedName);
-    dest->credentials().setSessionToken(&m_sessionToken);
-    dest->credentials().setSignature(&m_signature);
+    dest->credentials().setSessionToken(m_sessionToken);
+    dest->credentials().setSignature(m_signature.str());
 }
 
 ISecUser * CLdapSecUser::clone()
@@ -662,7 +662,7 @@ bool CLdapSecManager::authenticate(ISecUser* user)
         return true;
     }
 
-    if (user->credentials().getSessionToken().length())//Already authenticated it token exists
+    if ((user->credentials().getSessionToken() != 0) || user->credentials().getSignature())//Already authenticated it token or signature exist
     {
         user->setAuthenticateStatus(AS_AUTHENTICATED);
         if(m_permissionsCache->isCacheEnabled() && !m_usercache_off)

--- a/system/security/LdapSecurity/ldapsecurity.ipp
+++ b/system/security/LdapSecurity/ldapsecurity.ipp
@@ -67,8 +67,8 @@ private:
     StringAttr   m_sudoHost;
     StringAttr   m_sudoCommand;
     StringAttr   m_sudoOption;
-    MemoryBuffer m_sessionToken;//User's ESP session token
-    MemoryBuffer m_signature;//User's digital signature
+    unsigned     m_sessionToken;//User's ESP session token
+    StringBuffer m_signature;//User's digital signature
 
 public:
     IMPLEMENT_IINTERFACE
@@ -155,10 +155,10 @@ public:
     bool setPassword(const char * pw);
     const char* getPassword();
     bool setEncodedPassword(SecPasswordEncoding enc, void * pw, unsigned length, void * salt, unsigned saltlen);
-    void setSessionToken(const MemoryBuffer * const token);
-    const MemoryBuffer & getSessionToken();
-    void setSignature(const MemoryBuffer * const signature);
-    const MemoryBuffer & getSignature();
+    void setSessionToken(unsigned token);
+    unsigned getSessionToken();
+    void setSignature(const char * signature);
+    const char * getSignature();
 
 // Posix specific fields
     virtual void setGidnumber(const char* gidnumber)

--- a/system/security/plugins/htpasswdSecurity/htpasswdSecurity.cpp
+++ b/system/security/plugins/htpasswdSecurity/htpasswdSecurity.cpp
@@ -122,7 +122,7 @@ protected:
 		if (0 == user.length())
 			throw MakeStringException(-1, "htpasswd User name is NULL");
 
-		if (sec_user.credentials().getSessionToken().length())//Already authenticated it token exists
+		if ((sec_user.credentials().getSessionToken() != 0) || sec_user.credentials().getSignature())//Already authenticated it token or signature exist
 		    return true;
 
 		CriticalBlock block(crit);

--- a/system/security/shared/SecureUser.hpp
+++ b/system/security/shared/SecureUser.hpp
@@ -40,8 +40,8 @@ private:
     StringBuffer    m_Peer;
     SecUserStatus   m_status;
     Owned<IProperties> m_parameters;
-    MemoryBuffer    m_sessionToken;
-    MemoryBuffer    m_signature;
+    unsigned        m_sessionToken;
+    StringBuffer    m_signature;
 
     CriticalSection crit;
 public:
@@ -214,24 +214,24 @@ public:
         return m_pw.str();
     }
 
-    void setSessionToken(const MemoryBuffer * const token)
+    void setSessionToken(unsigned token)
     {
-        m_sessionToken.clear().append(token);
+        m_sessionToken = token;
     }
 
-    const MemoryBuffer & getSessionToken()
+    unsigned getSessionToken()
     {
         return m_sessionToken;
     }
 
-    void setSignature(const MemoryBuffer * const signature)
+    void setSignature(const char * signature)
     {
         m_signature.clear().append(signature);
     }
 
-    const MemoryBuffer & getSignature()
+    const char * getSignature()
     {
-        return m_signature;
+        return m_signature.str();
     }
 
     virtual unsigned getUserID()
@@ -257,6 +257,8 @@ public:
         destination.setFqdn(getFqdn());
         destination.setPeer(getPeer());
         destination.credentials().setPassword(credentials().getPassword());
+        destination.credentials().setSignature(credentials().getSignature());
+        destination.credentials().setSessionToken(credentials().getSessionToken());
         CDateTime tmpTime;
         destination.setPasswordExpiration(getPasswordExpiration(tmpTime));
         destination.setStatus(getStatus());

--- a/system/security/shared/caching.cpp
+++ b/system/security/shared/caching.cpp
@@ -358,7 +358,7 @@ bool CPermissionsCache::lookup(ISecUser& sec_user)
             const char* cachedpw = user->queryUser()->credentials().getPassword();
             const char * pw = sec_user.credentials().getPassword();
 
-            if ((sec_user.credentials().getSessionToken().length() > 0) ||  (sec_user.credentials().getSignature().length() > 0))
+            if (sec_user.credentials().getSessionToken() != 0 || sec_user.credentials().getSignature())
             {//presence of session token or signature means user is authenticated
 #ifdef _DEBUG
                 DBGLOG("CACHE: CPermissionsCache Found validated user %s", username);

--- a/system/security/shared/seclib.hpp
+++ b/system/security/shared/seclib.hpp
@@ -142,10 +142,10 @@ interface ISecCredentials : extends IInterface
 {
     virtual bool setPassword(const char * pw) = 0;
     virtual const char * getPassword() = 0;
-    virtual void setSessionToken(const MemoryBuffer * const token) = 0;
-    virtual const MemoryBuffer & getSessionToken() = 0;
-    virtual void setSignature(const MemoryBuffer * const signature) = 0;
-    virtual const MemoryBuffer & getSignature() = 0;
+    virtual void setSessionToken(unsigned token) = 0;
+    virtual unsigned getSessionToken() = 0;
+    virtual void setSignature(const char * signature) = 0;
+    virtual const char * getSignature() = 0;
     virtual bool setPasswordExpiration(CDateTime & expirationDate) = 0;
     virtual CDateTime & getPasswordExpiration(CDateTime & expirationDate) = 0;
     virtual int getPasswordDaysRemaining() = 0;


### PR DESCRIPTION
Currently ESP stores a user's digital signature and ESP Session ID in
MemoryBuffers. The ESP Session ID is really just an unsigned value,
and should be stored and returned as such. The digital signature will
be a base 64 encoded string, and should be passed as const char *.
This PR makes those changes

HPCC-18658 Refactor ESP sessionID and digital signature data types

Currently ESP stores a user's digital signature and ESP Session ID in
MemoryBuffers. The ESP Session ID is really just an unsigned value,
and should be stored and returned as such. The digital signature will
be a base 64 encoded string, and should be passed as const char *.
This PR implements those changes

Signed-off-by: Russ Whitehead <william.whitehead@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [x] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [x] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [x] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
