### PR TITLE
HPCC-19171 Add a new semantic check stage to the compiler

### DIFF
--- a/ecl/hql/hqlgram2.cpp
+++ b/ecl/hql/hqlgram2.cpp
@@ -8236,38 +8236,6 @@ void HqlGram::checkJoinFlags(const attribute &err, IHqlExpression * join)
         if (isKey(cur))
             reportWarning(CategoryEfficiency, ERR_BAD_JOINFLAG, err.pos, "Filtered RIGHT prevents a keyed join being used.  Consider including the filter in the join condition.");
     }
-
-    IHqlExpression * group = join->queryAttribute(groupAtom);
-    if (group)
-    {
-        //Check that each of the fields mentioned in the group are projected into the output.
-        OwnedHqlExpr left = createSelector(no_left, join->queryChild(0), querySelSeq(join));
-        OwnedHqlExpr right = createSelector(no_right, join->queryChild(1), querySelSeq(join));
-        NewProjectMapper2 mapper;
-        mapper.setMapping(join->queryChild(3));
-        IHqlExpression * sortlist = group->queryChild(0);
-        ForEachChild(i, sortlist)
-        {
-            IHqlExpression * cur = sortlist->queryChild(i);
-            if (cur->usesSelector(right))
-            {
-                StringBuffer s;
-                getExprECL(cur, s);
-                reportError(ERR_BAD_JOINGROUP_FIELD, err, "GROUP expression '%s' cannot include fields from RIGHT", s.str());
-            }
-            else
-            {
-                bool matchedAll = true;
-                OwnedHqlExpr mapped = mapper.collapseFields(cur, left, queryActiveTableSelector(), left, &matchedAll);
-                if (!matchedAll)
-                {
-                    StringBuffer s;
-                    getExprECL(cur, s);
-                    reportError(ERR_BAD_JOINGROUP_FIELD, err, "GROUP expression '%s' is not included in the JOIN output", s.str());
-                }
-            }
-        }
-    }
 }
 
 

