### PR TITLE
HPCC-19513 Roxie does not free all static objects on closedown

### DIFF
--- a/roxie/ccd/ccdlistener.cpp
+++ b/roxie/ccd/ccdlistener.cpp
@@ -1850,6 +1850,18 @@ IArrayOf<IHpccProtocolListener> socketListeners;
 MapStringToMyClass<SharedObject> protocolDlls;
 MapStringToMyClass<IHpccProtocolPlugin> protocolPlugins;
 
+MODULE_INIT(INIT_PRIORITY_STANDARD)
+{
+    return true;
+}
+
+MODULE_EXIT()
+{
+    socketListeners.kill();
+    protocolPlugins.kill();
+    protocolDlls.kill();
+}
+
 IHpccProtocolPlugin *ensureProtocolPlugin(IHpccProtocolPluginContext &protocolCtx, const char *soname)
 {
     IHpccProtocolPlugin *plugin = protocolPlugins.getValue(soname ? soname : "native");
@@ -1858,7 +1870,7 @@ IHpccProtocolPlugin *ensureProtocolPlugin(IHpccProtocolPluginContext &protocolCt
     if (!soname)
     {
         Owned<IHpccProtocolPlugin> protocolPlugin = loadHpccProtocolPlugin(&protocolCtx, ensureLimiterFactory());
-        protocolPlugins.setValue("native", protocolPlugin.getLink());
+        protocolPlugins.setValue("native", protocolPlugin);
         return protocolPlugin.getClear();
     }
     Owned<SharedObject> so = new SharedObject();

--- a/roxie/ccd/ccdmain.cpp
+++ b/roxie/ccd/ccdmain.cpp
@@ -1216,6 +1216,7 @@ int STARTQUERY_API start_query(int argc, const char *argv[])
     globalPackageSetManager = NULL;
     stopDelayedReleaser();
     cleanupPlugins();
+    unloadHpccProtocolPlugin();
     closeMulticastSockets();
     releaseSlaveDynamicFileCache();
     releaseRoxieStateCache();
@@ -1223,6 +1224,7 @@ int STARTQUERY_API start_query(int argc, const char *argv[])
     setNodeCaching(false); // ditto
     perfMonHook.clear();
     strdup("Make sure leak checking is working");
+    roxiemem::releaseRoxieHeap();
     UseSysLogForOperatorMessages(false);
     ExitModuleObjects();
     releaseAtoms();

--- a/roxie/ccd/ccdprotocol.cpp
+++ b/roxie/ccd/ccdprotocol.cpp
@@ -2132,5 +2132,10 @@ extern IHpccProtocolPlugin *loadHpccProtocolPlugin(IHpccProtocolPluginContext *c
     return global.getLink();
 }
 
+extern void unloadHpccProtocolPlugin()
+{
+    queryLimiterFactory.clear();
+    global.clear();
+}
 
 //================================================================================================================================

--- a/roxie/ccd/hpccprotocol.hpp
+++ b/roxie/ccd/hpccprotocol.hpp
@@ -142,6 +142,7 @@ interface IHpccProtocolPlugin : extends IInterface
 };
 
 extern IHpccProtocolPlugin *loadHpccProtocolPlugin(IHpccProtocolPluginContext *ctx, IActiveQueryLimiterFactory *limiterFactory);
+extern void unloadHpccProtocolPlugin();
 typedef IHpccProtocolPlugin *(HpccProtocolInstallFunction)(IHpccProtocolPluginContext *ctx, IActiveQueryLimiterFactory *limiterFactory);
 
 

--- a/rtl/eclrtl/eclrtl.cpp
+++ b/rtl/eclrtl/eclrtl.cpp
@@ -33,6 +33,7 @@
 #include "unicode/ucol.h"
 #include "unicode/ustring.h"
 #include "unicode/ucnv.h"
+#include "unicode/uclean.h"
 #include "unicode/schriter.h"
 #include "unicode/regex.h"
 #include "unicode/normlzr.h"
@@ -267,6 +268,7 @@ MODULE_INIT(INIT_PRIORITY_STANDARD)
 MODULE_EXIT()
 {
     delete localeMap;
+    u_cleanup();
 }
 
 RTLLocale * queryRTLLocale(char const * locale)


### PR DESCRIPTION
Signed-off-by: Richard Chapman <rchapman@hpccsystems.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [x] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [x] All new and existing tests passed.
  - [x] I have checked that this change does not introduce memory leaks.
  - [x] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
Ran subset of regression suite under valgrind.
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
