### PR TITLE
HPCC-19329 Allow parallel init for faster start/stop

### DIFF
--- a/initfiles/bash/etc/init.d/dafilesrv.in
+++ b/initfiles/bash/etc/init.d/dafilesrv.in
@@ -57,6 +57,8 @@ function print_usage {
     exit 0
 }
 
+cfggenpre=()
+
 source  ${INSTALL_DIR}/etc/init.d/lock.sh
 source  ${INSTALL_DIR}/etc/init.d/pid.sh
 source  ${INSTALL_DIR}/etc/init.d/hpcc_common

--- a/initfiles/bash/etc/init.d/hpcc-init.in
+++ b/initfiles/bash/etc/init.d/hpcc-init.in
@@ -89,6 +89,7 @@ function print_types {
 }
 
 
+cfggenpre=()
 
 source  ${INSTALL_DIR}/etc/init.d/lock.sh
 source  ${INSTALL_DIR}/etc/init.d/pid.sh
@@ -277,13 +278,18 @@ if [ -z $arg ] || [ $# -ne 1 ]; then
     print_usage
 fi
 
-log "Debug log written to $LOG_DIR/hpcc-init.debug"
-[ -e $LOG_DIR/hpcc-init.debug ] && rm -rf ${LOG_DIR}/hpcc-init.debug
-touch ${LOG_DIR}/hpcc-init.debug
-chown ${user}:${group} ${LOG_DIR}/hpcc-init.debug
-PS4='+\011$(date "+%T.%N")\011'
-exec 3>&2 2>$LOG_DIR/hpcc-init.debug
-set -x
+os=$(uname -s)
+if [[ -n "$HPCC_DEVELOPER" && "$os" = "Linux" && -f "${envfile}" ]] ; then
+    cfggenpre=(flock ${envfile})
+else
+    log "Debug log written to $LOG_DIR/hpcc-init.debug"
+    [ -e $LOG_DIR/hpcc-init.debug ] && rm -rf ${LOG_DIR}/hpcc-init.debug
+    touch ${LOG_DIR}/hpcc-init.debug
+    chown ${user}:${group} ${LOG_DIR}/hpcc-init.debug
+    PS4='+\011$(date "+%T.%N")\011'
+    exec 3>&2 2>$LOG_DIR/hpcc-init.debug
+    set -x
+fi
 
 if [ -z ${component} ]; then
     for (( i=0; i<=${compListLen}; i++ ));do

--- a/initfiles/bash/etc/init.d/hpcc-init.in
+++ b/initfiles/bash/etc/init.d/hpcc-init.in
@@ -278,10 +278,14 @@ if [ -z $arg ] || [ $# -ne 1 ]; then
     print_usage
 fi
 
-os=$(uname -s)
-if [[ -n "$HPCC_DEVELOPER" && "$os" = "Linux" && -f "${envfile}" ]] ; then
+thisos=$(uname -s)
+if [[ "$thisos" = "Linux" && -f "${envfile}" && -n "${component}" && \
+    "${DEBUG}" = "NO_DEBUG" && -z "$HPCC_NO_FLOCK" ]] ; then
     cfggenpre=(flock ${envfile})
-else
+fi
+
+# verbose output of all shell cmds to .debug file only if -d specified on cmdline
+if [[ "${DEBUG}" != "NO_DEBUG" ]] ; then
     log "Debug log written to $LOG_DIR/hpcc-init.debug"
     [ -e $LOG_DIR/hpcc-init.debug ] && rm -rf ${LOG_DIR}/hpcc-init.debug
     touch ${LOG_DIR}/hpcc-init.debug
@@ -291,7 +295,7 @@ else
     set -x
 fi
 
-if [ -z ${component} ]; then
+if [ -z "${component}" ]; then
     for (( i=0; i<=${compListLen}; i++ ));do
         component="$component ${compList[$i]}"
     done

--- a/initfiles/bash/etc/init.d/hpcc_common.in
+++ b/initfiles/bash/etc/init.d/hpcc_common.in
@@ -274,7 +274,9 @@ set_componentvars() {
 }
 
 validate_configuration() {
-    if ! validation_error=$(${configgen_path}/configgen -env ${envfile} -validateonly 2>&1); then
+    validation_error=$(${cfggenpre[@]} ${configgen_path}/configgen -env ${envfile} -validateonly 2>&1)
+    rc=$?
+    if [[ $rc -ne 0 ]]; then
         log  "validate_configuration(): validation failure ${envfile}"
         log  "${validation_error}"
         echo -e "\033[31merror\033[0m: configgen xml validation failure"
@@ -284,7 +286,7 @@ validate_configuration() {
 
 get_commondirs() {
     componentFile="${path}/componentfiles/configxml"
-    DIRS=$(${configgen_path}/configgen -env ${envfile} -id ${componentFile} -listcommondirs)
+    DIRS=$(${cfggenpre[@]} ${configgen_path}/configgen -env ${envfile} -id ${componentFile} -listcommondirs)
     rc=$?
     if [[ $rc -ne 0 ]]; then
         log  "get_commondirs(): failure in configgen call"
@@ -300,7 +302,7 @@ configGenCmd() {
     # Creating logfiles for component
     logDir=$log/${compName}
 
-    configcmd="${configgen_path}/configgen -env ${envfile} -od ${runtime} -id ${componentFile} -c ${compName}"
+    configcmd="${cfggenpre[@]} ${configgen_path}/configgen -env ${envfile} -od ${runtime} -id ${componentFile} -c ${compName}"
     log "$configcmd"
     if [ "$(whoami)" != "${user}" ]; then
         su ${user} -c "$configcmd" 2>/dev/null
@@ -571,15 +573,16 @@ startCmd() {
         if [[ ${RCSTART} -eq 0 ]]; then
             log_success_msg
             return 0;
-        fi
-        checkPidExist $PIDPATH
-        local initRunning=$__pidExists
-        if [[ $initRunning -eq 0 ]]; then
-            log "${compName} failed to start cleanly"
-            log "Refer to the log file for the binary ${compName} for more information"
-            log_failure_msg
-            cleanupRuntimeEnvironment
-            return 1;
+        elif [[ ${RCSTART} -ne 4 ]]; then
+            checkPidExist $PIDPATH
+            local initRunning=$__pidExists
+            if [[ $initRunning -eq 0 ]]; then
+                log "${compName} failed to start cleanly"
+                log "Refer to the log file for the binary ${compName} for more information"
+                log_failure_msg
+                cleanupRuntimeEnvironment
+                return 1;
+            fi
         fi
         sleep 1
     done
@@ -739,7 +742,7 @@ setup_component() {
 create_dropzone() {
     OIFS=${IFS}
     unset IFS
-    dropzones=$(${configgen_path}/configgen -env ${envfile} -listdirs)
+    dropzones=$(${cfggenpre[@]} ${configgen_path}/configgen -env ${envfile} -listdirs)
     rc=$?
     if [[ $rc -ne 0 ]]; then
         log  "create_dropzone(): failure in configgen call"

--- a/initfiles/bash/etc/init.d/init-functions
+++ b/initfiles/bash/etc/init.d/init-functions
@@ -201,7 +201,7 @@ log_timeout_msg () {
 # general logging message for init scripts
 # expects $logfile to exist within the context of where it's called
 log() {
-  if [[ -z ${logfile+x} ]]; then
+  if [[ -z "${logfile}" ]]; then
     # logfile isn't set within the context of this function call
     return 1
   fi
@@ -209,7 +209,8 @@ log() {
   local msg=$@
   local header=$( date +%Y_%m_%d_%H_%M_%S )
   local header="${header}: "
-  (printf "%s%s\n" "$header" "$msg" >> $logfile) 2> /dev/null
+  local thispid=$$
+  (printf "%d %s%s\n" "$thispid" "$header" "$msg" >> $logfile) 2> /dev/null
   if [[ $? -ne 0 ]]; then
     echo "unable to write to ${logfile}" 1>&2
     return 1


### PR DESCRIPTION
Add a lock around configgen so that hpcc-init components can be started/stopped in the background concurrently.

Signed-off-by: Mark Kelly <mark.kelly@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [ ] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

Start / stop many combinations of hpcc-init components.

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
