### PR TITLE
HPCC-20684 Minor improvements to the simplified expression flags

### DIFF
--- a/ecl/eclcc/eclcc.cpp
+++ b/ecl/eclcc/eclcc.cpp
@@ -415,6 +415,7 @@ protected:
     bool optRegenerateCache = false;
     bool optIgnoreUnknownImport = false;
     bool optIgnoreCache = false;
+    bool optIgnoreSimplified = false;
     bool optExtraStats = false;
 
     mutable bool daliConnected = false;
@@ -1225,6 +1226,8 @@ void EclCC::processSingleQuery(EclCompileInstance & instance,
             parseCtx.setRegenerateCache();
         if (optIgnoreCache)
             parseCtx.setIgnoreCache();
+        if (optIgnoreSimplified)
+            parseCtx.setIgnoreSimplified();
         if (neverSimplifyRegEx)
             parseCtx.setNeverSimplify(neverSimplifyRegEx.str());
 
@@ -2706,7 +2709,10 @@ int EclCC::parseCommandLineOptions(int argc, const char* argv[])
         else if (iter.matchFlag(optRegenerateCache, "--regeneratecache"))
         {
         }
-        else if (iter.matchFlag(optIgnoreCache, "--internalignorecache"))  // may generate cache but don't use to simplified expressions
+        else if (iter.matchFlag(optIgnoreCache, "--internalignorecache"))
+        {
+        }
+        else if (iter.matchFlag(optIgnoreSimplified, "--ignoresimplified"))
         {
         }
         else if (iter.matchFlag(optExtraStats, "--internalextrastats"))

--- a/ecl/eclcc/eclcc.hpp
+++ b/ecl/eclcc/eclcc.hpp
@@ -90,6 +90,7 @@ const char * const helpText[] = {
     "?!  --fastsyntax  Delay expanding functions when parsing.  May speed up processing for some queries",
     "    -help, --help Display this message",
     "    -help -v      Display verbose help message",
+    "!   --ignoresimplified Do not use simplified expressions when syntax checking",
     "!   --ignoreunknownimport Do not report an error on an unknown import",
     "!   -internal     Run internal tests",
     "?!  -legacy       Use legacy import and when semantics (deprecated)",

--- a/ecl/hql/hqlexpr.hpp
+++ b/ecl/hql/hqlexpr.hpp
@@ -913,6 +913,7 @@ public:
     inline void setCheckSimpleDef() { checkSimpleDef = true; }
     inline void setRegenerateCache() { regenerateCache = true; }
     inline void setIgnoreCache() { ignoreCache = true; }
+    inline void setIgnoreSimplified() { ignoreSimplified = true; }
     void setNeverSimplify(const char *regex) { neverSimplifyRegEx.assign(regex, std::regex_constants::icase); neverSimplifyEnabled = true; };
     bool neverSimplify(const char *fullname) { return neverSimplifyEnabled? std::regex_match(fullname, neverSimplifyRegEx):false; };
     inline IPropertyTree * queryNestedDependTree() const { return nestedDependTree; }
@@ -945,6 +946,7 @@ public:
     bool checkSimpleDef = false;
     bool regenerateCache = false;
     bool ignoreCache = false;
+    bool ignoreSimplified = false;
     Linked<ICodegenContextCallback> codegenCtx;
     CIArrayOf<FileParseMeta> metaStack;
     IEclCachedDefinitionCollection * cache = nullptr;
@@ -1024,6 +1026,7 @@ public:
     inline bool hasCacheLocation() const { return parseCtx.hasCacheLocation();}
     inline bool checkSimpleDef() const { return parseCtx.checkSimpleDef; }
     inline bool ignoreCache() const { return parseCtx.ignoreCache; }
+    inline bool ignoreSimplified() const { return parseCtx.ignoreSimplified; }
     inline bool createCache(IHqlExpression * simplified, bool isMacro) { return parseCtx.createCache(simplified, isMacro); }
     void reportTiming(const char * name);
     inline void incrementAttribsSimplified() { ++parseCtx.numAttribsSimplified; }


### PR DESCRIPTION
Signed-off-by: Shamser Ahmed <shamser.ahmed@lexisnexis.co.uk>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [x] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
