### PR TITLE
HPCC-20627 New defects reported by Coverity Scan

### DIFF
--- a/common/deftype/deffield.cpp
+++ b/common/deftype/deffield.cpp
@@ -259,7 +259,8 @@ static void addElementToPTree(IPropertyTree * root, IDefRecordElement * elem)
     {
     case DEKnone:
         branchName.set("None");
-        assertex(elem->numChildren() == 0);
+        if (elem)
+            assertex(elem->numChildren() == 0);
         break;
     case DEKrecord:
         {

--- a/common/deftype/deftype.cpp
+++ b/common/deftype/deftype.cpp
@@ -1223,6 +1223,7 @@ bool CTransformTypeInfo::assignableFrom(ITypeInfo *t2)
 bool CSortListTypeInfo::assignableFrom(ITypeInfo *t2)
 {
     return (getTypeCode()==t2->getTypeCode());
+/*
     {
         //Not convinced any of this should be here...
         ITypeInfo *c1 = queryChildType();
@@ -1236,6 +1237,7 @@ bool CSortListTypeInfo::assignableFrom(ITypeInfo *t2)
         return false;
     }
     return queryChildType()->assignableFrom(t2);
+*/
 }
 
 bool CRowTypeInfo::assignableFrom(ITypeInfo *t2)
@@ -1881,7 +1883,6 @@ extern DEFTYPE_API ITypeInfo *makeGroupedTableType(ITypeInfo *basetype)
 
 extern DEFTYPE_API ITypeInfo *makeFunctionType(ITypeInfo *basetype, IInterface * parameters, IInterface * defaults, IInterface * attrs)
 {
-    assertex(basetype->getTypeCode() != type_function); // not just yet anyway
     if (!basetype || !parameters)
     {
         ::Release(basetype);
@@ -1890,6 +1891,7 @@ extern DEFTYPE_API ITypeInfo *makeFunctionType(ITypeInfo *basetype, IInterface *
         ::Release(attrs);
         throwUnexpected();
     }
+    assertex(basetype->getTypeCode() != type_function); // not just yet anyway
     return commonUpType(new CFunctionTypeInfo(basetype, parameters, defaults, attrs));
 }
 


### PR DESCRIPTION
Fix some (harmless) Coverity warnings.

Signed-off-by: Richard Chapman <rchapman@hpccsystems.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [x] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [ ] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
Compiled
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
