### PR TITLE
HPCC-20777 Refactor so regenerateDefinition is called just once

### DIFF
--- a/ecl/hql/hqlexpr.cpp
+++ b/ecl/hql/hqlexpr.cpp
@@ -1071,7 +1071,7 @@ bool HqlParseContext::checkEndMeta()
     return wasGathering;
 }
 
-bool HqlParseContext::createCache(IHqlExpression * simplifiedDefinition, bool isMacro)
+bool HqlParseContext::createCache(const char *simplifiedEcl, bool isMacro)
 {
     StringBuffer fullName;
     StringBuffer baseFilename;
@@ -1080,23 +1080,12 @@ bool HqlParseContext::createCache(IHqlExpression * simplifiedDefinition, bool is
     if (!baseFilename)
         return false;
 
+    // This is actually checked in parseAttribute - consider removing
     if (!regenerateCache)
     {
         Owned<IEclCachedDefinition> cached = cache->getDefinition(fullName);
         if (cached->isUpToDate(optionHash))
             return false;
-    }
-
-    StringBuffer ecl;
-    if (simplifiedDefinition)
-    {
-        regenerateDefinition(simplifiedDefinition, ecl);
-        if (checkSimpleDef)
-        {
-            ecl.append("\n/* Simplified expression IR:\n");
-            EclIR::getIRText(ecl, 0, queryLocationIndependent(simplifiedDefinition));
-            ecl.append("*/\n");
-        }
     }
 
     recursiveCreateDirectoryForFile(baseFilename);
@@ -1121,10 +1110,10 @@ bool HqlParseContext::createCache(IHqlExpression * simplifiedDefinition, bool is
         if (curMeta().dependencies)
             saveXML(*stream, curMeta().dependencies, 0, XML_Embed|XML_LineBreak);
 
-        if (ecl.length())
+        if (simplifiedEcl && *simplifiedEcl)
         {
             writeStringToStream(*stream, "<Simplified>\n");
-            encodeXML(ecl, *stream, 0, -1, false);
+            encodeXML(simplifiedEcl, *stream, 0, -1, false);
             writeStringToStream(*stream, "</Simplified>\n");
         }
         writeStringToStream(*stream, "</Cache>\n");

--- a/ecl/hql/hqlexpr.hpp
+++ b/ecl/hql/hqlexpr.hpp
@@ -921,7 +921,7 @@ public:
     void beginMetaScope() { metaStack.append(*new FileParseMeta); }
     void beginMetaScope(FileParseMeta & active) { metaStack.append(OLINK(active)); }
     void endMetaScope() { metaStack.pop(); }
-    bool createCache(IHqlExpression * simplifiedDefinition, bool isMacro);
+    bool createCache(const char *simplifiedEcl, bool isMacro);
     inline FileParseMeta & curMeta() { return metaStack.tos(); }
     inline bool hasCacheLocation( ) const { return !metaOptions.cacheLocation.isEmpty();}
 public:
@@ -1027,7 +1027,7 @@ public:
     inline bool checkSimpleDef() const { return parseCtx.checkSimpleDef; }
     inline bool ignoreCache() const { return parseCtx.ignoreCache; }
     inline bool ignoreSimplified() const { return parseCtx.ignoreSimplified; }
-    inline bool createCache(IHqlExpression * simplified, bool isMacro) { return parseCtx.createCache(simplified, isMacro); }
+    inline bool createCache(const char * simplifiedEcl, bool isMacro) { return parseCtx.createCache(simplifiedEcl, isMacro); }
     void reportTiming(const char * name);
     inline void incrementAttribsSimplified() { ++parseCtx.numAttribsSimplified; }
     inline void incrementAttribsProcessed() { ++parseCtx.numAttribsProcessed; }

--- a/ecl/hql/hqlexpr.ipp
+++ b/ecl/hql/hqlexpr.ipp
@@ -1914,7 +1914,7 @@ class HqlGramCtx;
 extern void defineSymbol(IIdAtom * id, IHqlExpression *value);
 extern void parseAttribute(IHqlScope *scope, IFileContents * contents, HqlLookupContext & ctx, IIdAtom * id, const char * fullName);
 extern IHqlExpression * parseDefinition(const char * ecl, IIdAtom * name, MultiErrorReceiver &errors);
-extern bool verifySimpifiedDefinition(IHqlExpression *origExpr, IHqlExpression *simplifiedDefinition, HqlLookupContext & ctx);
+extern bool verifySimplifiedDefinition(IHqlExpression *origExpr, IHqlExpression *simplifiedDefinition, const char * simplifiedEcl, HqlLookupContext & ctx);
 extern bool parseForwardModuleMember(HqlGramCtx & _parent, IHqlScope *scope, IHqlExpression * forwardSymbol, HqlLookupContext & ctx);
 
 IHqlExpression *createAttribute(node_operator op, IAtom * name, IHqlExpression * value, IHqlExpression *value2, IHqlExpression * value3);


### PR DESCRIPTION
Signed-off-by: Shamser Ahmed <shamser.ahmed@lexisnexis.co.uk>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [x] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
