### PR TITLE
HPCC-21144 replace "/" in library file name pattern

### DIFF
--- a/lib2/CMakeLists.txt
+++ b/lib2/CMakeLists.txt
@@ -78,7 +78,7 @@ foreach(dylib ${DYLIBS})
         install(CODE "
            file(GLOB files \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${EXEC_DIR}/*\" \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${LIB_DIR}/*.dylib\" \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/plugins/*.dylib\" \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/lib2/*.dylib\")
            foreach(file \${files})
-               execute_process(COMMAND bash \"-c\"  \"otool -L \\\"\${file}\\\" | egrep \\\"/${dylib_name_only}(.[0-9]{1,})*.dylib\\\" | sed \\\"s/^[[:space:]]//g\\\" | cut -d' ' -f1\"
+               execute_process(COMMAND bash \"-c\"  \"otool -L \\\"\${file}\\\" | egrep \\\"(\\\\s|/)${dylib_name_only}(.[0-9]{1,})*.dylib\\\" | sed \\\"s/^[[:space:]]//g\\\" | cut -d' ' -f1\"
                   OUTPUT_VARIABLE otoolOut
                   ERROR_VARIABLE  otoolErr
                   OUTPUT_STRIP_TRAILING_WHITESPACE


### PR DESCRIPTION
On Mac OS compiler incorrectly link ICU libraries, for example /usr/local/lib/libicuuc.dylib is linked as libicuuc.60.dylib in eclcc. The path is removed which cause lib2 cmake script skip to process these libraries with correct link.
Replace "/" with [/s|\] will fix the problem.
 Signed-off-by: Xiaoming Wang <xiaoming.wang@lexisnexi.com> 

@Michael-Gardner please review


## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.


<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->

Test build: http://10.240.32.243/view/custom/job/CE-Clienttools-JIRA-21144-Mac/2/