### PR TITLE
HPCC-19862 include Spark package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,6 +196,10 @@ if(APPLE)
     HPCC_ADD_SUBDIRECTORY(package)
 endif(APPLE)
 
+if(USE_SPARK)
+    HPCC_ADD_SUBDIRECTORY(spark "PLATFORM")
+endif(USE_SPARK)
+
 ###
 ## CPack install and packaging setup.
 ###

--- a/cmake_modules/commonSetup.cmake
+++ b/cmake_modules/commonSetup.cmake
@@ -99,6 +99,7 @@ IF ("${COMMONSETUP_DONE}" STREQUAL "")
   option(USE_PYTHON3 "Enable python3 language support for platform build" ON)
   option(USE_OPTIONAL "Automatically disable requested features with missing dependencies" ON)
   option(JLIB_ONLY  "Build JLIB for other projects such as Configurator, Ganglia Monitoring, etc" OFF)
+  option(USE_SPARK  "Packaging Spark with HPCC" OFF)
   # Generates code that is more efficient, but will cause problems if target platforms do not support it.
   if (CMAKE_SIZEOF_VOID_P EQUAL 8)
     option(USE_INLINE_TSC "Inline calls to read TSC (time stamp counter)" ON)

--- a/spark/CMakeLists.txt
+++ b/spark/CMakeLists.txt
@@ -1,0 +1,110 @@
+################################################################################
+#    HPCC SYSTEMS software Copyright (C) 2018 HPCC Systems.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+################################################################################
+
+
+#########################################################
+# Description:
+# ------------
+#    Spark with HPCC
+#
+#
+#########################################################
+cmake_minimum_required(VERSION 3.3)
+
+project(spark-integration)
+
+if(USE_SPARK)
+
+  if(SPARK_URL)
+    string( REPLACE "\/" ";" SPARK_URL_LIST ${SPARK_URL} )
+    list( GET SPARK_URL_LIST "-1"  spark_file_name_w_ext )
+    string( REPLACE "\.tgz" "" spark_file_name_only ${spark_file_name_w_ext} )
+    string( REPLACE "-" ";" spark_file_name_parts ${spark_file_name_only} )
+    list( GET spark_file_name_parts 1 SPARK_VERSION )
+    list( GET spark_file_name_parts 3 hadoop_version_w_head )
+    string( REPLACE "hadoop" "" HADOOP_VERSION ${hadoop_version_w_head} )
+
+  else(SPARK_URL)
+    if (NOT HADOOP_VERSION)
+      set(HADOOP_VERSION 2.7)
+    endif (NOT HADOOP_VERSION)
+
+    if (NOT SPARK_VERSION)
+      set(SPARK_VERSION 2.3.1)
+    endif (NOT SPARK_VERSION)
+
+    if (NOT SPARK_URL_BASE)
+      set(SPARK_URL_BASE  "http://apache.mirrors.pair.com")
+    endif (NOT SPARK_URL_BASE)
+
+    set(SPARK_PACKAGE_NAME "spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}")
+    set(SPARK_URL  "${SPARK_URL_BASE}/spark/spark-${SPARK_VERSION}/${SPARK_PACKAGE_NAME}.tgz")
+  endif(SPARK_URL)
+
+  if (NOT SPARK_HPCC)
+    message(FATAL_ERROR "Missing Spark HPCC Jar file. Set it with -DSPARK_HPCC=<value>")
+  endif (NOT SPARK_HPCC)
+
+
+  message("")
+  message("SPARK VERSION: ${SPARK_VERSION}")
+  message("HADOOP VERSION: ${HADOOP_VERSION}")
+  message("SPARK Package URI: ${SPARK_URL}")
+  message("")
+
+  if(SHA512)
+     set( SHA512STRING "${SHA512}" )
+  else(SHA512)
+     set( SHA512STRING "DC3A97F3D99791D363E4F70A622B84D6E313BD852F6FDBC777D31EAB44CBC112CEEAA20F7BF835492FB654F48AE57E9969F93D3B0E6EC92076D1C5E1B40B4696" )
+  endif(SHA512)
+
+  if (SHA512STRING)
+    install(CODE "file(
+      DOWNLOAD ${SPARK_URL}
+      ${CMAKE_BINARY_DIR}/downloads/${SPARK_PACKAGE_NAME}.tgz
+      EXPECTED_HASH SHA512=${SHA512STRING}
+      TIMEOUT 180
+      INACTIVITY_TIMEOUT 120)"
+    )
+  else (SHA512STRING)
+    install(CODE "file(
+      DOWNLOAD ${SPARK_URL}
+      ${CMAKE_BINARY_DIR}/downloads/${SPARK_PACKAGE_NAME}.tgz
+      TIMEOUT 120
+      INACTIVITY_TIMEOUT 30)"
+    )
+  endif (SHA512STRING)
+
+  install(
+     CODE "
+     execute_process( WORKING_DIRECTORY \"${CMAKE_BINARY_DIR}/downloads\" COMMAND \"${CMAKE_COMMAND}\" -E tar -zxf \"${SPARK_PACKAGE_NAME}.tgz\" )
+     execute_process( WORKING_DIRECTORY \"${CMAKE_BINARY_DIR}/downloads\" COMMAND \"${CMAKE_COMMAND}\" -E remove -f  \"${SPARK_PACKAGE_NAME}.tgz\" )
+    "
+  )
+
+  install(
+    DIRECTORY "${CMAKE_BINARY_DIR}/downloads/${SPARK_PACKAGE_NAME}"
+    COMPONENT runtime
+    DESTINATION "externals"
+  )
+
+  install(
+    FILES "${CMAKE_BINARY_DIR}/${SPARK_HPCC}"
+    COMPONENT runtime
+    DESTINATION "jars/spark/"
+  )
+
+endif(USE_SPARK)

--- a/spark/CMakeLists.txt
+++ b/spark/CMakeLists.txt
@@ -76,21 +76,22 @@ if(USE_SPARK)
       DOWNLOAD ${SPARK_URL}
       ${CMAKE_BINARY_DIR}/downloads/${SPARK_PACKAGE_NAME}.tgz
       EXPECTED_HASH SHA512=${SHA512STRING}
-      TIMEOUT 180
+      TIMEOUT 300
       INACTIVITY_TIMEOUT 120)"
     )
   else (SHA512STRING)
     install(CODE "file(
       DOWNLOAD ${SPARK_URL}
       ${CMAKE_BINARY_DIR}/downloads/${SPARK_PACKAGE_NAME}.tgz
-      TIMEOUT 120
-      INACTIVITY_TIMEOUT 30)"
+      TIMEOUT 300
+      INACTIVITY_TIMEOUT 120)"
     )
   endif (SHA512STRING)
 
   install(
      CODE "
      execute_process( WORKING_DIRECTORY \"${CMAKE_BINARY_DIR}/downloads\" COMMAND \"${CMAKE_COMMAND}\" -E tar -zxf \"${SPARK_PACKAGE_NAME}.tgz\" )
+     execute_process( WORKING_DIRECTORY \"${CMAKE_BINARY_DIR}/downloads\" COMMAND \"${CMAKE_COMMAND}\" -E rename \"${SPARK_PACKAGE_NAME}\" \"spark-hadoop\" )
      execute_process( WORKING_DIRECTORY \"${CMAKE_BINARY_DIR}/downloads\" COMMAND \"${CMAKE_COMMAND}\" -E remove -f  \"${SPARK_PACKAGE_NAME}.tgz\" )
     "
   )


### PR DESCRIPTION
Spark package is deployed under <HPCC Install directory>/external/
Spark-HPCC jar file is deployed under <HPCC Install directory>/jar/spark/
CMake options:
-DUSE_SPARK=ON : this will trigger build Platform or LN to include Spark

-DSPARK_URL=<value>: This is a URL to download spark/hadoop package. The default is "http://apache.mirrors.pair.com/spark/spark-2.3.1/spark-2.3.1-bin-hadoop2.7.tgz". In local build we use http://10.240.32.242/data3/software/spark/spark-2.3.1-bin-hadoop2.7.tgz

-DSHA512=<value>. It is for verify downloaded package. The default value is for spark-2.3.1-bin-hadoop2.7.gz. User can disable by set '-DSHA512=OFF" or "-DSHA512=", though it is no recommended.

-DSPARK_URL_BASE: The defaulit is "http://apache.mirrors.pair.com"

-DSPARK_VERSION: The default is "2.3.1"
-DHADOOP_VERSION: The default is "2.7"
When "SPARK_URL" is provided the versions will be parsed from the URL.

-DSPARK_HPCC=<value> : spark-hpcc jar file. The path will be related to build directory.

Signed-off-by: Xiaoming Wang <xiaoming.wang@lexisnexi.com>

@Michael-Gardner  @rpastrana please review

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).


## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [x] The change has been fully tested:
  - [x] I have added tests to cover my changes.
  

## Testing:
<!-- Please describe how this change has been tested.-->
http://10.240.32.243/view/Spark/job/Spark-Package/
<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
