### PR TITLE
HPCC-20412 Report authentication failures to TxSummary in wsesdlconfig

### DIFF
--- a/esp/services/ws_esdlconfig/ws_esdlconfigservice.cpp
+++ b/esp/services/ws_esdlconfig/ws_esdlconfigservice.cpp
@@ -188,8 +188,7 @@ bool CWsESDLConfigEx::onPublishESDLDefinition(IEspContext &context, IEspPublishE
         if (m_isDetachedFromDali)
           throw MakeStringException(-1, "Cannot publish ESDL Service definition. ESP is currently detached from DALI.");
 
-        if (!context.validateFeatureAccess(FEATURE_URL, SecAccess_Write, false))
-            throw MakeStringException(ECLWATCH_ROXIE_QUERY_ACCESS_DENIED, "Failed to Publish ESDL Service definition. Permission denied.");
+        context.ensureFeatureAccess(FEATURE_URL, SecAccess_Write, ECLWATCH_ROXIE_QUERY_ACCESS_DENIED, "WsESDLConfigEx::PublishESDLDefinition: Permission denied.");
 
         Owned<IUserDescriptor> userdesc;
         const char *user = context.queryUserId();
@@ -407,8 +406,7 @@ bool CWsESDLConfigEx::onPublishESDLBinding(IEspContext &context, IEspPublishESDL
         if (m_isDetachedFromDali)
             throw MakeStringException(-1, "Cannot publish ESDL Binding. ESP is currently detached from DALI.");
 
-        if (!context.validateFeatureAccess(FEATURE_URL, SecAccess_Write, false))
-            throw MakeStringException(ECLWATCH_ROXIE_QUERY_ACCESS_DENIED, "Failed to Configure ESDL Service. Permission denied.");
+        context.ensureFeatureAccess(FEATURE_URL, SecAccess_Write, ECLWATCH_ROXIE_QUERY_ACCESS_DENIED, "WsESDLConfigEx::PublishESDLBinding: Permission denied.");
 
         double ver = context.getClientVersion();
 
@@ -647,8 +645,7 @@ bool CWsESDLConfigEx::onConfigureESDLBindingMethod(IEspContext &context, IEspCon
         if (m_isDetachedFromDali)
             throw MakeStringException(-1, "Cannot Configure ESDL Binding Method. ESP is currently detached from DALI.");
 
-        if (!context.validateFeatureAccess(FEATURE_URL, SecAccess_Write, false))
-            throw MakeStringException(ECLWATCH_ROXIE_QUERY_ACCESS_DENIED, "Failed to Configure ESDL Method. Permission denied.");
+        context.ensureFeatureAccess(FEATURE_URL, SecAccess_Write, ECLWATCH_ROXIE_QUERY_ACCESS_DENIED, "WsESDLConfigEx::ConfigureESDLBindingMethod: Permission denied.");
 
         StringBuffer username;
         context.getUserID(username);
@@ -975,8 +972,7 @@ bool CWsESDLConfigEx::onGetESDLBinding(IEspContext &context, IEspGetESDLBindingR
         if (m_isDetachedFromDali)
             throw MakeStringException(-1, "Cannot fetch ESDL Binding. ESP is currently detached from DALI.");
 
-        if (!context.validateFeatureAccess(FEATURE_URL, SecAccess_Read, false))
-            throw MakeStringException(ECLWATCH_ROXIE_QUERY_ACCESS_DENIED, "Failed to fetch ESDL Service Configuration. Permission denied.");
+        context.ensureFeatureAccess(FEATURE_URL, SecAccess_Read, ECLWATCH_ROXIE_QUERY_ACCESS_DENIED, "WsESDLConfigEx::GetESDLBinding: Permission denied.");
 
         double ver = context.getClientVersion();
         StringBuffer username;
@@ -1214,8 +1210,7 @@ bool CWsESDLConfigEx::onDeleteESDLDefinition(IEspContext &context, IEspDeleteESD
     if (m_isDetachedFromDali)
         throw MakeStringException(-1, "Cannot delete ESDL Definition. ESP is currently detached from DALI.");
 
-    if (!context.validateFeatureAccess(FEATURE_URL, SecAccess_Full, false))
-        throw MakeStringException(ECLWATCH_ROXIE_QUERY_ACCESS_DENIED, "Failed to DELETE ESDL entry. Permission denied.");
+    context.ensureFeatureAccess(FEATURE_URL, SecAccess_Full, ECLWATCH_ROXIE_QUERY_ACCESS_DENIED, "WsESDLConfigEx::DeleteESDLDefinition: Permission denied.");
 
     StringBuffer esdlDefinitionId(req.getId());
     if (esdlDefinitionId.length()<=0)
@@ -1259,8 +1254,7 @@ bool CWsESDLConfigEx::onDeleteESDLBinding(IEspContext &context, IEspDeleteESDLBi
     if (m_isDetachedFromDali)
         throw MakeStringException(-1, "Cannot fetch ESDL Binding. ESP is currently detached from DALI.");
 
-    if (!context.validateFeatureAccess(FEATURE_URL, SecAccess_Full, false))
-        throw MakeStringException(ECLWATCH_ROXIE_QUERY_ACCESS_DENIED, "Failed to DELETE ESDL entry. Permission denied.");
+    context.ensureFeatureAccess(FEATURE_URL, SecAccess_Full, ECLWATCH_ROXIE_QUERY_ACCESS_DENIED, "WsESDLConfigEx::DeleteESDLBinding: Permission denied.");
 
     double ver = context.getClientVersion();
     StringBuffer esdlBindingId(req.getId());
@@ -1357,8 +1351,7 @@ bool CWsESDLConfigEx::onGetESDLDefinition(IEspContext &context, IEspGetESDLDefin
      if (m_isDetachedFromDali)
          throw MakeStringException(-1, "Cannot fetch ESDL Definition. ESP is currently detached from DALI.");
 
-    if (!context.validateFeatureAccess(FEATURE_URL, SecAccess_Read, false))
-        throw MakeStringException(ECLWATCH_ROXIE_QUERY_ACCESS_DENIED, "Failed to fetch ESDL definition. Permission denied.");
+    context.ensureFeatureAccess(FEATURE_URL, SecAccess_Read, ECLWATCH_ROXIE_QUERY_ACCESS_DENIED, "WsESDLConfigEx::GetESDLDefinition: Permission denied.");
 
     StringBuffer id = req.getId();
     StringBuffer definition;


### PR DESCRIPTION
Inside ESP wsesdlconfig service code, call ensureFeatureAccess() to
report authorization failures to TxSummary.

Signed-off-by: wangkx <kevin.wang@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
