### PR TITLE
HPCC-20242 Remove password from legacy workunit token

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -7461,7 +7461,7 @@ IUserDescriptor *CLocalWorkUnit::queryUserDescriptor() const
     {
         SCMStringBuffer token, user, password;
         getSecurityToken(token);
-        extractToken(token.str(), queryWuid(), user, password);
+        extractToken(token.str(), queryWuid(), user);
         userDesc.setown(createUserDescriptor());
         userDesc->set(user.str(), password.str());
     }
@@ -11413,7 +11413,7 @@ extern WORKUNIT_API void submitWorkUnit(const char *wuid, const char *username, 
     assertex(workunit);
 
     SCMStringBuffer token;
-    createToken(wuid, username, password, token);
+    createToken(wuid, username, token);
     workunit->setSecurityToken(token.str());
     StringAttr clusterName(workunit->queryClusterName());
     if (!clusterName.length()) 
@@ -12129,17 +12129,17 @@ extern WORKUNIT_API bool getWorkUnitCreateTime(const char *wuid,CDateTime &time)
     return false;
 }
 
-extern WORKUNIT_API IStringVal& createToken(const char *wuid, const char *user, const char *password, IStringVal &str)
+extern WORKUNIT_API IStringVal& createToken(const char *wuid, const char *user, IStringVal &str)
 {
     StringBuffer wu, token("X");
-    wu.append(wuid).append(';').append(user).append(';').append(password);
+    wu.append(wuid).append(';').append(user).append(';');
     encrypt(token,wu.str());
     str.set(token.str());
     return str;
 }
 
 // This will be replaced by something more secure!
