### PR TITLE
HPCC-18148 Std.Date: Fix handling of of local time and DST

### DIFF
--- a/ecllibrary/std/Date.ecl
+++ b/ecllibrary/std/Date.ecl
@@ -173,13 +173,16 @@ EXPORT Seconds_t SecondsFromParts(INTEGER2 year,
  * Gregorian calendar after the year 1600.
  *
  * @param seconds               The number of seconds since epoch.
+ * @param is_local_time         TRUE if seconds is expressed in local time
+ *                              rather than UTC, FALSE if seconds is expressed
+ *                              in UTC.  Optional, defaults to FALSE.
  * @return                      Module with exported attributes for year, month,
  *                              day, hour, minute, second, day_of_week, date
  *                              and time.
  */
 
-EXPORT SecondsToParts(Seconds_t seconds) := FUNCTION
-    parts := ROW(TimeLib.SecondsToParts(seconds));
+EXPORT SecondsToParts(Seconds_t seconds, BOOLEAN is_local_time = FALSE) := FUNCTION
+    parts := ROW(TimeLib.SecondsToParts(seconds, is_local_time));
 
     result := MODULE
         EXPORT INTEGER2 year := parts.year + 1900;
@@ -1065,7 +1068,8 @@ EXPORT BOOLEAN IsLocalDaylightSavingsInEffect() :=
  * Returns the offset (in seconds) of the time represented from UTC, with
  * positive values indicating locations east of the Prime Meridian.  Given a
  * UTC time in seconds since epoch, you can find the local time by adding the
- * result of this function to the seconds.
+ * result of this function to the seconds.  Note that daylight savings time is
+ * factored into the offset.
  *
  * @return              The number of seconds offset from UTC.
  */
@@ -1262,12 +1266,16 @@ END;
 /**
  * A transform to create a Date_rec from a Seconds_t value.
  *
- * @param seconds       The number seconds since epoch.
- * @return              A transform that creates a Date_rec containing the date.
+ * @param seconds               The number seconds since epoch.
+ * @param is_local_time         TRUE if seconds is expressed in local time
+ *                              rather than UTC, FALSE if seconds is expressed
+ *                              in UTC.  Optional, defaults to FALSE.
+ * @return                      A transform that creates a Date_rec containing
+ *                              the date.
  */
 
-EXPORT Date_rec CreateDateFromSeconds(Seconds_t seconds) := TRANSFORM
-    timeParts := SecondsToParts(seconds);
+EXPORT Date_rec CreateDateFromSeconds(Seconds_t seconds, BOOLEAN is_local_time = FALSE) := TRANSFORM
+    timeParts := SecondsToParts(seconds, is_local_time);
 
     SELF.year := timeParts.year;
     SELF.month := timeParts.month;
@@ -1294,12 +1302,16 @@ END;
 /**
  * A transform to create a Time_rec from a Seconds_t value.
  *
- * @param seconds       The number seconds since epoch.
- * @return              A transform that creates a Time_rec containing the time of day.
+ * @param seconds               The number seconds since epoch.
+ * @param is_local_time         TRUE if seconds is expressed in local time
+ *                              rather than UTC, FALSE if seconds is expressed
+ *                              in UTC.  Optional, defaults to FALSE.
+ * @return                      A transform that creates a Time_rec containing
+ *                              the time of day.
  */
 
-EXPORT Time_rec CreateTimeFromSeconds(Seconds_t seconds) := TRANSFORM
-    timeParts := SecondsToParts(seconds);
+EXPORT Time_rec CreateTimeFromSeconds(Seconds_t seconds, BOOLEAN is_local_time = FALSE) := TRANSFORM
+    timeParts := SecondsToParts(seconds, is_local_time);
 
     SELF.hour := timeParts.hour;
     SELF.minute := timeParts.minute;
@@ -1338,13 +1350,16 @@ END;
 /**
  * A transform to create a DateTime_rec from a Seconds_t value.
  *
- * @param seconds       The number seconds since epoch.
- * @return              A transform that creates a DateTime_rec containing
- *                      date and time components.
+ * @param seconds               The number seconds since epoch.
+ * @param is_local_time         TRUE if seconds is expressed in local time
+ *                              rather than UTC, FALSE if seconds is expressed
+ *                              in UTC.  Optional, defaults to FALSE.
+ * @return                      A transform that creates a DateTime_rec
+ *                              containing date and time components.
  */
 
-EXPORT DateTime_rec CreateDateTimeFromSeconds(Seconds_t seconds) := TRANSFORM
-    timeParts := SecondsToParts(seconds);
+EXPORT DateTime_rec CreateDateTimeFromSeconds(Seconds_t seconds, BOOLEAN is_local_time = FALSE) := TRANSFORM
+    timeParts := SecondsToParts(seconds, is_local_time);
 
     SELF.year := timeParts.year;
     SELF.month := timeParts.month;

--- a/ecllibrary/teststd/Date/TestDate.ecl
+++ b/ecllibrary/teststd/Date/TestDate.ecl
@@ -7,9 +7,12 @@ IMPORT Std.Date;
 
 EXPORT TestDate := MODULE
 
-  SHARED vCreateDateTimeFromSeconds := ROW(Date.CreateDateTimeFromSeconds(917872496)); // Feb 1, 1999 @ 12:34:56
-  SHARED vCreateDateFromSeconds := ROW(Date.CreateDateFromSeconds(917872496)); // Feb 1, 1999
-  SHARED vCreateTimeFromSeconds := ROW(Date.CreateTimeFromSeconds(917872496)); // 12:34:56
+  // Note:  Cannot perform static local time zone checks because success depends
+  // on the time zone of the cluster
+
+  SHARED vCreateDateTimeFromSeconds := ROW(Date.CreateDateTimeFromSeconds(917872496)); // Feb 1, 1999 @ 12:34:56 (UTC)
+  SHARED vCreateDateFromSeconds := ROW(Date.CreateDateFromSeconds(917872496)); // Feb 1, 1999 (UTC)
+  SHARED vCreateTimeFromSeconds := ROW(Date.CreateTimeFromSeconds(917872496)); // 12:34:56 (UTC)
   SHARED vCreateTime := ROW(Date.CreateTime(12,34,56)); // 12:34:56
   SHARED vCreateDateTime := ROW(Date.CreateDateTime(1999,2,1,12,34,56)); // Feb 1, 1999 @ 12:34:56
   SHARED vDate := Date.CurrentDate(); // UTC
@@ -117,6 +120,14 @@ EXPORT TestDate := MODULE
   EXPORT TestDynamicFunctions := [
     ASSERT(Date.SecondsFromParts(1999,2,1,12,34,56,FALSE) = 917872496);     // UTC
     ASSERT(Date.SecondsFromParts(1965,2,17,0,0,0,FALSE) = -153705600);      // UTC
+
+    // UTC vs. local round-trip testing
+    ASSERT(ROW(Std.Date.CreateDateTimeFromSeconds(Std.Date.SecondsFromParts(1999,2,1,12,34,56,FALSE),FALSE)).year = ROW(Std.Date.CreateDateTimeFromSeconds(Std.Date.SecondsFromParts(1999,2,1,12,34,56,TRUE),TRUE)).year);
+    ASSERT(ROW(Std.Date.CreateDateTimeFromSeconds(Std.Date.SecondsFromParts(1999,2,1,12,34,56,FALSE),FALSE)).month = ROW(Std.Date.CreateDateTimeFromSeconds(Std.Date.SecondsFromParts(1999,2,1,12,34,56,TRUE),TRUE)).month);
+    ASSERT(ROW(Std.Date.CreateDateTimeFromSeconds(Std.Date.SecondsFromParts(1999,2,1,12,34,56,FALSE),FALSE)).day = ROW(Std.Date.CreateDateTimeFromSeconds(Std.Date.SecondsFromParts(1999,2,1,12,34,56,TRUE),TRUE)).day);
+    ASSERT(ROW(Std.Date.CreateDateTimeFromSeconds(Std.Date.SecondsFromParts(1999,2,1,12,34,56,FALSE),FALSE)).hour = ROW(Std.Date.CreateDateTimeFromSeconds(Std.Date.SecondsFromParts(1999,2,1,12,34,56,TRUE),TRUE)).hour);
+    ASSERT(ROW(Std.Date.CreateDateTimeFromSeconds(Std.Date.SecondsFromParts(1999,2,1,12,34,56,FALSE),FALSE)).minute = ROW(Std.Date.CreateDateTimeFromSeconds(Std.Date.SecondsFromParts(1999,2,1,12,34,56,TRUE),TRUE)).minute);
+    ASSERT(ROW(Std.Date.CreateDateTimeFromSeconds(Std.Date.SecondsFromParts(1999,2,1,12,34,56,FALSE),FALSE)).second = ROW(Std.Date.CreateDateTimeFromSeconds(Std.Date.SecondsFromParts(1999,2,1,12,34,56,TRUE),TRUE)).second);
 
     ASSERT(Date.SecondsToParts(917872496).year = 1999);
     ASSERT(Date.SecondsToParts(917872496).month = 2);

--- a/plugins/timelib/timelib.hpp
+++ b/plugins/timelib/timelib.hpp
@@ -44,7 +44,7 @@ TIMELIB_API bool getECLPluginDefinition(ECLPluginDefinitionBlock *pb);
 TIMELIB_API void setPluginContext(IPluginContext * _ctx);
 #endif
 
-void tlMakeTimeStructFromUTCSeconds(time_t seconds, struct tm* timeInfo);
+void tlMakeTimeStructFromSeconds(time_t seconds, struct tm* timeInfo, bool inLocalTimeZone);
 void tlInsertDateIntoTimeStruct(struct tm* timeInfo, unsigned int date);
 unsigned int tlExtractDateFromTimeStruct(const struct tm* timeInfo);
 void tlInsertTimeIntoTimeStruct(struct tm* timeInfo, unsigned int time);
@@ -55,7 +55,7 @@ void tlGMTime_r(const time_t* clock, struct tm* timeInfoPtr);
 time_t tlMKTime(struct tm* timeInfoPtr, bool inLocalTimeZone = true);
 
 TIMELIB_API __int64 TIMELIB_CALL tlSecondsFromParts(int year, unsigned int month, unsigned int day, unsigned int hour, unsigned int minute, unsigned int second, bool is_local_time = false);
-TIMELIB_API size32_t TIMELIB_CALL tlSecondsToParts(ARowBuilder & __self, __int64 seconds);
+TIMELIB_API size32_t TIMELIB_CALL tlSecondsToParts(ARowBuilder & __self, __int64 seconds, bool is_local_time);
 TIMELIB_API unsigned int TIMELIB_CALL tlGetDayOfYear(short year, unsigned short month, unsigned short day);
 TIMELIB_API unsigned int TIMELIB_CALL tlGetDayOfWeek(short year, unsigned short month, unsigned short day);
 TIMELIB_API void TIMELIB_CALL tlDateToString(size32_t &__lenResult, char* &__result, unsigned int date, const char* format);


### PR DESCRIPTION
Correct problem where daylight savings time was not automatically determined when creating new time structures from date/time parts, which resulted in incorrect "number of seconds since epoch" results.

Also added optional is_local_time argument to SecondsToParts function, CreateDateFromSeconds transform, CreateTimeFromSeconds transform, and CreateDateTimeFromSeconds transform.  The new argument fixes incorrect inverse translations from SecondsFromParts(is_local_time := TRUE) results.

Signed-off-by: Dan S. Camper <dan.camper@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [x] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [x] I have added tests to cover my changes.
  - [x] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [x] This change fixes the problem, not just the symptom
  - [x] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [x] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

Manual testing, plus passing of existing and new unit tests.

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
