### PR TITLE
HPCC-19717 standardize StringBuffer methods to size_t

### DIFF
--- a/system/jlib/jstring.hpp
+++ b/system/jlib/jstring.hpp
@@ -39,16 +39,16 @@ public:
     StringBuffer(String & value);
     StringBuffer(const char *value);
     StringBuffer(StringBuffer && value);
-    StringBuffer(unsigned len, const char *value);
+    StringBuffer(size_t len, const char *value);
     StringBuffer(const StringBuffer & value);
     StringBuffer(bool useInternal);
     StringBuffer(char value);
     ~StringBuffer();
 
-    inline size32_t length() const                      { return curLen; }
+    inline size32_t length() const                      { return (size32_t)curLen; }
     inline bool     isEmpty() const                     { return (curLen == 0); }
-    void            setLength(unsigned len);
-    inline void     ensureCapacity(unsigned max)        { if (maxLen <= curLen + max) _realloc(curLen + max); }
+    void            setLength(size_t len);
+    inline void     ensureCapacity(size_t max)        { if (maxLen <= curLen + max) _realloc(curLen + max); }
     size32_t        lengthUtf8() const;
 
     StringBuffer &  append(char value);
@@ -57,7 +57,7 @@ public:
     StringBuffer &  append(const unsigned char * value);
     StringBuffer &  append(const IAtom * value);
     StringBuffer &  append(size_t len, const char * value);
-    StringBuffer &  append(const char * value, int offset, int len);
+    StringBuffer &  append(const char * value, size_t offset, size_t len);
     StringBuffer &  append(double value);
     StringBuffer &  append(float value);
     StringBuffer &  append(int value);
@@ -67,34 +67,34 @@ public:
     StringBuffer &  append(const String & value);
     StringBuffer &  append(const IStringVal & value);
     StringBuffer &  append(const IStringVal * value);
-    StringBuffer &  appendN(size32_t count, char fill);
+    StringBuffer &  appendN(size_t count, char fill);
     StringBuffer &  appendf(const char *format, ...) __attribute__((format(printf, 2, 3)));
-    StringBuffer &  appendLower(unsigned len, const char * value);
+    StringBuffer &  appendLower(size_t len, const char * value);
     StringBuffer &  appendLower(const char * value) { return appendLower(strlen(value), value); }
 
     StringBuffer &  setf(const char* format, ...) __attribute__((format(printf,2,3)));
-    StringBuffer &  limited_valist_appendf(unsigned szLimit, const char *format, va_list args) __attribute__((format(printf,3,0)));
+    StringBuffer &  limited_valist_appendf(size_t szLimit, const char *format, va_list args) __attribute__((format(printf,3,0)));
     inline StringBuffer &valist_appendf(const char *format, va_list args) __attribute__((format(printf,2,0))) { return limited_valist_appendf(0, format, args); }
     StringBuffer &  appendhex(unsigned char value, char lower);
-    inline char     charAt(size32_t pos) { return buffer[pos]; }
+    inline char     charAt(size_t pos) { return buffer[pos]; }
     inline StringBuffer & clear() { curLen = 0; return *this; }
     void            kill();
-    void            getChars(int srcBegin, int srcEnd, char * target) const;
-    StringBuffer &  insert(int offset, char value);
-    StringBuffer &  insert(int offset, unsigned char value);
-    StringBuffer &  insert(int offset, const char * value);
-    StringBuffer &  insert(int offset, const unsigned char * value);
-    StringBuffer &  insert(int offset, double value);
-    StringBuffer &  insert(int offset, float value);
-    StringBuffer &  insert(int offset, int value);
-    StringBuffer &  insert(int offset, unsigned value);
-    StringBuffer &  insert(int offset, __int64 value);
-    StringBuffer &  insert(int offset, const String & value);
-    StringBuffer &  insert(int offset, const StringBuffer & value);
-    StringBuffer &  insert(int offset, const IStringVal & value);
-    StringBuffer &  insert(int offset, const IStringVal * value);
+    void            getChars(size_t srcBegin, size_t srcEnd, char * target) const;
+    StringBuffer &  insert(size_t offset, char value);
+    StringBuffer &  insert(size_t offset, unsigned char value);
+    StringBuffer &  insert(size_t offset, const char * value);
+    StringBuffer &  insert(size_t offset, const unsigned char * value);
+    StringBuffer &  insert(size_t offset, double value);
+    StringBuffer &  insert(size_t offset, float value);
+    StringBuffer &  insert(size_t offset, int value);
+    StringBuffer &  insert(size_t offset, unsigned value);
+    StringBuffer &  insert(size_t offset, __int64 value);
+    StringBuffer &  insert(size_t offset, const String & value);
+    StringBuffer &  insert(size_t offset, const StringBuffer & value);
+    StringBuffer &  insert(size_t offset, const IStringVal & value);
+    StringBuffer &  insert(size_t offset, const IStringVal * value);
     StringBuffer &  reverse();
