### PR TITLE
HPCC-18934 Fix Windows build broken by libbase58 use of C99 extensions

### DIFF
--- a/testing/unittests/CMakeLists.txt
+++ b/testing/unittests/CMakeLists.txt
@@ -38,6 +38,7 @@ include_directories (
          ./../../system/include
          ./../../system/jlib
          ./../../system/mp
+         ./../../system/libbase58
          ./../../common/remote
          ./../../dali/base
          ./../../system/security/shared
@@ -54,6 +55,7 @@ target_link_libraries ( unittests
          remote
          dalibase
          deftype
+         libbase58
          ${CPPUNIT_LIBRARIES}
     )
 

--- a/testing/unittests/unittests.cpp
+++ b/testing/unittests/unittests.cpp
@@ -22,6 +22,7 @@
 #include "jfile.hpp"
 #include "deftype.hpp"
 #include "rmtfile.hpp"
+#include "libbase58.h"
 
 /*
  * This is the main unittest driver for HPCC. From here,
@@ -569,5 +570,108 @@ class StringBufferTest : public CppUnit::TestFixture
 CPPUNIT_TEST_SUITE_REGISTRATION( StringBufferTest );
 CPPUNIT_TEST_SUITE_NAMED_REGISTRATION( StringBufferTest, "StringBufferTest" );
 
+StringBuffer &mbToBase58(StringBuffer &s, const MemoryBuffer &data)
+{
+    size_t b58Length = data.length() * 2 + 1;
+
+    ASSERT(b58enc(s.clear().reserve(b58Length), &b58Length, data.toByteArray(), data.length()));
+
+    s.setLength(b58Length);
+    return s;
+}
+
+StringBuffer &base64ToBase58(StringBuffer &s, const char *b64)
+{
+    MemoryBuffer mb;
+    JBASE64_Decode(b64, mb);
+    return mbToBase58(s, mb);
+}
+
+StringBuffer &textToBase58(StringBuffer &s, const char *text)
+{
+    MemoryBuffer mb;
+    mb.append((size_t)strlen(text), text);
+    return mbToBase58(s, mb);
+}
+
+MemoryBuffer &base58ToMb(MemoryBuffer &data, const char *b58)
+{
+    size_t len = strlen(b58);
+    size_t offset = len;
+    b58tobin(data.clear().reserveTruncate(len), &len, b58, 0);
+    offset -= len;
+    if (offset) //if we ever start using b58tobin we should fix this weird behavior
+    {
+        MemoryBuffer weird;
+        weird.append(len, data.toByteArray()+offset);
+        data.swapWith(weird);
+    }
+    return data;
+}
+
+StringBuffer &base58ToBase64(StringBuffer &s, const char *b58)
+{
+    MemoryBuffer mb;
+    base58ToMb(mb, b58);
+    JBASE64_Encode(mb.toByteArray(), mb.length(), s.clear());
+    return s;
+}
+
+StringBuffer &base58ToText(StringBuffer &s, const char *b58)
+{
+    MemoryBuffer mb;
+    base58ToMb(mb, b58);
+    return s.clear().append(mb.length(), mb.toByteArray());
+}
+
+class Base58Test : public CppUnit::TestFixture
+{
+    CPPUNIT_TEST_SUITE( Base58Test  );
+        CPPUNIT_TEST(testEncodeDecode);
+    CPPUNIT_TEST_SUITE_END();
+
+    void doTestEncodeDecodeText(const char *text, const char *b58)
+    {
+        StringBuffer s;
+        ASSERT(streq(textToBase58(s, text), b58));
+        ASSERT(streq(base58ToText(s, b58), text));
+    }
+    void doTestEncodeDecodeBase64(const char *b64, const char *b58)
+    {
+        StringBuffer s;
+        ASSERT(streq(base64ToBase58(s, b64), b58));
+        ASSERT(streq(base58ToBase64(s, b58), b64));
+    }
+    void testEncodeDecode()
+    {
+        StringBuffer s;
+
+        //short string
+        doTestEncodeDecodeText("1", "r");
+
+        //text string
+        doTestEncodeDecodeText("Fifty-eight is the sum of the first seven prime numbers.", "2ubdTkzo5vaWL4FKQGro88zp8v6Q5EftVBq2fbZsWCDRzQxGDb1heKFsMReJNhsRsK6TfvrgqVeRB");
+
+        //hex 005A1FC5DD9E6F03819FCA94A2D89669469667F9A074655946
+        doTestEncodeDecodeBase64("AFofxd2ebwOBn8qUotiWaUaWZ/mgdGVZRg==", "19DXstMaV43WpYg4ceREiiTv2UntmoiA9j");
+
+        //hex FEEFAEF022FA
+        doTestEncodeDecodeBase64("/u+u8CL6", "3Bx9Y4pUR");
+
+        //hex FFFEEFAEF022FA
+        doTestEncodeDecodeBase64("//7vrvAi+g==", "AhfV5sjWb3");
+
+        //This input causes the loop iteration counter to go negative
+        //hex 00CEF022FA
+        doTestEncodeDecodeBase64("AM7wIvo=", "16Ho7Hs");
+
+        //empty input
+        MemoryBuffer mb;
+        ASSERT(streq(mbToBase58(s, mb), ""));
+}
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION( Base58Test );
+CPPUNIT_TEST_SUITE_NAMED_REGISTRATION( Base58Test, "Base58Test" );
 
 #endif // _USE_CPPUNIT


### PR DESCRIPTION
Also add cppunit test for libbase58 b58enc().

Signed-off-by: Anthony Fishbeck <anthony.fishbeck@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [ ] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [x] I have added tests to cover my changes.
  - [x] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
