### PR TITLE
HPCC-19975 Remove session token support from IUserDescriptor

### DIFF
--- a/dali/base/dasess.cpp
+++ b/dali/base/dasess.cpp
@@ -2090,7 +2090,7 @@ public:
         encrypt(buf,password);
         passwordenc.set(buf.str());
     }
-    void set(const char *_name, const char *_password, unsigned _sessionToken, const char *_signature)
+    void set(const char *_name, const char *_password, const char *_signature)
     {
         set(_name, _password);
         signature.clear().append(_signature);

--- a/dali/base/dasess.hpp
+++ b/dali/base/dasess.hpp
@@ -78,7 +78,7 @@ interface IUserDescriptor: extends serializable
     virtual StringBuffer &getPassword(StringBuffer &buf)=0;
     virtual const char *querySignature()=0;//user's digital signature
     virtual void set(const char *name,const char *password)=0;
-    virtual void set(const char *name,const char *password, unsigned sessionToken, const char *_signature)=0;
+    virtual void set(const char *name,const char *password, const char *_signature)=0;
     virtual void clear()=0;
 };
 

--- a/esp/services/ws_access/ws_accessService.cpp
+++ b/esp/services/ws_access/ws_accessService.cpp
@@ -1756,7 +1756,7 @@ bool Cws_accessEx::onResources(IEspContext &context, IEspResourcesRequest &req, 
         {
             Owned<IUserDescriptor> userdesc;
             userdesc.setown(createUserDescriptor());
-            userdesc->set(context.queryUserId(), context.queryPassword(), context.querySessionToken(), context.querySignature());
+            userdesc->set(context.queryUserId(), context.queryPassword(), context.querySignature());
             int retCode;
             StringBuffer retMsg;
             bool isEnabled = querySessionManager().queryScopeScansEnabled(userdesc, &retCode, retMsg);
@@ -2780,7 +2780,7 @@ bool Cws_accessEx::onClearPermissionsCache(IEspContext &context, IEspClearPermis
     {
         Owned<IUserDescriptor> userdesc;
         userdesc.setown(createUserDescriptor());
-        userdesc->set(context.queryUserId(), context.queryPassword(), context.querySessionToken(), context.querySignature());
+        userdesc->set(context.queryUserId(), context.queryPassword(), context.querySignature());
         ok = querySessionManager().clearPermissionsCache(userdesc);
     }
 
@@ -2796,7 +2796,7 @@ bool Cws_accessEx::onQueryScopeScansEnabled(IEspContext &context, IEspQueryScope
 
     Owned<IUserDescriptor> userdesc;
     userdesc.setown(createUserDescriptor());
-    userdesc->set(context.queryUserId(), context.queryPassword(), context.querySessionToken(), context.querySignature());
+    userdesc->set(context.queryUserId(), context.queryPassword(), context.querySignature());
     int retCode;
     StringBuffer retMsg;
     bool isEnabled = querySessionManager().queryScopeScansEnabled(userdesc, &retCode, retMsg);
@@ -2841,7 +2841,7 @@ int Cws_accessEx::enableDisableScopeScans(IEspContext &context, bool doEnable, S
 
     Owned<IUserDescriptor> userdesc;
     userdesc.setown(createUserDescriptor());
-    userdesc->set(context.queryUserId(), context.queryPassword(), context.querySessionToken(), context.querySignature());
+    userdesc->set(context.queryUserId(), context.queryPassword(), context.querySignature());
     int retCode;
     bool rc = querySessionManager().enableScopeScans(userdesc, doEnable, &retCode, retMsg);
     if (!rc || retCode != 0)

--- a/esp/services/ws_dfu/ws_dfuService.cpp
+++ b/esp/services/ws_dfu/ws_dfuService.cpp
@@ -185,7 +185,7 @@ bool CWsDfuEx::onDFUSearch(IEspContext &context, IEspDFUSearchRequest & req, IEs
         if(username.length() > 0)
         {
             userdesc.setown(createUserDescriptor());
-            userdesc->set(username.str(), context.queryPassword(), context.querySessionToken(), context.querySignature());
+            userdesc->set(username.str(), context.queryPassword(), context.querySignature());
         }
 
         CTpWrapper dummy;
@@ -323,7 +323,7 @@ bool CWsDfuEx::onDFUQuery(IEspContext &context, IEspDFUQueryRequest & req, IEspD
         if(username.length() > 0)
         {
             userdesc.setown(createUserDescriptor());
-            userdesc->set(username.str(), context.queryPassword(), context.querySessionToken(), context.querySignature());
+            userdesc->set(username.str(), context.queryPassword(), context.querySignature());
         }
 
         doLogicalFileSearch(context, userdesc.get(), req, resp);
@@ -350,7 +350,7 @@ bool CWsDfuEx::onDFUInfo(IEspContext &context, IEspDFUInfoRequest &req, IEspDFUI
         if(username.length() > 0)
         {
             userdesc.setown(createUserDescriptor());
-            userdesc->set(username.str(), context.queryPassword(), context.querySessionToken(), context.querySignature());
+            userdesc->set(username.str(), context.queryPassword(), context.querySignature());
         }
 
         if (req.getUpdateDescription())
@@ -391,7 +391,7 @@ bool CWsDfuEx::onDFUSpace(IEspContext &context, IEspDFUSpaceRequest & req, IEspD
         if(username.length() > 0)
         {
             userdesc.setown(createUserDescriptor());
-            userdesc->set(username.str(), context.queryPassword(), context.querySessionToken(), context.querySignature());
+            userdesc->set(username.str(), context.queryPassword(), context.querySignature());
         }
 
         const char *countby = req.getCountBy();
@@ -1088,7 +1088,7 @@ int CWsDfuEx::superfileAction(IEspContext &context, const char* action, const ch
     if(username.length() > 0)
     {
         userdesc.setown(createUserDescriptor());
-        userdesc->set(username.str(), context.queryPassword(), context.querySessionToken(), context.querySignature());
+        userdesc->set(username.str(), context.queryPassword(), context.querySignature());
     }
 
     if (!autocreatesuper)
@@ -1396,7 +1396,7 @@ bool CWsDfuEx::DFUDeleteFiles(IEspContext &context, IEspDFUArrayActionRequest &r
     if(username && *username)
     {
         userdesc.setown(createUserDescriptor());
-        userdesc->set(username, context.queryPassword(), context.querySessionToken(), context.querySignature());
+        userdesc->set(username, context.queryPassword(), context.querySignature());
     }
 
     StringBuffer returnStr, auditStr = (",FileAccess,WsDfu,DELETED,");
@@ -1457,7 +1457,7 @@ bool CWsDfuEx::onDFUArrayAction(IEspContext &context, IEspDFUArrayActionRequest 
         if(username.length() > 0)
         {
             userdesc.setown(createUserDescriptor());
-            userdesc->set(username.str(), context.queryPassword(), context.querySessionToken(), context.querySignature());
+            userdesc->set(username.str(), context.queryPassword(), context.querySignature());
         }
 
         IArrayOf<IEspDFUActionInfo> actionResults;
@@ -1557,7 +1557,7 @@ bool CWsDfuEx::onDFUDefFile(IEspContext &context,IEspDFUDefFileRequest &req, IEs
         if(username.length() > 0)
         {
             userdesc.setown(createUserDescriptor());
-            userdesc->set(username.str(), context.queryPassword(), context.querySessionToken(), context.querySignature());
+            userdesc->set(username.str(), context.queryPassword(), context.querySignature());
         }
 
         getDefFile(userdesc.get(), req.getName(),rawStr);
@@ -1630,7 +1630,7 @@ bool CWsDfuEx::onDFURecordTypeInfo(IEspContext &context, IEspDFURecordTypeInfoRe
         if(userId && *userId)
         {
             userdesc.setown(createUserDescriptor());
-            userdesc->set(userId, context.queryPassword(), context.querySessionToken(), context.querySignature());
+            userdesc->set(userId, context.queryPassword(), context.querySignature());
         }
         Owned<IDistributedFile> df = queryDistributedFileDirectory().lookup(fileName, userdesc);
         if(!df)
@@ -2535,7 +2535,7 @@ bool CWsDfuEx::onDFUFileView(IEspContext &context, IEspDFUFileViewRequest &req, 
         if(username.length() > 0)
         {
             userdesc.setown(createUserDescriptor());
-            userdesc->set(username.str(), context.queryPassword(), context.querySessionToken(), context.querySignature());
+            userdesc->set(username.str(), context.queryPassword(), context.querySignature());
         }
 
         int numDirs = 0;
@@ -3788,7 +3788,7 @@ bool CWsDfuEx::onSuperfileList(IEspContext &context, IEspSuperfileListRequest &r
         if(username.length() > 0)
         {
             userdesc.setown(createUserDescriptor());
-            userdesc->set(username.str(), context.queryPassword(), context.querySessionToken(), context.querySignature());
+            userdesc->set(username.str(), context.queryPassword(), context.querySignature());
         }
 
         Owned<IDFUhelper> dfuhelper = createIDFUhelper();
@@ -3828,7 +3828,7 @@ bool CWsDfuEx::onSuperfileAction(IEspContext &context, IEspSuperfileActionReques
         {
             Owned<IUserDescriptor> udesc;
             udesc.setown(createUserDescriptor());
-            udesc->set(context.queryUserId(), context.queryPassword(), context.querySessionToken(), context.querySignature());
+            udesc->set(context.queryUserId(), context.queryPassword(), context.querySignature());
             Owned<IDistributedSuperFile> fp = queryDistributedFileDirectory().lookupSuperFile(superfile,udesc);
             if (!fp)
                 resp.setRetcode(-1); //Superfile has been removed.
@@ -3852,7 +3852,7 @@ bool CWsDfuEx::onSavexml(IEspContext &context, IEspSavexmlRequest &req, IEspSave
         if(username.length() > 0)
         {
             userdesc.setown(createUserDescriptor());
-            userdesc->set(username.str(), context.queryPassword(), context.querySessionToken(), context.querySignature());
+            userdesc->set(username.str(), context.queryPassword(), context.querySignature());
         }
 
         if (!req.getName() || !*req.getName())
@@ -3884,7 +3884,7 @@ bool CWsDfuEx::onAdd(IEspContext &context, IEspAddRequest &req, IEspAddResponse 
         if(username.length() > 0)
         {
             userdesc.setown(createUserDescriptor());
-            userdesc->set(username.str(), context.queryPassword(), context.querySessionToken(), context.querySignature());
+            userdesc->set(username.str(), context.queryPassword(), context.querySignature());
         }
 
         if (!req.getDstname() || !*req.getDstname())
@@ -3912,7 +3912,7 @@ bool CWsDfuEx::onAddRemote(IEspContext &context, IEspAddRemoteRequest &req, IEsp
         if(username.length() > 0)
         {
             userdesc.setown(createUserDescriptor());
-            userdesc->set(username.str(), context.queryPassword(), context.querySessionToken(), context.querySignature());
+            userdesc->set(username.str(), context.queryPassword(), context.querySignature());
         }
 
         const char* srcusername = req.getSrcusername();
@@ -3920,7 +3920,7 @@ bool CWsDfuEx::onAddRemote(IEspContext &context, IEspAddRemoteRequest &req, IEsp
         if(srcusername && *srcusername)
         {
             srcuserdesc.setown(createUserDescriptor());
-            srcuserdesc->set(srcusername, req.getSrcpassword(), context.querySessionToken(), context.querySignature());
+            srcuserdesc->set(srcusername, req.getSrcpassword(), context.querySignature());
         }
 
         const char* srcname = req.getSrcname();
@@ -3998,7 +3998,7 @@ bool CWsDfuEx::onDFUGetDataColumns(IEspContext &context, IEspDFUGetDataColumnsRe
 
             Owned<IUserDescriptor> userdesc;
             userdesc.setown(createUserDescriptor());
-            userdesc->set(username.str(), context.queryPassword(), context.querySessionToken(), context.querySignature());
+            userdesc->set(username.str(), context.queryPassword(), context.querySignature());
 
             {
                 Owned<IDistributedFile> df = queryDistributedFileDirectory().lookup(logicalNameStr.str(), userdesc);
@@ -4721,7 +4721,7 @@ bool CWsDfuEx::onDFUGetFileMetaData(IEspContext &context, IEspDFUGetFileMetaData
         {//Check whether the meta data is available for the file. If not, throw an exception.
             StringBuffer nameStr;
             Owned<IUserDescriptor> userdesc = createUserDescriptor();
-            userdesc->set(context.getUserID(nameStr).str(), context.queryPassword(), context.querySessionToken(), context.querySignature());
+            userdesc->set(context.getUserID(nameStr).str(), context.queryPassword(), context.querySignature());
             Owned<IDistributedFile> df = queryDistributedFileDirectory().lookup(fileName, userdesc);
             if(!df)
                 throw MakeStringException(ECLWATCH_FILE_NOT_EXIST,"CWsDfuEx::onDFUGetFileMetaData: Could not find file %s.", fileName);
@@ -4998,7 +4998,7 @@ bool CWsDfuEx::onListHistory(IEspContext &context, IEspListHistoryRequest &req, 
         if (username.length() > 0)
         {
             userdesc.setown(createUserDescriptor());
-            userdesc->set(username.str(), context.queryPassword(), context.querySessionToken(), context.querySignature());
+            userdesc->set(username.str(), context.queryPassword(), context.querySignature());
         }
 
         if (!req.getName() || !*req.getName())
@@ -5047,7 +5047,7 @@ bool CWsDfuEx::onEraseHistory(IEspContext &context, IEspEraseHistoryRequest &req
         if (username.length() > 0)
         {
             userdesc.setown(createUserDescriptor());
-            userdesc->set(username.str(), context.queryPassword(), context.querySessionToken(), context.querySignature());
+            userdesc->set(username.str(), context.queryPassword(), context.querySignature());
         }
 
         if (!req.getName() || !*req.getName())
@@ -5662,7 +5662,7 @@ int CWsDfuEx::GetIndexData(IEspContext &context, bool bSchemaOnly, const char* i
     try
     {
         userdesc.setown(createUserDescriptor());
-        userdesc->set(username.str(), context.queryPassword(), context.querySessionToken(), context.querySignature());
+        userdesc->set(username.str(), context.queryPassword(), context.querySignature());
         df.setown(queryDistributedFileDirectory().lookup(indexName, userdesc));
         if(!df)
             throw MakeStringException(ECLWATCH_FILE_NOT_EXIST,"Could not find file %s.", indexName);
@@ -5703,7 +5703,7 @@ int CWsDfuEx::GetIndexData(IEspContext &context, bool bSchemaOnly, const char* i
     if(secUser && secUser->getName() && *secUser->getName())
     {
         udesc.setown(createUserDescriptor());
-        udesc->set(secUser->getName(), secUser->credentials().getPassword(), context.querySessionToken(), context.querySignature());
+        udesc->set(secUser->getName(), secUser->credentials().getPassword(), context.querySignature());
     }
 
     if (cluster.length())

--- a/esp/services/ws_dfu/ws_dfuXRefService.cpp
+++ b/esp/services/ws_dfu/ws_dfuXRefService.cpp
@@ -114,7 +114,7 @@ bool CWsDfuXRefEx::onDFUXRefArrayAction(IEspContext &context, IEspDFUXRefArrayAc
         if(username.length() > 0)
         {
             userdesc.setown(createUserDescriptor());
-            userdesc->set(username.str(), context.queryPassword(), context.querySessionToken(), context.querySignature());
+            userdesc->set(username.str(), context.queryPassword(), context.querySignature());
         }
 
         if(*req.getAction() == 0 || *req.getType() == 0 || *req.getCluster() == 0)
@@ -210,7 +210,7 @@ void CWsDfuXRefEx::readLostFileQueryResult(IEspContext &context, StringBuffer& b
     if(username.length() > 0)
     {
         userdesc.setown(createUserDescriptor());
-        userdesc->set(username.str(), context.queryPassword(), context.querySessionToken(), context.querySignature());
+        userdesc->set(username.str(), context.queryPassword(), context.querySignature());
     }
 
     Owned<IPropertyTreeIterator> iter = lostFilesQueryResult->getElements("File");

--- a/esp/services/ws_esdlconfig/ws_esdlconfigservice.cpp
+++ b/esp/services/ws_esdlconfig/ws_esdlconfigservice.cpp
@@ -197,7 +197,7 @@ bool CWsESDLConfigEx::onPublishESDLDefinition(IEspContext &context, IEspPublishE
         if (user && *user)
         {
             userdesc.setown(createUserDescriptor());
-            userdesc->set(user, password, context.querySessionToken(), context.querySignature());
+            userdesc->set(user, password, context.querySignature());
         }
 
         DBGLOG("CWsESDLConfigEx::onPublishESDLDefinition User=%s",user);

--- a/esp/services/ws_fs/ws_fsBinding.cpp
+++ b/esp/services/ws_fs/ws_fsBinding.cpp
@@ -127,7 +127,7 @@ int CFileSpraySoapBindingEx::onGetInstantQuery(IEspContext &context, CHttpReques
                 {
                     const char* passwd = context.queryPassword();
                     userdesc.setown(createUserDescriptor());
-                    userdesc->set(username.str(), passwd, context.querySessionToken(), context.querySignature());
+                    userdesc->set(username.str(), passwd, context.querySignature());
 
                     try 
                     {

--- a/esp/services/ws_workunits/ws_workunitsHelpers.cpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.cpp
@@ -116,7 +116,7 @@ void ensureWsCreateWorkunitAccess(IEspContext& cxt)
 StringBuffer &getWuidFromLogicalFileName(IEspContext &context, const char *logicalName, StringBuffer &wuid)
 {
     Owned<IUserDescriptor> userdesc = createUserDescriptor();
-    userdesc->set(context.queryUserId(), context.queryPassword(), context.querySessionToken(), context.querySignature());
+    userdesc->set(context.queryUserId(), context.queryPassword(), context.querySignature());
     Owned<IDistributedFile> df = queryDistributedFileDirectory().lookup(logicalName, userdesc);
     if (!df)
         throw MakeStringException(ECLWATCH_FILE_NOT_EXIST,"Cannot find file %s.",logicalName);
@@ -206,7 +206,7 @@ void WsWuInfo::getSourceFiles(IEspECLWorkunit &info, unsigned long flags)
         context.getUserID(username);
         const char* passwd = context.queryPassword();
         userdesc.setown(createUserDescriptor());
-        userdesc->set(username.str(), passwd, context.querySessionToken(), context.querySignature());
+        userdesc->set(username.str(), passwd, context.querySignature());
 
         IArrayOf<IEspECLSourceFile> files;
         if (version < 1.27)
@@ -1328,7 +1328,7 @@ IDistributedFile* WsWuInfo::getLogicalFileData(IEspContext& context, const char*
     StringBuffer username;
     context.getUserID(username);
     Owned<IUserDescriptor> userdesc(createUserDescriptor());
-    userdesc->set(username.str(), context.queryPassword(), context.querySessionToken(), context.querySignature());
+    userdesc->set(username.str(), context.queryPassword(), context.querySignature());
     Owned<IDistributedFile> df = queryDistributedFileDirectory().lookup(logicalName, userdesc);
     if (!df)
         return NULL;

--- a/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
+++ b/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
@@ -179,7 +179,7 @@ bool copyWULogicalFiles(IEspContext &context, IConstWorkUnit &cw, const char *cl
         throw MakeStringException(ECLWATCH_INVALID_CLUSTER_NAME, "copyWULogicalFiles Cluster parameter not set.");
 
     Owned<IUserDescriptor> udesc = createUserDescriptor();
-    udesc->set(context.queryUserId(), context.queryPassword(), context.querySessionToken(), context.querySignature());
+    udesc->set(context.queryUserId(), context.queryPassword(), context.querySignature());
 
     IArrayOf<IEspWULogicalFileCopyInfo> foreign;
     IArrayOf<IEspWULogicalFileCopyInfo> onCluster;


### PR DESCRIPTION
A while back I added SessionToken support to the Dali IUserDescriptor.
This support is not needed and is removed with this PR.

Signed-off-by: Russ Whitehead <william.whitehead@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [x] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
