### PR TITLE
HPCC-19601 Connect logMsgManager only when dali is available

### DIFF
--- a/esp/platform/espcfg.cpp
+++ b/esp/platform/espcfg.cpp
@@ -34,6 +34,7 @@
 #include "espcfg.ipp"
 #include "xslprocessor.hpp" 
 #include "espcontext.hpp"
+#include "mplog.hpp"
 
 #include <dalienv.hpp>
 
@@ -528,6 +529,10 @@ void CEspConfig::initDali(const char *servers)
 
         serverstatus = new CSDSServerStatus("ESPserver");
         ensureSDSSessionDomains();
+
+        // for auditing
+        startLogMsgParentReceiver();
+        connectLogMsgManagerToDali();
     }
 }
 
@@ -1042,6 +1047,7 @@ bool CEspConfig::detachESPFromDali(bool force)
             iter++;
         }
         setIsDetachedFromDali(true);
+        disconnectLogMsgManagerFromDali();
         closedownClientProcess();
         saveAttachState();
     }

--- a/esp/platform/espp.cpp
+++ b/esp/platform/espp.cpp
@@ -44,7 +44,6 @@
 #include "esplog.hpp"
 #include "espcontext.hpp"
 #include "build-config.h"
-#include "mplog.hpp"
 
 #ifdef _WIN32
 /*******************************************
@@ -395,10 +394,6 @@ int init_main(int argc, char* argv[])
 
         writeSentinelFile(sentinelFile);
 
-        // for auditing
-        startLogMsgParentReceiver();
-        connectLogMsgManagerToDali();
-
         result = work_main(*config, *server.get());
     }
     else
@@ -419,7 +414,6 @@ int main(int argc, char* argv[])
 {
     start_init_main(argc, argv, init_main);
     stopPerformanceMonitor();
-    disconnectLogMsgManagerFromDali();
     UseSysLogForOperatorMessages(false);
     releaseAtoms();
     return 0;

--- a/esp/services/ws_dfu/ws_dfuService.cpp
+++ b/esp/services/ws_dfu/ws_dfuService.cpp
@@ -1386,6 +1386,9 @@ inline void doDeleteSubFiles(StringArray &files, IUserDescriptor *userdesc, Stri
 
 bool CWsDfuEx::DFUDeleteFiles(IEspContext &context, IEspDFUArrayActionRequest &req, IEspDFUArrayActionResponse &resp)
 {
+    if (isDetachedFromDali())
+        throw MakeStringException(ECLWATCH_INVALID_INPUT, "ESP server is detached from Dali. Please try later.");
+
     double version = context.getClientVersion();
     Owned<IUserDescriptor> userdesc;
     const char *username = context.queryUserId();

--- a/esp/services/ws_dfu/ws_dfuService.hpp
+++ b/esp/services/ws_dfu/ws_dfuService.hpp
@@ -134,6 +134,8 @@ private:
     Mutex m_superfilemutex;
     unsigned nodeGroupCacheTimeout;
     Owned<CThorNodeGroupCache> thorNodeGroupCache;
+    bool m_daliDetached = false;
+    SpinLock m_daliDetachedStateLock;
 
 public:
     IMPLEMENT_IINTERFACE;
@@ -225,6 +227,26 @@ private:
     void getFilePartsOnClusters(IEspContext &context, const char* clusterReq, StringArray& clusters, IDistributedFile* df, IEspDFUFileDetail& FileDetails,
         offset_t& mn, offset_t& mx, offset_t& sum, offset_t& count);
     bool getQueryFile(const char *logicalName, const char *querySet, const char *queryID, IEspDFUFileDetail &fileDetails);
+    bool attachServiceToDali() override
+    {
+        SpinBlock b(m_daliDetachedStateLock);
+        m_daliDetached = false;
+        return true;
+    }
+
+    bool detachServiceFromDali() override
+    {
+        SpinBlock b(m_daliDetachedStateLock);
+        m_daliDetached = true;
+        return true;
+    }
+
+    bool isDetachedFromDali()
+    {
+        SpinBlock b(m_daliDetachedStateLock);
+        return m_daliDetached;
+    }
+
 private:
     bool         m_disableUppercaseTranslation;
     StringBuffer m_clusterName;


### PR DESCRIPTION
- Moves dali log manager connection from esp main to initdali section
- Moves the disconnectLogMsgManagerFromDali() call to detachESPFromDali()
- Adds synchronized check for dali attach state in WsDfu.DFUDeleteFiles()

Signed-off-by: Rodrigo Pastrana <rodrigo.pastrana@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [x] Scalability
  - [x] Performance
  - [ ] Security
  - [x] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
