### PR TITLE
HPCC-20323 Ensure loader stats are reset each iteration

### DIFF
--- a/thorlcr/thorutil/thmem.cpp
+++ b/thorlcr/thorutil/thmem.cpp
@@ -1627,19 +1627,19 @@ protected:
     IPointerArrayOf<CFileOwner> spillFiles;
     Owned<IOutputRowSerializer> serializer;
     RowCollectorSpillFlags diskMemMix;
-    rowcount_t totalRows;
-    unsigned overflowCount;
-    unsigned maxCores;
-    unsigned outStreams;
-    offset_t sizeSpill;
+    rowcount_t totalRows = 0;
+    unsigned overflowCount = 0;
+    unsigned maxCores = 0;
+    unsigned outStreams = 0;
+    offset_t sizeSpill = 0;
     ICompare *iCompare;
     StableSortFlag stableSort;
     EmptyRowSemantics emptyRowSemantics = ers_forbidden;
     Owned<CSharedSpillableRowSet> spillableRowSet;
-    unsigned options;
+    unsigned options = 0;
     unsigned spillCompInfo = 0;
-    __uint64 spillCycles;
-    __uint64 sortCycles;
+    __uint64 spillCycles = 0;
+    __uint64 sortCycles = 0;
 
     bool spillRows(bool critical)
     {
@@ -1828,6 +1828,8 @@ protected:
         totalRows = 0;
         overflowCount = outStreams = 0;
         sizeSpill = 0;
+        spillCycles = 0;
+        sortCycles = 0;
     }
 public:
     CThorRowCollectorBase(CActivityBase &_activity, IThorRowInterfaces *_rowIf, ICompare *_iCompare, StableSortFlag _stableSort, RowCollectorSpillFlags _diskMemMix, unsigned _spillPriority)
@@ -1835,9 +1837,6 @@ public:
           iCompare(_iCompare), stableSort(_stableSort), diskMemMix(_diskMemMix),
           spillableRows(_activity)
     {
-        totalRows = 0;
-        overflowCount = outStreams = 0;
-        sizeSpill = 0;
         if (rc_allMem == diskMemMix)
             spillPriority = SPILL_PRIORITY_DISABLE; // all mem, implies no spilling
         else
@@ -1851,8 +1850,6 @@ public:
             activity.getOpt(THOROPT_COMPRESS_SPILL_TYPE, compType);
             setCompFlag(compType, spillCompInfo);
         }
-        spillCycles = 0;
-        sortCycles = 0;
         if (iCompare)
         {
             /* NB: See HPCC-17231 for details


### PR DESCRIPTION
The loader used to load and sort the LHS of a local join, tracks
sort and spill cycles used. When in a child query these were not
being reset, consequently, the total accumulated time was wrong.

Signed-off-by: Jake Smith <jake.smith@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
