### PR TITLE
HPCC-19970 In simplified expr use no_simplified operator and don't simplify constants

### DIFF
--- a/ecl/hql/hqlattr.cpp
+++ b/ecl/hql/hqlattr.cpp
@@ -556,7 +556,7 @@ unsigned getOperatorMetaFlags(node_operator op)
     case no_notify:
     case no_setgraphresult:
     case no_extractresult:
-    case no_unused81:
+    case no_simplified:
     case no_definesideeffect:
 
 // Scopes etc.

--- a/ecl/hql/hqlcache.cpp
+++ b/ecl/hql/hqlcache.cpp
@@ -355,7 +355,7 @@ static IHqlExpression * createSimplifiedDefinitionFromType(ITypeInfo * type, boo
         return nullptr;
     case type_real:
     case type_decimal:
-        return createNullExpr(type);
+        return createValue(no_simplified, LINK(type), createNullExpr(type));
     case type_int:
         if (implicitConstantType)
         {
@@ -363,9 +363,9 @@ static IHqlExpression * createSimplifiedDefinitionFromType(ITypeInfo * type, boo
             // its ECL representation. ECL integer constants cannot specify a type - and are always parsed as int8,
             // so the constants are created as int8 for consistency.
             Owned<ITypeInfo> tempType = makeIntType(8, true);
-            return createNullExpr(tempType);
+            return createValue(no_simplified, tempType.getLink(), createNullExpr(tempType));
         }
-        return createNullExpr(type);
+        return createValue(no_simplified, LINK(type), createNullExpr(type));
     }
 
     return nullptr;
@@ -373,6 +373,8 @@ static IHqlExpression * createSimplifiedDefinitionFromType(ITypeInfo * type, boo
 
 static IHqlExpression * createSimplifiedBodyDefinition(IHqlExpression * expr, bool implicitConstantType=false)
 {
+    if (expr->isConstant())
+        return LINK(expr);
     if (expr->isFunction())
     {
         if (!expr->isFunctionDefinition())
@@ -413,7 +415,7 @@ static IHqlExpression * createSimplifiedBodyDefinition(IHqlExpression * expr, bo
             ForEachChild(idx, origDefaults)
             {
                 IHqlExpression * defaultValue = origDefaults->queryChild(idx);
-                if (defaultValue->getOperator() == no_omitted)
+                if (defaultValue->getOperator() == no_omitted || defaultValue->isConstant())
                     newDefaultsArray.append(*(LINK(defaultValue)));
                 else
                 {

--- a/ecl/hql/hqlexpr.cpp
+++ b/ecl/hql/hqlexpr.cpp
@@ -1958,6 +1958,7 @@ const char *getOpString(node_operator op)
     case no_id: return "no_id";
     case no_orderedactionlist: return "ORDERED";
     case no_unordered: return "UNORDERED";
+    case no_simplified: return "SIMPLIFIED";
 
     case no_unused6:
     case no_unused13: case no_unused14: case no_unused15:
@@ -1965,7 +1966,6 @@ const char *getOpString(node_operator op)
     case no_unused40: case no_unused41: case no_unused42: case no_unused43: case no_unused44: case no_unused45: case no_unused46: case no_unused47: case no_unused48: case no_unused49:
     case no_unused50: case no_unused52:
     case no_unused80:
-    case no_unused81:
     case no_unused102:
         return "unused";
     /* if fail, use "hqltest -internal" to find out why. */

--- a/ecl/hql/hqlexpr.hpp
+++ b/ecl/hql/hqlexpr.hpp
@@ -711,7 +711,7 @@ enum node_operator : unsigned short {
         no_sectioninput,
         no_forcegraph,
         no_eventextra,
-    no_unused81,
+        no_simplified,
         no_related,
         no_executewhen,
         no_definesideeffect,

--- a/ecl/hql/hqlfold.cpp
+++ b/ecl/hql/hqlfold.cpp
@@ -4285,6 +4285,10 @@ IHqlExpression * foldConstantOperator(IHqlExpression * expr, unsigned foldOption
                 return LINK(arg);
             break;
         }
+    case  no_simplified:  // Only used during syntax checking:
+        {                 // When syntax checking, some constant expressions are expanded during parsing
+            return LINK(expr->queryChild(0));
+        }
     }
 
     return LINK(expr);

--- a/ecl/hql/hqlir.cpp
+++ b/ecl/hql/hqlir.cpp
@@ -643,7 +643,7 @@ const char * getOperatorIRText(node_operator op)
     EXPAND_CASE(no,sectioninput);
     EXPAND_CASE(no,forcegraph);
     EXPAND_CASE(no,eventextra);
-    EXPAND_CASE(no,unused81);
+    EXPAND_CASE(no,simplified);
     EXPAND_CASE(no,related);
     EXPAND_CASE(no,executewhen);
     EXPAND_CASE(no,definesideeffect);


### PR DESCRIPTION


Signed-off-by: Shamser Ahmed <shamser.ahmed@lexisnexis.co.uk>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [x] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
