### PR TITLE
HPCC-19389 Expose global and local IDs to ECL via lib_logging

### DIFF
--- a/ecllibrary/std/system/Log.ecl
+++ b/ecllibrary/std/system/Log.ecl
@@ -49,4 +49,21 @@ EXPORT addWorkunitWarning(varstring text, unsigned code=0) := lib_logging.Loggin
 
 EXPORT addWorkunitError(varstring text, unsigned code=0) := lib_logging.Logging.addWorkunitError(text, code, 2);
 
+/*
+ * Gets the Global Id associated with the current query or workunit.
+ *
+ * Returns the Global Id
+ */
+
+EXPORT getGlobalId() := lib_logging.Logging.getGlobalId();
+
+/*
+ * Gets the Local Id associated with the current query or workunit.
+ *
+ * Returns the Local Id
+ */
+
+EXPORT getLocalId() := lib_logging.Logging.getLocalId();
+
+
 END;

--- a/plugins/logging/CMakeLists.txt
+++ b/plugins/logging/CMakeLists.txt
@@ -31,6 +31,7 @@ set (    SRCS
 include_directories ( 
          ./../../system/include 
          ./../../system/jlib 
+         ./../../rtl/include
     )
 
 ADD_DEFINITIONS( -D_USRDLL -DLOGGING_EXPORTS )

--- a/plugins/logging/logging.cpp
+++ b/plugins/logging/logging.cpp
@@ -34,6 +34,8 @@ static const char * EclDefinition =
 "  addWorkunitInformation(const varstring txt, unsigned code=0, unsigned severity=0, const varstring source='user') : ctxmethod,action,entrypoint='addWuException'; \n"
 "  addWorkunitWarning(const varstring txt, unsigned code=0, unsigned severity=1, const varstring source='user') : ctxmethod,action,entrypoint='addWuException'; \n"
 "  addWorkunitError(const varstring txt, unsigned code=0, unsigned severity=2, const varstring source='user') : ctxmethod,action,entrypoint='addWuException'; \n"
+"  varstring getGlobalId() : c,context,entrypoint='logGetGlobalId'; \n"
+"  varstring getLocalId() : c,context,entrypoint='logGetLocalId'; \n"
 "END;";
 
 LOGGING_API bool getECLPluginDefinition(ECLPluginDefinitionBlock *pb) 
@@ -61,3 +63,14 @@ LOGGING_API void LOGGING_CALL logDbgLog(unsigned srcLen, const char * src)
     DBGLOG("%.*s", srcLen, src);
 }
 
+LOGGING_API char *  LOGGING_CALL logGetGlobalId(ICodeContext *ctx)
+{
+    StringBuffer ret = ctx->queryContextLogger().queryGlobalId();
+    return ret.detach();
+}
+
+LOGGING_API char *  LOGGING_CALL logGetLocalId(ICodeContext *ctx)
+{
+    StringBuffer ret = ctx->queryContextLogger().queryLocalId();
+    return ret.detach();
+}

--- a/plugins/logging/logging.hpp
+++ b/plugins/logging/logging.hpp
@@ -31,10 +31,13 @@
 #endif
 
 #include "hqlplugins.hpp"
+#include "eclhelper.hpp"
 
 extern "C" {
 LOGGING_API bool getECLPluginDefinition(ECLPluginDefinitionBlock *pb);
 LOGGING_API void LOGGING_CALL logDbgLog(unsigned srcLen, const char * src);
+LOGGING_API char * LOGGING_CALL logGetGlobalId(ICodeContext *ctx);
+LOGGING_API char * LOGGING_CALL logGetLocalId(ICodeContext *ctx);
 }
 
 #endif


### PR DESCRIPTION
Global and Local IDs will be accessable to the ECL developer.

For Example:

output(std.system.log.getGlobalId(), named('globalid'));
output(std.system.log.getLocalId(), named('localid'));

Signed-off-by: Anthony Fishbeck <anthony.fishbeck@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [x] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [x] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
