### PR TITLE
HPCC-19233 Add env. option to force local file to be remote read

### DIFF
--- a/common/remote/rmtfile.hpp
+++ b/common/remote/rmtfile.hpp
@@ -41,6 +41,7 @@ extern REMOTE_API void filenameToUrl(StringBuffer & out, const char * filename);
 
 interface IDaFileSrvHook : extends IRemoteFileCreateHook
 {
+    virtual void forceRemote(const char *pattern) = 0; // NB: forces all local files matching pattern to be remote reads
     virtual void addSubnetFilter(const char *subnet, const char *mask, const char *dir, const char *sourceRange, bool trace) = 0;
     virtual void addRangeFilter(const char *range, const char *dir, const char *sourceRange, bool trace) = 0;
     virtual IPropertyTree *addFilters(IPropertyTree *filters, const SocketEndpoint *ipAddress) = 0;
@@ -58,6 +59,9 @@ extern REMOTE_API unsigned short getActiveDaliServixPort(const IpAddress &ip);
 extern REMOTE_API unsigned getDaliServixVersion(const IpAddress &ip,StringBuffer &ver);
 extern REMOTE_API unsigned getDaliServixVersion(const SocketEndpoint &ep,StringBuffer &ver);
 extern REMOTE_API DAFS_OS getDaliServixOs(const SocketEndpoint &ep);
+extern REMOTE_API void enableForceRemoteReads(); // forces file reads to be remote reads if they match environment setting 'forceRemotePattern' pattern.
+extern REMOTE_API bool testForceRemote(const char *path); // return true if forceRemote setup/pattern will make this path a remote read.
+
 
 extern REMOTE_API void setLocalMountRedirect(const IpAddress &ip,const char *dir,const char *mountdir);
 // redirects a daliservix file to a local mount. To remove redirect use NULL for mount dir or NULL for dir

--- a/dali/dafilesrv/dafilesrv.cpp
+++ b/dali/dafilesrv/dafilesrv.cpp
@@ -25,6 +25,7 @@
 #include "jfile.hpp"
 #include "jlog.hpp"
 #include "jmisc.hpp"
+#include "rmtfile.hpp"
 #include "dalienv.hpp"
 
 #ifdef _MSC_VER
@@ -332,6 +333,14 @@ int initDaemon()
 int main(int argc,char **argv) 
 {
     InitModuleObjects();
+
+    /* The dafilesrv hook is installed via the MODULE_INIT process
+     * but it is not wanted in dafilesrv itself, so remove it now.
+    */
+    IDaFileSrvHook *remoteHook = queryDaFileSrvHook();
+    if (remoteHook)
+        removeIFileCreateHook(remoteHook);
+
     EnableSEHtoExceptionMapping();
 #ifndef __64BIT__
     // Restrict stack sizes on 32-bit systems

--- a/dali/dfu/dfuserver.cpp
+++ b/dali/dfu/dfuserver.cpp
@@ -237,6 +237,8 @@ int main(int argc, const char *argv[])
 
             writeSentinelFile(sentinelFile);
 
+            enableForceRemoteReads(); // forces file reads to be remote reads if they match environment setting 'forceRemotePattern' pattern.
+
             engine->joinListeners();
             if (replserver.get())
                 replserver->stopServer();

--- a/ecl/eclagent/eclagent.cpp
+++ b/ecl/eclagent/eclagent.cpp
@@ -3432,6 +3432,8 @@ extern int HTHOR_API eclagent_main(int argc, const char *argv[], StringBuffer * 
     if (globals->getPropInt("DAFILESRVCACHE", 1))
         setDaliServixSocketCaching(true);
 
+    enableForceRemoteReads(); // forces file reads to be remote reads if they match environment setting 'forceRemotePattern' pattern.
+
     try
     {
 #ifdef MONITOR_ECLAGENT_STATUS  

--- a/initfiles/etc/DIR_NAME/environment.conf.in
+++ b/initfiles/etc/DIR_NAME/environment.conf.in
@@ -58,3 +58,5 @@ additionalPlugins=python2
 # To en-/disable Drop Zone restriction.
 # Default is enabled (true).
 useDropZoneRestriction=true
+# If set, will force matching local file paths to become remote reads, e.g:
+#forceRemotePattern=/var/lib/HPCCSystems/hpcc-data/eclagent/*

--- a/roxie/ccd/ccdfile.cpp
+++ b/roxie/ccd/ccdfile.cpp
@@ -743,7 +743,7 @@ class CRoxieFileCache : implements IRoxieFileCache, implements ICopyFileProgress
             ret->setRemote(true);
         }
         ret->setCache(this);
-        files.setValue(localLocation, (ILazyFileIO *)ret);
+        files.setValue(local->queryFilename(), (ILazyFileIO *)ret);
         return ret.getClear();
     }
 

--- a/roxie/ccd/ccdmain.cpp
+++ b/roxie/ccd/ccdmain.cpp
@@ -1022,6 +1022,8 @@ int STARTQUERY_API start_query(int argc, const char *argv[])
             openMulticastSocket();
 
         setDaliServixSocketCaching(true);  // enable daliservix caching
+        enableForceRemoteReads(); // forces file reads to be remote reads if they match environment setting 'forceRemotePattern' pattern.
+
         loadPlugins();
         createDelayedReleaser();
         globalPackageSetManager = createRoxiePackageSetManager(standAloneDll.getClear());

--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -12247,7 +12247,14 @@ public:
         if(clusterHandler)
             clusterHandler->splitPhysicalFilename(dir, base);
         else
-            splitFilename(filename.str(), &dir, &dir, &base, &base);
+        {
+            // Check filename is URL and get localpath, only actually necessary if force remote reads are are on
+            RemoteFilename rfn;
+            rfn.setRemotePath(filename);
+            StringBuffer localPath;
+            rfn.getLocalPath(localPath);
+            splitFilename(localPath, &dir, &dir, &base, &base);
+        }
 
         desc->setDefaultDir(dir.str());
 

--- a/thorlcr/master/thgraphmanager.cpp
+++ b/thorlcr/master/thgraphmanager.cpp
@@ -21,6 +21,7 @@
 #include "jfile.hpp"
 #include "jmutex.hpp"
 #include "jlog.hpp"
+#include "rmtfile.hpp"
 
 #include "portlist.h"
 #include "wujobq.hpp"
@@ -1052,6 +1053,8 @@ void thorMain(ILogMsgHandler *logHandler)
         initFileManager();
         CThorResourceMaster masterResource;
         setIThorResource(masterResource);
+
+        enableForceRemoteReads(); // forces file reads to be remote reads if they match environment setting 'forceRemotePattern' pattern.
 
         Owned<CJobManager> jobManager = new CJobManager(logHandler);
         try {

--- a/thorlcr/slave/thslavemain.cpp
+++ b/thorlcr/slave/thslavemain.cpp
@@ -381,6 +381,8 @@ int main( int argc, char *argv[]  )
             if (daFileSrvHook) // probably always installed
                 daFileSrvHook->addFilters(globals->queryPropTree("NAS"), &slfEp);
 
+            enableForceRemoteReads(); // forces file reads to be remote reads if they match environment setting 'forceRemotePattern' pattern.
+
             StringBuffer thorPath;
             globals->getProp("@thorPath", thorPath);
             recursiveCreateDirectory(thorPath.str());


### PR DESCRIPTION
Option 'forceRemotePattern' added to environment.conf, if set
components calling enableForceRemoteReads() will treat local files
as if they were remote files (i.e. read them from dafilesrv).

enableForceRemoteReads() calls are added to hthor, roxie, thor
and dfuserver. So setting e.g.:
 forceRemotePattern=/var/lib/HPCCSystems/hpcc-data/*

will cause those components to read any local file under that
path via dafilesrv.

Signed-off-by: Jake Smith <jake.smith@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

Tested by enabling with a few patterns and checking engines correctly read from dafilesrv.

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
