### PR TITLE
HPCC-20220 Dali cores when getPermissions called internally

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -6426,7 +6426,8 @@ void CLocalWorkUnit::remoteCheckAccess(IUserDescriptor *user, bool writeaccess) 
     if (scopename&&*scopename) {
         if (!user)
             user = queryUserDescriptor();
-        perm = querySessionManager().getPermissionsLDAP("workunit",scopename,user,auditflags);
+        CDateTime now;
+        perm = querySessionManager().getPermissionsLDAP("workunit",scopename,user,auditflags,nullptr,now);
         if (perm<0) {
             if (perm == SecAccess_Unavailable)
                 perm = SecAccess_Full;

--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -1256,7 +1256,13 @@ static SecAccessFlags getScopePermissions(const char *scopename,IUserDescriptor 
 #endif
             user = queryDistributedFileDirectory().queryDefaultUser();
         }
-        perms = querySessionManager().getPermissionsLDAP(queryDfsXmlBranchName(DXB_Scope),scopename,user,auditflags);
+
+        //Create signature
+        CDateTime now;
+        StringBuffer b64sig;
+        createDaliSignature(scopename, user, now, b64sig);
+
+        perms = querySessionManager().getPermissionsLDAP(queryDfsXmlBranchName(DXB_Scope),scopename,user,auditflags, b64sig.str(), now);
         if (perms<0) {
             if (perms == SecAccess_Unavailable) {
                 scopePermissionsAvail=false;

--- a/dali/base/dasess.hpp
+++ b/dali/base/dasess.hpp
@@ -114,7 +114,7 @@ interface ISessionManager: extends IInterface
     virtual StringBuffer &getClientProcessEndpoint(SessionId id,StringBuffer &buf)=0; // for diagnostics
     virtual unsigned queryClientCount() = 0; // for SNMP
 
-    virtual SecAccessFlags getPermissionsLDAP(const char *key,const char *obj,IUserDescriptor *udesc,unsigned auditflags, const char * reqSignature=nullptr, CDateTime * reqUTCTimestamp=nullptr, int *err=NULL)=0;
+    virtual SecAccessFlags getPermissionsLDAP(const char *key,const char *obj,IUserDescriptor *udesc,unsigned auditflags, const char * reqSignature, CDateTime & reqUTCTimestamp, int *err=NULL)=0;
     virtual bool checkScopeScansLDAP()=0;
     virtual unsigned getLDAPflags()=0;
     virtual void setLDAPflags(unsigned flags)=0;
@@ -135,6 +135,8 @@ interface ISessionManager: extends IInterface
 extern da_decl ISessionManager &querySessionManager();
 
 #define myProcessSession() (querySessionManager().lookupProcessSession())
+
+extern da_decl bool createDaliSignature(const char * scope, IUserDescriptor *udesc, CDateTime &now, StringBuffer &b64sig);
 
 interface IMessageWrapper
 {

--- a/dali/server/daldap.cpp
+++ b/dali/server/daldap.cpp
@@ -121,7 +121,7 @@ public:
     }
 
 
-    SecAccessFlags getPermissions(const char *key,const char *obj,IUserDescriptor *udesc,unsigned auditflags,const char * reqSignature, CDateTime * reqUTCTimestamp)
+    SecAccessFlags getPermissions(const char *key,const char *obj,IUserDescriptor *udesc,unsigned auditflags,const char * reqSignature, CDateTime & reqUTCTimestamp)
     {
         if (!ldapsecurity||((getLDAPflags()&DLF_ENABLED)==0)) 
             return SecAccess_Full;
@@ -157,11 +157,11 @@ public:
             if (pDSM && pDSM->isDigiVerifierConfigured())
             {
                 StringBuffer requestTimestamp;
-                reqUTCTimestamp->getString(requestTimestamp, false);//extract timestamp string from Dali request
+                reqUTCTimestamp.getString(requestTimestamp, false);//extract timestamp string from Dali request
 
                 CDateTime now;
                 now.setNow();
-                if (now.compare(*reqUTCTimestamp) < 0)//timestamp from the future?
+                if (now.compare(reqUTCTimestamp) < 0)//timestamp from the future?
                 {
                     ERRLOG("LDAP: getPermissions(%s) scope=%s user=%s Request digital signature timestamp %s from the future",key?key:"NULL",obj?obj:"NULL",username.str(), requestTimestamp.str());
                     return SecAccess_None;//deny
@@ -171,7 +171,7 @@ public:
                 expiry.set(now);
                 expiry.adjustTime(requestSignatureExpiryMinutes);//compute expiration timestamp
 
-                if (expiry.compare(*reqUTCTimestamp) < 0)//timestamp too far in the past?
+                if (expiry.compare(reqUTCTimestamp) < 0)//timestamp too far in the past?
                 {
                     ERRLOG("LDAP: getPermissions(%s) scope=%s user=%s Expired request digital signature timestamp %s",key?key:"NULL",obj?obj:"NULL",username.str(), requestTimestamp.str());
                     return SecAccess_None;//deny

--- a/dali/server/daldap.hpp
+++ b/dali/server/daldap.hpp
@@ -26,7 +26,7 @@ interface IUserDescriptor;
 
 interface IDaliLdapConnection: extends IInterface
 {
-    virtual SecAccessFlags getPermissions(const char *key,const char *obj,IUserDescriptor *udesc,unsigned auditflags,const char * reqSignature, CDateTime * reqUTCTimestamp)=0;
+    virtual SecAccessFlags getPermissions(const char *key,const char *obj,IUserDescriptor *udesc,unsigned auditflags,const char * reqSignature, CDateTime & reqUTCTimestamp)=0;
     virtual bool checkScopeScans() = 0;
     virtual unsigned getLDAPflags() = 0;
     virtual void setLDAPflags(unsigned flags) = 0;

--- a/plugins/workunitservices/workunitservices.cpp
+++ b/plugins/workunitservices/workunitservices.cpp
@@ -219,7 +219,12 @@ static bool checkScopeAuthorized(IUserDescriptor *user, const char *scopename)
     SecAccessFlags perm = SecAccess_Full;
     if (scopename && *scopename)
     {
-        perm = querySessionManager().getPermissionsLDAP("workunit",scopename,user,auditflags);
+        //Create signature
+        CDateTime now;
+        StringBuffer b64sig;
+        createDaliSignature(scopename, user, now, b64sig);
+
+        perm = querySessionManager().getPermissionsLDAP("workunit",scopename,user,auditflags, b64sig.str(), now);
         if (perm<0)
         {
             if (perm == SecAccess_Unavailable)


### PR DESCRIPTION
When certificates are not enabled, signatures are not created and the CDatTime
structure never gets set. Calls to clone that datetime structure core because
of null contents.  This PR also adds signatures to some additional permission
requests that were previously not preparing them

Signed-off-by: Russ Whitehead <william.whitehead@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