--- a/ecl/hql/hqlvalid.cpp
+++ b/ecl/hql/hqlvalid.cpp
@@ -68,6 +68,9 @@ bool ECLlocation::extractLocationAttr(const IHqlExpression * location)
     }
     if (location->isAttribute())
     {
+        if (location->queryName() != _location_Atom)
+            return false;
+
         IHqlExpression * sourceExpr = location->queryChild(3);
         if (sourceExpr)
             sourcePath = static_cast<ISourcePath *>(sourceExpr->queryUnknownExtra());

--- a/ecl/hqlcpp/hqlhtcpp.cpp
+++ b/ecl/hqlcpp/hqlhtcpp.cpp
@@ -5761,6 +5761,11 @@ bool isLibraryScope(IHqlExpression * expr)
 
 bool HqlCppTranslator::prepareToGenerate(HqlQueryContext & query, WorkflowArray & actions, bool isEmbeddedLibrary)
 {
+    query.expr.setown(expandDelayedFunctionCalls(&queryErrorProcessor(), query.expr));
+    //Pass localOnWarnings so that multiple semantic errors are all reported
+    if (reportSemanticErrors(query.expr, *localOnWarnings))
+        return false;
+
     bool createLibrary = isLibraryScope(query.expr);
 
     if (createLibrary)

--- a/ecl/hqlcpp/hqlttcpp.cpp
+++ b/ecl/hqlcpp/hqlttcpp.cpp
@@ -13911,7 +13911,123 @@ bool HqlCppTranslator::transformGraphForGeneration(HqlQueryContext & query, Work
     return true;
 }
 
-//---------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------------------------------------
+
+static HqlTransformerInfo semanticErrorCheckerInfo("SemanticErrorChecker");
+class SemanticErrorChecker : public QuickHqlTransformer
+{
+public:
+    SemanticErrorChecker(IErrorReceiver & _errs) :
+        QuickHqlTransformer(semanticErrorCheckerInfo, &_errs), mapper(_errs)
+    {
+    }
+
+    virtual void doAnalyse(IHqlExpression * expr)
+    {
+        switch (expr->getAnnotationKind())
+        {
+        case annotate_meta:
+            {
+                unsigned max = mapper.processMetaAnnotation(expr);
+                QuickHqlTransformer::doAnalyse(expr);
+                mapper.restoreLocalOnWarnings(max);
+                return;
+            }
+        case annotate_symbol:
+            {
+                ErrorSeverityMapper::SymbolScope saved(mapper, expr);
+                locations.append(*expr);
+                QuickHqlTransformer::doAnalyse(expr);
+                locations.pop();
+                return;
+            }
+        case annotate_location:
+            {
+                locations.append(*expr);
+                QuickHqlTransformer::doAnalyse(expr);
+                locations.pop();
+                return;
+            }
+        }
+        switch (expr->getOperator())
+        {
+        case no_join:
+            checkJoin(expr);
+            break;
+        }
+        QuickHqlTransformer::doAnalyse(expr);
+    }
+
+protected:
+    void checkJoin(IHqlExpression * expr);
+    void reportError(int errNo, const char * format, ...) __attribute__((format(printf, 3, 4)));
+
+protected:
+    ErrorSeverityMapper mapper;
+    HqlExprCopyArray locations;
+};
+
+void SemanticErrorChecker::checkJoin(IHqlExpression * join)
+{
+    IHqlExpression * group = join->queryAttribute(groupAtom);
+    if (group)
+    {
+        //Check that each of the fields mentioned in the group are projected into the output.
+        OwnedHqlExpr left = createSelector(no_left, join->queryChild(0), querySelSeq(join));
+        OwnedHqlExpr right = createSelector(no_right, join->queryChild(1), querySelSeq(join));
+        NewProjectMapper2 mapper;
+        mapper.setMapping(join->queryChild(3));
+        IHqlExpression * sortlist = group->queryChild(0);
+        ForEachChild(i, sortlist)
+        {
+            IHqlExpression * cur = sortlist->queryChild(i);
+            if (cur->usesSelector(right))
+            {
+                StringBuffer s;
+                getExprECL(cur, s);
+                reportError(ERR_BAD_JOINGROUP_FIELD, "GROUP expression '%s' cannot include fields from RIGHT", s.str());
+            }
+            else
+            {
+                bool matchedAll = true;
+                OwnedHqlExpr mapped = mapper.collapseFields(cur, left, queryActiveTableSelector(), left, &matchedAll);
+                if (!matchedAll)
+                {
+                    StringBuffer s;
+                    getExprECL(cur, s);
+                    reportError(ERR_BAD_JOINGROUP_FIELD, "GROUP expression '%s' is not included in the JOIN output", s.str());
+                }
+            }
+        }
+    }
+}
+
+
+void SemanticErrorChecker::reportError(int errNo, const char * format, ...)
+{
+    ECLlocation location;
+    ForEachItemInRev(i, locations)
+    {
+        if (location.extractLocationAttr(&locations.item(i)))
+            break;
+    }
+    va_list args;
+    va_start(args, format);
+    reportErrorVa(&mapper, errNo, location, format, args);
+    va_end(args);
+}
+
+
+bool reportSemanticErrors(IHqlExpression * expr, IErrorReceiver & errors)
+{
+    SemanticErrorChecker checker(errors);
+    checker.analyse(expr);
+    return errors.errCount() != 0;
+}
+
+
+//---------------------------------------------------------------------------------------------------------------------
+
 /*
 Different transformers:
 merge: required if a child get removed or merged with a parent of a non-table dataset.

--- a/ecl/hqlcpp/hqlttcpp.ipp
+++ b/ecl/hqlcpp/hqlttcpp.ipp
@@ -1301,6 +1301,8 @@ void optimizeActivities(unsigned wfid, HqlExprArray & exprs, bool optimizeCountC
 IHqlExpression * insertImplicitProjects(HqlCppTranslator & translator, IHqlExpression * expr, bool optimizeSpills);
 void insertImplicitProjects(HqlCppTranslator & translator, HqlExprArray & exprs);
 
+bool reportSemanticErrors(IHqlExpression * expr, IErrorReceiver & errors);
+
 //------------------------------------------------------------------------
 
 #endif


### PR DESCRIPTION
Signed-off-by: Gavin Halliday <gavin.halliday@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [x] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [x] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
