### PR TITLE
HPCC-18956: Adjust eclcc to emit valid code when compiling for Linux/ARM using GCC

### DIFF
--- a/ecl/hqlcpp/hqlres.cpp
+++ b/ecl/hqlcpp/hqlres.cpp
@@ -489,7 +489,7 @@ bool ResourceManager::flush(StringBuffer &filename, const char *basename, bool f
         else
         {
 #if defined(__linux__) && defined(__GNUC__) && defined(__arm__)
-            fprintf(f, " .section .note.GNU-stack,\"\"\n");
+            fprintf(f, " .section .note.GNU-stack,\"\",%%progbits\n");   // Prevent the stack from being marked as executable
 #else
             fprintf(f, " .section .note.GNU-stack,\"\",@progbits\n");   // Prevent the stack from being marked as executable
 #endif

--- a/ecl/hqlcpp/hqlres.cpp
+++ b/ecl/hqlcpp/hqlres.cpp
@@ -488,7 +488,11 @@ bool ResourceManager::flush(StringBuffer &filename, const char *basename, bool f
         }
         else
         {
+#if defined(__linux__) && defined(__GNUC__) && defined(__arm__)
+            fprintf(f, " .section .note.GNU-stack,\"\"\n");
+#else
             fprintf(f, " .section .note.GNU-stack,\"\",@progbits\n");   // Prevent the stack from being marked as executable
+#endif
             fprintf(f, " .section %s_%u,\"a\"\n", type, id);
             fprintf(f, " .global %s\n", label.str());
             fprintf(f, " .type %s,STT_OBJECT\n", label.str());


### PR DESCRIPTION
Signed-off-by: BrianB644 <brianb@brianb.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [ ] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->
The change being submitted was tested in an armv7l GNU/Linux environment. Specifically on an Odroid HC-1 (XU4 platform) running Ubuntu 18.04 (also Ubuntu 16.04.3 and a version of Arch Linux). The GCC compiler for these platforms does not support the @progbits modifier when declaring program sections. The fix was tested by running eclcc by hand supplying the -save-temps options and examining the emitted assembly code. Additionally, submitted workunits run and graph information is visible in ECL Watch. Full test suites have not been completed against the target system.

The platform was also compiled for a x86_64 GNU/Linux system, and the .s code emitted by eclcc included the @progbits modifier.

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
