### PR TITLE
HPCC-19052 Add epoll handler thread optimizations

### DIFF
--- a/system/jlib/jsocket.cpp
+++ b/system/jlib/jsocket.cpp
@@ -78,7 +78,8 @@
 //  Centos 5.x bug - epoll.h does not define but its in the kernel
 #   define EPOLLRDHUP 0x2000
 #  endif
-#  define MAX_RET_EVENTS  5000 // max events returned from epoll_wait() call
+#  define MAX_EPOLL_FD_EVENTS 5000 // max events returned from epoll_wait() call
+                                   // and max fds per epoll handler thread
 # endif
 #endif
 
@@ -3756,7 +3757,7 @@ struct SelectItem
     T_SOCKET handle;
     ISocketSelectNotify *nfy;
     byte mode;
-    bool del;
+    bool del; // only used in select handler method
     bool operator == (const SelectItem & other) const { return sock == other.sock; }
 };
 
@@ -3894,7 +3895,7 @@ public:
 
     bool sockOk(T_SOCKET sock)
     {
-        PROGLOG("CSocketBaseThread: sockOk testing %d",sock);
+        // PROGLOG("CSocketBaseThread: sockOk testing %d",sock);
         int t=0;
         socklen_t tl = sizeof(t);
         if (getsockopt(sock, SOL_SOCKET, SO_TYPE, (char *)&t, &tl)!=0) {
@@ -3919,8 +3920,8 @@ public:
             LOGERR2(ERRNO(),2,"CSocketBaseThread select handle");
             return false;
         }
-        else if (rc>0)
-            PROGLOG("CSocketBaseThread: select handle %d selected(2) %d",sock,rc);
+        // else if (rc>0)
+        //     PROGLOG("CSocketBaseThread: select handle %d selected(2) %d",sock,rc);
         XFD_ZERO(&fds);
         FD_SET((unsigned)sock, &fds);
         tv.tv_sec = 0;
@@ -3932,8 +3933,8 @@ public:
             LOGERR2(ERRNO(),3,"CSocketBaseThread select handle");
             return false;
         }
-        else if (rc>0)
-            PROGLOG("CSocketBaseThread: select handle %d selected(2) %d",sock,rc);
+        // else if (rc>0)
+        //     PROGLOG("CSocketBaseThread: select handle %d selected(2) %d",sock,rc);
         return true;
 #else
         struct pollfd fds[1];
@@ -3947,7 +3948,7 @@ public:
         {
             if ( !(fds[0].revents & POLLNVAL) ) // TODO: MCK - also check POLLERR here ?
             {
-                PROGLOG("CSocketBaseThread: poll handle %d selected(2) %d",sock,rc);
+                // PROGLOG("CSocketBaseThread: poll handle %d selected(2) %d",sock,rc);
                 return true;
             }
         }
@@ -4224,6 +4225,9 @@ public:
                     n++;
             }
         }
+        // seems this should be 1/4 or 1/8 or so
+        // of the overall XFD_SETSIZE fd maximum
+        // to get multiple select handler threads
         if (n>=XFD_SETSIZE-1)   // leave 1 spare
             return false;
         SelectItem sn;
@@ -4589,6 +4593,8 @@ public:
     }
 };
 
+// == EPOLL ========================
+
 #ifdef _HAS_EPOLL_SUPPORT
 class CSocketEpollThread: public CSocketBaseThread
 {
@@ -4688,6 +4694,35 @@ class CSocketEpollThread: public CSocketBaseThread
         }
     }
 
+    void delSelItem(SelectItem *si)
+    {
+        epoll_op(epfd, EPOLL_CTL_DEL, si, 0);
+        // Release/dtors should not throw but leaving try/catch here until all paths checked
+        try
+        {
+            si->nfy->Release();
+            si->sock->Release();
+            delete si;
+        }
+        catch (IException *e)
+        {
+            EXCLOG(e,"CSocketEpollThread::delSelItem()");
+            e->Release();
+        }
+    }
+
+    void delSelItemPos(SelectItem *si, unsigned pos)
+    {
+        unsigned last = items.ordinality();
+        if ( (last == 0) || (pos >= last) )
+            return;
+        delSelItem(si);
+        last--;
+        if (pos < last)
+            items.swap(pos, last);
+        items.remove(last);
+    }
+
 public:
     IMPLEMENT_IINTERFACE;
     CSocketEpollThread(const char *trc)
