### PR TITLE
HPCC-20407 Report authorization failures to TxSummary in WsMachine

### DIFF
--- a/esp/services/ws_machine/ws_machineService.cpp
+++ b/esp/services/ws_machine/ws_machineService.cpp
@@ -224,8 +224,7 @@ bool Cws_machineEx::onGetMachineInfo(IEspContext &context, IEspGetMachineInfoReq
 {
     try
     {
-        if (!context.validateFeatureAccess(FEATURE_URL, SecAccess_Read, false))
-            throw MakeStringException(ECLWATCH_MACHINE_INFO_ACCESS_DENIED, "Failed to Get Machine Information. Permission denied.");
+        context.ensureFeatureAccess(FEATURE_URL, SecAccess_Read, ECLWATCH_MACHINE_INFO_ACCESS_DENIED, "Failed to Get Machine Information. Permission denied.");
 
         StringArray& addresses = req.getAddresses();
         if (addresses.empty())
@@ -249,8 +248,7 @@ bool Cws_machineEx::onGetMachineInfoEx(IEspContext &context, IEspGetMachineInfoR
 {
     try
     {
-        if (!context.validateFeatureAccess(FEATURE_URL, SecAccess_Read, false))
-            throw MakeStringException(ECLWATCH_MACHINE_INFO_ACCESS_DENIED, "Failed to Get Machine Information. Permission denied.");
+        context.ensureFeatureAccess(FEATURE_URL, SecAccess_Read, ECLWATCH_MACHINE_INFO_ACCESS_DENIED, "Failed to Get Machine Information. Permission denied.");
 
         StringArray& addresses = req.getAddresses();
         if (addresses.empty())
@@ -280,8 +278,7 @@ bool Cws_machineEx::onGetTargetClusterInfo(IEspContext &context, IEspGetTargetCl
 {
     try
     {
-        if (!context.validateFeatureAccess(FEATURE_URL, SecAccess_Read, false))
-            throw MakeStringException(ECLWATCH_MACHINE_INFO_ACCESS_DENIED, "Failed to Get Machine Information. Permission denied.");
+        context.ensureFeatureAccess(FEATURE_URL, SecAccess_Read, ECLWATCH_MACHINE_INFO_ACCESS_DENIED, "Failed to Get Target Cluster Information. Permission denied.");
 
         StringArray& targetClusters = req.getTargetClusters();
         if (targetClusters.empty())
@@ -2254,8 +2251,7 @@ bool Cws_machineEx::onGetComponentStatus(IEspContext &context, IEspGetComponentS
 {
     try
     {
-        if (!context.validateFeatureAccess(FEATURE_URL, SecAccess_Read, false))
-            throw MakeStringException(ECLWATCH_MACHINE_INFO_ACCESS_DENIED, "Failed to Get Component Status. Permission denied.");
+        context.ensureFeatureAccess(FEATURE_URL, SecAccess_Read, ECLWATCH_MACHINE_INFO_ACCESS_DENIED, "Failed to Get Component Status. Permission denied.");
 
         Owned<IComponentStatusFactory> factory = getComponentStatusFactory();
         Owned<IESPComponentStatusInfo> status = factory->getComponentStatus();
@@ -2296,8 +2292,7 @@ bool Cws_machineEx::onUpdateComponentStatus(IEspContext &context, IEspUpdateComp
 {
     try
     {
-        if (!context.validateFeatureAccess(FEATURE_URL, SecAccess_Write, false))
-            throw MakeStringException(ECLWATCH_MACHINE_INFO_ACCESS_DENIED, "Failed to Update Component Status. Permission denied.");
+        context.ensureFeatureAccess(FEATURE_URL, SecAccess_Write, ECLWATCH_MACHINE_INFO_ACCESS_DENIED, "Failed to Update Component Status. Permission denied.");
 
         const char* reporter = req.getReporter();
         if (!reporter || !*reporter)

--- a/esp/services/ws_machine/ws_machineServiceMetrics.cpp
+++ b/esp/services/ws_machine/ws_machineServiceMetrics.cpp
@@ -456,8 +456,7 @@ bool Cws_machineEx::onGetMetrics(IEspContext &context, IEspMetricsRequest &req,
 {
     try
     {
-        if (!context.validateFeatureAccess(METRICS_FEATURE_URL, SecAccess_Read, false))
-            throw MakeStringException(ECLWATCH_METRICS_ACCESS_DENIED, "Failed to Get Metrics. Permission denied.");
+        context.ensureFeatureAccess(METRICS_FEATURE_URL, SecAccess_Read, ECLWATCH_METRICS_ACCESS_DENIED, "Failed to Get Metrics. Permission denied.");
 
         //insert entries in an array - one per IP address, sorted by IP address
         //

--- a/esp/services/ws_machine/ws_machineServiceRexec.cpp
+++ b/esp/services/ws_machine/ws_machineServiceRexec.cpp
@@ -647,8 +647,7 @@ bool Cws_machineEx::onStartStop( IEspContext &context, IEspStartStopRequest &req
 
     try
     {
-        if (!context.validateFeatureAccess(EXEC_FEATURE_URL, SecAccess_Full, false))
-            throw MakeStringException(ECLWATCH_EXECUTION_ACCESS_DENIED, "Permission denied.");
+        context.ensureFeatureAccess(EXEC_FEATURE_URL, SecAccess_Full, ECLWATCH_EXECUTION_ACCESS_DENIED, "Failed to Start/stop. Permission denied.");
 
         char* userName = (char*) m_sTestStr1.str();
         char* password = (char*) m_sTestStr2.str();
@@ -716,8 +715,7 @@ bool Cws_machineEx::onStartStopBegin( IEspContext &context, IEspStartStopBeginRe
 
     try
     {
-        if (!context.validateFeatureAccess(EXEC_FEATURE_URL, SecAccess_Full, false))
-            throw MakeStringException(ECLWATCH_EXECUTION_ACCESS_DENIED, "Permission denied.");
+        context.ensureFeatureAccess(EXEC_FEATURE_URL, SecAccess_Full, ECLWATCH_EXECUTION_ACCESS_DENIED, "Failed to Start/stop. Permission denied.");
 
         StringBuffer addresses;
         StringArray& addresses0 = req.getAddresses();
@@ -762,8 +760,7 @@ bool Cws_machineEx::onStartStopDone( IEspContext &context, IEspStartStopDoneRequ
 
     try
     {
-        if (!context.validateFeatureAccess(EXEC_FEATURE_URL, SecAccess_Full, false))
-            throw MakeStringException(ECLWATCH_EXECUTION_ACCESS_DENIED, "Permission denied.");
+        context.ensureFeatureAccess(EXEC_FEATURE_URL, SecAccess_Full, ECLWATCH_EXECUTION_ACCESS_DENIED, "Failed to Start/stop. Permission denied.");
 
         const char*addresses0 = req.getAddresses();
         bool bStop = req.getStop();


### PR DESCRIPTION
Inside ESP WsMachine service code, call ensureFeatureAccess() to
report authorization failures to TxSummary.

Signed-off-by: wangkx <kevin.wang@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
