### PR TITLE
HPCC-20750 move processing sparkThor xsd and xsl files to platform build

### DIFF
--- a/initfiles/componentfiles/configxml/CMakeLists.txt
+++ b/initfiles/componentfiles/configxml/CMakeLists.txt
@@ -25,6 +25,12 @@ CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/RoxieTopology.xsl ${CMAKE_CURRENT_BIN
 CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/thor.xsd.in ${CMAKE_CURRENT_BINARY_DIR}/thor.xsd)
 CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/thor.xsl ${CMAKE_CURRENT_BINARY_DIR}/thor.xsl)
 
+if( NOT SPARK)
+   configure_file(${CMAKE_SOURCE_DIR}/plugins/spark/sparkThor.xsl.in ${CMAKE_CURRENT_BINARY_DIR}/sparkThor.xsl @ONLY)
+   configure_file(${CMAKE_SOURCE_DIR}/plugins/spark/spark-defaults.xsl.in ${CMAKE_CURRENT_BINARY_DIR}/spark-defaults.xsl @ONLY)
+endif()
+
+
 configure_file(environment.xsd.in environment.xsd @ONLY)
 configure_file(cgencomplist_linux.xml.in cgencomplist_linux.xml @ONLY)
 configure_file(cgencomplist_win.xml.in cgencomplist_win.xml @ONLY)
@@ -98,7 +104,19 @@ FOREACH( iFILES
     ${CMAKE_CURRENT_SOURCE_DIR}/backupnode.xsd
     ${CMAKE_CURRENT_SOURCE_DIR}/backupnode_vars.xsl
 )
+
+
     Install ( FILES ${iFILES} DESTINATION componentfiles/configxml COMPONENT Runtime)
 ENDFOREACH ( iFILES )
+
+if( NOT SPARK)
+   FOREACH( iFILES
+       ${CMAKE_SOURCE_DIR}/plugins/spark/sparkThor.xsd
+       ${CMAKE_CURRENT_BINARY_DIR}/sparkThor.xsl
+       ${CMAKE_CURRENT_BINARY_DIR}/spark-defaults.xsl
+   )
+       Install ( FILES ${iFILES} DESTINATION componentfiles/configxml COMPONENT Runtime)
+   ENDFOREACH ( iFILES )
+endif( )
 
 add_subdirectory (@temp)


### PR DESCRIPTION
If the platform build with no "SPARK" flag it will add sparkThor.xsd and sparkThor.xsl to
componentfiles/configxml/ directory. This will make platform image "spark" ready which means
this platform image can be used in HPCC cluster as non-spark node. It will handle the environment.xml with spark configuration correctly.

Signed-off-by: Xiaoming Wang <xiaoming.wang@lexisnexi.com> 
@rpastrana please review.


## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
-[ x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [ ] I have read the CONTRIBUTORS document.
- [ ] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->
Platform build: http://10.240.32.243/view/custom/job/CE-Candidate-HPCC-20570/
Spark plugin build: http://10.240.32.243/view/custom/job/CE-Candidate-Plugins-Spark-JIRA-20570/
LN + Spark build: http://10.240.32.243/view/custom/job/LN-Candidate-with-Plugins-Spark-JIRA-20570/

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