@@ -4701,7 +4736,7 @@ public:
         validateerrcount = 0;
         offset = 0;
         selecttrace = trc;
-        epfd = ::epoll_create(MAX_RET_EVENTS);
+        epfd = ::epoll_create(MAX_EPOLL_FD_EVENTS);
         if (epfd < 0)
         {
             int err = ERRNO();
@@ -4721,7 +4756,7 @@ public:
 # endif
         try
         {
-            epevents = new struct epoll_event[MAX_RET_EVENTS];
+            epevents = new struct epoll_event[MAX_EPOLL_FD_EVENTS];
         }
         catch (const std::bad_alloc &e)
         {
@@ -4732,38 +4767,13 @@ public:
         opendummy();
     }
 
-    void delSelItem(SelectItem *si)
-    {
-        if (nullptr == si)
-            return;
-        epoll_op(epfd, EPOLL_CTL_DEL, si, 0);
-        // Release/dtors should not throw but leaving try/catch here until all paths checked
-        try
-        {
-            si->nfy->Release();
-            si->sock->Release();
-            delete si;
-        }
-        catch (IException *e)
-        {
-            EXCLOG(e,"CSocketEpollThread::delSelItem()");
-            e->Release();
-        }
-    }
-
     ~CSocketEpollThread()
     {
         closedummy();
-        unsigned n = items.ordinality();
-        for (unsigned i=0;i<n;)
+        ForEachItemIn(i, items)
         {
             SelectItem *si = items.element(i);
             delSelItem(si);
-            n--;
-            if (i<n)
-                items.swap(i,n);
-            items.remove(n);
-            i++;
         }
         if (epfd >= 0)
         {
@@ -4788,11 +4798,8 @@ public:
             SelectItem *si = items.element(i);
             if (!sockOk(si->handle))
             {
-                delSelItem(si);
+                delSelItemPos(si, i);
                 n--;
-                if (i<n)
-                    items.swap(i,n);
-                items.remove(n);
                 ret = true;
             }
             else
@@ -4801,7 +4808,7 @@ public:
         return ret;
     }
 
-    bool removeSelItem(ISocket *sock)
+    bool removeSock(ISocket *sock)
     {
         // must be holding CriticalBlock (sect)
         unsigned n = items.ordinality();
@@ -4810,11 +4817,8 @@ public:
             SelectItem *si = items.element(i);
             if (si->sock==sock)
             {
-                delSelItem(si);
+                delSelItemPos(si, i);
                 n--;
-                if (i<n)
-                    items.swap(i,n);
-                items.remove(n);
                 return true;
             }
             else
@@ -4838,7 +4842,7 @@ public:
             }
             return true;
         }
-        if (removeSelItem(sock))
+        if (removeSock(sock))
         {
             selectvarschange = true;
             triggerselect();
@@ -4857,7 +4861,11 @@ public:
             return false;
         }
         CriticalBlock block(sect);
-        removeSelItem(sock);
+        removeSock(sock);
+        unsigned n = items.ordinality();
+        // new handler thread
+        if (n >= MAX_EPOLL_FD_EVENTS)
+            return false;
         SelectItem *sn = new SelectItem;
         sn->nfy = LINK(nfy);
         sn->sock = LINK(sock);
@@ -4921,7 +4929,7 @@ public:
             while (!terminating)
             {
                 if (selectvarschange)
-                        updateEpollVars(ni);
+                    updateEpollVars(ni);
 
                 if (ni==0)
                 {
@@ -4933,7 +4941,10 @@ public:
                     continue;
                 }
 
-                int n = ::epoll_wait(epfd, epevents, MAX_RET_EVENTS, 1000);
+                int err = 0;
+                int n = ::epoll_wait(epfd, epevents, MAX_EPOLL_FD_EVENTS, 1000);
+                if (n < 0)
+                    err = ERRNO();
 
 # ifdef EPOLLTRACE
                 if(n > 0)
@@ -4945,7 +4956,6 @@ public:
                 if (n < 0)
                 {
                     CriticalBlock block(sect);
-                    int err = ERRNO();
                     if (err != JSE_INTR)
                     {
                         if (dummysockopen)
@@ -4990,37 +5000,34 @@ public:
                                     continue;
                                 }
 # endif
-                                if (!epsi->del)
+                                if (!epsi->sock || !epsi->nfy)
                                 {
-                                    if (!epsi->sock || !epsi->nfy)
+                                    WARNLOG("EPOLL: epevents[%d].data.fd = %d, emask = %u, sock or nfy is NULL", j, tfd, epevents[j].events);
+                                }
+                                else
+                                {
+                                    unsigned int ep_mode = 0;
+                                    if (epevents[j].events & (EPOLLIN | EPOLLHUP | EPOLLERR))
+                                        ep_mode |= SELECTMODE_READ;
+                                    if (epevents[j].events & EPOLLOUT)
+                                        ep_mode |= SELECTMODE_WRITE;
+                                    if (epevents[j].events & EPOLLPRI)
+                                        ep_mode |= SELECTMODE_EXCEPT;
+                                    if (ep_mode != 0)
                                     {
-                                        WARNLOG("EPOLL: epevents[%d].data.fd = %d, emask = %u, del = false but sock or nfy is NULL", j, tfd, epevents[j].events);
-                                    }
-                                    else
-                                    {
-                                        unsigned int ep_mode = 0;
-                                        if (epevents[j].events & (EPOLLIN | EPOLLHUP | EPOLLERR))
-                                            ep_mode |= SELECTMODE_READ;
-                                        if (epevents[j].events & EPOLLOUT)
-                                            ep_mode |= SELECTMODE_WRITE;
-                                        if (epevents[j].events & EPOLLPRI)
-                                            ep_mode |= SELECTMODE_EXCEPT;
-                                        if (ep_mode != 0)
-                                        {
-                                            tonotify.append(*epsi);
-                                            SelectItem &itm = tonotify.element(tonotify.length()-1);
-                                            itm.nfy->Link();
-                                            itm.sock->Link();
+                                        tonotify.append(*epsi);
+                                        SelectItem &itm = tonotify.element(tonotify.length()-1);
+                                        itm.nfy->Link();
+                                        itm.sock->Link();
 #ifdef _TRACELINKCLOSED
-                                            // temporary, to help diagnose spurious socket closes (hpcc-15043)
-                                            // currently no implementation of notifySelected() uses the mode
-                                            // argument so we can pass in the epoll events mask and log that
-                                            // if there is no data and the socket gets closed
-                                            itm.mode = epevents[j].events;
+                                        // temporary, to help diagnose spurious socket closes (hpcc-15043)
+                                        // currently no implementation of notifySelected() uses the mode
+                                        // argument so we can pass in the epoll events mask and log that
+                                        // if there is no data and the socket gets closed
+                                        itm.mode = epevents[j].events;
 #else
-                                            itm.mode = ep_mode;
+                                        itm.mode = ep_mode;
 #endif
-                                        }
                                     }
                                 }
                             }
@@ -5083,51 +5090,89 @@ public:
 
 class CSocketEpollHandler: implements ISocketSelectHandler, public CInterface
 {
-    CSocketEpollThread *epollthread;
+    CIArrayOf<CSocketEpollThread> threads;
     CriticalSection sect;
+    bool started;
     StringAttr epolltrace;
 public:
     IMPLEMENT_IINTERFACE;
     CSocketEpollHandler(const char *trc)
         : epolltrace(trc)
     {
-        epollthread = new CSocketEpollThread(epolltrace);
+        started = false;
     }
 
     ~CSocketEpollHandler()
     {
-        delete epollthread;
+        stop(true);
+        threads.kill();
     }
 
     void start()
     {
         CriticalBlock block(sect);
-        epollthread->start();
+        if (!started)
+        {
+            started = true;
+            ForEachItemIn(i,threads)
+            {
+                threads.item(i).start();
+            }
+        }
     }
 
     void add(ISocket *sock,unsigned mode,ISocketSelectNotify *nfy)
     {
-        CriticalBlock block(sect); // JCS->MK - are these blocks necessary? epollthread->add() uses it's own CS.
-
-        /* JCS->MK, the CSocketSelectHandler variety, checks result of thread->add and spins up another handler
-         * Shouldn't epoll version do the same?
-         */
-        if (!epollthread->add(sock,mode,nfy))
-            throw MakeStringException(-1, "CSocketEpollHandler: failed to add socket to epollthread handler: sock # = %d", sock->OShandle());
+        CriticalBlock block(sect);
+        // Create new handler thread if current one has many fds
+        // epoll() handles many fds faster than select so this would
+        // seem not as important, but we are still serializing on
+        // nfy events and spreading those over a few threads may help
+        for (;;)
+        {
+            bool added=false;
+            ForEachItemIn(i,threads)
+            {
+                if (added)
+                    threads.item(i).remove(sock);
+                else
+                    added = threads.item(i).add(sock,mode,nfy);
+            }
+            if (added)
+                return;
+            CSocketEpollThread *thread = new CSocketEpollThread(epolltrace);
+            threads.append(*thread);
+            if (started)
+                thread->start();
+        }
     }
 
     void remove(ISocket *sock)
     {
-        CriticalBlock block(sect); // JCS->MK - are these blocks necessary? epollthread->add() uses it's own CS.
-        epollthread->remove(sock);
+        CriticalBlock block(sect);
+        ForEachItemIn(i,threads)
+        {
+            if (threads.item(i).remove(sock)&&sock)
+                break;
+        }
     }
 
     void stop(bool wait)
     {
-        IException *e=NULL;
-        epollthread->stop(wait);           // not quite as quick as could be if wait true
-        if (wait && !e && epollthread->termexcept)
-            e = epollthread->termexcept.getClear();
+        IException *e = nullptr;
+        CriticalBlock block(sect);
+        unsigned i = 0;
+        while (i<threads.ordinality())
+        {
+            CSocketEpollThread &t=threads.item(i);
+            {
+                CriticalUnblock unblock(sect);
+                t.stop(wait);           // not quite as quick as could be if wait true
+            }
+            if (wait && !e && t.termexcept)
+                e = t.termexcept.getClear();
+            i++;
+        }
 #if 0 // don't throw error as too late
         if (e)
             throw e;
@@ -5156,7 +5201,7 @@ ISocketSelectHandler *createSocketSelectHandler(const char *trc)
                 epoll_method = EPOLL_ENABLED;
             else
                 epoll_method = EPOLL_DISABLED;
-        // DBGLOG("createSocketSelectHandler(): after reading conf file, epoll_method = %d",epoll_method);
+            // DBGLOG("createSocketSelectHandler(): after reading conf file, epoll_method = %d",epoll_method);
         }
     }
     if (epoll_method == EPOLL_ENABLED)
@@ -5176,6 +5221,8 @@ ISocketSelectHandler *createSocketEpollHandler(const char *trc)
     return new CSocketSelectHandler(trc);
 #endif
 }
+
+// == EPOLL ========================
 
 void readBuffer(ISocket * socket, MemoryBuffer & buffer)
 {


### PR DESCRIPTION
NOTE: This PR is based off HPCC-18996
(https://track.hpccsystems.com/browse/HPCC-18996)
(https://github.com/hpcc-systems/HPCC-Platform/pull/10846)
And will be rebased once HPCC-18996 is reviewed/finalized/merged

Epoll does a good job of handling events in a large list of file descriptors as no need to loop over all fds in its set to see which ones have events pending.
But tonotify events are built up and executed serially and this code adds threads to create new epoll handlers whenever the number of fds grows beyond MAX_EPOLL_FD_EVENTS (currently 5000)

Signed-off-by: Mark Kelly <mark.kelly@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [x] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [x] Scalability
  - [x] Performance
  - [ ] Security
  - [x] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

Full QA suite with multi-channel / multi-slave thors gave expected results.

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
