### PR TITLE
HPCC-19417 CmdGetDir duplicate directory in file path

### DIFF
--- a/common/remote/sockfile.cpp
+++ b/common/remote/sockfile.cpp
@@ -5359,7 +5359,7 @@ public:
                 CDateTime dt;
                 iFile->getTime(nullptr, &dt, nullptr);
                 dt.serialize(reply);
-                reply.append(iFile->queryFilename());
+                reply.append(mask);
                 b = 0;
                 reply.append(b);
             }

--- a/common/remote/sockfile.cpp
+++ b/common/remote/sockfile.cpp
@@ -6635,6 +6635,27 @@ protected:
         iFile2->remove();
         iFile->move(subDirFilePath);
 
+        // open sub-directory file2 explicitly
+        RemoteFilename rfn;
+        rfn.setRemotePath(subDirPath.str());
+        Owned<IFile> dir = createIFile(rfn);
+        Owned<IDirectoryIterator> diriter = dir->directoryFiles("file2");
+        if (!diriter->first())
+        {
+            CPPUNIT_ASSERT_MESSAGE("Error, file2 diriter->first() is null", 0);
+        }
+
+        Linked<IFile> iFile3 = &diriter->query();
+        diriter.clear();
+        dir.clear();
+
+        OwnedIFileIO iFile3IO = iFile3->openShared(IFOread, IFSHfull);
+        if (!iFile3IO)
+        {
+            CPPUNIT_ASSERT_MESSAGE("Error, file2 openShared() failed", 0);
+        }
+        iFile3IO->close();
+
         // count sub-directory files with a wildcard
         unsigned count=0;
         Owned<IDirectoryIterator> iter = subDirIFile->directoryFiles("*2");
@@ -6659,9 +6680,15 @@ protected:
         CPPUNIT_ASSERT(subDirIFile->getTime(&createTime, &modifiedTime, &accessedTime));
         CPPUNIT_ASSERT(modifiedTime == newModifiedTime);
 
-
         // test set file permissions
-        iFile2->setFilePermissions(0777);
+        try
+        {
+            iFile2->setFilePermissions(0777);
+        }
+        catch (...)
+        {
+            CPPUNIT_ASSERT_MESSAGE("iFile2->setFilePermissions() exception", 0);
+        }
     }
     void testConfiguration()
     {


### PR DESCRIPTION
HPCC-18725 update

Signed-off-by: Mark Kelly <mark.kelly@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [x] Existing deployed queries will not be broken
  - [x] This change fixes the problem, not just the symptom
  - [x] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

QA suite passed as expected
Kevin tried to download slave logs from this dafilesrv version

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
