### PR TITLE
HPCC-19903 Ensure localPath filled for remoteFiles

### DIFF
--- a/common/remote/sockfile.cpp
+++ b/common/remote/sockfile.cpp
@@ -3972,6 +3972,8 @@ protected:
     void initCommon(IPropertyTree &config)
     {
         fileName.set(config.queryProp("fileName"));
+        if (isEmptyString(fileName))
+            throw MakeStringException(0, "CRemoteDiskBaseActivity: fileName missing");
 
         record = &inMeta->queryRecordAccessor(true);
         translator.setown(createRecordTranslator(outMeta->queryRecordAccessor(true), *record));
@@ -4060,6 +4062,7 @@ class CRemoteDiskReadActivity : public CRemoteDiskBaseActivity
         }
 
         OwnedIFile iFile = createIFile(fileName);
+        assertex(iFile);
         iFileIO.setown(createCompressedFileReader(iFile));
         if (iFileIO)
         {

--- a/ecl/hthor/hthor.cpp
+++ b/ecl/hthor/hthor.cpp
@@ -166,12 +166,15 @@ ILocalOrDistributedFile *resolveLFNFlat(IAgentContext &agent, const char *logica
     return ldFile.getClear();
 }
 
+// NB: If returns true, localPath contains the local path of rfn
 bool isRemoteReadCandidate(const IAgentContext &agent, const RemoteFilename &rfn, StringBuffer &localPath)
 {
     if (!agent.queryWorkUnit()->getDebugValueBool("forceRemoteDisabled", false))
     {
-        if (!rfn.isLocal() || agent.queryWorkUnit()->getDebugValueBool("forceRemoteRead", testForceRemote(rfn.getLocalPath(localPath))))
+        rfn.getLocalPath(localPath);
+        if (!rfn.isLocal() || agent.queryWorkUnit()->getDebugValueBool("forceRemoteRead", testForceRemote(localPath)))
             return true;
+        localPath.clear();
     }
     return false;
 }

--- a/thorlcr/thorutil/thormisc.cpp
+++ b/thorlcr/thorutil/thormisc.cpp
@@ -1468,12 +1468,15 @@ const ITranslator *getLayoutTranslation(const char *fname, IPartDescriptor &part
     return getTranslators(fname, expectedFormatCrc, expectedFormat, publishedFormatCrc, actualFormat, projectedFormatCrc, projectedFormat, translationMode);
 }
 
+// NB: If returns true, localPath contains the local path of rfn
 bool isRemoteReadCandidate(const CActivityBase &activity, const RemoteFilename &rfn, StringBuffer &localPath)
 {
     if (!activity.getOptBool(THOROPT_FORCE_REMOTE_DISABLED))
     {
-        if (!rfn.isLocal() || activity.getOptBool(THOROPT_FORCE_REMOTE_READ, testForceRemote(rfn.getLocalPath(localPath))))
+        rfn.getLocalPath(localPath);
+        if (!rfn.isLocal() || activity.getOptBool(THOROPT_FORCE_REMOTE_READ, testForceRemote(localPath)))
             return true;
+        localPath.clear();
     }
     return false;
 }


### PR DESCRIPTION
Regression introduced by HPCC-19687, caused remote files to
crash dafilesrv.

Signed-off-by: Jake Smith <jake.smith@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
