### PR TITLE
HPCC-13971 Improve timeouts and polling for ecl command

### DIFF
--- a/ecl/ecl-package/ecl-package.cpp
+++ b/ecl/ecl-package/ecl-package.cpp
@@ -104,6 +104,8 @@ public:
     {
         Owned<IClientWsPackageProcess> packageProcessClient = createCmdClient(WsPackageProcess, *this);
         Owned<IClientActivatePackageRequest> request = packageProcessClient->createActivatePackageRequest();
+        setCmdRequestTimeouts(request->rpc(), 0, optWaitConnectMs, optWaitReadSec);
+
         request->setTarget(optTarget);
         request->setPackageMap(optPackageMap);
         request->setProcess(optProcess);
@@ -193,6 +195,8 @@ public:
     {
         Owned<IClientWsPackageProcess> packageProcessClient = createCmdClient(WsPackageProcess, *this);
         Owned<IClientDeActivatePackageRequest> request = packageProcessClient->createDeActivatePackageRequest();
+        setCmdRequestTimeouts(request->rpc(), 0, optWaitConnectMs, optWaitReadSec);
+
         request->setTarget(optTarget);
         request->setPackageMap(optPackageMap);
         request->setProcess(optProcess);
@@ -261,6 +265,8 @@ public:
     {
         Owned<IClientWsPackageProcess> packageProcessClient = createCmdClient(WsPackageProcess, *this);
         Owned<IClientListPackageRequest> request = packageProcessClient->createListPackageRequest();
+        setCmdRequestTimeouts(request->rpc(), 0, optWaitConnectMs, optWaitReadSec);
+
         request->setTarget(optTarget);
         request->setProcess("*");
 
@@ -350,6 +356,8 @@ public:
     {
         Owned<IClientWsPackageProcess> packageProcessClient = createCmdClient(WsPackageProcess, *this);
         Owned<IClientGetPackageRequest> request = packageProcessClient->createGetPackageRequest();
+        setCmdRequestTimeouts(request->rpc(), 0, optWaitConnectMs, optWaitReadSec);
+
         request->setTarget(optTarget);
         request->setProcess("*");
 
@@ -440,6 +448,8 @@ public:
 
         Owned<IClientWsPackageProcess> packageProcessClient = createCmdClient(WsPackageProcess, *this);
         Owned<IClientDeletePackageRequest> request = packageProcessClient->createDeletePackageRequest();
+        setCmdRequestTimeouts(request->rpc(), 0, optWaitConnectMs, optWaitReadSec);
+
         request->setTarget(optTarget);
         request->setPackageMap(optPackageMap);
         request->setProcess(optProcess);
@@ -571,6 +581,8 @@ public:
         fprintf(stdout, "\n ... adding package map %s now\n\n", optFileName.str());
 
         Owned<IClientAddPackageRequest> request = packageProcessClient->createAddPackageRequest();
+        setCmdRequestTimeouts(request->rpc(), 0, optWaitConnectMs, optWaitReadSec);
+
         request->setActivate(optActivate);
         request->setInfo(pkgInfo);
         request->setTarget(optTarget);
@@ -726,6 +738,8 @@ public:
         fprintf(stdout, "\n ... copy package map %s to %s\n\n", optSrcPath.str(), optTarget.str());
 
         Owned<IClientCopyPackageMapRequest> request = packageProcessClient->createCopyPackageMapRequest();
+        setCmdRequestTimeouts(request->rpc(), 0, optWaitConnectMs, optWaitReadSec);
+
         request->setSourcePath(optSrcPath);
         request->setTarget(optTarget);
         request->setProcess("*");
@@ -900,6 +914,7 @@ public:
     {
         Owned<IClientWsPackageProcess> packageProcessClient = getWsPackageSoapService(optServer, optPort, optUsername, optPassword);
         Owned<IClientValidatePackageRequest> request = packageProcessClient->createValidatePackageRequest();
+        setCmdRequestTimeouts(request->rpc(), 0, optWaitConnectMs, optWaitReadSec);
 
         if (optFileName.length())
         {
@@ -1086,6 +1101,7 @@ public:
     {
         Owned<IClientWsPackageProcess> packageProcessClient = getWsPackageSoapService(optServer, optPort, optUsername, optPassword);
         Owned<IClientGetQueryFileMappingRequest> request = packageProcessClient->createGetQueryFileMappingRequest();
+        setCmdRequestTimeouts(request->rpc(), 0, optWaitConnectMs, optWaitReadSec);
 
         request->setTarget(optTarget);
         request->setQueryName(optQueryId);
@@ -1246,6 +1262,8 @@ public:
         fprintf(stdout, "\n ... adding packagemap %s part %s from file %s\n\n", optPMID.get(), optPartName.get(), optFileName.get());
 
         Owned<IClientAddPartToPackageMapRequest> request = packageProcessClient->createAddPartToPackageMapRequest();
+        setCmdRequestTimeouts(request->rpc(), 0, optWaitConnectMs, optWaitReadSec);
+
         request->setTarget(optTarget);
         request->setPackageMap(optPMID);
         request->setPartName(optPartName);
@@ -1382,6 +1400,8 @@ public:
 
         Owned<IClientWsPackageProcess> packageProcessClient = createCmdClient(WsPackageProcess, *this);
         Owned<IClientRemovePartFromPackageMapRequest> request = packageProcessClient->createRemovePartFromPackageMapRequest();
+        setCmdRequestTimeouts(request->rpc(), 0, optWaitConnectMs, optWaitReadSec);
+
         request->setTarget(optTarget);
         request->setPackageMap(optPMID);
         request->setGlobalScope(optGlobalScope);
@@ -1480,6 +1500,8 @@ public:
     {
         Owned<IClientWsPackageProcess> packageProcessClient = createCmdClient(WsPackageProcess, *this);
         Owned<IClientGetPartFromPackageMapRequest> request = packageProcessClient->createGetPartFromPackageMapRequest();
+        setCmdRequestTimeouts(request->rpc(), 0, optWaitConnectMs, optWaitReadSec);
+
         request->setTarget(optTarget);
         request->setPackageMap(optPMID);
         request->setGlobalScope(optGlobalScope);

--- a/ecl/eclcmd/eclcmd_common.cpp
+++ b/ecl/eclcmd/eclcmd_common.cpp
@@ -47,6 +47,11 @@ const char *queryEclccPath(bool optVerbose)
     return eclccpath.str();
 }
 
+void outputExceptionEx(IException &e)
+{
+    StringBuffer msg;
+    fprintf(stderr, "%d: %s\n", e.errorCode(), e.errorMessage(msg).str());
+}
 
 int outputMultiExceptionsEx(const IMultiException &me)
 {
@@ -55,11 +60,7 @@ int outputMultiExceptionsEx(const IMultiException &me)
     fprintf(stderr, "\nException(s):\n");
     aindex_t count = me.ordinality();
     for (aindex_t i=0; i<count; i++)
-    {
-        IException& e = me.item(i);
-        StringBuffer msg;
-        fprintf(stderr, "%d: %s\n", e.errorCode(), e.errorMessage(msg).str());
-    }
+        outputExceptionEx(me.item(i));
     fprintf(stderr, "\n");
     return 1;
 }
@@ -380,6 +381,10 @@ eclCmdOptionMatchIndicator EclCmdCommon::matchCommandLineOption(ArgvIterator &it
     if (iter.matchOption(optServer, ECLOPT_SERVER)||iter.matchOption(optServer, ECLOPT_SERVER_S))
         return EclCmdOptionMatch;
     if (iter.matchOption(optPort, ECLOPT_PORT))
+        return EclCmdOptionMatch;
+    if (iter.matchOption(optWaitConnectMs, ECLOPT_WAIT_CONNECT))
+        return EclCmdOptionMatch;
+    if (iter.matchOption(optWaitReadSec, ECLOPT_WAIT_READ))
         return EclCmdOptionMatch;
     if (iter.matchOption(optUsername, ECLOPT_USERNAME)||iter.matchOption(optUsername, ECLOPT_USERNAME_S))
         return EclCmdOptionMatch;

--- a/ecl/eclcmd/eclcmd_core.cpp
+++ b/ecl/eclcmd/eclcmd_core.cpp
@@ -66,11 +66,12 @@ void expandDefintionsAsDebugValues(const IArrayOf<IEspNamedValue> & definitions,
 
 }
 
-void checkFeatures(IClientWsWorkunits *client, bool &useCompression, int &major, int &minor, int &point)
+void checkFeatures(IClientWsWorkunits *client, bool &useCompression, int &major, int &minor, int &point, unsigned waitMs, unsigned waitConnectMs, unsigned waitReadSec)
 {
     try
     {
         Owned<IClientWUCheckFeaturesRequest> req = client->createWUCheckFeaturesRequest();
+        setCmdRequestTimeouts(req->rpc(), waitMs, waitConnectMs, waitReadSec);
         Owned<IClientWUCheckFeaturesResponse> resp = client->WUCheckFeatures(req);
         useCompression = resp->getDeployment().getUseCompression();
         major = resp->getBuildVersionMajor();
@@ -86,13 +87,13 @@ void checkFeatures(IClientWsWorkunits *client, bool &useCompression, int &major,
     }
 }
 
-bool doDeploy(EclCmdWithEclTarget &cmd, IClientWsWorkunits *client, const char *cluster, const char *name, StringBuffer *wuid, StringBuffer *wucluster, bool noarchive, bool displayWuid=true, bool compress=true)
+bool doDeploy(EclCmdWithEclTarget &cmd, IClientWsWorkunits *client, unsigned waitMs, const char *cluster, const char *name, StringBuffer *wuid, StringBuffer *wucluster, bool noarchive, bool displayWuid=true, bool compress=true)
 {
     int major = 0;
     int minor = 0;
     int point = 0;
     bool useCompression = false;
-    checkFeatures(client, useCompression, major, minor, point);
+    checkFeatures(client, useCompression, major, minor, point, 0, cmd.optWaitConnectMs, cmd.optWaitReadSec);
 
     bool compressed = false;
     if (useCompression)
@@ -109,6 +110,8 @@ bool doDeploy(EclCmdWithEclTarget &cmd, IClientWsWorkunits *client, const char *
 
     StringBuffer objType(compressed ? "compressed_" : ""); //change compressed type string so old ESPs will fail gracefully
     Owned<IClientWUDeployWorkunitRequest> req = client->createWUDeployWorkunitRequest();
+    setCmdRequestTimeouts(req->rpc(), waitMs, cmd.optWaitConnectMs, cmd.optWaitReadSec);
+
     switch (cmd.optObj.type)
     {
         case eclObjArchive:
@@ -266,7 +269,7 @@ public:
     virtual int processCMD()
     {
         Owned<IClientWsWorkunits> client = createCmdClientExt(WsWorkunits, *this, "?upload_"); //upload_ disables maxRequestEntityLength
-        return doDeploy(*this, client, optTargetCluster.get(), optName.get(), NULL, NULL, optNoArchive) ? 0 : 1;
+        return doDeploy(*this, client, 0, optTargetCluster.get(), optName.get(), NULL, NULL, optNoArchive) ? 0 : 1;
     }
     virtual void usage()
     {
@@ -411,7 +414,7 @@ public:
         StringBuffer wuid;
         if (optObj.type==eclObjWuid)
             wuid.set(optObj.value.get());
-        else if (!doDeploy(*this, client, optTargetCluster.get(), optName.get(), &wuid, NULL, optNoArchive))
+        else if (!doDeploy(*this, client, optMsToWait, optTargetCluster.get(), optName.get(), &wuid, NULL, optNoArchive))
             return 1;
 
         StringBuffer descr;
@@ -419,6 +422,7 @@ public:
             fprintf(stdout, "\nPublishing %s\n", wuid.str());
 
         Owned<IClientWUPublishWorkunitRequest> req = client->createWUPublishWorkunitRequest();
+        setCmdRequestTimeouts(req->rpc(), optMsToWait, optWaitConnectMs, optWaitReadSec);
         req->setWuid(wuid.str());
         if (optDeletePrevious)
             req->setActivate(CWUQueryActivationMode_ActivateDeletePrevious);
@@ -608,26 +612,74 @@ public:
         return true;
     }
 
+    inline bool isSoapRpcException(IException *E)
+    {
+        StringBuffer msg;
+        const char *finger = E->errorMessage(msg).str();
+        if (strncmp(finger, "SOAP ", 5))
+            return false;
+        finger+=5;
+        if (!strncmp(finger, "rpc error", 9))
+            return true;
+        if (!strncmp(finger, "Connection error", 16))
+            return true;
+        return false;
+    }
     int checkComplete(IClientWsWorkunits* client, IClientWUWaitRequest* req)
     {
-        Owned<IClientWUWaitResponse> resp = client->WUWaitComplete(req);
-        if (resp->getExceptions().ordinality())
-            throw LINK(&resp->getExceptions());
-        return resp->getStateID();
+        try
+        {
+            Owned<IClientWUWaitResponse> resp = client->WUWaitComplete(req);
+            if (resp->getExceptions().ordinality())
+                throw LINK(&resp->getExceptions());
+            return resp->getStateID();
+        }
+        catch (IJSOCK_Exception *E)
+        {
+            outputExceptionEx(*E);
+            E->Release();
+        }
+        catch (IException *E)
+        {
+            if (!isSoapRpcException(E))
+                throw E;
+            outputExceptionEx(*E);
+            E->Release();
+        }
+
+        fputs("Still polling...\n", stderr);
+        return WUStateUnknown; //socket issue, keep polling
     }
 
     int checkComplete(IClientWsWorkunits* client, IClientWUInfoRequest* req)
     {
-        Owned<IClientWUInfoResponse> resp = client->WUInfo(req);
-        if (resp->getExceptions().ordinality())
-            throw LINK(&resp->getExceptions());
-        int state = resp->getWorkunit().getStateID();
-        switch (state)
+        try
         {
-        case WUStateCompleted:
-        case WUStateFailed:
-        case WUStateAborted:
-            return state;
+            Owned<IClientWUInfoResponse> resp = client->WUInfo(req);
+            if (resp->getExceptions().ordinality())
+                throw LINK(&resp->getExceptions());
+            int state = resp->getWorkunit().getStateID();
+            switch (state)
+            {
+            case WUStateCompleted:
+            case WUStateFailed:
+            case WUStateAborted:
+                return state;
+            }
+        }
+        catch (IJSOCK_Exception *E)
+        {
+            outputExceptionEx(*E);
+            E->Release();
+            fputs("Still polling...\n", stderr);
+        }
+        catch (IException *E)
+        {
+            if (!isSoapRpcException(E))
+                throw E;
+            outputExceptionEx(*E);
+            E->Release();
+            fputs("Still polling...\n", stderr);
         }
 
         return WUStateUnknown; //emulate result from waitForWorkUnit which will be called for non-legacy builds
@@ -670,6 +722,8 @@ public:
         else
             initPollRequest(reqInfo, client, wuid);
 
+        if (optVerbose)
+            fputs("Polling for completion...\n", stdout);
         int state = WUStateUnknown;
         for(;;)
         {
@@ -689,7 +743,12 @@ public:
 
     void gatherLegacyServerResults(IClientWsWorkunits* client, const char *wuid)
     {
+        if (optVerbose)
+            fputs("Getting Workunit Information\n", stdout);
+
         Owned<IClientWUInfoRequest> req = client->createWUInfoRequest();
+        setCmdRequestTimeouts(req->rpc(), optWaitTime, optWaitConnectMs, optWaitReadSec);
+
         req->setWuid(wuid);
         req->setIncludeExceptions(true);
         req->setIncludeGraphs(false);
@@ -711,6 +770,10 @@ public:
         unsigned count = wu.getResultCount();
         if (count<=0 && exceptions.ordinality()<=0)
             return;
+
+        if (optVerbose)
+            fputs("Getting Results\n", stdout);
+
         fputs("<Result>\n", stdout);
         ForEachItemIn(pos, exceptions)
         {
@@ -737,7 +800,11 @@ public:
 
     void getAndOutputResults(IClientWsWorkunits* client, const char *wuid)
     {
+        if (optVerbose)
+            fputs("Retrieving Results\n", stdout);
         Owned<IClientWUFullResultRequest> req = client->createWUFullResultRequest();
+        setCmdRequestTimeouts(req->rpc(), optWaitTime, optWaitConnectMs, optWaitReadSec);
+
         req->setWuid(wuid);
         req->setNoRootTag(optNoRoot);
         req->setExceptionSeverity(optExceptionSeverity);
@@ -761,7 +828,7 @@ public:
         int minor = 0;
         int point = 0;
         bool useCompression = false;
-        checkFeatures(client, useCompression, major, minor, point);
+        checkFeatures(client, useCompression, major, minor, point, optWaitTime, optWaitConnectMs, optWaitReadSec);
         bool optimized = !optPre64 && (major>=6 && minor>=3);
 
         try
@@ -822,6 +889,7 @@ public:
     {
         Owned<IClientWsWorkunits> client = createCmdClientExt(WsWorkunits, *this, "?upload_"); //upload_ disables maxRequestEntityLength
         Owned<IClientWURunRequest> req = client->createWURunRequest();
+        setCmdRequestTimeouts(req->rpc(), optWaitTime, optWaitConnectMs, optWaitReadSec);
         req->setCloneWorkunit(true);
         req->setNoRootTag(optNoRoot);
 
@@ -845,7 +913,7 @@ public:
         else
         {
             req->setCloneWorkunit(false);
-            if (!doDeploy(*this, client, optTargetCluster.get(), optName.get(), &wuid, &wuCluster, optNoArchive, optVerbose))
+            if (!doDeploy(*this, client, optWaitTime, optTargetCluster.get(), optName.get(), &wuid, &wuCluster, optNoArchive, optVerbose))
                 return 1;
             req->setWuid(wuid.str());
             if (optVerbose)
@@ -869,7 +937,23 @@ public:
             req->setVariables(variables);
 
         startTimeMs = msTick();
-        Owned<IClientWURunResponse> resp = client->WURun(req);
+        Owned<IClientWURunResponse> resp;
+        try
+        {
+            resp.setown(client->WURun(req));
+        }
+        catch (IJSOCK_Exception *E)
+        {
+            if (optPoll)
+                fputs("Socket error, no WUID, can't continue but workunit may still be running...\n", stderr);
+            throw E;
+        }
+        catch (IException *E)
+        {
+            if (optPoll && isSoapRpcException(E))
+                fputs("SOAP error, no WUID, can't continue but workunit may still be running...\n", stderr);
+            throw E;
+        }
 
         if (checkMultiExceptionsQueryNotFound(resp->getExceptions()))
         {
@@ -1025,6 +1109,8 @@ public:
     int gatherLegacyServerResults(IClientWsWorkunits* client, const char *wuid)
     {
         Owned<IClientWUInfoRequest> req = client->createWUInfoRequest();
+        setCmdRequestTimeouts(req->rpc(), 0, optWaitConnectMs, optWaitReadSec);
+
         req->setWuid(wuid);
         req->setIncludeExceptions(true);
         req->setIncludeGraphs(false);
@@ -1073,6 +1159,8 @@ public:
     int getAndOutputResults(IClientWsWorkunits* client, const char *wuid)
     {
         Owned<IClientWUFullResultRequest> req = client->createWUFullResultRequest();
+        setCmdRequestTimeouts(req->rpc(), 0, optWaitConnectMs, optWaitReadSec);
+
         req->setWuid(wuid);
         req->setNoRootTag(optNoRoot);
         req->setExceptionSeverity(optExceptionSeverity);
@@ -1092,7 +1180,7 @@ public:
         int minor = 0;
         int point = 0;
         bool useCompression = false;
-        checkFeatures(client, useCompression, major, minor, point);
+        checkFeatures(client, useCompression, major, minor, point, 0, optWaitConnectMs, optWaitReadSec);
 
         if (!optPre64 && (major>=6 && minor>=3))
             return getAndOutputResults(client, optWuid);
@@ -1150,6 +1238,8 @@ public:
     {
         Owned<IClientWsWorkunits> client = createCmdClient(WsWorkunits, *this);
         Owned<IClientWUQuerySetQueryActionRequest> req = client->createWUQuerysetQueryActionRequest();
+        setCmdRequestTimeouts(req->rpc(), 0, optWaitConnectMs, optWaitReadSec);
+
         IArrayOf<IEspQuerySetQueryActionItem> queries;
         Owned<IEspQuerySetQueryActionItem> item = createQuerySetQueryActionItem();
         item->setQueryId(optQuery.get());
@@ -1198,6 +1288,7 @@ public:
     {
         Owned<IClientWsWorkunits> client = createCmdClient(WsWorkunits, *this);
         Owned<IClientWUQuerySetQueryActionRequest> req = client->createWUQuerysetQueryActionRequest();
+        setCmdRequestTimeouts(req->rpc(), 0, optWaitConnectMs, optWaitReadSec);
 
         req->setQuerySetName(optQuerySet.get());
         req->setAction("Delete");
@@ -1247,6 +1338,8 @@ public:
         StringBuffer s;
         Owned<IClientWsWorkunits> client = createCmdClient(WsWorkunits, *this);
         Owned<IClientWUQuerySetAliasActionRequest> req = client->createWUQuerysetAliasActionRequest();
+        setCmdRequestTimeouts(req->rpc(), 0, optWaitConnectMs, optWaitReadSec);
+
         IArrayOf<IEspQuerySetAliasActionItem> aliases;
         Owned<IEspQuerySetAliasActionItem> item = createQuerySetAliasActionItem();
         item->setName(optQuery.get());
@@ -1363,6 +1456,8 @@ public:
 
         // Abort
         Owned<IClientWUAbortRequest> req = client->createWUAbortRequest();
+        setCmdRequestTimeouts(req->rpc(), 0, optWaitConnectMs, optWaitReadSec);
+
 
         req->setWuids(wuids);
         Owned<IClientWUAbortResponse> resp = client->WUAbort(req);
@@ -1462,6 +1557,8 @@ public:
     {
         Owned<IClientWsWorkunits> client = createCmdClient(WsWorkunits, *this);
         Owned<IClientWUQueryRequest> req = client->createWUQueryRequest();
+        setCmdRequestTimeouts(req->rpc(), 0, optWaitConnectMs, optWaitReadSec);
+
 
         if (optName.isEmpty())
             return 0;
@@ -1545,6 +1642,7 @@ public:
     {
         Owned<IClientWsWorkunits> client = createCmdClient(WsWorkunits, *this);
         Owned<IClientWUQueryRequest> req = client->createWUQueryRequest();
+        setCmdRequestTimeouts(req->rpc(), 0, optWaitConnectMs, optWaitReadSec);
 
         if (optName.isEmpty())
             return 0;
@@ -1636,6 +1734,7 @@ public:
     {
         Owned<IClientWsWorkunits> client = createCmdClient(WsWorkunits, *this);
         Owned<IClientWUQueryRequest> req = client->createWUQueryRequest();
+        setCmdRequestTimeouts(req->rpc(), 0, optWaitConnectMs, optWaitReadSec);
 
         if (optName.isEmpty())
         {

--- a/ecl/eclcmd/queries/ecl-queries.cpp
+++ b/ecl/eclcmd/queries/ecl-queries.cpp
@@ -259,6 +259,8 @@ public:
     {
         Owned<IClientWsWorkunits> client = createCmdClient(WsWorkunits, *this);
         Owned<IClientWUMultiQuerySetDetailsRequest> req = client->createWUMultiQuerysetDetailsRequest();
+        setCmdRequestTimeouts(req->rpc(), 0, optWaitConnectMs, optWaitReadSec);
+
         req->setQuerySetName(optTargetCluster.get());
         req->setClusterName(optTargetCluster.get());
         req->setFilterType("All");
@@ -359,6 +361,8 @@ public:
     {
         Owned<IClientWsWorkunits> client = createCmdClient(WsWorkunits, *this);
         Owned<IClientWUQueryFilesRequest> req = client->createWUQueryFilesRequest();
+        setCmdRequestTimeouts(req->rpc(), 0, optWaitConnectMs, optWaitReadSec);
+
         req->setTarget(optTarget.get());
         req->setQueryId(optQuery.get());
 
@@ -511,6 +515,8 @@ public:
     {
         Owned<IClientWsWorkunits> client = createCmdClient(WsWorkunits, *this);
         Owned<IClientWUQuerySetCopyQueryRequest> req = client->createWUQuerysetCopyQueryRequest();
+        setCmdRequestTimeouts(req->rpc(), 0, optWaitConnectMs, optWaitReadSec);
+
         req->setSource(optSourceQueryPath.get());
         req->setTarget(optTargetCluster.get());
         req->setCluster(optTargetCluster.get());
@@ -686,6 +692,8 @@ public:
     {
         Owned<IClientWsWorkunits> client = createCmdClient(WsWorkunits, *this);
         Owned<IClientWUCopyQuerySetRequest> req = client->createWUCopyQuerySetRequest();
+        setCmdRequestTimeouts(req->rpc(), 0, optWaitConnectMs, optWaitReadSec);
+
         req->setActiveOnly(!optAllQueries);
         req->setSource(optSourceQuerySet.get());
         req->setTarget(optDestQuerySet.get());
@@ -848,6 +856,8 @@ public:
     {
         Owned<IClientWsWorkunits> client = createCmdClient(WsWorkunits, *this);
         Owned<IClientWUQueryConfigRequest> req = client->createWUQueryConfigRequest();
+        setCmdRequestTimeouts(req->rpc(), optMsToWait, optWaitConnectMs, optWaitReadSec);
+
         req->setTarget(optTargetCluster.get());
         req->setQueryId(optQueryId.get());
         req->setWait(optMsToWait);
@@ -1053,6 +1063,7 @@ public:
 
         Owned<IClientWsWorkunits> client = createCmdClient(WsWorkunits, *this); //upload_ disables maxRequestEntityLength
         Owned<IClientWURecreateQueryRequest> req = client->createWURecreateQueryRequest();
+        setCmdRequestTimeouts(req->rpc(), optMsToWait, optWaitConnectMs, optWaitReadSec);
 
         if (optDeletePrevious)
             req->setActivate(CWUQueryActivationMode_ActivateDeletePrevious);
@@ -1259,6 +1270,8 @@ public:
     {
         Owned<IClientWsWorkunits> client = createCmdClient(WsWorkunits, *this);
         Owned<IClientWUQuerysetExportRequest> req = client->createWUQuerysetExportRequest();
+        setCmdRequestTimeouts(req->rpc(), 0, optWaitConnectMs, optWaitReadSec);
+
         req->setTarget(optTarget);
         req->setActiveOnly(optActiveOnly);
         req->setCompress(true);
@@ -1389,6 +1402,7 @@ public:
     {
         Owned<IClientWsWorkunits> client = createCmdClient(WsWorkunits, *this);
         Owned<IClientWUQuerysetImportRequest> req = client->createWUQuerysetImportRequest();
+        setCmdRequestTimeouts(req->rpc(), 0, optWaitConnectMs, optWaitReadSec);
 
         MemoryBuffer compressed;
         fastLZCompressToBuffer(compressed, content.length()+1, content.str());

--- a/ecl/eclcmd/roxie/ecl-roxie.cpp
+++ b/ecl/eclcmd/roxie/ecl-roxie.cpp
@@ -188,6 +188,8 @@ public:
     {
         Owned<IClientWsSMC> client = createCmdClient(WsSMC, *this);
         Owned<IClientRoxieControlCmdRequest> req = client->createRoxieControlCmdRequest();
+        setCmdRequestTimeouts(req->rpc(), optMsToWait, optWaitConnectMs, optWaitReadSec);
+
         req->setWait(optMsToWait);
         req->setProcessCluster(optProcess);
         req->setCommand(attach ? CRoxieControlCmdType_ATTACH : CRoxieControlCmdType_DETACH);
@@ -296,6 +298,8 @@ public:
     {
         Owned<IClientWsSMC> client = createCmdClient(WsSMC, *this);
         Owned<IClientRoxieControlCmdRequest> req = client->createRoxieControlCmdRequest();
+        setCmdRequestTimeouts(req->rpc(), optMsToWait, optWaitConnectMs, optWaitReadSec);
+
         req->setWait(optMsToWait);
         req->setProcessCluster(optProcess);
         if (!reload)
@@ -424,6 +428,8 @@ public:
     {
         Owned<IClientWsDFUXRef> client = createCmdClientExt(WsDFUXRef, *this, "?ver_=1.29");
         Owned<IClientDFUXRefUnusedFilesRequest> req = client->createDFUXRefUnusedFilesRequest();
+        setCmdRequestTimeouts(req->rpc(), 0, optWaitConnectMs, optWaitReadSec);
+
         req->setProcessCluster(optProcess);
         req->setCheckPackageMaps(optCheckPackageMaps);
 


### PR DESCRIPTION
Add more flexibility to control socket level timeouts.
--wait will now affect socket timeouts if not set explicitly.
--wait-connect can now be used to explicity control connect timeout.
--wait-read can now be used to explicity control read timeout.

Make polling less susceptible to socket and SOAP errors.

Improve verbose output during ecl-run.

Signed-off-by: Anthony Fishbeck <anthony.fishbeck@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [x] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [x] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
