### PR TITLE
Fix doc links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ ESP (Enterprise Services Platform) provides an easy to use interface to access E
 
 The following links describe the structure of the system and detail some of the key components:
 
-* [An overview of workunits and the different stages in executing a query](https://github.com/hpcc-systems/HPCC-Platform/blob/master/devdocs/WORKUNITS.rst)
-* [An introduction to the code generator - eclcc](https://github.com/hpcc-systems/HPCC-Platform/blob/master/devdocs/DOCUMENTATION.rst)
+* [An overview of workunits and the different stages in executing a query](https://github.com/hpcc-systems/HPCC-Platform/blob/master/devdoc/WORKUNITS.rst)
+* [An introduction to the code generator - eclcc](https://github.com/hpcc-systems/HPCC-Platform/blob/master/devdoc/DOCUMENTATION.rst)
 * [The memory manager used by roxie and thor](https://github.com/hpcc-systems/HPCC-Platform/blob/master/roxie/roxiemem/DOCUMENTATION.rst)
 * [The structure of the initialization scripts](https://github.com/hpcc-systems/HPCC-Platform/blob/master/initfiles/DOCUMENTATION.rst)
 * [Outline of ecl-bundle](https://github.com/hpcc-systems/HPCC-Platform/blob/master/ecl/ecl-bundle/DOCUMENTATION.rst)

--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ ESP (Enterprise Services Platform) provides an easy to use interface to access E
 
 The following links describe the structure of the system and detail some of the key components:
 
-* [An overview of workunits and the different stages in executing a query](https://github.com/hpcc-systems/HPCC-Platform/blob/master/devdoc/WORKUNITS.rst)
-* [An introduction to the code generator - eclcc](https://github.com/hpcc-systems/HPCC-Platform/blob/master/devdoc/DOCUMENTATION.rst)
+* [An overview of workunits and the different stages in executing a query](https://github.com/hpcc-systems/HPCC-Platform/blob/master/devdoc/WorkUnits.rst)
+* [An introduction to the code generator - eclcc](https://github.com/hpcc-systems/HPCC-Platform/blob/master/devdoc/CodeGenerator.rst)
 * [The memory manager used by roxie and thor](https://github.com/hpcc-systems/HPCC-Platform/blob/master/roxie/roxiemem/DOCUMENTATION.rst)
 * [The structure of the initialization scripts](https://github.com/hpcc-systems/HPCC-Platform/blob/master/initfiles/DOCUMENTATION.rst)
 * [Outline of ecl-bundle](https://github.com/hpcc-systems/HPCC-Platform/blob/master/ecl/ecl-bundle/DOCUMENTATION.rst)

--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ ESP (Enterprise Services Platform) provides an easy to use interface to access E
 
 The following links describe the structure of the system and detail some of the key components:
 
-* [An overview of workunits and the different stages in executing a query](https://github.com/hpcc-systems/HPCC-Platform/blob/master/ecl/eclcc/WORKUNITS.rst)
-* [An introduction to the code generator - eclcc](https://github.com/hpcc-systems/HPCC-Platform/blob/master/ecl/eclcc/DOCUMENTATION.rst)
+* [An overview of workunits and the different stages in executing a query](https://github.com/hpcc-systems/HPCC-Platform/blob/master/devdocs/WORKUNITS.rst)
+* [An introduction to the code generator - eclcc](https://github.com/hpcc-systems/HPCC-Platform/blob/master/devdocs/DOCUMENTATION.rst)
 * [The memory manager used by roxie and thor](https://github.com/hpcc-systems/HPCC-Platform/blob/master/roxie/roxiemem/DOCUMENTATION.rst)
 * [The structure of the initialization scripts](https://github.com/hpcc-systems/HPCC-Platform/blob/master/initfiles/DOCUMENTATION.rst)
 * [Outline of ecl-bundle](https://github.com/hpcc-systems/HPCC-Platform/blob/master/ecl/ecl-bundle/DOCUMENTATION.rst)

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The following links describe the structure of the system and detail some of the 
 
 * [An overview of workunits and the different stages in executing a query](https://github.com/hpcc-systems/HPCC-Platform/blob/master/devdoc/WorkUnits.rst)
 * [An introduction to the code generator - eclcc](https://github.com/hpcc-systems/HPCC-Platform/blob/master/devdoc/CodeGenerator.rst)
-* [The memory manager used by roxie and thor](https://github.com/hpcc-systems/HPCC-Platform/blob/master/roxie/roxiemem/DOCUMENTATION.rst)
+* [The memory manager used by roxie and thor](https://github.com/hpcc-systems/HPCC-Platform/blob/master/devdoc/MemoryManager.rst)
 * [The structure of the initialization scripts](https://github.com/hpcc-systems/HPCC-Platform/blob/master/initfiles/DOCUMENTATION.rst)
 * [Outline of ecl-bundle](https://github.com/hpcc-systems/HPCC-Platform/blob/master/ecl/ecl-bundle/DOCUMENTATION.rst)
 * [The structure and some details of the cmake files](https://github.com/hpcc-systems/HPCC-Platform/blob/master/cmake_modules/DOCUMENTATION.rst)


### PR DESCRIPTION
Fixing the doc links in the README which were broken in HPCC-20089 / 88e1bd2280e44861f4fa56e379164275c72620d1
