### PR TITLE
HPCC-19805 Report authentication failures in ESP TxSummary

### DIFF
--- a/esp/bindings/SOAP/Platform/soapservice.cpp
+++ b/esp/bindings/SOAP/Platform/soapservice.cpp
@@ -112,7 +112,11 @@ int CSoapService::processHeader(CHeader* header, IEspContext* ctx)
     if (returnValue == 0)
     {
         if (authenticated)
+        {
+            if (ctx->toBeAuthenticated())
+                ctx->setAuthStatus(AUTH_STATUS_OK); //May be changed to AUTH_STATUS_NOACCESS if failed in feature level authorization.
             return 0;
+        }
         returnValue = SOAP_AUTHENTICATION_REQUIRED;
     }
 
@@ -124,6 +128,7 @@ int CSoapService::processHeader(CHeader* header, IEspContext* ctx)
         msg.append(" User authentication failed");
     else
         msg.append(" User authentication required");
+    ctx->setAuthStatus(AUTH_STATUS_FAIL);
     DBGLOG("%s", msg.str());
 
     return returnValue;

--- a/esp/bindings/http/platform/httptransport.cpp
+++ b/esp/bindings/http/platform/httptransport.cpp
@@ -600,6 +600,9 @@ int CHttpMessage::readContentTillSocketClosed()
 
 int CHttpMessage::receive(bool alwaysReadContent, IMultiException *me)
 {
+    //Set the auth to AUTH_STATUS_NA as default. Later on, it may be changed to
+    //other value (AUTH_STATUS_OK, AUTH_STATUS_FAIL, etc) when applicable.
+    m_context->addTraceSummaryValue(LogMin, "auth", AUTH_STATUS_NA);
     if (processHeaders(me)==-1)
         return -1;
 

--- a/esp/platform/espcontext.cpp
+++ b/esp/platform/espcontext.cpp
@@ -79,6 +79,7 @@ private:
     bool        m_hasException;
     int         m_exceptionCode;
     StringAttr  respMsg;
+    StringAttr  authStatus = AUTH_STATUS_NA;
     StringAttr  authenticationMethod;
     AuthType    domainAuthType;
     AuthError   authError = EspAuthErrorNone;
@@ -493,7 +494,10 @@ public:
     {
         updateTraceSummaryHeader();
         if (m_txSummary && (getTxSummaryLevel() >= LogMin))
+        {
+            m_txSummary->set("auth", authStatus.get());
             m_txSummary->append("total", m_processingTime, "ms");
+        }
     }
     virtual void addTraceSummaryCumulativeTime(LogLevel logLevel, const char* name, unsigned __int64 time)
     {
@@ -511,6 +515,11 @@ public:
 
         m_txSummary->clear();
         m_txSummary.clear();
+    }
+
+    virtual void setAuthStatus(const char* status)
+    {
+        authStatus.set(status);
     }
 
     virtual void setAuthenticationMethod(const char* method)

--- a/esp/platform/espcontext.hpp
+++ b/esp/platform/espcontext.hpp
@@ -46,6 +46,10 @@ static const char* const SESSION_AUTH_MSG_COOKIE = "ESPAuthenticationMSG";
 static const char* const DEFAULT_LOGIN_URL = "/esp/files/Login.html";
 static const char* const DEFAULT_GET_USER_NAME_URL = "/esp/files/GetUserName.html";
 static const char* const DEFAULT_UNRESTRICTED_RESOURCES = "/favicon.ico,/esp/files/*,/esp/xslt/*";
+static const char* const AUTH_STATUS_NA = "NA";
+static const char* const AUTH_STATUS_FAIL = "Fail";
+static const char* const AUTH_STATUS_OK = "Ok";
+static const char* const AUTH_STATUS_NOACCESS = "NoAccess"; //failed for feature level authorization
 
 //xpath in dali
 static const char* const PathSessionRoot="Sessions";

--- a/esp/scm/esp.ecm
+++ b/esp/scm/esp.ecm
@@ -199,6 +199,7 @@ interface IEspContext : extends IInterface
     virtual AuthType getDomainAuthType()=0;
     virtual void setAuthError(AuthError error)=0;
     virtual AuthError getAuthError()=0;
+    virtual void setAuthStatus(const char * status)=0;
     virtual const char * getRespMsg()=0;
     virtual void setRespMsg(const char * msg)=0;
 };

--- a/esp/services/esdl_svc_engine/esdl_binding.cpp
+++ b/esp/services/esdl_svc_engine/esdl_binding.cpp
@@ -1554,6 +1554,7 @@ int EsdlBindingImpl::HandleSoapRequest(CHttpRequest* request,
     IEspContext *ctx = request->queryContext();
     if(ctx->toBeAuthenticated()) //no HTTP basic auth info?
     {
+        ctx->setAuthStatus(AUTH_STATUS_FAIL);
         response->sendBasicChallenge("ESP", false);
         return 0;
     }

--- a/esp/services/ws_access/ws_accessService.cpp
+++ b/esp/services/ws_access/ws_accessService.cpp
@@ -46,12 +46,18 @@ void checkUser(IEspContext& context, const char* rtype = NULL, const char* rtitl
     if (rtype && rtitle && strieq(rtype, FILE_SCOPE_RTYPE) && strieq(rtitle, FILE_SCOPE_RTITLE))
     {
         if (!context.validateFeatureAccess(FILE_SCOPE_URL, SecAccessFlags, false))
+        {
+            context.setAuthStatus(AUTH_STATUS_NOACCESS);
             throw MakeStringException(ECLWATCH_DFU_WU_ACCESS_DENIED, "Access to File Scope is denied.");
+        }
         return;
     }
 
     if(!secmgr->isSuperUser(context.queryUser()))
+    {
+        context.setAuthStatus(AUTH_STATUS_NOACCESS);
         throw MakeStringException(ECLWATCH_ADMIN_ACCESS_DENIED, "Access denied, administrators only.");
+    }
 }
 
 void Cws_accessEx::init(IPropertyTree *cfg, const char *process, const char *service)

--- a/esp/services/ws_ecl/ws_ecl_service.cpp
+++ b/esp/services/ws_ecl/ws_ecl_service.cpp
@@ -2806,6 +2806,7 @@ int CWsEclBinding::HandleSoapRequest(CHttpRequest* request, CHttpResponse* respo
 
     if(ctx->toBeAuthenticated()) //future support WsSecurity tags?
     {
+        ctx->setAuthStatus(AUTH_STATUS_FAIL);
         response->sendBasicChallenge(getChallengeRealm(), false);
         return 0;
     }


### PR DESCRIPTION
The code is added to report authentication failures into ESP
TxSummary. The 'auth' tag in the TxSummary indicates the
authentication/authorization status of the ESP request: NA -
no authentication/authorization needed, Fail - failed in
authentication, NoAccess - failed in feature level authorization,
Ok - authenticated and authorized.

This fix also has the code to report feature level authorization
for ESP ws_access service. Similar code will be added for other
ESP services in other PRs.

Signed-off-by: wangkx <kevin.wang@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
