### PR TITLE
HPCC-19508 Fix KJ remote muti packet serialization issue

### DIFF
--- a/thorlcr/activities/keyedjoin/thkeyedjoinslave.cpp
+++ b/thorlcr/activities/keyedjoin/thkeyedjoinslave.cpp
@@ -1062,7 +1062,8 @@ class CKeyedJoinSlave : public CSlaveActivity, implements IJoinProcessor
                 readErrorCode(msg);
                 MemoryBuffer tmpMB;
                 MemoryBuffer &mb = doUncompress(tmpMB, msg);
-                mb.read(handles[selected]);
+                if (0 == received)
+                    mb.read(handles[selected]);
                 unsigned count;
                 mb.read(count); // amount processed, could be all (i.e. numRows)
                 while (count--)
@@ -1338,6 +1339,7 @@ class CKeyedJoinSlave : public CSlaveActivity, implements IJoinProcessor
             // read back results and feed in to appropriate join groups.
             unsigned accepted = 0;
             unsigned rejected = 0;
+
             unsigned received = 0;
             while (true)
             {
@@ -1346,7 +1348,8 @@ class CKeyedJoinSlave : public CSlaveActivity, implements IJoinProcessor
                 readErrorCode(msg);
                 MemoryBuffer tmpMB;
                 MemoryBuffer &mb = doUncompress(tmpMB, msg);
-                mb.read(handles[selected]);
+                if (0 == received)
+                    mb.read(handles[selected]);
                 unsigned count;
                 mb.read(count); // amount processed, could be all (i.e. numRows)
                 if (count)

--- a/thorlcr/slave/slavmain.cpp
+++ b/thorlcr/slave/slavmain.cpp
@@ -741,7 +741,7 @@ class CKJService : public CSimpleInterfaceOf<IKJService>, implements IThreaded, 
                 MemoryBuffer tmpMB;
                 MemoryBuffer &replyMb = activityCtx->useMessageCompression() ? tmpMB : replyMsg;
 
-                replyMb.append(kmc->queryHandle());
+                replyMb.append(kmc->queryHandle()); // NB: not resent if multiple packets, see below
                 DelayedMarker<unsigned> countMarker(replyMb);
                 unsigned rowCount = getRowCount();
                 unsigned rowNum = 0;
@@ -765,6 +765,7 @@ class CKJService : public CSimpleInterfaceOf<IKJService>, implements IThreaded, 
                             break;
                         replyMsg.setLength(startPos);
                         countMarker.restart();
+                        // NB: handle not resent, 1st packet was { errorCode, handle, key-row-count, key-row-data.. }, subsequent packets are { errorCode, key-row-count, key-row-data.. }
                         rowStart = rowNum;
                     }
                     lookupResult.clear();
@@ -885,7 +886,7 @@ class CKJService : public CSimpleInterfaceOf<IKJService>, implements IThreaded, 
                 MemoryBuffer tmpMB;
                 MemoryBuffer &replyMb = activityCtx->useMessageCompression() ? tmpMB : replyMsg;
 
-                replyMb.append(fetchContext->queryHandle());
+                replyMb.append(fetchContext->queryHandle()); // NB: not resent if multiple packets, see below
                 unsigned rowCount = getRowCount();
                 unsigned rowNum = 0;
 
@@ -907,6 +908,7 @@ class CKJService : public CSimpleInterfaceOf<IKJService>, implements IThreaded, 
                         if (last)
                             break;
                         replyMsg.setLength(startPos);
+                        // NB: handle not resent, 1st packet was { errorCode, handle, fetch-row-count, fetch-row-data.. }, subsequent packets are { errorCode, fetch-row-count, fetch-row-data.. }
                         fetchLookupResult.clear();
                     }
                 }


### PR DESCRIPTION
If reponse from a remote kj request was broken into more than
one packet, the client was wrongly re-reading the handle.
This usually caused a stall because of a serializtion issue.

Signed-off-by: Jake Smith <jake.smith@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

Some configuration could hit this issue depending on number of rows sent in request etc.
Tested by reproducing by forcing a case where packet would be split and confirming fix resolved the issue.

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
