### PR TITLE
HPCC-19597 Pass CMake OPENSSL options to Couchbase CMake call

### DIFF
--- a/plugins/couchbase/CMakeLists.txt
+++ b/plugins/couchbase/CMakeLists.txt
@@ -35,10 +35,31 @@ IF ( COUCHBASEEMBED )
         set(LIBCOUCHBASE_LIB_SONAME ${CMAKE_CURRENT_BINARY_DIR}/libcouchbase-build/lib/libcouchbase.so.2)
         set(LIBCOUCHBASE_LIB_REAL ${CMAKE_CURRENT_BINARY_DIR}/libcouchbase-build/lib/libcouchbase.so.2.0.38)
     endif()
+
+    set(SSL_INC "")
+    if (OPENSSL_INCLUDE_DIR)
+       set (SSL_INC "-DOPENSSL_INCLUDE_DIR=${OPENSSL_INCLUDE_DIR}")
+    endif()
+
+    set(SSL_LIB "")
+    if (OPENSSL_LIBRARIES)
+       set (SSL_LIB "-DOPENSSL_LIBRARIES=${OPENSSL_LIBRARIES}")
+    endif()
+
+    set(SSL2_LIB "")
+    if (OPENSSL_SSL_LIBRARY)
+       set (SSL2_LIB "-DOPENSSL_SSL_LIBRARY=${OPENSSL_SSL_LIBRARY}")
+    endif()
+
+    set(CYP_LIB "")
+    if (OPENSSL_CRYPTO_LIBRARY)
+       set (CYP_LIB "-DOPENSSL_CRYPTO_LIBRARY=${OPENSSL_CRYPTO_LIBRARY}")
+    endif()
+
     add_custom_command(
         OUTPUT ${LIBCOUCHBASE_LIB}
         COMMAND mkdir -p ${CMAKE_CURRENT_BINARY_DIR}/libcouchbase-build
-        COMMAND cd ${CMAKE_CURRENT_BINARY_DIR}/libcouchbase-build && ${CMAKE_COMMAND} ${CMAKE_CURRENT_SOURCE_DIR}/libcouchbase && ${CMAKE_MAKE_PROGRAM}
+        COMMAND cd ${CMAKE_CURRENT_BINARY_DIR}/libcouchbase-build && ${CMAKE_COMMAND} ${SSL2_LIB} ${SSL_INC} ${SSL_LIB}  ${CMAKE_CURRENT_SOURCE_DIR}/libcouchbase && ${CMAKE_MAKE_PROGRAM}
         COMMENT Building libcouchbase for import)
     add_custom_target(libcouchbase-build ALL DEPENDS ${LIBCOUCHBASE_LIB})
     add_library(libcouchbase SHARED IMPORTED)


### PR DESCRIPTION
 Couchbase cannot build with Openssl 1.1. Like HPCC it need to use Openssl 1.0.2 instead for now.
Top cmake call will pass followings 
      -DOPENSSL_INCLUDE_DIR=/usr/local/ssl/include 
      -DOPENSSL_CRYPTO_LIBRARY=/usr/local/ssl/lib/libcrypto.so
      -DOPENSSL_LIBRARIES=/usr/local/ssl/lib/libssl.so 
      -DOPENSSL_SSL_LIBRARY=/usr/local/ssl/lib/libssl.so
/usr/local/ssl is openssl 1.0.2
This is mainly for Ubuntu 18.04 which has Openssl 1.1 dev package. It does have both 1.0.2 and 1.1.0 runtime packages so we don't need ship Openssl 1.0.2 libraries.
I cannot find a easy way to just pass a OPENSSL library directory.  Maybe others can suggest a better way to do it. 
There are at least three projects depend on OpenSSL:  HPCC, Cassandra and Couchbase

Signed-off-by: Xiaoming Wang <xiaoming.wang@lexisnexi.com>
@Michael-Gardner please help to review it.


 

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [x] The change has been fully tested:
 
## Testing:
http://10.240.32.243/view/custom/job/CE-JIRA-19597-Couchbase-Openssl/
