### PR TITLE
HPCC-19868 Fix Std.Date parsing of two-digit years when four digits are expected

### DIFF
--- a/ecllibrary/std/Date.ecl
+++ b/ecllibrary/std/Date.ecl
@@ -762,8 +762,13 @@ EXPORT STRING ToString(Date_t date, VARSTRING format) := DateToString(date, form
  * @return              The converted string, or blank if it failed to match the format.
  */
 
-EXPORT STRING ConvertDateFormat(STRING date_text, VARSTRING from_format='%m/%d/%Y', VARSTRING to_format='%Y%m%d') :=
-    DateToString(FromStringToDate(date_text, from_format), to_format);
+EXPORT STRING ConvertDateFormat(STRING date_text, VARSTRING from_format='%m/%d/%Y', VARSTRING to_format='%Y%m%d') := FUNCTION
+    parsedDate := FromStringToDate(date_text, from_format);
+
+    reformatResult := IF(parsedDate = (Date_t)0, '', DateToString(parsedDate, to_format));
+
+    RETURN reformatResult;
+END;
 
 
 /**

--- a/ecllibrary/teststd/Date/TestFormat.ecl
+++ b/ecllibrary/teststd/Date/TestFormat.ecl
@@ -7,6 +7,7 @@ IMPORT Std.Date;
 EXPORT TestFormat := MODULE
 
   SHARED DateFormats := ['%d %b %Y', '%Y %b %d', '%Y%m%d', '%Y-%m-%d', '%d/%m/%Y', '%m/%d/%Y'];
+  SHARED DateFormats2Y := ['%d %b %y', '%y %b %d', '%y%m%d', '%y-%m-%d', '%d/%m/%y', '%m/%d/%y'];
   SHARED TimeFormats := ['%H%M%S', '%H:%M:%S', '%H:%M'];
 
   EXPORT TestConstant := [
@@ -29,12 +30,21 @@ EXPORT TestFormat := MODULE
 
   EXPORT TestDynamic := [
     ASSERT(Date.MatchDateString('1dec2011',DateFormats) = 20111201);
+    ASSERT(Date.MatchDateString('1dec11',DateFormats2Y) = 20111201);
     ASSERT(Date.MatchDateString('2011dec1',DateFormats) = 20111201);
+    ASSERT(Date.MatchDateString('11dec1',DateFormats2Y) = 20011211);
     ASSERT(Date.MatchDateString('1 december 2011',DateFormats) = 20111201);
+    ASSERT(Date.MatchDateString('1 december 11',DateFormats2Y) = 20111201);
     ASSERT(Date.MatchDateString('2011\tdecem\t01',DateFormats) = 20111201);
+    ASSERT(Date.MatchDateString('11\tdecem\t01',DateFormats2Y) = 20011211);
     ASSERT(Date.MatchDateString('20111201',DateFormats) = 20111201);
+    ASSERT(Date.MatchDateString('111201',DateFormats2Y) = 20111201);
     ASSERT(Date.MatchDateString('2011-12-01',DateFormats) = 20111201);
+    ASSERT(Date.MatchDateString('11-12-01',DateFormats2Y) = 20111201);
     ASSERT(Date.MatchDateString('1/12/2011',DateFormats) = 20111201);
+    ASSERT(Date.MatchDateString('1/12/11',DateFormats2Y) = 20111201);
+    ASSERT(Date.MatchDateString('1/12/11',DateFormats) = 111201);
+    ASSERT(Date.MatchDateString('1/12/11',DateFormats2Y) = 20111201);
 
     ASSERT(Date.DateToString(19700101, '%Y-%m-%d') = '1970-01-01');
     ASSERT(Date.DateToString(19700101, '%d/%m/%y') = '01/01/70');
@@ -52,12 +62,18 @@ EXPORT TestFormat := MODULE
     ASSERT(Date.SecondsToString(917872496,'%Y-%m-%dT%H:%M:%S') = '1999-02-01T12:34:56');
 
     ASSERT(Date.ConvertDateFormat('1/12/2011','%m/%d/%Y','%Y-%m-%d') = '2011-01-12');
+    ASSERT(Date.ConvertDateFormat('','%m/%d/%Y','%Y-%m-%d') = ''); // Invalid input date
+    ASSERT(Date.ConvertDateFormat('1234','%m/%d/%Y','%Y-%m-%d') = ''); // Invalid input date
 
     ASSERT(Date.ConvertTimeFormat('123456','%H%M%S','%H:%M:%S') = '12:34:56');
 
     ASSERT(Date.ConvertDateFormatMultiple('1/31/2011',DateFormats,'%Y-%m-%d') = '2011-01-31');
+    ASSERT(Date.ConvertDateFormatMultiple('1/31/11',DateFormats2Y,'%Y-%m-%d') = '2011-01-31');
+    ASSERT(Date.ConvertDateFormatMultiple('1/31/11',DateFormats,'%Y-%m-%d') = '11-01-31');
+    ASSERT(Date.ConvertDateFormatMultiple('1/31/11',DateFormats2Y,'%Y-%m-%d') = '2011-01-31');
 
     ASSERT(Date.ConvertDateFormatMultiple('',DateFormats,'%Y-%m-%d') = '');
+    ASSERT(Date.ConvertDateFormatMultiple('',DateFormats2Y,'%Y-%m-%d') = '');
 
     ASSERT(Date.ConvertTimeFormatMultiple('123456',TimeFormats,'%H:%M:%S') = '12:34:56');
 

--- a/plugins/timelib/timelib.cpp
+++ b/plugins/timelib/timelib.cpp
@@ -49,8 +49,8 @@ static const char * EclDefinition =
 "  UNSIGNED4 endDate; \n"
 "END;"
 "EXPORT TimeLib := SERVICE : fold\n"
-"  INTEGER8 SecondsFromParts(integer2 year, unsigned1 month, unsigned1 day, unsigned1 hour, unsigned1 minute, unsigned1 second, boolean is_local_time) : c,pure,entrypoint='tlSecondsFromParts'; \n"
-"  TRANSFORM(TMPartsRec) SecondsToParts(INTEGER8 seconds) : c,pure,entrypoint='tlSecondsToParts'; \n"
+"  INTEGER8 SecondsFromParts(INTEGER2 year, UNSIGNED1 month, UNSIGNED1 day, UNSIGNED1 hour, UNSIGNED1 minute, UNSIGNED1 second, BOOLEAN is_local_time) : c,pure,entrypoint='tlSecondsFromParts'; \n"
+"  TRANSFORM(TMPartsRec) SecondsToParts(INTEGER8 seconds, BOOLEAN is_local_time) : c,pure,entrypoint='tlSecondsToParts'; \n"
 "  UNSIGNED2 GetDayOfYear(INTEGER2 year, UNSIGNED1 month, UNSIGNED1 day) : c,pure,entrypoint='tlGetDayOfYear'; \n"
 "  UNSIGNED1 GetDayOfWeek(INTEGER2 year, UNSIGNED1 month, UNSIGNED1 day) : c,pure,entrypoint='tlGetDayOfWeek'; \n"
 "  STRING DateToString(UNSIGNED4 date, CONST VARSTRING format) : c,pure,entrypoint='tlDateToString'; \n"
@@ -215,7 +215,7 @@ static __int64 tlLocalTimeZoneDiffIn100nsIntervals()
     GetLocalTime(&systemLocal);
 
     SystemTimeToFileTime(&systemUTC, &fileUTC);
-    SystemTimeToFileTime(&systemLocal, &fileLocal);
+    SystemTimeToFileTime(&systemLocal, &fileLocal); // DST is accounted for
 
     return tlFileTimeToInt64(fileLocal) - tlFileTimeToInt64(fileUTC);
 }
@@ -377,7 +377,7 @@ time_t tlMKTime(struct tm* timeInfoPtr, bool inLocalTimeZone)
 
     if (!inLocalTimeZone)
     {
-        // Adjust for time zone offset
+        // Adjust for time zone and DST offset
         the_time += (tlLocalTimeZoneDiffIn100nsIntervals() / _onesec_in100ns);
     }
     #else
@@ -396,9 +396,16 @@ time_t tlMKTime(struct tm* timeInfoPtr, bool inLocalTimeZone)
 
 //------------------------------------------------------------------------------
 
-void tlMakeTimeStructFromUTCSeconds(time_t seconds, struct tm* timeInfo)
+void tlMakeTimeStructFromSeconds(time_t seconds, struct tm* timeInfo, bool inLocalTimeZone)
 {
-    tlGMTime_r(&seconds, timeInfo);
+    if (inLocalTimeZone)
+    {
+        tlLocalTime_r(&seconds, timeInfo);
+    }
+    else
+    {
+        tlGMTime_r(&seconds, timeInfo);
+    }
 }
 
 void tlInsertDateIntoTimeStruct(struct tm* timeInfo, unsigned int date)
@@ -461,6 +468,7 @@ TIMELIB_API __int64 TIMELIB_CALL tlSecondsFromParts(int year, unsigned int month
     timeInfo.tm_mday = day;
     timeInfo.tm_mon = month - 1;
     timeInfo.tm_year = year - 1900;
+    timeInfo.tm_isdst = -1;
 
     the_time = tlMKTime(&timeInfo, is_local_time);
 
@@ -469,7 +477,7 @@ TIMELIB_API __int64 TIMELIB_CALL tlSecondsFromParts(int year, unsigned int month
 
 //------------------------------------------------------------------------------
 
-TIMELIB_API size32_t TIMELIB_CALL tlSecondsToParts(ARowBuilder& __self, __int64 seconds)
+TIMELIB_API size32_t TIMELIB_CALL tlSecondsToParts(ARowBuilder& __self, __int64 seconds, bool is_local_time)
 {
     struct tm       timeInfo;
 
@@ -484,7 +492,7 @@ TIMELIB_API size32_t TIMELIB_CALL tlSecondsToParts(ARowBuilder& __self, __int64 
         __int32 wday;
     };
 
-    tlMakeTimeStructFromUTCSeconds(seconds, &timeInfo);
+    tlMakeTimeStructFromSeconds(seconds, &timeInfo, is_local_time);
 
     TMParts* result = reinterpret_cast<TMParts*>(__self.getSelf());
 
@@ -524,6 +532,7 @@ TIMELIB_API unsigned int TIMELIB_CALL tlGetDayOfYear(short year, unsigned short 
     timeInfo.tm_mday = day;
     timeInfo.tm_mon = month - 1;
     timeInfo.tm_year = year - 1900;
+    timeInfo.tm_isdst = -1;
 
     tlMKTime(&timeInfo);
 
@@ -545,6 +554,7 @@ TIMELIB_API unsigned int TIMELIB_CALL tlGetDayOfWeek(short year, unsigned short 
     timeInfo.tm_mday = day;
     timeInfo.tm_mon = month - 1;
     timeInfo.tm_year = year - 1900;
+    timeInfo.tm_isdst = -1;
 
     tlMKTime(&timeInfo);
 
@@ -558,32 +568,30 @@ TIMELIB_API void TIMELIB_CALL tlDateToString(size32_t &__lenResult, char* &__res
     __result = NULL;  // Return blank string on error
     __lenResult = 0;
 
-    // date is expected to be in form year*10000 + month * 100 + day, and must be later than 1900
-    // or we can't store it in a struct tm
+    // date is expected to be in form year*10000 + month * 100 + day
 
-    if (date >= 1900 * 10000)
-    {
-        struct tm       timeInfo;
-        const size_t    kBufferSize = 256;
-        char            buffer[kBufferSize];
+    struct tm       timeInfo;
+    const size_t    kBufferSize = 256;
+    char            buffer[kBufferSize];
 
         memset(&timeInfo, 0, sizeof(timeInfo));
         tlInsertDateIntoTimeStruct(&timeInfo, date);
+        timeInfo.tm_isdst = -1;
         tlMKTime(&timeInfo);
 
 #if defined(__clang__) || defined(__GNUC__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-nonliteral"
 #endif
-        __lenResult = strftime(buffer, kBufferSize, format, &timeInfo);
+    __lenResult = strftime(buffer, kBufferSize, format, &timeInfo);
 #if defined(__clang__) || defined(__GNUC__)
 #pragma GCC diagnostic pop
 #endif
-        if (__lenResult > 0)
-        {
-            __result = reinterpret_cast<char*>(CTXMALLOC(parentCtx, __lenResult));
-            memcpy(__result, buffer, __lenResult);
-        }
+
+    if (__lenResult > 0)
+    {
+        __result = reinterpret_cast<char*>(CTXMALLOC(parentCtx, __lenResult));
+        memcpy(__result, buffer, __lenResult);
     }
 }
 
@@ -597,6 +605,7 @@ TIMELIB_API void TIMELIB_CALL tlTimeToString(size32_t &__lenResult, char* &__res
 
     memset(&timeInfo, 0, sizeof(timeInfo));
     tlInsertTimeIntoTimeStruct(&timeInfo, time);
+    timeInfo.tm_isdst = -1;
     tlMKTime(&timeInfo);
 
 #if defined(__clang__) || defined(__GNUC__)
@@ -660,6 +669,7 @@ TIMELIB_API unsigned int TIMELIB_CALL tlAdjustDate(unsigned int date, short year
     timeInfo.tm_year += year_delta;
     timeInfo.tm_mon += month_delta;
     timeInfo.tm_mday += day_delta;
+    timeInfo.tm_isdst = -1;
 
     tlMKTime(&timeInfo);
 
@@ -678,6 +688,7 @@ TIMELIB_API unsigned int TIMELIB_CALL tlAdjustDateBySeconds(unsigned int date, i
     memset(&timeInfo, 0, sizeof(timeInfo));
 
     tlInsertDateIntoTimeStruct(&timeInfo, date);
+    timeInfo.tm_isdst = -1;
     timeInfo.tm_sec = seconds_delta;
 
     tlMKTime(&timeInfo);
@@ -700,6 +711,7 @@ TIMELIB_API unsigned int TIMELIB_CALL tlAdjustTime(unsigned int time, short hour
 #endif
 
     tlInsertTimeIntoTimeStruct(&timeInfo, time);
+    timeInfo.tm_isdst = -1;
 
     timeInfo.tm_hour += hour_delta;
     timeInfo.tm_min += minute_delta;
@@ -725,6 +737,7 @@ TIMELIB_API unsigned int TIMELIB_CALL tlAdjustTimeBySeconds(unsigned int time, i
 #endif
 
     tlInsertTimeIntoTimeStruct(&timeInfo, time);
+    timeInfo.tm_isdst = -1;
     timeInfo.tm_sec += seconds_delta;
 
     tlMKTime(&timeInfo);
@@ -786,6 +799,7 @@ TIMELIB_API unsigned int TIMELIB_CALL tlAdjustCalendar(unsigned int date, short 
 
     timeInfo.tm_year += year_delta;
     timeInfo.tm_mon += month_delta;
+    timeInfo.tm_isdst = -1;
 
     seconds = tlMKTime(&timeInfo);
 
@@ -941,6 +955,7 @@ TIMELIB_API unsigned int TIMELIB_CALL tlGetLastDayOfMonth(unsigned int date)
 
     memset(&timeInfo, 0, sizeof(timeInfo));
     tlInsertDateIntoTimeStruct(&timeInfo, date);
+    timeInfo.tm_isdst = -1;
 
     // Call mktime once to fix up any bogus data
     tlMKTime(&timeInfo);
@@ -971,6 +986,7 @@ TIMELIB_API size32_t TIMELIB_CALL tlDatesForWeek(ARowBuilder& __self, unsigned i
 
     memset(&timeInfo, 0, sizeof(timeInfo));
     tlInsertDateIntoTimeStruct(&timeInfo, date);
+    timeInfo.tm_isdst = -1;
 
     // Call mktime once to fix up any bogus data
     tlMKTime(&timeInfo);


### PR DESCRIPTION
Also add function documentation to Std.Date.MatchDateString and Std.Date.ConvertDateFormatMultiple recommending that callers place more-specific date formats first in the set of parsing formats to try.

Note that this changes the behavior of the %Y date format input field descriptor.  It now matches exactly four digits, where previously it would match from one to four digits.  This change affects the behavior of not only the two functions mentioned above but also Std.Date.FromStringToDate.

Signed-off-by: Dan S. Camper <dan.camper@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [x] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [x] Any new interfaces or exported functions are appropriately commented.
- [ ] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [x] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [x] Scalability
  - [x] Performance
  - [x] Security
  - [x] Thread-safety
  - [x] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [x] This change fixes the problem, not just the symptom
  - [x] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

Manual testing and new unit tests.  Note that two existing tests have been changed to accommodate the new behavior of the %Y input field descriptor.

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->