### PR TITLE
HPCC-19738  Suppress REMBED build warnning

### DIFF
--- a/plugins/Rembed/CMakeLists.txt
+++ b/plugins/Rembed/CMakeLists.txt
@@ -43,6 +43,8 @@ if(REMBED)
             ./../../system/mp
             ./../../system/jlib)
 
+        set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-error=format-nonliteral")
+        set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=format-nonliteral")
         set_property (SOURCE Rembed.cpp APPEND_STRING PROPERTY COMPILE_FLAGS " -Wno-format-nonliteral")
         add_definitions(-D_USRDLL -DREMBED_EXPORTS)
         if(RCPP_LIBRARY STREQUAL "")


### PR DESCRIPTION
Suppress build warning "format not a string literal, format string not checked"
Signed-off-by: Xiaoming Wang <xiaoming.wang@lexisnexi.com> 

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [x] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.

## Testing:
<!-- Please describe how this change has been tested.-->
http://10.240.32.243/job/CE-Plugins-Ubuntu18.04/CE=ubuntu-18.04-amd64/16/


<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