-    void            setCharAt(unsigned offset, char value);
+    void            setCharAt(size_t offset, char value);
 
     //Non-standard functions:
     MemoryBuffer &  deserialize(MemoryBuffer & in);
@@ -104,26 +104,26 @@ public:
 
     StringBuffer &  append(const StringBuffer & value);
     StringBuffer &  newline();
-    StringBuffer &  pad(unsigned count);
-    StringBuffer &  padTo(unsigned count);
+    StringBuffer &  pad(size_t count);
+    StringBuffer &  padTo(size_t count);
     char *          detach();
     StringBuffer &  clip();
     StringBuffer &  trim();
     StringBuffer &  trimLeft();
     inline StringBuffer &  trimRight() {  return clip(); }
-    StringBuffer &  remove(unsigned start, unsigned len);
-    const char *   str() const;
+    StringBuffer &  remove(size_t start, size_t len);
+    const char *    str() const;
     StringBuffer &  toLowerCase();
     StringBuffer &  toUpperCase();
     StringBuffer &  replace(char oldChar, char newChar);
     StringBuffer &  replaceString(const char* oldStr, const char* newStr);
     StringBuffer &  replaceStringNoCase(const char* oldStr, const char* newStr);
-    char *          reserve(size32_t size);
-    char *          reserveTruncate(size32_t size);
+    char *          reserve(size_t size);
+    char *          reserveTruncate(size_t size);
     void            setown(StringBuffer &other);
     StringBuffer &  stripChar(char oldChar);
     void            swapWith(StringBuffer &other);
-    void setBuffer(size32_t buffLen, char * newBuff, size32_t strLen);
+    void setBuffer(size_t buffLen, char * newBuff, size_t strLen);
 
     inline StringBuffer& set(const char* value) { return clear().append(value); }
     inline operator const char* () const { return str(); }
@@ -143,7 +143,7 @@ public:
 private: // long depreciated
     StringBuffer &  append(long value);
     StringBuffer &  append(unsigned long value);
-    StringBuffer &  insert(int offset, long value);
+    StringBuffer &  insert(size_t offset, long value);
 
 protected:
     inline bool useInternal() const { return buffer == internalBuffer; }
@@ -160,14 +160,14 @@ protected:
         maxLen = 0;
     }
     void freeBuffer();
-    void _insert(unsigned offset, size32_t insertLen);
-    void _realloc(size32_t newLen);
+    void _insert(size_t offset, size_t insertLen);
+    void _realloc(size_t newLen);
 
 private:    
     char                internalBuffer[InternalBufferSize];
     char *              buffer;
-    size32_t            curLen;
-    size32_t            maxLen;
+    size_t              curLen;
+    size_t              maxLen;
 };
 
 // add a variable-parameter constructor to StringBuffer.
@@ -320,7 +320,7 @@ public:
     virtual unsigned length() const { return buffer.length(); };
 
 private:
-    size32_t initsize;
+    size_t initsize;
     StringBuffer & buffer;
 };
 
@@ -401,7 +401,7 @@ extern jlib_decl void decodeXML(ISimpleReadStream &in, StringBuffer &out, unsign
 extern jlib_decl int utf8CharLen(unsigned char ch);
 extern jlib_decl int utf8CharLen(const unsigned char *ch, unsigned maxsize = (unsigned)-1);
 
-extern jlib_decl StringBuffer &replaceString(StringBuffer & result, size32_t lenSource, const char *source, size32_t lenOldStr, const char* oldStr, size32_t lenNewStr, const char* newStr);
+extern jlib_decl StringBuffer &replaceString(StringBuffer & result, size_t lenSource, const char *source, size_t lenOldStr, const char* oldStr, size_t lenNewStr, const char* newStr);
 
 inline const char *encodeUtf8XML(const char *x, StringBuffer &ret, unsigned flags=false, unsigned len=(unsigned)-1)
 {


### PR DESCRIPTION
Signed-off-by: Jake Smith <jake.smith@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [x] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
