### PR TITLE
HPCC-19784 Improve access to user and resource name value pairs

### DIFF
--- a/system/security/LdapSecurity/ldapsecurity.cpp
+++ b/system/security/LdapSecurity/ldapsecurity.cpp
@@ -318,6 +318,11 @@ const char * CLdapSecResource::getParameter(const char * name)
 
 }
 
+IPropertyIterator * CLdapSecResource::getParameterIterator() const
+{
+    return (m_parameters.get() ? m_parameters->getIterator() : nullptr);
+}
+
 void CLdapSecResource::setDescription(const char* description)
 {
     m_description.clear().append(description);

--- a/system/security/LdapSecurity/ldapsecurity.ipp
+++ b/system/security/LdapSecurity/ldapsecurity.ipp
@@ -149,6 +149,7 @@ public:
 
     virtual void setPropertyInt(const char* name, int value){}
     virtual int getPropertyInt(const char* name){ return 0;}
+    IPropertyIterator * getPropertyIterator() const override { return nullptr;}
 
 
 //interface ISecCredentials
@@ -270,6 +271,7 @@ public:
     virtual SecAccessFlags getAccessFlags();
     virtual int addParameter(const char* name, const char* value);
     virtual const char * getParameter(const char * name);
+    virtual IPropertyIterator * getParameterIterator() const override;
     virtual void setDescription(const char* description);
     virtual const char* getDescription();
 

--- a/system/security/shared/SecureUser.hpp
+++ b/system/security/shared/SecureUser.hpp
@@ -200,7 +200,12 @@ public:
         return 0;
     }
 
-    
+    IPropertyIterator * getPropertyIterator() const override
+    {
+        return (m_parameters.get() ? m_parameters->getIterator() : nullptr);
+    }
+
+
 
 //interface ISecCredentials
     bool setPassword(const char * pw)

--- a/system/security/shared/SecurityResource.hpp
+++ b/system/security/shared/SecurityResource.hpp
@@ -79,6 +79,12 @@ public:
         return NULL;
 
     }
+
+    virtual IPropertyIterator * getParameterIterator() const override
+    {
+        return (m_parameters.get() ? m_parameters->getIterator() : nullptr);
+    }
+
     virtual void setRequiredAccessFlags(SecAccessFlags flags)
     {
         m_required_access = flags;
@@ -139,22 +145,18 @@ public:
     {
         if(!from)
             return;
-        CSecurityResource* _res = (CSecurityResource*)(from);
-        if(!_res)
+
+        setDescription(from->getDescription());
+        setValue(from->getValue());
+        setAccessFlags(from->getAccessFlags());
+
+        Owned<IPropertyIterator> Itr = from->getParameterIterator();
+        if(!Itr.get())
             return;
-
-        setDescription(_res->m_description.str());
-        setValue(_res->m_value.str());
-        setAccessFlags(_res->getAccessFlags());
-
-        if(!_res->m_parameters)
-            return;
-
-        Owned<IPropertyIterator> Itr = _res->m_parameters->getIterator();
         Itr->first();
         while(Itr->isValid())
         {
-            addParameter(Itr->getPropKey(), _res->m_parameters->queryProp(Itr->getPropKey()));
+            addParameter(Itr->getPropKey(), from->getParameter(Itr->getPropKey()));
             Itr->next();
         }
         return;

--- a/system/security/shared/seclib.hpp
+++ b/system/security/shared/seclib.hpp
@@ -163,6 +163,7 @@ enum authStatus : int
 };
 
 class CDateTime;
+interface IPropertyIterator;
 interface ISecUser : extends IInterface
 {
     virtual const char * getName() = 0;
@@ -197,6 +198,7 @@ interface ISecUser : extends IInterface
     virtual const char * getProperty(const char * name) = 0;
     virtual void setPropertyInt(const char * name, int value) = 0;
     virtual int getPropertyInt(const char * name) = 0;
+    virtual IPropertyIterator * getPropertyIterator() const = 0;
     virtual ISecUser * clone() = 0;
 };
 
@@ -231,6 +233,7 @@ interface ISecResource : extends ISecProperty
     virtual SecAccessFlags getRequiredAccessFlags() = 0;
     virtual int addParameter(const char * name, const char * value) = 0;
     virtual const char * getParameter(const char * name) = 0;
+    virtual IPropertyIterator * getParameterIterator() const = 0;
     virtual void setDescription(const char * description) = 0;
     virtual const char * getDescription() = 0;
     virtual ISecResource * clone() = 0;


### PR DESCRIPTION
Expose iterators to ISecUser's properties and ISecResource's
parameters. Without these iterators, the data can only be
accessed within the concrete implementation class or by code
that knows exactly what names to look for. With the iterators,
the data may be manipulated by generic code that only knows
that some arbitrary data may be present.

Fix HPCC-19784

Signed-off-by: Tim Klemm <Tim.Klemm@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [x] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
