### PR TITLE
HPCC-20142 Never return NULL property iterators

### DIFF
--- a/system/security/LdapSecurity/ldapsecurity.ipp
+++ b/system/security/LdapSecurity/ldapsecurity.ipp
@@ -70,6 +70,8 @@ private:
     unsigned     m_sessionToken;//User's ESP session token
     StringBuffer m_signature;//User's digital signature
 
+    static Owned<IProperties> sm_emptyParameters;
+
 public:
     IMPLEMENT_IINTERFACE
 
@@ -149,7 +151,7 @@ public:
 
     virtual void setPropertyInt(const char* name, int value){}
     virtual int getPropertyInt(const char* name){ return 0;}
-    IPropertyIterator * getPropertyIterator() const override { return nullptr;}
+    IPropertyIterator * getPropertyIterator() const override { return sm_emptyParameters->getIterator();}
 
 
 //interface ISecCredentials

--- a/system/security/shared/SecureUser.hpp
+++ b/system/security/shared/SecureUser.hpp
@@ -47,8 +47,8 @@ private:
 public:
     IMPLEMENT_IINTERFACE
 
-    CSecureUser(const char *name, const char *pw) : 
-        m_name(name), m_pw(pw), m_authenticateStatus(AS_UNKNOWN), m_userID(0), m_status(SecUserStatus_Unknown), m_sessionToken(0)
+    CSecureUser(const char *name, const char *pw) :
+        m_name(name), m_pw(pw), m_authenticateStatus(AS_UNKNOWN), m_userID(0), m_status(SecUserStatus_Unknown), m_sessionToken(0), m_parameters(createProperties(false))
     {
     }
 
@@ -174,35 +174,27 @@ public:
 
     void setProperty(const char* name, const char* value)
     {
-        if (!m_parameters)
-            m_parameters.setown(createProperties(false));
         m_parameters->setProp(name, value);
     }
 
     const char* getProperty(const char* name)
     {
-        if (m_parameters)
-            return m_parameters->queryProp(name);
-        return NULL;
+        return m_parameters->queryProp(name);
     }
 
     void setPropertyInt(const char* name, int value)
     {
-        if (!m_parameters)
-            m_parameters.setown(createProperties(false));
         m_parameters->setProp(name, value);
     }
 
     int getPropertyInt(const char* name)
     {
-        if (m_parameters)
-            return m_parameters->getPropInt(name);
-        return 0;
+        return m_parameters->getPropInt(name);
     }
 
     IPropertyIterator * getPropertyIterator() const override
     {
-        return (m_parameters.get() ? m_parameters->getIterator() : nullptr);
+        return m_parameters->getIterator();
     }
 
 
@@ -270,15 +262,11 @@ public:
         CDateTime tmpTime;
         destination.setPasswordExpiration(getPasswordExpiration(tmpTime));
         destination.setStatus(getStatus());
-        if(m_parameters.get()==NULL)
-            return;
         CriticalBlock b(crit);
         Owned<IPropertyIterator> Itr = m_parameters->getIterator();
-        Itr->first();
-        while(Itr->isValid())
+        ForEach(*Itr)
         {
             destination.setProperty(Itr->getPropKey(),m_parameters->queryProp(Itr->getPropKey()));
-            Itr->next();
         }
 
 


### PR DESCRIPTION
Return iterator for empty property collections instead of NULL.
Remove lazy property initialization to ensure that possibly empty
property collections exist at the time of each request.

Signed-off-by: Tim Klemm <Tim.Klemm@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [x] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [ ] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [x] All new and existing tests passed.
  - [x] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [x] Scalability
  - [x] Performance
  - [x] Security
  - [x] Thread-safety
  - [x] Premature optimization
  - [x] Existing deployed queries will not be broken
  - [x] This change fixes the problem, not just the symptom
  - [x] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [x] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
