### PR TITLE
HPCC-18657 Fix problem where import $.^.^ cannot access container

### DIFF
--- a/ecl/hql/hqlgram2.cpp
+++ b/ecl/hql/hqlgram2.cpp
@@ -10600,7 +10600,7 @@ IHqlExpression * HqlGram::resolveImportModule(const attribute & errpos, IHqlExpr
     const char * parentName = str(parent->queryId());
     if (name == _container_Atom)
     {
-        const char * containerName = str(parent->queryFullContainerId());
+        const char * containerName = str(parent->queryBody()->queryFullContainerId());
         //This is a bit ugly - remove the last qualified module, and resolve the name again.  A more "correct" method
         //saving container pointers hit problems because remote scopes within CHqlMergedScope containers have a remote
         //scope as the parent, rather than the merged scope...

--- a/ecl/regress/issue18657.eclxml
+++ b/ecl/regress/issue18657.eclxml
@@ -1,0 +1,19 @@
+<Archive build="internal_6.4.8-rc1Debug"
+         eclVersion="6.4.8"
+         legacyImport="0"
+         legacyWhen="0">
+ <Query attributePath="TestX.Fred.Sue.Jo.BWR_Test"/>
+ <Module key="testx" name="TestX"/>
+ <Module key="testx.fred" name="TestX.Fred">
+  <Attribute key="testme" name="TestMe" sourcePath="/home/gavin/dev/issue18657/./TestX/Fred/TestMe.ecl">
+   export TestMe := 10;&#10;&#10;
+  </Attribute>
+ </Module>
+ <Module key="testx.fred.sue" name="TestX.Fred.Sue"/>
+ <Module key="testx.fred.sue.jo" name="TestX.Fred.Sue.Jo">
+  <Attribute key="bwr_test" name="BWR_Test" sourcePath="TestX/Fred/Sue/Jo/BWR_Test.ecl">
+   IMPORT $.^.^ AS M1;
+OUTPUT(M1.TestMe);&#10;
+  </Attribute>
+ </Module>
+</Archive>


### PR DESCRIPTION
Signed-off-by: Gavin Halliday <gavin.halliday@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [x] I have added tests to cover my changes.
  - [x] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [x] This change fixes the problem, not just the symptom
  - [x] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->
Ran full regression suite, and also added test archive that demonstrates the problem.

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
