### PR TITLE
HPCC-20957 Allow DESDL gateway transformations

### DIFF
--- a/esp/services/esdl_svc_engine/esdl_binding.cpp
+++ b/esp/services/esdl_svc_engine/esdl_binding.cpp
@@ -843,7 +843,7 @@ void EsdlServiceImpl::handleFinalRequest(IEspContext &context,
     if(isroxie)
     {
         const char *tgtQueryName = tgtcfg->queryProp("@queryname");
-        if (tgtQueryName && *tgtQueryName)
+        if (!isEmptyString(tgtQueryName))
         {
             soapmsg.append("<soap:Body><").append(tgtQueryName).append(">");
             soapmsg.appendf("<_TransactionId>%s</_TransactionId>", context.queryTransactionID());
@@ -853,6 +853,28 @@ void EsdlServiceImpl::handleFinalRequest(IEspContext &context,
 
             soapmsg.append(req.str());
             soapmsg.append("</").append(tgtQueryName).append("></soap:Body>");
+
+            auto cfgGateways = tgtcfg->queryBranch("Gateways");
+            if (cfgGateways)
+            {
+                auto baseXpath = cfgGateways->queryProp("@legacyTransformTarget");
+                if (!isEmptyString(baseXpath))
+                {
+                    Owned<IPTree> gws = createPTree("gateways", 0);
+                    Owned<IPTree> soapTree = createPTreeFromXMLString(soapmsg.append("</soap:Envelope>"), ipt_ordered);
+                    StringBuffer xpath(baseXpath);
+
+                    EsdlBindingImpl::transformGatewaysConfig(tgtcfg, gws, "row");
+                    xpath.replaceString("{$query}", tgtQueryName);
+                    xpath.replaceString("{$method}", mthdef.queryMethodName());
+                    xpath.replaceString("{$service}", srvdef.queryName());
+                    xpath.replaceString("{$request}", mthdef.queryRequestType());
+                    mergePTree(ensurePTree(soapTree, xpath), gws);
+                    toXML(soapTree, soapmsg.clear());
+                    soapmsg.setLength(strstr(soapmsg, "</soap:Envelope>") - soapmsg.str());
+                    soapmsg.trim();
+                }
+            }
         }
         else
             throw makeWsException( ERR_ESDL_BINDING_INTERNERR, WSERR_SERVER, "ESP",
@@ -871,7 +893,7 @@ void EsdlServiceImpl::handleFinalRequest(IEspContext &context,
     soapmsg.append("</soap:Envelope>");
 
     const char *tgtUrl = tgtcfg->queryProp("@url");
-    if (tgtUrl && *tgtUrl)
+    if (!isEmptyString(tgtUrl))
     {
         if (crt)
         {
@@ -3119,7 +3141,7 @@ int EsdlBindingImpl::onGetSampleXml(bool isRequest, IEspContext &ctx, CHttpReque
     return 0;
 }
 
-void EsdlBindingImpl::transformGatewaysConfig( IPropertyTree* srvcfg, IPropertyTree* forRoxie )
+void EsdlBindingImpl::transformGatewaysConfig( IPropertyTree* srvcfg, IPropertyTree* forRoxie, const char* altElementName )
 {
     // Do we need to handle 'local FQDN'? It doesn't appear to be in the
     // Gateway element. Not sure where it's set but the RemoteNSClient
@@ -3131,6 +3153,8 @@ void EsdlBindingImpl::transformGatewaysConfig( IPropertyTree* srvcfg, IPropertyT
         cfgIter->first();
         if( cfgIter->isValid() )
         {
+            const char* treeName = (!isEmptyString(altElementName) ? altElementName : "Gateway");
+
             while( cfgIter->isValid() )
             {
                 IPropertyTree& cfgGateway = cfgIter->query();
@@ -3141,11 +3165,11 @@ void EsdlBindingImpl::transformGatewaysConfig( IPropertyTree* srvcfg, IPropertyT
                     cfgGateway.getProp("@name", service);
                     service.toLowerCase();
 
-                    Owned<IPropertyTree> gw = createPTree("Gateway", false);
+                    Owned<IPropertyTree> gw = createPTree(treeName, false);
                     gw->addProp("ServiceName", service.str());
                     gw->addProp("URL", url.str());
 
-                    forRoxie->addPropTree("Gateway", gw.getLink());
+                    forRoxie->addPropTree(treeName, gw.getLink());
                 }
                 else
                 {

--- a/esp/services/esdl_svc_engine/esdl_binding.hpp
+++ b/esp/services/esdl_svc_engine/esdl_binding.hpp
@@ -289,7 +289,7 @@ public:
 
     int onGetSampleXml(bool isRequest, IEspContext &ctx, CHttpRequest* request, CHttpResponse* response, const char *serv, const char *method);
     static void splitURLList(const char* urlList, StringBuffer& protocol,StringBuffer& UserName,StringBuffer& Password, StringBuffer& ipportlistbody, StringBuffer& path, StringBuffer& options);
-    static void transformGatewaysConfig( IPropertyTree* srvcfg, IPropertyTree* forRoxie );
+    static void transformGatewaysConfig( IPropertyTree* srvcfg, IPropertyTree* forRoxie, const char* altElementName = nullptr );
     static bool makeURL( StringBuffer& url, IPropertyTree& cfg );
 
     bool usesESDLDefinition(const char * name, int version);


### PR DESCRIPTION
- Recognize Gateways[@transformTarget]/Gateway as a meaningful xpath in the
  dynamic method configuration.
- Transform Gateway elements from <Gateway name="my_name" password=
  "my_encrypted_password" url="the_scheme://the_url" username="my_username"/> to
  <row><ServiceName>my_name</ServiceName><URL>the_scheme://my_username:
  my_decrypted_password@the_url</URL></row>.
- Place the transformed elements at the path indicated by @transformTarget.
- Leave dynamic method configuration unchanged, so existing deployments are
  unaffected.

Signed-off-by: Tim Klemm <Tim.Klemm@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [x] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [x] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
