### PR TITLE
HPCC-19633 Skip OPENSSL for digisign on APPLE

### DIFF
--- a/system/security/digisign/digisign.cpp
+++ b/system/security/digisign/digisign.cpp
@@ -15,7 +15,7 @@
     limitations under the License.
 ############################################################################## */
 #include "jliball.hpp"
-#if defined(_USE_OPENSSL) && !defined(_WIN32)
+#if defined(_USE_OPENSSL) && !defined(_WIN32) && !defined(__APPLE__)
 #include <openssl/pem.h>
 #include <openssl/err.h>
 #include <openssl/evp.h>
@@ -25,7 +25,7 @@
 #include <mutex>
 
 
-#if defined(_USE_OPENSSL) && !defined(_WIN32)
+#if defined(_USE_OPENSSL) && !defined(_WIN32) && !defined(__APPLE__)
 
 #define EVP_CLEANUP(key,ctx) EVP_PKEY_free(key);       \
                              EVP_MD_CTX_destroy(ctx);


### PR DESCRIPTION
We can't turn off OpenSSL since libcrypto and maybe other HPCC components require it.

Signed-off-by: Xiaoming Wang <xiaoming.wang@lexisnexi.com> 
@RussWhitehead please help to review

## Type of change:
- [x] This change is a new feature (non-breaking change which adds functionality).

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.

## Testing:
http://10.240.32.243/view/Nightly_Builds/job/CE-Candidate-Clienttools-OSX-master-Nightly-Build/
