### PR TITLE
HPCC-19893 Avoid known local count race conditional stall

### DIFF
--- a/thorlcr/activities/countproject/thcountprojectslave.cpp
+++ b/thorlcr/activities/countproject/thcountprojectslave.cpp
@@ -105,9 +105,10 @@ class CountProjectActivity : public BaseCountProjectActivity, implements ILookAh
     typedef BaseCountProjectActivity PARENT;
     bool first = false; // until start
     Semaphore prevRecCountSem;
-    rowcount_t prevRecCount, localRecCount;
+    rowcount_t prevRecCount = 0;
+    std::atomic<rowcount_t> localRecCount = {RCUNSET};
+    bool onInputFinishSends = false;
 
-    bool haveLocalCount() { return RCUNSET != localRecCount; }
     void sendCount(rowcount_t _count)
     {
         // either called by onInputFinished(signaled by nextRow/stop) or by nextRow/stop itself
@@ -133,9 +134,9 @@ class CountProjectActivity : public BaseCountProjectActivity, implements ILookAh
     }
     void signalNext()
     {
-        if (haveLocalCount()) // if local total count known, send total now
+        if (!onInputFinishSends) // if local total count known at start() and lookahead not already sent, send now
         {
-            ActPrintLog("COUNTPROJECT: row count pre-known to be %" RCPF "d", localRecCount);
+            ActPrintLog("COUNTPROJECT: row count pre-known to be %" RCPF "d", localRecCount.load());
             sendCount(prevRecCount + localRecCount);
         }
         else
@@ -158,13 +159,21 @@ public:
     virtual void start()
     {
         ActivityTimer s(totalCycles, timeActivities);
+        localRecCount = RCUNSET;
+        onInputFinishSends = true;
         PARENT::start();
         ActPrintLog( "COUNTPROJECT: Is Global");
         first = true;
         prevRecCount = 0;
         ThorDataLinkMetaInfo info;
         input->getMetaInfo(info);
-        localRecCount = (info.totalRowsMin == info.totalRowsMax) ? (rowcount_t)info.totalRowsMax : RCUNSET;
+        if (info.totalRowsMin == info.totalRowsMax)
+        {
+            // NB: onInputFinished could have already set localRecCount before it gets here.
+            rowcount_t expectedState = RCUNSET;
+            if (localRecCount.compare_exchange_strong(expectedState, info.totalRowsMax))
+                onInputFinishSends = false;
+        }
     }
     virtual void stop()
     {
@@ -207,15 +216,20 @@ public:
         return NULL;
     }
     virtual bool isGrouped() const override { return false; }
-    virtual void onInputFinished(rowcount_t localRecCount)
+    virtual void onInputFinished(rowcount_t _localRecCount)
     {
-        if (!haveLocalCount())
+        /* localRecCount may already be known/set by start()
+         * If it's known (set in start(), the count will be sent by nextRow() or stop()
+         * If not known, send now that input read and total count known.
+         */
+        rowcount_t expectedState = RCUNSET;
+        if (localRecCount.compare_exchange_strong(expectedState, _localRecCount))
         {
             prevRecCountSem.wait();
             if (!abortSoon)
             {
-                ActPrintLog("count is %" RCPF "d", localRecCount);
-                sendCount(prevRecCount + localRecCount);
+                ActPrintLog("count is %" RCPF "d", _localRecCount);
+                sendCount(prevRecCount + _localRecCount);
             }
         }
     }


### PR DESCRIPTION
Ensure that the count project lookahead sends the count if
required and doesn't clash with start() that discovers a
pre-known count.

Signed-off-by: Jake Smith <jake.smith@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

setup.ecl (regression suite) and other queries was hitting this, but required a multinode system to see (the more nodes the more likely to be seen).
Fixed and tested repeatedly.


<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
