### PR TITLE
HPCC-19881 Ensure that parameters are consistent for uni and str functions

### DIFF
--- a/ecllibrary/std/Uni.ecl
+++ b/ecllibrary/std/Uni.ecl
@@ -433,8 +433,8 @@ EXPORT unicode ExcludeLastWord(unicode text, varstring localename = '') :=
  * @return              The string containing the source string but with the translated characters.
  */
 
-EXPORT Translate(unicode text, unicode sear, unicode repl) :=
-    lib_unicodelib.UnicodeLib.UnicodeLocaleTranslate(text, sear, repl);
+EXPORT Translate(unicode text, unicode search, unicode replacement) :=
+    lib_unicodelib.UnicodeLib.UnicodeLocaleTranslate(text, search, replacement);
 
 /**
  * Returns true if the prefix string matches the leading characters in the source string.  Trailing and Leading spaces
@@ -442,12 +442,12 @@ EXPORT Translate(unicode text, unicode sear, unicode repl) :=
  * then converted to Unicode using TRANSFER, ecl will perform its own normalization on your declared Unicode string.
  *
  * @param src           The string being searched in.
- * @param pref          The prefix to search for.
+ * @param prefix        The prefix to search for.
  * @param form          The type of Normalization to be employed.
  */
 
-EXPORT BOOLEAN StartsWith(unicode src, unicode pref, string form) :=
-	lib_unicodelib.UnicodeLib.UnicodeLocaleStartsWith(src, pref, form);
+EXPORT BOOLEAN StartsWith(unicode src, unicode prefix, string form) :=
+    lib_unicodelib.UnicodeLib.UnicodeLocaleStartsWith(src, prefix, form);
 
 /**
  * Returns true if the suffix string matches the trailing characters in the source string.  Trailing and Leading spaces
@@ -455,12 +455,12 @@ EXPORT BOOLEAN StartsWith(unicode src, unicode pref, string form) :=
  * then converted to Unicode using TRANSFER, ecl will perform its own normalization on your declared Unicode string.
  *
  * @param src           The string being searched in.
- * @param suff          The suffix to search for.
+ * @param suffix        The suffix to search for.
  * @param form          The type of Normalization to be employed.
  */
 
-EXPORT BOOLEAN EndsWith(unicode src, unicode suff, string form) :=
-	lib_unicodelib.UnicodeLib.UnicodeLocaleEndsWith(src, suff, form);
+EXPORT BOOLEAN EndsWith(unicode src, unicode suffix, string form) :=
+    lib_unicodelib.UnicodeLib.UnicodeLocaleEndsWith(src, suffix, form);
 
 /**
  * Returns a string containing the version of icu being used to implement the unicode library.
@@ -478,56 +478,56 @@ EXPORT STRING Version() := lib_unicodelib.UnicodeLib.UnicodeVersion();
  * @return              The string excluding the suffix, if endsWith is true
  */
 
-EXPORT RemoveSuffix(unicode src, unicode suff, string form) :=
-    lib_unicodelib.UnicodeLib.UnicodeLocaleRemoveSuffix(src, suff, form);
+EXPORT RemoveSuffix(unicode src, unicode suffix, string form) :=
+    lib_unicodelib.UnicodeLib.UnicodeLocaleRemoveSuffix(src, suffix, form);
 
 /*
  * Returns a string containing text repeated n times.
  *
- * @param src           The string to be repeated.
+ * @param text          The string to be repeated.
  * @param n             Number of repetitions.
  * @return              A string containing n concatenations of the string text.
  */
 
-EXPORT Repeat(unicode src, unsigned4 n) :=
-    lib_unicodelib.UnicodeLib.UnicodeLocaleRepeat(src, n);
+EXPORT Repeat(unicode text, unsigned4 n) :=
+    lib_unicodelib.UnicodeLib.UnicodeLocaleRepeat(text, n);
 
 /**
  * Returns the number of occurences of the second string within the first string.
  *
  * @param src           The string that is searched.
- * @param hit           The string being sought.
+ * @param sought        The string being sought.
  * @param form          The optional, specified normalization form.
  * @return              The number of occurences, matches.
  */
 
-EXPORT unsigned4 FindCount(unicode src, unicode hit, string form) :=
-    lib_unicodelib.UnicodeLib.UnicodeLocaleFindCount(src, hit, form);
+EXPORT unsigned4 FindCount(unicode src, unicode sought, string form) :=
+    lib_unicodelib.UnicodeLib.UnicodeLocaleFindCount(src, sought, form);
 
 /**
  * Returns the number of words that the string contains.  Words are separated by one or more separator strings. No 
  * spaces are stripped from either string before matching. allowBlankItems set to false by default.
  *
  * @param src               The string being searched in.
- * @param delim             The string used to separate words
- * @param allowBlankItems   Indicates if empty/blank string items are included in the results.
+ * @param separator         The string used to separate words
+ * @param allow_blank       Indicates if empty/blank string items are included in the results.
  * @return                  The number of delimited tokens in the source string
  */
 
-EXPORT unsigned4 CountWords(unicode src, unicode delim, boolean allowBlankItems = FALSE) :=
-    lib_unicodelib.UnicodeLib.UnicodeLocaleCountWords(src, delim, allowBlankItems);
+EXPORT unsigned4 CountWords(unicode src, unicode separator, boolean allow_blank = FALSE) :=
+    lib_unicodelib.UnicodeLib.UnicodeLocaleCountWords(src, separator, allow_blank);
 
 /**
  * Returns the delimited words that the string contains in a UnicodeSet.  Words are separated by one or more separator strings. No 
  * spaces are stripped from either string before matching. allowBlankItems set to false by default.
  *
  * @param src               The string being searched in.
- * @param delim             The string used to separate words
- * @param allowBlankItems   Indicates if empty/blank string items are included in the results.
+ * @param separator         The string used to separate words
+ * @param allow_blank       Indicates if empty/blank string items are included in the results.
  * @return                  A UnicodeSet whose members are the delimited words
  */
 
-EXPORT SplitWords(unicode src, unicode delim, boolean allowBlankItems = FALSE) :=
-    lib_unicodelib.UnicodeLib.UnicodeLocaleSplitWords(src, delim, allowBlankItems);
+EXPORT SplitWords(unicode src, unicode separator, boolean allow_blank = FALSE) :=
+    lib_unicodelib.UnicodeLib.UnicodeLocaleSplitWords(src, separator, allow_blank);
 
 END;


### PR DESCRIPTION
Signed-off-by: Gavin Halliday <gavin.halliday@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [x] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [x] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [ ] I have read the CONTRIBUTORS document.
- [ ] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
