### PR TITLE
HPCC-19787 Send timestamped signature for Dali file requests

### DIFF
--- a/dali/base/dacoven.cpp
+++ b/dali/base/dacoven.cpp
@@ -37,7 +37,7 @@ extern void closedownDFS();
 // base is saved in store whenever block exhausted, so replacement coven servers can restart 
 
 // server side versioning.
-#define ServerVersion    "3.14"
+#define ServerVersion    "3.15"
 #define MinClientVersion "1.5"
 
 

--- a/dali/base/dasess.hpp
+++ b/dali/base/dasess.hpp
@@ -77,14 +77,9 @@ interface IUserDescriptor: extends serializable
     virtual StringBuffer &getUserName(StringBuffer &buf)=0;
     virtual StringBuffer &getPassword(StringBuffer &buf)=0;
     virtual const char *querySignature()=0;//user's digital signature
-    virtual unsigned querySessionToken()=0;//ESP session token
-    virtual const CDateTime & queryUTCTimeStamp()=0;//Time stamp when a Dali request was requested
-    virtual const char *queryUserTimeStampSignature()=0;//digital signature of "username;TimeStampString"
     virtual void set(const char *name,const char *password)=0;
     virtual void set(const char *name,const char *password, unsigned sessionToken, const char *_signature)=0;
     virtual void clear()=0;
-    virtual void serializeSignature(MemoryBuffer &tgt)=0;
-    virtual void deserializeSignature(MemoryBuffer &src)=0;
 };
 
 extern da_decl IUserDescriptor *createUserDescriptor();
@@ -119,7 +114,7 @@ interface ISessionManager: extends IInterface
     virtual StringBuffer &getClientProcessEndpoint(SessionId id,StringBuffer &buf)=0; // for diagnostics
     virtual unsigned queryClientCount() = 0; // for SNMP
 
-    virtual SecAccessFlags getPermissionsLDAP(const char *key,const char *obj,IUserDescriptor *udesc,unsigned auditflags, int *err=NULL)=0;
+    virtual SecAccessFlags getPermissionsLDAP(const char *key,const char *obj,IUserDescriptor *udesc,unsigned auditflags, const char * reqSignature=nullptr, CDateTime * reqUTCTimestamp=nullptr, int *err=NULL)=0;
     virtual bool checkScopeScansLDAP()=0;
     virtual unsigned getLDAPflags()=0;
     virtual void setLDAPflags(unsigned flags)=0;

--- a/dali/base/dasess.hpp
+++ b/dali/base/dasess.hpp
@@ -27,6 +27,7 @@
 #endif
 
 #include "dacoven.hpp"
+#include "jtime.hpp"
 
 typedef DALI_UID SessionId;
 typedef DALI_UID SubscriptionId;
@@ -77,11 +78,13 @@ interface IUserDescriptor: extends serializable
     virtual StringBuffer &getPassword(StringBuffer &buf)=0;
     virtual const char *querySignature()=0;//user's digital signature
     virtual unsigned querySessionToken()=0;//ESP session token
+    virtual const CDateTime & queryUTCTimeStamp()=0;//Time stamp when a Dali request was requested
+    virtual const char *queryUserTimeStampSignature()=0;//digital signature of "username;TimeStampString"
     virtual void set(const char *name,const char *password)=0;
     virtual void set(const char *name,const char *password, unsigned sessionToken, const char *_signature)=0;
     virtual void clear()=0;
-    virtual void serializeExtra(MemoryBuffer &tgt)=0;
-    virtual void deserializeExtra(MemoryBuffer &src)=0;
+    virtual void serializeSignature(MemoryBuffer &tgt)=0;
+    virtual void deserializeSignature(MemoryBuffer &src)=0;
 };
 
 extern da_decl IUserDescriptor *createUserDescriptor();

--- a/dali/server/daldap.cpp
+++ b/dali/server/daldap.cpp
@@ -50,6 +50,7 @@ class CDaliLdapConnection: implements IDaliLdapConnection, public CInterface
     StringAttr              filesdefaultuser;
     StringAttr              filesdefaultpassword;
     unsigned                ldapflags;
+    unsigned                requestSignatureExpiryMinutes;//Age at which a dali permissions request signature becomes invalid
     IDigitalSignatureManager * pDSM = nullptr;
 
     void createDefaultScopes()