-extern WORKUNIT_API void extractToken(const char *token, const char *wuid, IStringVal &user, IStringVal &password)
+extern WORKUNIT_API void extractToken(const char *token, const char *wuid, IStringVal &user)
 {
     if (token && *token)
     {
@@ -12152,8 +12152,6 @@ extern WORKUNIT_API void extractToken(const char *token, const char *wuid, IStri
             if(finger1)
             {
                 user.setLen(finger, (size32_t)(finger1-finger));
-                finger1++;
-                password.setLen(finger1, (size32_t)(wu.str() + wu.length() - finger1));
                 return;
             }
         }

--- a/common/workunit/workunit.hpp
+++ b/common/workunit/workunit.hpp
@@ -1603,9 +1603,9 @@ extern WORKUNIT_API bool waitForWorkUnitToCompile(const char * wuid, int timeout
 extern WORKUNIT_API WUState secWaitForWorkUnitToComplete(const char * wuid, ISecManager &secmgr, ISecUser &secuser, int timeout = -1, bool returnOnWaitState = false);
 extern WORKUNIT_API bool secWaitForWorkUnitToCompile(const char * wuid, ISecManager &secmgr, ISecUser &secuser, int timeout = -1);
 extern WORKUNIT_API bool secDebugWorkunit(const char * wuid, ISecManager &secmgr, ISecUser &secuser, const char *command, StringBuffer &response);
-extern WORKUNIT_API IStringVal& createToken(const char *wuid, const char *user, const char *password, IStringVal &str);
+extern WORKUNIT_API IStringVal& createToken(const char *wuid, const char *user, IStringVal &str);
 // This latter is temporary - tokens will be replaced by something more secure
-extern WORKUNIT_API void extractToken(const char *token, const char *wuid, IStringVal &user, IStringVal &password);
+extern WORKUNIT_API void extractToken(const char *token, const char *wuid, IStringVal &user);
 extern WORKUNIT_API WUState getWorkUnitState(const char* state);
 extern WORKUNIT_API IWorkflowScheduleConnection * getWorkflowScheduleConnection(char const * wuid);
 extern WORKUNIT_API const char *skipLeadingXml(const char *text);

--- a/ecl/eclcc/eclcc.cpp
+++ b/ecl/eclcc/eclcc.cpp
@@ -2433,7 +2433,7 @@ int EclCC::parseCommandLineOptions(int argc, const char* argv[])
         else if (iter.matchOption(tempArg, "-token"))
         {
             // For use by eclccserver - not documented in usage()
-            extractToken(tempArg, optWUID, StringAttrAdaptor(optUser), StringAttrAdaptor(optPassword));
+            extractToken(tempArg, optWUID, StringAttrAdaptor(optUser));
         }
         else if (iter.matchOption(optWUID, "-wuid"))
         {

--- a/esp/services/ws_ecl/ws_ecl_service.cpp
+++ b/esp/services/ws_ecl/ws_ecl_service.cpp
@@ -1907,7 +1907,7 @@ int CWsEclBinding::submitWsEclWorkunit(IEspContext & context, WsEclWuInfo &wsinf
     }
 
     SCMStringBuffer token;
-    createToken(wuid.str(), context.queryUserId(), context.queryPassword(), token);
+    createToken(wuid.str(), context.queryUserId(), token);
     workunit->setSecurityToken(token.str());
     workunit->setState(WUStateSubmitted);
     workunit->commit();

--- a/esp/services/ws_workunits/ws_workunitsHelpers.cpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.cpp
@@ -3279,7 +3279,7 @@ void WsWuHelpers::copyWsWorkunit(IEspContext &context, IWorkUnit &wu, const char
     queryExtendedWU(&wu)->copyWorkUnit(src, false, false);
 
     SCMStringBuffer token;
-    wu.setSecurityToken(createToken(wu.queryWuid(), context.queryUserId(), context.queryPassword(), token).str());
+    wu.setSecurityToken(createToken(wu.queryWuid(), context.queryUserId(), token).str());
     wu.commit();
 }
 

--- a/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
+++ b/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
@@ -1671,7 +1671,7 @@ void copyWorkunitForRecompile(IEspContext &context, IWorkUnitFactory *factory, c
     wu->setAction(WUActionCompile);
 
     SCMStringBuffer token;
-    wu->setSecurityToken(createToken(wuid.str(), context.queryUserId(), context.queryPassword(), token).str());
+    wu->setSecurityToken(createToken(wuid.str(), context.queryUserId(), token).str());
 
     jobname.set(src->queryJobName());
     if (jobname.length())

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -834,7 +834,7 @@ bool CWsWorkunitsEx::onWUResubmit(IEspContext &context, IEspWUResubmitRequest &r
                     queryExtendedWU(wu)->copyWorkUnit(src, false, false);
 
                     SCMStringBuffer token;
-                    wu->setSecurityToken(createToken(wuid.str(), context.queryUserId(), context.queryPassword(), token).str());
+                    wu->setSecurityToken(createToken(wuid.str(), context.queryUserId(), token).str());
                 }
 
                 wuids.append(wuid.str());
@@ -964,7 +964,7 @@ bool CWsWorkunitsEx::onWUSchedule(IEspContext &context, IEspWUScheduleRequest &r
             wu->setDebugValueInt("maxRunTime", req.getMaxRunTime(), true);
 
         SCMStringBuffer token;
-        wu->setSecurityToken(createToken(wuid.str(), context.queryUserId(), context.queryPassword(), token).str());
+        wu->setSecurityToken(createToken(wuid.str(), context.queryUserId(), token).str());
 
         AuditSystemAccess(context.queryUserId(), true, "Scheduled %s", wuid.str());
     }

--- a/plugins/fileservices/fileservices.cpp
+++ b/plugins/fileservices/fileservices.cpp
@@ -202,10 +202,10 @@ static IPropertyTree *getEnvironmentTree(IConstEnvironment * daliEnv)
 
 static void setServerAccess(CClientFileSpray &server, IConstWorkUnit * wu)
 {
-    StringBuffer user, password, token;
+    StringBuffer user, token;
     wu->getSecurityToken(StringBufferAdaptor(token));
-    extractToken(token.str(), wu->queryWuid(), StringBufferAdaptor(user), StringBufferAdaptor(password));
-    server.setUsernameToken(user.str(), password.str(), "");
+    extractToken(token.str(), wu->queryWuid(), StringBufferAdaptor(user));
+    server.setUsernameToken(user.str(), nullptr, "");
 }
 
 static StringArray availableWsFS;

--- a/thorlcr/graph/thgraph.cpp
+++ b/thorlcr/graph/thgraph.cpp
@@ -2674,10 +2674,10 @@ void CJobBase::init()
     tmp.append(graphName);
     key.set(tmp.str());
 
-    SCMStringBuffer tokenUser, password;
-    extractToken(token.str(), wuid.str(), tokenUser, password);
+    SCMStringBuffer tokenUser;
+    extractToken(token.str(), wuid.str(), tokenUser);
     userDesc = createUserDescriptor();
-    userDesc->set(user.str(), password.str());
+    userDesc->set(user.str(), nullptr);
 
     forceLogGraphIdMin = (graph_id)getWorkUnitValueInt("forceLogGraphIdMin", 0);
     forceLogGraphIdMax = (graph_id)getWorkUnitValueInt("forceLogGraphIdMax", 0);

--- a/tools/swapnode/swapnodelib.cpp
+++ b/tools/swapnode/swapnodelib.cpp
@@ -87,13 +87,11 @@ bool WuResubmit(const char *wuid)
     SCMStringBuffer token;
     wu->getSecurityToken(token);
     SCMStringBuffer user;
-    SCMStringBuffer password;
-    extractToken(token.str(), wuid, user, password);
     wu->resetWorkflow();
     wu->setState(WUStateSubmitted);
     wu->commit();
     wu.clear();
-    submitWorkUnit(wuid,user.str(),password.str());
+    submitWorkUnit(wuid,user.str(),nullptr);//TODO remove password from signature
 
     PROGLOG("WuResubmit(%s): resubmitted",wuid);
     return true;


### PR DESCRIPTION
In order to find the features that break when a password is not available,
temporarily remove the password from the legacy workunit token

Signed-off-by: Russ Whitehead <william.whitehead@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [x] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [ ] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
