### PR TITLE
HPCC-20590 Suppress all semantic errors when syntax checking

### DIFF
--- a/ecl/hql/hqlexpr.hpp
+++ b/ecl/hql/hqlexpr.hpp
@@ -1022,7 +1022,6 @@ public:
     inline bool syntaxChecking() const { return parseCtx.isSyntaxChecking(); }
     inline bool regenerateCache() const { return parseCtx.regenerateCache; }
     inline bool hasCacheLocation() const { return parseCtx.hasCacheLocation();}
-    inline bool syntaxCheckingUsingCache() const { return parseCtx.isSyntaxChecking() && parseCtx.hasCacheLocation(); }
     inline bool checkSimpleDef() const { return parseCtx.checkSimpleDef; }
     inline bool ignoreCache() const { return parseCtx.ignoreCache; }
     inline bool createCache(IHqlExpression * simplified, bool isMacro) { return parseCtx.createCache(simplified, isMacro); }

--- a/ecl/hql/hqlexpr.hpp
+++ b/ecl/hql/hqlexpr.hpp
@@ -1022,6 +1022,7 @@ public:
     inline bool syntaxChecking() const { return parseCtx.isSyntaxChecking(); }
     inline bool regenerateCache() const { return parseCtx.regenerateCache; }
     inline bool hasCacheLocation() const { return parseCtx.hasCacheLocation();}
+    inline bool syntaxCheckingUsingCache() const { return parseCtx.isSyntaxChecking() && parseCtx.hasCacheLocation(); }
     inline bool checkSimpleDef() const { return parseCtx.checkSimpleDef; }
     inline bool ignoreCache() const { return parseCtx.ignoreCache; }
     inline bool createCache(IHqlExpression * simplified, bool isMacro) { return parseCtx.createCache(simplified, isMacro); }

--- a/ecl/hql/hqlgram2.cpp
+++ b/ecl/hql/hqlgram2.cpp
@@ -6171,8 +6171,11 @@ void HqlGram::reportErrorUnexpectedX(const attribute& errpos, IAtom * unexpected
 
 void HqlGram::doReportWarning(WarnErrorCategory category, int warnNo, const char *msg, const char *filename, int lineno, int column, int pos)
 {
-    Owned<IError> error = createError(category, queryDefaultSeverity(category), warnNo, msg, filename, lineno, column, pos);
-    report(error);
+	if (!lookupCtx.syntaxCheckingUsingCache() || category==CategorySyntax || category==CategoryError)
+	{
+		Owned<IError> error = createError(category, queryDefaultSeverity(category), warnNo, msg, filename, lineno, column, pos);
+		report(error);
+	}
 }
 
 void HqlGram::reportMacroExpansionPosition(IError * warning, HqlLex * lexer)
@@ -6213,7 +6216,7 @@ void HqlGram::reportError(int errNo, const char *msg, int lineno, int column, in
 
 void HqlGram::reportWarning(WarnErrorCategory category, int warnNo, const ECLlocation & pos, const char* format, ...)
 {
-    if (errorHandler && !errorDisabled)
+    if (errorHandler && !errorDisabled && (!lookupCtx.syntaxCheckingUsingCache() || category==CategorySyntax || category==CategoryError))
     {
         va_list args;
         va_start(args, format);
@@ -6226,7 +6229,7 @@ void HqlGram::reportWarning(WarnErrorCategory category, int warnNo, const ECLloc
 
 void HqlGram::reportWarning(WarnErrorCategory category, ErrorSeverity severity, int warnNo, const ECLlocation & pos, const char* format, ...)
 {
-    if (errorHandler && !errorDisabled)
+    if (errorHandler && !errorDisabled && (!lookupCtx.syntaxCheckingUsingCache() || category==CategorySyntax || category==CategoryError))
     {
         StringBuffer msg;
         va_list args;
@@ -6241,7 +6244,7 @@ void HqlGram::reportWarning(WarnErrorCategory category, ErrorSeverity severity, 
 void HqlGram::reportWarningVa(WarnErrorCategory category, int warnNo, const attribute& a, const char* format, va_list args)
 {
     const ECLlocation & pos = a.pos;
-    if (errorHandler && !errorDisabled)
+    if (errorHandler && !errorDisabled && (!lookupCtx.syntaxCheckingUsingCache() || category==CategorySyntax || category==CategoryError))
     {
         Owned<IError> error = createErrorVA(category, queryDefaultSeverity(category), warnNo, pos, format, args);
         report(error);
@@ -6250,7 +6253,7 @@ void HqlGram::reportWarningVa(WarnErrorCategory category, int warnNo, const attr
 
 void HqlGram::reportWarning(WarnErrorCategory category, int warnNo, const char *msg, int lineno, int column)
 {
-    if (errorHandler && !errorDisabled)
+    if (errorHandler && !errorDisabled && (!lookupCtx.syntaxCheckingUsingCache() || category==CategorySyntax || category==CategoryError))
         doReportWarning(category, warnNo, msg, querySourcePathText(), lineno, column, 0);
 }
 
@@ -12277,7 +12280,7 @@ void parseAttribute(IHqlScope * scope, IFileContents * contents, HqlLookupContex
     attrCtx.noteBeginAttribute(scope, contents, name);
 
     // Use simplified definition if syntax checking
-    if (!ctx.regenerateCache() && ctx.syntaxChecking() && ctx.hasCacheLocation() && !ctx.ignoreCache())
+    if (!ctx.regenerateCache() && ctx.syntaxCheckingUsingCache() && !ctx.ignoreCache())
     {
         HqlParseContext & parseContext = ctx.queryParseContext();
         Owned<IEclCachedDefinition> cached = parseContext.cache->getDefinition(fullName);


### PR DESCRIPTION
Signed-off-by: Shamser Ahmed <shamser.ahmed@lexisnexis.co.uk>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [x] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [ ] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
