### PR TITLE
HPCC-19544 Clean up CKeyCursor ahead of migration to new field filters

### DIFF
--- a/common/remote/sockfile.cpp
+++ b/common/remote/sockfile.cpp
@@ -4725,7 +4725,7 @@ class CRemoteFileServer : implements IRemoteFileServer, public CInterface
         unsigned pos = reply.length();
         while (keyManager->lookup(true))
         {
-            unsigned size = keyManager->queryRecordSize();
+            unsigned size = keyManager->queryRowSize();
             const byte *result = keyManager->queryKeyBuffer();
             reply.append(size);
             reply.append(size, result);

--- a/rtl/eclrtl/rtlkey.hpp
+++ b/rtl/eclrtl/rtlkey.hpp
@@ -28,7 +28,6 @@ enum KeySegmentMonitorSerializeType
     KSMST_SINGLEBIGSIGNEDKEYSEGMENTMONITOR,
     KSMST_SINGLELITTLESIGNEDKEYSEGMENTMONITOR,
     KSMST_CSINGLELITTLEKEYSEGMENTMONITOR,
-    KSMST_OVERRIDEABLEKEYSEGMENTMONITOR,
     KSMST_max
 };
 
@@ -115,11 +114,6 @@ public:
     virtual bool setOffset(unsigned _offset) = 0;  // Used by old record layout translator - to be removed at some point
 };
 
-interface IOverrideableKeySegmentMonitor  : public IKeySegmentMonitor
-{
-    virtual void setOverrideBuffer(const void *ptr) = 0;
-};
-
 interface IBlobProvider
 {
     virtual byte * lookupBlob(unsigned __int64 id) = 0;         // return reference, not freed by code generator, can dispose once transform() has returned.
@@ -165,8 +159,6 @@ ECLRTL_API IKeySegmentMonitor *createSingleKeySegmentMonitor(bool optional, unsi
 ECLRTL_API IKeySegmentMonitor *createSingleBigSignedKeySegmentMonitor(bool optional, unsigned _fieldIdx, unsigned offset, unsigned size, const void * value);
 ECLRTL_API IKeySegmentMonitor *createSingleLittleSignedKeySegmentMonitor(bool optional, unsigned _fieldIdx, unsigned offset, unsigned size, const void * value);
 ECLRTL_API IKeySegmentMonitor *createSingleLittleKeySegmentMonitor(bool optional, unsigned _fieldIdx, unsigned offset, unsigned size, const void * value);
-
-ECLRTL_API IOverrideableKeySegmentMonitor *createOverrideableKeySegmentMonitor(IKeySegmentMonitor *base);
 
 ECLRTL_API IKeySegmentMonitor *deserializeKeySegmentMonitor(MemoryBuffer &mb);
 ECLRTL_API void deserializeSet(IStringSet & set, size32_t minRecordSize, const RtlTypeInfo * fieldType, const char * filter);

--- a/system/jhtree/ctfile.cpp
+++ b/system/jhtree/ctfile.cpp
@@ -794,7 +794,7 @@ bool CJHTreeNode::getValueAt(unsigned int index, char *dst) const
         {
             //It would make sense to have the fileposition at the start of the row from he perspective of the
             //internal representation, but that would complicate everything else which assumes the keyed
-            //fields start at the begining of the row.
+            //fields start at the beginning of the row.
             if (rowexp.get())
             {
                 rowexp->expandRow(dst,index,sizeof(offset_t),keyLen);


### PR DESCRIPTION
Also remove some unused code, reduce memory footprint of CKeyCursor objects,
and generally clean things up a bit.

Also addresses HPCC-19545 Remove overrideable segmonitor support

Signed-off-by: Richard Chapman <rchapman@hpccsystems.com>
<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [x] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [x] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [x] Performance
  - [ ] Security
  - [x] Thread-safety
  - [x] Premature optimization
  - [x] Existing deployed queries will not be broken
  - [x] This change fixes the problem, not just the symptom
  - [x] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [x] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
Roxie regression suite clean.
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
