### PR TITLE
HPCC-20504 Add dafilesrv reply errors codes and normalize json response/specialize testsocket response

### DIFF
--- a/common/remote/remoteerr.hpp
+++ b/common/remote/remoteerr.hpp
@@ -99,7 +99,13 @@ enum DAFS_ERROR_CODES {
     DAFSERR_authenticate_failed             = -2,
     DAFSERR_protocol_failure                = -3,
     DAFSERR_serveraccept_failed             = -4,
-    DAFSERR_serverinit_failed               = -5
+    DAFSERR_serverinit_failed               = -5,
+    DAFSERR_cmdstream_invalidexpiry         = -6,
+    DAFSERR_cmdstream_authexpired           = -7,
+    DAFSERR_cmdstream_unsupported_recfmt    = -8,
+    DAFSERR_cmdstream_openfailure           = -9,
+    DAFSERR_cmdstream_protocol_failure      = -10,
+    DAFSERR_cmdstream_unauthorized          = -11
 };
 
 

--- a/common/remote/sockfile.hpp
+++ b/common/remote/sockfile.hpp
@@ -61,7 +61,7 @@ interface IRemoteFileServer : extends IInterface
     virtual StringBuffer &getStats(StringBuffer &stats, bool reset) = 0;
 };
 
-#define FILESRV_VERSION 23 // don't forget VERSTRING in sockfile.cpp
+#define FILESRV_VERSION 24 // don't forget VERSTRING in sockfile.cpp
 
 interface IKeyManager;
 interface IDelayedFile;
@@ -117,5 +117,8 @@ extern bool clientAsyncCopyFileSection(const char *uuid,    // from genUUID - mu
 
 extern void clientSetRemoteFileTimeouts(unsigned maxconnecttime,unsigned maxreadtime);
 extern void clientAddSocketToCache(SocketEndpoint &ep,ISocket *socket);
+
+typedef unsigned char RemoteFileCommandType;
+extern RemoteFileCommandType queryRemoteStreamCmd(); // used by testsocket only
 
 #endif

--- a/tools/testsocket/CMakeLists.txt
+++ b/tools/testsocket/CMakeLists.txt
@@ -27,6 +27,7 @@ include_directories (
          ./../../system/jlib
          ./../../system/include 
          ./../../system/security/securesocket
+         ./../../common/remote
     )
 
 ADD_DEFINITIONS( -D_CONSOLE )
@@ -35,6 +36,7 @@ set ( SRCS testsocket.cpp )
 HPCC_ADD_EXECUTABLE ( testsocket ${SRCS} )
 target_link_libraries ( testsocket
          jlib
+         remote
          )
 
 IF (USE_OPENSSL)


### PR DESCRIPTION
Also make JSON request response standard/differentiate with
special handling of testsocket client.

Signed-off-by: Jake Smith <jake.smith@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [x] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
