### PR TITLE
HPCC-21121 Maintain XSD attribute and element order as set in XSDs

### DIFF
--- a/configuration/configmgr/configmgrlib/SchemaItem.hpp
+++ b/configuration/configmgr/configmgrlib/SchemaItem.hpp
@@ -50,8 +50,7 @@ class DECL_EXPORT SchemaItem : public std::enable_shared_from_this<SchemaItem>
         void addSchemaType(const std::shared_ptr<SchemaItem> &pItem, const std::string &typeName);
         std::shared_ptr<SchemaItem> getSchemaType(const std::string &name, bool throwIfNotPresent=true) const;
         void insertSchemaType(const std::shared_ptr<SchemaItem> pTypeItem);
-        void addChild(const std::shared_ptr<SchemaItem> &pItem) { m_children.insert({ pItem->getProperty("name"), pItem }); }
-        void addChild(const std::shared_ptr<SchemaItem> &pItem, const std::string &name) { m_children.insert({ name, pItem }); }
+        void addChild(const std::shared_ptr<SchemaItem> &pItem) { m_children.emplace_back(pItem); }
         void getChildren(std::vector<std::shared_ptr<SchemaItem>> &children, const std::string &name = std::string(""), const std::string &itemType = std::string("")) const;
         void setItemSchemaValue(const std::shared_ptr<SchemaValue> &pValue) { m_pItemValue = pValue; }
         std::shared_ptr<SchemaValue> getItemSchemaValue() const { return m_pItemValue; }
@@ -99,7 +98,7 @@ class DECL_EXPORT SchemaItem : public std::enable_shared_from_this<SchemaItem>
         bool m_hidden;
         unsigned m_minInstances;
         unsigned m_maxInstances;
-        std::multimap<std::string, std::shared_ptr<SchemaItem>> m_children;
+        std::vector<std::shared_ptr<SchemaItem>> m_children;
         std::shared_ptr<SchemaValue> m_pItemValue;   // value for this item (think of it as the VALUE for an element <xx attr= att1>VALUE</xx>)
         std::map<std::string, std::shared_ptr<SchemaValue>> m_attributes;   // attributes for this item (think in xml terms <m_name attr1="val" attr2="val" .../> where attrN is in this vector
         std::set<std::string> m_keys;   // generic set of key values for use by any component to prevent duplicate operations
@@ -127,7 +126,6 @@ class DECL_EXPORT SchemaItem : public std::enable_shared_from_this<SchemaItem>
 
         // Following are NOT copied in copy constructor
         std::weak_ptr<SchemaItem> m_pParent;
-
 };
 
 #endif // _CONFIG2_CONFIGITEM_HPP_

--- a/configuration/configmgr/configmgrlib/SchemaValue.cpp
+++ b/configuration/configmgr/configmgrlib/SchemaValue.cpp
@@ -33,6 +33,7 @@ SchemaValue::SchemaValue(const std::string &name, bool isDefined) :
     bitMask.m_isUnique = 0;
     bitMask.m_isDefined = isDefined;
     bitMask.m_noOutput = 0;
+    m_ordinal = 0;
 }
 
 
@@ -60,6 +61,8 @@ SchemaValue::SchemaValue(const SchemaValue &value)
     // special processing? Maybe after inserting?
     std::vector<std::shared_ptr<SchemaValue>> m_mirrorToSchemaValues;
     std::vector<std::weak_ptr<SchemaValue>> m_pUniqueValueSetRefs;    // this value serves as the key from which values are valid
+
+    m_ordinal = 0;  // assigned when inserted
 }
 
 

--- a/configuration/configmgr/configmgrlib/SchemaValue.hpp
+++ b/configuration/configmgr/configmgrlib/SchemaValue.hpp
@@ -92,6 +92,8 @@ class DECL_EXPORT SchemaValue
         const std::string &getRequiredIf() const { return m_requiredIf; }
         void setGroupByName(const std::string &group) { m_groupByName = group; }
         const std::string &getGroupByName() const { return m_groupByName; }
+        void setOrdinal(unsigned val) { m_ordinal = val; }
+        unsigned getOrdinal() const { return m_ordinal; }
         void setNoOutput(bool noOutput) { bitMask.m_noOutput = noOutput; }
         bool isNoOutput() const { return bitMask.m_noOutput; }
 
@@ -104,6 +106,7 @@ class DECL_EXPORT SchemaValue
     protected:
 
         // DON'T FORGET IF DATA ADDED, IT MAY MAY TO BE COPIED IN THE COPY CONSTRUCTOR!!
+        unsigned m_ordinal;
         std::shared_ptr<SchemaType> m_pType;
         std::string m_name;
         std::string m_displayName;

--- a/esp/scm/ws_configmgr.ecm
+++ b/esp/scm/ws_configmgr.ecm
@@ -202,6 +202,7 @@ ESPstruct AttributeType
 {
     string     DisplayName;
     string     Name;
+    unsigned   Ordinal;
     string     Group("");
     string     Tooltip("");
     ESPstruct  TypeInfo Type;

--- a/esp/services/ws_configmgr/ws_configmgrService.cpp
+++ b/esp/services/ws_configmgr/ws_configmgrService.cpp
@@ -868,6 +868,11 @@ void Cws_configMgrEx::getAttributes(const std::shared_ptr<EnvironmentNode> &pEnv
     std::vector<std::shared_ptr<SchemaValue>> schemaValues;
     pEnvNode->getSchemaItem()->getAttributes(schemaValues);
 
+    //
+    // Because the config manager creates a schema value for ALL attributes of a node (even those that are not explicitly defined
+    // in the schema), all attributes of the environment node are processed. Additionally, if the environment node is missing
+    // attributes that are defined in the schema, they are found and returned as missing (if indicated by the includeMissing
+    // parameter)
     for (auto it=schemaValues.begin(); it!=schemaValues.end(); ++it)
     {
         const std::shared_ptr<SchemaValue> pSchemaValue = *it;
@@ -879,6 +884,7 @@ void Cws_configMgrEx::getAttributes(const std::shared_ptr<EnvironmentNode> &pEnv
             pAttribute->setName(pSchemaValue->getName().c_str());
             pAttribute->setDisplayName(pSchemaValue->getDisplayName().c_str());
             pAttribute->setTooltip(pSchemaValue->getTooltip().c_str());
+            pAttribute->setOrdinal(pSchemaValue->getOrdinal());
 
             const std::shared_ptr<SchemaType> &pType = pSchemaValue->getType();
             std::shared_ptr<SchemaTypeLimits> &pLimits = pType->getLimits();


### PR DESCRIPTION
Add ordinal value to attribute for use by UI
Store elements in vector to maintain order

Signed-off-by: Ken Rowland <kenneth.rowland@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [x] Scalability
  - [x] Performance
  - [x] Security
  - [x] Thread-safety
  - [x] Premature optimization
  - [x] Existing deployed queries will not be broken
  - [x] This change fixes the problem, not just the symptom
  - [x] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
