### PR TITLE
HPCC-19168 A IFile::size() call for a dafilesrv file throws an exception (8019) if file is missing, a std. (local) file returns (offset_t)-1

### DIFF
--- a/common/remote/remoteerr.hpp
+++ b/common/remote/remoteerr.hpp
@@ -86,13 +86,14 @@
 
 #define RAERR_InvalidUsernamePassword_Text      "Invalid (upper case U) in username/password"
 
+#define RFSERR_GetDirFailed_Text                "Failed to open file."
 
 interface REMOTE_API IDAFS_Exception: extends IException
 { // Raise by dafilesrv calls
 };
 
 enum DAFS_ERROR_CODES {
-    DAFSERR_connection_failed               = -1,   
+    DAFSERR_connection_failed               = -1,
     DAFSERR_authenticate_failed             = -2,
     DAFSERR_protocol_failure                = -3,
     DAFSERR_serveraccept_failed             = -4,

--- a/common/remote/sockfile.cpp
+++ b/common/remote/sockfile.cpp
@@ -60,7 +60,7 @@
 #define DUMMY_TIMEOUT_MAX (1000*10)
 
 static bool errorSimulationOn = true;
-static ISocket *timeoutreadsock = NULL; // used to trigger 
+static ISocket *timeoutreadsock = NULL; // used to trigger
 
 
 struct dummyReadWrite
@@ -97,9 +97,9 @@ struct dummyReadWrite
         {
             return str.append("timeout expired");
         }
-        MessageAudience errorAudience() const 
-        { 
-            return MSGAUD_user; 
+        MessageAudience errorAudience() const
+        {
+            return MSGAUD_user;
         }
     };
 
@@ -144,7 +144,7 @@ struct dummyReadWrite
             PrintStackReport();
             PROGLOG("** Simulate Packet loss (size %d)",size);
             timeoutreadsock=sock;
-            return size; 
+            return size;
         }
         return sock->write(buf,size);
     }
@@ -228,7 +228,7 @@ void clientSetRemoteFileTimeouts(unsigned maxconnecttime,unsigned maxreadtime)
 }
 
 
