### PR TITLE
HPCC-19463 Add option USE_DIGISIGN

### DIFF
--- a/cmake_modules/commonSetup.cmake
+++ b/cmake_modules/commonSetup.cmake
@@ -114,6 +114,7 @@ IF ("${COMMONSETUP_DONE}" STREQUAL "")
   endif()
   option(LOGGING_SERVICE "Configure use of logging service" ON)
   option(WSSQL_SERVICE "Configure use of ws_sql service" ON)
+  option(USE_DIGISIGN "Use digisign" ON)
 
 
 

--- a/system/security/CMakeLists.txt
+++ b/system/security/CMakeLists.txt
@@ -24,7 +24,9 @@ if (USE_ZLIB)
   HPCC_ADD_SUBDIRECTORY (zcrypt)
 endif()
 
-HPCC_ADD_SUBDIRECTORY (digisign)
+if (USE_DIGISIGN)
+  HPCC_ADD_SUBDIRECTORY (digisign)
+endif()
 
 IF (USE_APR)
   HPCC_ADD_SUBDIRECTORY (plugins/htpasswdSecurity)


### PR DESCRIPTION
This will allow user to turn off Digisign component on Windows Clienttools build
In CMake options provide "-DUSE_DIGISIGN=OFF" to turn off Digisign.

Signed-off-by: Xiaoming Wang <xiaoming.wang@lexisnexi.com> 
@RussWhitehead please review


## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).

## Checklist:
- [x] My code follows the code style of this project.
 - [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [x ] The change has been fully tested:


## Testing:
http://10.240.32.243/job/CE-CT-W32-ds/