@@ -81,6 +82,7 @@ public:
     {
         ldapflags = 0;
         if (ldapprops) {
+            requestSignatureExpiryMinutes = ldapprops->getPropInt("@reqSignatureExpiry", 10);
             if (ldapprops->getPropBool("@checkScopeScans",true))
                 ldapflags |= DLF_SCOPESCANS;
             if (ldapprops->getPropBool("@safeLookup",true))
@@ -144,24 +146,50 @@ public:
         Owned<ISecUser> user = ldapsecurity->createUser(username);
         user->credentials().setPassword(password);
 
-        //Check user's digital signature, if present
         bool authenticated = false;
-        if (!isEmptyString(udesc->querySignature()))
+
+        //Check that the digital signature provided by the caller (signature of
+        //caller's "username;timeStamp") matches what we expect it to be
+        if (!isEmptyString(udesc->queryUserTimeStampSignature()))
         {
             if (nullptr == pDSM)
                 pDSM = createDigitalSignatureManagerInstanceFromEnv();
             if (pDSM && pDSM->isDigiVerifierConfigured())
             {
-                StringBuffer b64Signature(udesc->querySignature());
-                if (!pDSM->digiVerify(username, b64Signature))//digital signature valid?
+                StringBuffer requestTimestamp;
+                udesc->queryUTCTimeStamp().getString(requestTimestamp, false);//extract timestamp string from Dali request
+
+                CDateTime now;
+                now.setNow();
+                if (now.compare(udesc->queryUTCTimeStamp()) < 0)//timestamp from the future?
                 {
-                    ERRLOG("LDAP: getPermissions(%s) scope=%s user=%s invalid user digital signature",key?key:"NULL",obj?obj:"NULL",username.str());
+                    ERRLOG("LDAP: getPermissions(%s) scope=%s user=%s Request digital signature timestamp %s from the future",key?key:"NULL",obj?obj:"NULL",username.str(), requestTimestamp.str());
                     return SecAccess_None;//deny
                 }
-                else
-                    authenticated = true;
+
+                CDateTime expiry;
+                expiry.set(now);
+                expiry.adjustTime(requestSignatureExpiryMinutes);//compute expiration timestamp
+
+                if (expiry.compare(udesc->queryUTCTimeStamp()) < 0)//timestamp too far in the past?
+                {
+                    ERRLOG("LDAP: getPermissions(%s) scope=%s user=%s Expired request digital signature timestamp %s",key?key:"NULL",obj?obj:"NULL",username.str(), requestTimestamp.str());
+                    return SecAccess_None;//deny
+                }
+
+                VStringBuffer expectedUserDateStr("%s;%s", username.str(), requestTimestamp.str());
+                StringBuffer b64Signature(udesc->queryUserTimeStampSignature());//extract user;timestamp signature from Dali request
+
+                if (!pDSM->digiVerify(expectedUserDateStr, b64Signature))//digital signature match what we expect?
+                {
+                    ERRLOG("LDAP: getPermissions(%s) scope=%s user=%s fails digital signature verification",key?key:"NULL",obj?obj:"NULL",username.str());
+                    return SecAccess_None;//deny
+                }
+
+                authenticated = true;//Digital signature verified
             }
-            user->credentials().setSignature(udesc->querySignature());
+            else
+                ERRLOG("LDAP: getPermissions(%s) scope=%s user=%s digital signature support not available",key?key:"NULL",obj?obj:"NULL",username.str());
         }
 
         if (!authenticated && !ldapsecurity->authenticateUser(*user, NULL))

--- a/dali/server/daldap.hpp
+++ b/dali/server/daldap.hpp
@@ -26,7 +26,7 @@ interface IUserDescriptor;
 
 interface IDaliLdapConnection: extends IInterface
 {
-    virtual SecAccessFlags getPermissions(const char *key,const char *obj,IUserDescriptor *udesc,unsigned auditflags)=0;
+    virtual SecAccessFlags getPermissions(const char *key,const char *obj,IUserDescriptor *udesc,unsigned auditflags,const char * reqSignature, CDateTime * reqUTCTimestamp)=0;
     virtual bool checkScopeScans() = 0;
     virtual unsigned getLDAPflags() = 0;
     virtual void setLDAPflags(unsigned flags) = 0;

--- a/initfiles/componentfiles/config2xml/dali.xsd
+++ b/initfiles/componentfiles/config2xml/dali.xsd
@@ -419,6 +419,13 @@ Add a key for dali server names named dali_name that can be referred to from els
                 </xs:appinfo>
             </xs:annotation>
         </xs:attribute>
+        <xs:attribute name="reqSignatureExpiry" use="optional" type="xs:string" default="10">
+            <xs:annotation>
+                <xs:appinfo>
+                    <tooltip>Lifetime in minutes of a permissions request digital signature.</tooltip>
+                </xs:appinfo>
+            </xs:annotation>
+        </xs:attribute>
         <xs:attribute name="checkScopeScans" type="xs:boolean" use="optional" default="true">
             <xs:annotation>
                 <xs:appinfo>

--- a/initfiles/componentfiles/configxml/dali.xsd
+++ b/initfiles/componentfiles/configxml/dali.xsd
@@ -402,6 +402,13 @@
         </xs:appinfo>
       </xs:annotation>
     </xs:attribute>
+    <xs:attribute name="reqSignatureExpiry" use="optional" type="xs:string" default="10">
+      <xs:annotation>
+        <xs:appinfo>
+          <tooltip>Lifetime in minutes of a permissions request digital signature.</tooltip>
+        </xs:appinfo>
+      </xs:annotation>
+    </xs:attribute>
     <xs:attribute name="checkScopeScans" type="xs:boolean" use="optional" default="true">
       <xs:annotation>
         <xs:appinfo>

--- a/initfiles/componentfiles/configxml/dali.xsl
+++ b/initfiles/componentfiles/configxml/dali.xsl
@@ -240,7 +240,7 @@
         </xsl:element>
         <xsl:if test="string(@ldapServer) != ''">
           <xsl:element name="ldapSecurity">
-            <xsl:copy-of select="@ldapProtocol | @authMethod | @maxConnections | @workunitsBasedn | @filesDefaultUser | @filesDefaultPassword"/>
+            <xsl:copy-of select="@ldapProtocol | @authMethod | @maxConnections | @workunitsBasedn | @filesDefaultUser | @filesDefaultPassword | @reqSignatureExpiry"/>
             <xsl:variable name="ldapServerName" select="@ldapServer"/>
             <xsl:attribute name="filesBasedn">
                 <xsl:value-of select="/Environment/Software/LDAPServerProcess[@name=$ldapServerName]/@filesBasedn"/>


### PR DESCRIPTION
When engines send getPermissions to Dali, send a digital signature of the "username;timestamp"
string and the CDateTime containing that same timestamp. Dali will use that
CDateTime and user to rebuild the string, and call digisign verify() to ensure
the digital signature sent is valid. Additionally, ensure the request did not
hijack a signature by ensuring the timestamp in the signature was within a
configurable threshold. If deemed valid, LDAP authentication is unnecessary.

Signed-off-by: Russ Whitehead <william.whitehead@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [x] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
