### PR TITLE
HPCC-21081 7.0.0 engine cannot access 6.4.26 file

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -10365,7 +10365,13 @@ IDFAttributesIterator *CDistributedFileDirectory::getDFAttributesIterator(const 
     CMessageBuffer mb;
     mb.append((int)MDFS_ITERATE_FILES).append(wildname).append(recursive).append("").append(includesuper); // "" is legacy
     if (user)
-        user->serialize(mb);
+    {
+		Owned<IUserDescriptor> tmpUDesc = createUserDescriptor();
+		StringBuffer userName;
+		user->getUserName(userName);
+		tmpUDesc->set(userName.str(), nullptr);
+		tmpUDesc->serialize(mb);//serialize without password, since it is not checked
+    }
 #ifdef NULL_DALIUSER_STACKTRACE
     else
     {
@@ -10496,7 +10502,13 @@ void CDistributedFileDirectory::setFileAccessed(CDfsLogicalFileName &dlfn,IUserD
     mb.append((int)MDFS_SET_FILE_ACCESSED).append(lname);
     dt.serialize(mb);
     if (user)
-        user->serialize(mb);
+    {
+        Owned<IUserDescriptor> tmpUDesc = createUserDescriptor();
+        StringBuffer userName;
+        user->getUserName(userName);
+        tmpUDesc->set(userName.str(), nullptr);
+        tmpUDesc->serialize(mb);//serialize without password, since it is not checked
+    }
 #ifdef NULL_DALIUSER_STACKTRACE
     else
     {
@@ -10535,7 +10547,13 @@ void CDistributedFileDirectory::setFileProtect(CDfsLogicalFileName &dlfn,IUserDe
         owner = "";
     mb.append((int)MDFS_SET_FILE_PROTECT).append(lname).append(owner).append(set);
     if (user)
-        user->serialize(mb);
+    {
+		Owned<IUserDescriptor> tmpUDesc = createUserDescriptor();
+		StringBuffer userName;
+		user->getUserName(userName);
+		tmpUDesc->set(userName.str(), nullptr);
+		tmpUDesc->serialize(mb);//serialize without password, since it is not checked
+    }
 #ifdef NULL_DALIUSER_STACKTRACE
     else
     {
@@ -10570,7 +10588,13 @@ IPropertyTree *CDistributedFileDirectory::getFileTree(const char *lname, IUserDe
     mb.append((int)MDFS_GET_FILE_TREE).append(lname);
     mb.append(MDFS_GET_FILE_TREE_V2);
     if (user)
-        user->serialize(mb);
+    {
+        Owned<IUserDescriptor> tmpUDesc = createUserDescriptor();
+        StringBuffer userName;
+        user->getUserName(userName);
+        tmpUDesc->set(userName.str(), nullptr);
+        tmpUDesc->serialize(mb);//serialize without password, since it is not checked
+    }
 #ifdef NULL_DALIUSER_STACKTRACE
     else
     {
@@ -12444,7 +12468,13 @@ IPropertyTreeIterator *CDistributedFileDirectory::getDFAttributesTreeIterator(co
         mb.append((int)MDFS_ITERATE_FILTEREDFILES2);
     mb.append(filters).append(recursive);
     if (user)
-        user->serialize(mb);
+    {
+        Owned<IUserDescriptor> tmpUDesc = createUserDescriptor();
+        StringBuffer userName;
+        user->getUserName(userName);
+        tmpUDesc->set(userName.str(), nullptr);
+        tmpUDesc->serialize(mb);//serialize without password, since it is not checked
+    }
 
     if (foreigndali)
         foreignDaliSendRecv(foreigndali,mb,foreigndalitimeout);

--- a/dali/base/dasess.cpp
+++ b/dali/base/dasess.cpp
@@ -937,7 +937,15 @@ public:
             PrintStackReport();
         }
 #endif
-        udesc->serialize(mb);
+
+        {
+            Owned<IUserDescriptor> tmpUDesc = createUserDescriptor();
+            StringBuffer user;
+            udesc->getUserName(user);
+            tmpUDesc->set(user.str(), nullptr);
+            tmpUDesc->serialize(mb);//serialize without password, since it is not checked
+        }
+
         mb.append(auditflags);
 
         //Serialize signature. If not provided, compute it


### PR DESCRIPTION
Because 7.0.0 engines send the WU token as the password, authentication
fails at the 6.4.26 Dali. This PR removes the password from the request

Signed-off-by: Russ Whitehead <william.whitehead@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [ ] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
