### PR TITLE
HPCC-18876 Coverity - ensure ThorDataLinkMetaInfo is always initialised

### DIFF
--- a/thorlcr/slave/slave.hpp
+++ b/thorlcr/slave/slave.hpp
@@ -37,21 +37,21 @@
 
 struct ThorDataLinkMetaInfo
 {
-    __int64     totalRowsMin;           // set to 0 if not known
-    __int64     totalRowsMax;           // set to -1 if not known
-    offset_t    spilled;                // amount "spilled" to disk (approx) (offset_t)-1 for not known
+    __int64     totalRowsMin = 0;          // set to 0 if not known
+    __int64     totalRowsMax = -1;         // set to -1 if not known
+    offset_t    spilled = (offset_t)-1;    // amount "spilled" to disk (approx) (offset_t)-1 for not known
 
-    bool        isSource;
-    bool        isSequential;
-    bool        canStall;
-    bool        fastThrough;
-    bool        buffersInput;
-    bool        canBufferInput;
-    bool        singleRowOutput;
-    bool        canIncreaseNumRows;
-    bool        canReduceNumRows;
-    bool        unknownRowsOutput;      // cannot use input to deduce total
-    offset_t    byteTotal;                  // total (uncompressed) byte count of all rows
+    bool        isSource = false;
+    bool        isSequential = false;
+    bool        canStall = false;
+    bool        fastThrough = false;
+    bool        buffersInput = false;
+    bool        canBufferInput = false;
+    bool        singleRowOutput = false;
+    bool        canIncreaseNumRows = false;
+    bool        canReduceNumRows = false;
+    bool        unknownRowsOutput = false; // cannot use input to deduce total
+    offset_t    byteTotal = (offset_t)-1;  // total (uncompressed) byte count of all rows
 };
 
 #ifdef _MSC_VER


### PR DESCRIPTION
Signed-off-by: Gavin Halliday <gavin.halliday@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [x] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [ ] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