-struct sRFTM        
+struct sRFTM
 {
     CTimeMon *timemon;
     sRFTM(unsigned limit) {  timemon = limit ? new CTimeMon(limit) : NULL; }
@@ -309,7 +309,7 @@ enum {
     RFCsettrace,
     RFCgetinfo,
     RFCfirewall,    // not used currently          // 30
-    RFCunlock,  
+    RFCunlock,
     RFCunlockreply,
     RFCinvalid,
     RFCcopysection,
@@ -516,23 +516,23 @@ class DECL_EXCEPTION CDafsException: public IDAFS_Exception, public CInterface
 public:
     IMPLEMENT_IINTERFACE;
 
-    CDafsException(int code,const char *_msg) 
+    CDafsException(int code,const char *_msg)
         : errcode(code), msg(_msg)
     {
     };
 
-    int errorCode() const 
-    { 
-        return errcode; 
+    int errorCode() const
+    {
+        return errcode;
     }
 
     StringBuffer &  errorMessage(StringBuffer &str) const
-    { 
+    {
         return str.append(msg);
     }
-    MessageAudience errorAudience() const 
-    { 
-        return MSGAUD_user; 
+    MessageAudience errorAudience() const
+    {
+        return MSGAUD_user;
     }
 };
 
@@ -725,7 +725,7 @@ void setDafsLocalMountRedirect(const IpAddress &ip,const char *dir,const char *m
         if (dir==NULL) { // remove all matching mount
             if (!mountdir)
                 return;
-            if (strcmp(mount.local,mountdir)==0) 
+            if (strcmp(mount.local,mountdir)==0)
                 localMounts.remove(i);
         }
         else if (mount.ip.ipequals(ip)&&(strcmp(mount.dir,dir)==0)) {
@@ -778,13 +778,13 @@ static class CConnectionTable: public SuperHashTableOf<CConnectionRec,SocketEndp
 
     void onRemove(void *e)
     {
-        CConnectionRec *r=(CConnectionRec *)e;      
+        CConnectionRec *r=(CConnectionRec *)e;
         delete r;
     }
 
     unsigned getHashFromElement(const void *e) const
     {
-        const CConnectionRec &elem=*(const CConnectionRec *)e;      
+        const CConnectionRec &elem=*(const CConnectionRec *)e;
         return elem.ep.hash(0);
     }
 
@@ -795,7 +795,7 @@ static class CConnectionTable: public SuperHashTableOf<CConnectionRec,SocketEndp
 
     const void * getFindParam(const void *p) const
     {
-        const CConnectionRec &elem=*(const CConnectionRec *)p;      
+        const CConnectionRec &elem=*(const CConnectionRec *)p;
         return (void *)&elem.ep;
     }
 
@@ -811,11 +811,11 @@ static class CConnectionTable: public SuperHashTableOf<CConnectionRec,SocketEndp
 public:
     static CriticalSection crit;
 
-    CConnectionTable() 
+    CConnectionTable()
     {
         numsockets = 0;
     }
-    ~CConnectionTable() { 
+    ~CConnectionTable() {
         _releaseAll();
     }
 
@@ -840,7 +840,7 @@ public:
     {
         // always called from crit block
         while (numsockets>=SOCKET_CACHE_MAX) {
-            // find oldest 
+            // find oldest
             CConnectionRec *c = NULL;
             unsigned oldest = 0;
             CConnectionRec *old = NULL;
@@ -883,12 +883,12 @@ public:
     {
         // always called from crit block
         CConnectionRec *r = SuperHashTableOf<CConnectionRec,SocketEndpoint>::find(&ep);
-        if (r) 
+        if (r)
             if (r->socks.zap(*sock)&&numsockets)
                 numsockets--;
 
     }
-    
+
 
 } *ConnectionTable = NULL;
 
@@ -921,7 +921,7 @@ struct CTreeCopyItem: public CInterface
     offset_t sz;                // original size
     CDateTime dt;               // original date
     RemoteFilenameArray loc;    // locations for file - 0 is original
-    Owned<IBitSet> busy;    
+    Owned<IBitSet> busy;
     unsigned lastused;
 
     CTreeCopyItem(RemoteFilename &orig, const char *_net, const char *_mask, offset_t _sz, CDateTime &_dt)
@@ -933,7 +933,7 @@ struct CTreeCopyItem: public CInterface
         busy.setown(createThreadSafeBitSet());
         lastused = msTick();
     }
-    bool equals(const RemoteFilename &orig, const char *_net, const char *_mask, offset_t _sz, CDateTime &_dt) 
+    bool equals(const RemoteFilename &orig, const char *_net, const char *_mask, offset_t _sz, CDateTime &_dt)
     {
         if (!orig.equals(loc.item(0)))
             return false;
@@ -950,7 +950,7 @@ struct CTreeCopyItem: public CInterface
 static CIArrayOf<CTreeCopyItem>  treeCopyArray;
 static CriticalSection           treeCopyCrit;
 static unsigned                  treeCopyWaiting=0;
-static Semaphore                 treeCopySem;   
+static Semaphore                 treeCopySem;
 
 #define DEBUGSAMEIP false
 
@@ -1269,8 +1269,12 @@ protected: friend class CRemoteFileIO;
                         msg.appendf(" %2x",(int)rest[i]);
                 }
             }
-            else if(errCode == 8209)
+            //TODO This magic number 8209 defined in Solrais daliservix.cpp as RFSERR_GetDirFailed
+            //should clarify why it is different and use an RFSERR_xxx macro instead
+            else if (errCode == 8209)
                 msg.append("Failed to open directory.");
+            else if (errCode == RFSERR_GetDirFailed)
+                msg.append(RFSERR_GetDirFailed_Text);
             else
                 msg.append("ERROR #").append(errCode);
 #ifdef _DEBUG
@@ -1471,7 +1475,7 @@ public:
         //  True if there are valid directory entry follows this flag
         //  False if there are no more valid entry in this block aka end of block
         // If there is more data in the stream, the end of block flag should be removed
-        if (rest&&(rb[rest-1]!=0)) 
+        if (rest&&(rb[rest-1]!=0))
         {
             rest--; // remove stream live flag
             if(rest && (0 == rb[rest-1]))
@@ -1509,7 +1513,7 @@ public:
             byte isValidEntry;
             buf.read(isValidEntry);
             curvalid = isValidEntry!=0;
-            if (!curvalid) 
+            if (!curvalid)
                 return false;
             buf.read(curisdir);
             buf.read(cursize);
@@ -1527,12 +1531,12 @@ public:
         return true;
     }
 
-    bool isValid() 
-    { 
-        return curvalid; 
+    bool isValid()
+    {
+        return curvalid;
     }
-    IFile & query() 
-    { 
+    IFile & query()
+    {
         if (!cur) {
             StringBuffer full(dir);
             addPathSepChar(full).append(curname);
@@ -1544,15 +1548,15 @@ public:
                 cur.setown(createIFile(rfn));
             }
         }
-        return *cur; 
+        return *cur;
     }
     StringBuffer &getName(StringBuffer &buf)
     {
         return buf.append(curname);
     }
-    bool isDir() 
-    { 
-        return curisdir; 
+    bool isDir()
+    {
+        return curisdir;
     }
 
     __int64 getFileSize()
@@ -1573,7 +1577,7 @@ public:
     {
         mask = _mask;
     }
-    
+
     virtual unsigned getFlags()
     {
         if (flags&&(curidx<numflags))
@@ -1604,9 +1608,9 @@ public:
                 if (!iter->next())
                     break;
             }
-        }               
+        }
         b = 0;
-        mb.append(b);   
+        mb.append(b);
         return ret;
     }
 
@@ -1614,7 +1618,7 @@ public:
     {
         // bit slow
         MemoryBuffer flags;
-        ForEach(*iter) 
+        ForEach(*iter)
             flags.append((byte)iter->getFlags());
         if (flags.length()) {
             byte b = 2;
@@ -1720,7 +1724,7 @@ public:
         MemoryBuffer replyBuffer;
         sendBuffer.append((RemoteFileCommandType)RFCexists).append(filename);
         sendRemoteCommand(sendBuffer, replyBuffer);
-        
+
         bool ok;
         replyBuffer.read(ok);
         return ok;
@@ -1740,7 +1744,7 @@ public:
         MemoryBuffer replyBuffer;
         sendBuffer.append((RemoteFileCommandType)RFCgettime).append(filename);
         sendRemoteCommand(sendBuffer, replyBuffer);
-        
+
         bool ok;
         replyBuffer.read(ok);
         if (ok) {
@@ -1776,7 +1780,7 @@ public:
         else
             sendBuffer.append((bool)false);
         sendRemoteCommand(sendBuffer, replyBuffer);
-        
+
         bool ok;
         replyBuffer.read(ok);
         return ok;
@@ -1789,7 +1793,7 @@ public:
         MemoryBuffer replyBuffer;
         sendBuffer.append((RemoteFileCommandType)RFCisdirectory).append(filename);
         sendRemoteCommand(sendBuffer, replyBuffer);
-        
+
         unsigned ret;
         replyBuffer.read(ret);
         return (fileBool)ret;
@@ -1803,7 +1807,7 @@ public:
         MemoryBuffer replyBuffer;
         sendBuffer.append((RemoteFileCommandType)RFCisfile).append(filename);
         sendRemoteCommand(sendBuffer, replyBuffer);
-        
+
         unsigned ret;
         replyBuffer.read(ret);
         return (fileBool)ret;
@@ -1816,7 +1820,7 @@ public:
         MemoryBuffer replyBuffer;
         sendBuffer.append((RemoteFileCommandType)RFCisreadonly).append(filename);
         sendRemoteCommand(sendBuffer, replyBuffer);
-        
+
         unsigned ret;
         replyBuffer.read(ret);
         return (fileBool)ret;
@@ -1864,7 +1868,7 @@ public:
         splitDirTail(filename,path);
         StringBuffer newdir;
         path.append(splitDirTail(newname,newdir));
-        if (newdir.length()&&(strcmp(newdir.str(),path.str())!=0)) 
+        if (newdir.length()&&(strcmp(newdir.str(),path.str())!=0))
             WARNLOG("CRemoteFile::rename passed full path '%s' that may not to match original directory '%s'",newname,path.str());
         MemoryBuffer sendBuffer;
         initSendBuffer(sendBuffer);
@@ -1906,7 +1910,7 @@ public:
             newname = path;
             sendBuffer.append((RemoteFileCommandType)RFCrename);    // use rename if we can (supported on older dafilesrv)
         }
-        else 
+        else
             sendBuffer.append((RemoteFileCommandType)RFCmove);
         sendBuffer.append(filename).append(newname);
         sendRemoteCommand(sendBuffer, replyBuffer);
@@ -1964,7 +1968,22 @@ public:
             Owned<CEndpointCS> crit = dirCSTable->getCrit(ep); // NB dirCSTable doesn't own, last reference will remove from table
             CriticalBlock block(*crit);
             sendBuffer.append((RemoteFileCommandType)RFCgetdir).append(dir).append(tail).append(includedirs).append(sub);
-            sendRemoteCommand(sendBuffer, replyBuffer);
+            try
+            {
+                sendRemoteCommand(sendBuffer, replyBuffer);
+            }
+            catch (IDAFS_Exception * e)
+            {
+                // TODO This magic number 8209 defined in Solrais daliservix.cpp as RFSERR_GetDirFailed
+                //should clarify why it is different and use an RFSERR_xxx macro instead
+                if ((e->errorCode() == RFSERR_GetDirFailed) || (e->errorCode() == 8209))
+                {
+                    e->Release();
+                    return (offset_t)-1;
+                }
+                else
+                    throw e;
+            }
         }
         // now should be 0 or 1 files returned
         Owned<CRemoteDirectoryIterator> iter = new CRemoteDirectoryIterator(ep, dir.str());
@@ -1976,7 +1995,7 @@ public:
         IFileIO * io = open(IFOread);
         offset_t length = (offset_t)-1;
         if (io)
-        {   
+        {
             length = io->size();
             io->Release();
         }
@@ -2039,7 +2058,7 @@ public:
         sendBuffer.append(cancelid);
         byte isprev=(prev!=NULL)?1:0;
         sendBuffer.append(isprev);
-        if (prev) 
+        if (prev)
             CRemoteDirectoryIterator::serialize(sendBuffer,prev,0,true);
         sendRemoteCommand(sendBuffer, replyBuffer);
         byte status;
@@ -2113,7 +2132,7 @@ public:
         MemoryBuffer replyBuffer;
         sendBuffer.append((RemoteFileCommandType)RFCgetcrc).append(filename);
         sendRemoteCommand(sendBuffer, replyBuffer, true, true);
-        
+
         unsigned crc;
         replyBuffer.read(crc);
         return crc;
@@ -2196,7 +2215,7 @@ public:
 
 void clientAddSocketToCache(SocketEndpoint &ep,ISocket *socket)
 {
-    CriticalBlock block(CConnectionTable::crit); 
+    CriticalBlock block(CConnectionTable::crit);
     if (ConnectionTable)
         ConnectionTable->addLink(ep,socket);
 }
@@ -2221,7 +2240,7 @@ void clientDisconnectRemoteFile(IFile *file)
 bool clientResetFilename(IFile *file, const char *newname) // returns false if not remote
 {
     CRemoteFile *cfile = QUERYINTERFACE(file,CRemoteFile);
-    if (!cfile) 
+    if (!cfile)
         return false;
     cfile->resetLocalFilename(newname);
     return true;
@@ -2361,7 +2380,7 @@ public:
         return true;
     }
 
-    bool reopen() 
+    bool reopen()
     {
         StringBuffer s;
         PROGLOG("Attempting reopen of %s on %s",parent->queryLocalName(),parent->queryEp().getUrlStr(s).str());
@@ -2379,7 +2398,7 @@ public:
         initSendBuffer(sendBuffer);
         MemoryBuffer replyBuffer;
         sendBuffer.append((RemoteFileCommandType)RFCsize).append(handle);
-        parent->sendRemoteCommand(sendBuffer, replyBuffer, false);                      
+        parent->sendRemoteCommand(sendBuffer, replyBuffer, false);
         // Retry using reopen TBD
 
         offset_t ret;
@@ -2450,7 +2469,7 @@ public:
                 replyBuffer.clear();
                 sendBuffer.append((RemoteFileCommandType)RFCread).append(handle).append(pos).append(len);
                 parent->sendRemoteCommand(sendBuffer, replyBuffer,false);
-                // kludge dafilesrv versions <= 1.5e don't return error correctly 
+                // kludge dafilesrv versions <= 1.5e don't return error correctly
                 if (replyBuffer.length()>len+sizeof(size32_t)+sizeof(unsigned)) {
                     size32_t save = replyBuffer.getPos();
                     replyBuffer.reset(len+sizeof(size32_t)+sizeof(unsigned));
@@ -2555,7 +2574,7 @@ public:
         const char * fname = file->queryFilename();
         sendBuffer.append((RemoteFileCommandType)RFCappend).append(handle).append(fname).append(pos).append(len);
         parent->sendRemoteCommand(sendBuffer, replyBuffer, false, true); // retry not safe
-        
+
         offset_t ret;
         replyBuffer.read(ret);
 
@@ -2565,8 +2584,8 @@ public:
     }
 
 
-    void setSize(offset_t size) 
-    { 
+    void setSize(offset_t size)
+    {
         MemoryBuffer sendBuffer;
         initSendBuffer(sendBuffer);
         MemoryBuffer replyBuffer;
@@ -2678,7 +2697,7 @@ void CRemoteFile::copyTo(IFile *dest, size32_t buffersize, ICopyFileProgress *pr
             size32_t got;
             CRemoteFileIO *srcio = QUERYINTERFACE(from,CRemoteFileIO);
             const void *dst;
-            if (srcio) 
+            if (srcio)
                 dst = srcio->doRead(ofs,sz,mb.clear(),got,buf);
             else {
                 // shouldn't ever get here if source remote
@@ -3309,8 +3328,8 @@ extern unsigned stopRemoteServer(ISocket * socket)
         receiveBuffer(socket, replybuf, NORMAL_RETRIES, 1024);
         replybuf.read(errCode);
     }
-    catch (IJSOCK_Exception *e) { 
-        if ((e->errorCode()!=JSOCKERR_broken_pipe)&&(e->errorCode()!=JSOCKERR_graceful_close)) 
+    catch (IJSOCK_Exception *e) {
+        if ((e->errorCode()!=JSOCKERR_broken_pipe)&&(e->errorCode()!=JSOCKERR_graceful_close))
             EXCLOG(e);
         else
             errCode = 0;
@@ -3515,10 +3534,10 @@ class CAsyncCommandManager
         }
         AsyncCommandStatus poll(offset_t &_done, offset_t &_total,unsigned timeout)
         {
-            if (timeout&&finished.wait(timeout)) 
+            if (timeout&&finished.wait(timeout))
                 finished.signal();      // may need to call again
             CriticalBlock block(sect);
-            if (exc) 
+            if (exc)
                 throw exc.getClear();
             _done = done;
             _total = total;
@@ -3550,7 +3569,7 @@ class CAsyncCommandManager
         }
         void setException(IException *e)
         {
-            EXCLOG(e,"CAsyncCommandManager::CAsyncJob"); 
+            EXCLOG(e,"CAsyncCommandManager::CAsyncJob");
             CriticalBlock block(sect);
             if (exc.get())
                 e->Release();
@@ -3611,7 +3630,7 @@ public:
             if (cjob) {
                 job = QUERYINTERFACE(cjob.get(),CAsyncCopySection);
                 if (!job) {
-                    throw MakeStringException(-1,"Async job ID mismatch");  
+                    throw MakeStringException(-1,"Async job ID mismatch");
                 }
             }
             else {
@@ -4772,7 +4791,7 @@ public:
         return true;
     }
 
-    void onCloseSocket(CRemoteClientHandler *client, int which) 
+    void onCloseSocket(CRemoteClientHandler *client, int which)
     {
         if (!client)
             return;
@@ -4812,7 +4831,7 @@ public:
         Owned<StringAttrItem> name = new StringAttrItem;
         byte mode;
         byte share;
-        msg.read(name->text).read(mode).read(share);  
+        msg.read(name->text).read(mode).read(share);
         // also try to recv extra byte
         byte extra = 0;
         unsigned short sMode = IFUnone;
@@ -5242,13 +5261,13 @@ public:
         CDateTime accessedTime;
         msg.read(name);
         msg.read(creategot);
-        if (creategot) 
+        if (creategot)
             createTime.deserialize(msg);
         msg.read(modifiedgot);
-        if (modifiedgot) 
+        if (modifiedgot)
             modifiedTime.deserialize(msg);
         msg.read(accessedgot);
-        if (accessedgot) 
+        if (accessedgot)
             accessedTime.deserialize(msg);
 
         if (TF_TRACE)
@@ -5584,7 +5603,7 @@ public:
     {
         PROGLOG("Abort request received");
         stopping = true;
-        if (acceptsock) 
+        if (acceptsock)
             acceptsock->cancel_accept();
         if (securesock)
             securesock->cancel_accept();

--- a/common/remote/sockfile.cpp
+++ b/common/remote/sockfile.cpp
@@ -5315,15 +5315,13 @@ public:
             StringBuffer fullFilename(name);
             addPathSepChar(fullFilename).append(mask);
             Owned<IFile> iFile = createIFile(fullFilename);
+
+            // NB: This must preserve same serialization format as CRemoteDirectoryIterator::serialize produces for <=1 file.
+            reply.append((unsigned)RFEnoerror);
             if (!iFile->exists())
-            {
-                reply.append((unsigned)RFSERR_GetDirFailed);
-                return false;
-            }
+                reply.append((byte)0);
             else
             {
-                reply.append((unsigned)RFEnoerror);
-                // NB: This must preserve same serialization format as CRemoteDirectoryIterator::serialize produces for 1 file.
                 byte b=1;
                 reply.append(b);
                 bool isDir = foundYes == iFile->isDirectory();
@@ -5335,8 +5333,8 @@ public:
                 reply.append(iFile->queryFilename());
                 b = 0;
                 reply.append(b);
-                return true;
             }
+            return true;
         }
         else
         {


### PR DESCRIPTION
Add code to handle RFSERR_GetDirFailed (8019) exception in IFile::size() method
and return with -1 if remote file is missing.

Signed-off-by: Attila Vamos attila.vamos@gmail.com

HPCC-19168 getDir must return null iterator on invalid path/file
    
To preserve legacy semantics, a directoryIterator returns a empty
iterator on an non-existent or invalid file. For both
whether local or remote. HPCC-18725 changed that, causing a call
on a non-existent to return an error.
   
Signed-off-by: Jake Smith <jake.smith@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [ ] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [ ] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [ ] I have read the CONTRIBUTORS document.
- [ ] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

Tested with simple test:
```
        const char *fname = argv[1];
        PROGLOG("trying to open : %s", fname);
        Owned<IFile> file = createIFile(fname);
        offset_t sz = file->size();
        if ((offset_t)-1 == sz)
            PROGLOG("Failed to get size() of file: %s", fname);
        else
        {
            StringBuffer msg("size = ");
            msg.append(sz);
            PROGLOG("%s", msg.str());
        }
```

Failed on 6.4.12, succeeds with this PR.

NB: size() uses getDir command to dafilesrv, but so do other things, e.g. getInfo()

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
