### PR TITLE
HPCC-19730 Add information about bloom fields to file metadata in Dali

### DIFF
--- a/ecl/hthor/hthor.cpp
+++ b/ecl/hthor/hthor.cpp
@@ -1248,6 +1248,17 @@ void CHThorIndexWriteActivity::execute()
     }
     // New record layout info
     setRtlFormat(properties, helper.queryDiskRecordSize());
+    // Bloom info
+    const IBloomBuilderInfo * const *bloomFilters = helper.queryBloomInfo();
+    while (bloomFilters && *bloomFilters)
+    {
+        const IBloomBuilderInfo *info = *bloomFilters++;
+        IPropertyTree *bloom = properties.addPropTree("Bloom");
+        bloom->setPropInt64("@bloomFieldMask", info->getBloomFields());
+        bloom->setPropInt64("@bloomLimit", info->getBloomLimit());  // MORE - if we didn't actually build because of the limit that might be interesting. Though that's going to vary by part.
+        VStringBuffer pval("%f", info->getBloomProbability());
+        bloom->setProp("@bloomProbability", pval.str());
+    }
 
     StringBuffer lfn;
     Owned<IDistributedFile> dfile = NULL;

--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -12333,6 +12333,17 @@ public:
         }
         // New record layout info
         setRtlFormat(properties, helper.queryDiskRecordSize());
+        // Bloom info
+        const IBloomBuilderInfo * const *bloomFilters = helper.queryBloomInfo();
+        while (bloomFilters && *bloomFilters)
+        {
+            const IBloomBuilderInfo *info = *bloomFilters++;
+            IPropertyTree *bloom = properties.addPropTree("Bloom");
+            bloom->setPropInt64("@bloomFieldMask", info->getBloomFields());
+            bloom->setPropInt64("@bloomLimit", info->getBloomLimit());  // MORE - if we didn't actually build because of the limit that might be interesting. Though that's going to vary by part.
+            VStringBuffer pval("%f", info->getBloomProbability());
+            bloom->setProp("@bloomProbability", pval.str());
+        }
     }
 
     IUserDescriptor *queryUserDescriptor() const

--- a/thorlcr/activities/indexwrite/thindexwrite.cpp
+++ b/thorlcr/activities/indexwrite/thindexwrite.cpp
@@ -264,6 +264,16 @@ public:
                 if (helper->getPartitionFieldMask())
                     props.setPropInt64("@partitionFieldMask", helper->getPartitionFieldMask());
             }
+            const IBloomBuilderInfo * const *bloomFilters = helper->queryBloomInfo();
+            while (bloomFilters && *bloomFilters)
+            {
+                const IBloomBuilderInfo *info = *bloomFilters++;
+                IPropertyTree *bloom = props.addPropTree("Bloom");
+                bloom->setPropInt64("@bloomFieldMask", info->getBloomFields());
+                bloom->setPropInt64("@bloomLimit", info->getBloomLimit());  // MORE - if we didn't actually build because of the limit that might be interesting. Though that's going to vary by part.
+                VStringBuffer pval("%f", info->getBloomProbability());
+                bloom->setProp("@bloomProbability", pval.str());
+            }
             container.queryTempHandler()->registerFile(fileName, container.queryOwner().queryGraphId(), 0, false, WUFileStandard, &clusters);
             if (!dlfn.isExternal())
                 queryThorFileManager().publish(container.queryJob(), fileName, *fileDesc);


### PR DESCRIPTION
Note that it indicates whether a bloom filter was requested, not whether it
was actually created (which would be a per-part property).

Signed-off-by: Richard Chapman <rchapman@hpccsystems.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [ ] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
Examined dali metadata after running regression suite setup.
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
