### PR TITLE
HPCC-18370 Daliadmin silently quits when xpath ends with /

### DIFF
--- a/dali/daliadmin/daliadmin.cpp
+++ b/dali/daliadmin/daliadmin.cpp
@@ -171,7 +171,10 @@ static const char *splitpath(const char *path,StringBuffer &head,StringBuffer &t
 {
     if (path[0]!='/')
         path = tmp.append('/').append(path).str();
-    return splitXPath(path, head);
+    const char *tail = splitXPath(path, head);
+    if (!tail)
+        throw MakeStringException(0, "Expecting xpath tail node in: %s", path);
+    return tail;
 }
 
 // NB: there's strtoll under Linux
@@ -271,8 +274,6 @@ static void import(const char *path,const char *src,bool add)
     StringBuffer head;
     StringBuffer tmp;
     const char *tail=splitpath(path,head,tmp);
-    if (!tail)
-        return;
     if (!add) {
         Owned<IRemoteConnection> bconn = querySDS().connect(remLeading(path),myProcessSession(),RTM_LOCK_READ|RTM_SUB, daliConnectTimeoutMs);
         if (bconn) {
@@ -330,8 +331,6 @@ static void _delete_(const char *path,bool backup)
     StringBuffer head;
     StringBuffer tmp;
     const char *tail=splitpath(path,head,tmp);
-    if (!tail)
-        return;
     Owned<IRemoteConnection> conn = querySDS().connect(head.str(),myProcessSession(),RTM_LOCK_WRITE, daliConnectTimeoutMs);
     if (!conn) {
         ERRLOG("Could not connect to %s",path);
@@ -364,8 +363,6 @@ static void set(const char *path,const char *val)
     StringBuffer head;
     StringBuffer tmp;
     const char *tail=splitpath(path,head,tmp);
-    if (!tail)
-        return;
     Owned<IRemoteConnection> conn = querySDS().connect(head.str(),myProcessSession(),RTM_LOCK_WRITE, daliConnectTimeoutMs);
     if (!conn) {
         ERRLOG("Could not connect to %s",path);
@@ -389,8 +386,6 @@ static void get(const char *path)
     StringBuffer head;
     StringBuffer tmp;
     const char *tail=splitpath(path,head,tmp);
-    if (!tail)
-        return;
     Owned<IRemoteConnection> conn = querySDS().connect(head.str(),myProcessSession(),RTM_LOCK_READ, daliConnectTimeoutMs);
     if (!conn) {
         ERRLOG("Could not connect to %s",path);
@@ -411,8 +406,6 @@ static void bget(const char *path,const char *outfn)
     StringBuffer head;
     StringBuffer tmp;
     const char *tail=splitpath(path,head,tmp);
-    if (!tail)
-        return;
     Owned<IRemoteConnection> conn = querySDS().connect(head.str(),myProcessSession(),RTM_LOCK_READ, daliConnectTimeoutMs);
     if (!conn) {
         ERRLOG("Could not connect to %s",path);
@@ -480,8 +473,6 @@ static void wget(const char *path)
     StringBuffer head;
     StringBuffer tmp;
     const char *tail=splitpath(path,head,tmp);
-    if (!tail)
-        return;
     Owned<IRemoteConnection> conn = querySDS().connect(head.str(),myProcessSession(),RTM_LOCK_READ, daliConnectTimeoutMs);
     if (!conn) {
         ERRLOG("Could not connect to %s",path);
@@ -527,8 +518,6 @@ static void delv(const char *path)
     StringBuffer head;
     StringBuffer tmp;
     const char *tail=splitpath(path,head,tmp);
-    if (!tail)
-        return;
     Owned<IRemoteConnection> conn = querySDS().connect(head.str(),myProcessSession(),RTM_LOCK_WRITE, daliConnectTimeoutMs);
     if (!conn) {
         ERRLOG("Could not connect to %s",path);


### PR DESCRIPTION
- Print a warning message when the xpath is longer than 1 and ends with '/'

Signed-off-by: mayx <yanrui.ma@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [x] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [x] All new and existing tests passed.
  - [x] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [x] Scalability
  - [x] Performance
  - [x] Security
  - [x] Thread-safety
  - [x] Premature optimization
  - [x] Existing deployed queries will not be broken
  - [x] This change fixes the problem, not just the symptom
  - [x] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [x] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
