### PR TITLE
HPCC-18977 Ensure failing to start g++ is reported in the workunit

### DIFF
--- a/system/jlib/jcomp.cpp
+++ b/system/jlib/jcomp.cpp
@@ -279,6 +279,13 @@ void CppCompiler::setPrecompileHeader(bool _pch)
     precompileHeader = _pch;
 }
 
+bool CppCompiler::fireException(IException *e)
+{
+    CriticalBlock block(cs);
+    exceptions.append(*LINK(e));
+    return true;
+}
+
 void CppCompiler::addDefine(const char * symbolName, const char * value)
 {
     compilerOptions.append(" ").append(USE_DEFINE_FLAG[targetCompiler]).append(symbolName);
@@ -384,7 +391,7 @@ bool CppCompiler::compile()
 
     TIME_SECTION(!verbose ? NULL : onlyCompile ? "compile" : "compile/link");
 
-    Owned<IThreadPool> pool = createThreadPool("CCompilerWorker", this, NULL, maxCompileThreads?maxCompileThreads:1, INFINITE);
+    Owned<IThreadPool> pool = createThreadPool("CCompilerWorker", this, this, maxCompileThreads?maxCompileThreads:1, INFINITE);
     addCompileOption(COMPILE_ONLY[targetCompiler]);
 
     bool ret = false;
@@ -523,6 +530,13 @@ bool CppCompiler::compileFile(IThreadPool * pool, const char * filename, Semapho
 
 void CppCompiler::extractErrors(IArrayOf<IError> & errors)
 {
+    ForEachItemIn(i, exceptions)
+    {
+        IException & cur = exceptions.item(i);
+        StringBuffer msg;
+        cur.errorMessage(msg);
+        errors.append(*createError(JLIBERR_CppCompileError, msg, nullptr));
+    }
     const char* cclog = ccLogPath.get();
     if(!cclog||!*cclog)
         cclog = queryCcLogName();
@@ -684,7 +698,17 @@ bool CppCompiler::doLink()
         PrintLog("%s", expanded.str());
     StringBuffer logFile = StringBuffer(coreName).append("_link.log.tmp");
     logFiles.append(logFile);
-    bool ret = invoke_program(expanded.str(), runcode, true, logFile) && (runcode == 0);
+
+    bool ret;
+    try
+    {
+        ret = invoke_program(expanded.str(), runcode, true, logFile, nullptr, true) && (runcode == 0);
+    }
+    catch (IException * e)
+    {
+        exceptions.append(*e);
+        ret = false;
+    }
     linkFailed = !ret;
     return ret;
 }
@@ -901,9 +925,10 @@ public:
         bool success;
         aborted = false;
         handle = 0;
+        Owned<IException> error;
         try
         {
-            success = invoke_program(params->cmdline, runcode, false, params->logfile, &handle, false, okToAbort);
+            success = invoke_program(params->cmdline, runcode, false, params->logfile, &handle, true, okToAbort);
             if (success)
                 wait_program(handle, runcode, true);
         }
@@ -911,7 +936,7 @@ public:
         {
             StringBuffer sb;
             e->errorMessage(sb);
-            e->Release();
+            error.setown(e);
             if (sb.length())
                 PrintLog("%s", sb.str());
             success = false;
@@ -921,7 +946,8 @@ public:
         if (!success || aborted)
             compiler->numFailed++;
         params->finishedCompiling.signal();
-        return;
+        if (error)
+            throw error.getClear();
     }
 
 private:

--- a/system/jlib/jcomp.ipp
+++ b/system/jlib/jcomp.ipp
@@ -22,7 +22,7 @@
 
 #include "jlib.hpp"
 
-class CppCompiler : implements ICppCompiler, implements IThreadFactory, public CInterface
+class CppCompiler : implements ICppCompiler, implements IThreadFactory, public CInterface, implements IExceptionHandler
 {
 public:
     CppCompiler(const char * _coreName, const char * _sourceDir, const char * _targetDir, unsigned _targetCompiler, bool _verbose);
@@ -50,6 +50,7 @@ public:
     virtual void setSaveTemps(bool _save) { saveTemps = _save; }
     virtual void setPrecompileHeader(bool _pch);
     virtual void setAbortChecker(IAbortRequestCallback * _abortChecker) {abortChecker = _abortChecker;}
+    virtual bool fireException(IException *e);
 
 protected:
     void expandCompileOptions(StringBuffer & target);
@@ -85,6 +86,8 @@ protected:
     bool            precompileHeader;
     bool            linkFailed;
     IAbortRequestCallback * abortChecker;
+    CriticalSection cs;
+    IArrayOf<IException> exceptions;
 };
 
 


### PR DESCRIPTION
Signed-off-by: Gavin Halliday <gavin.halliday@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [ ] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
