### PR TITLE
HPCC-21059 Enhance custom request transform targeting

### DIFF
--- a/esp/services/esdl_svc_engine/esdl_binding.cpp
+++ b/esp/services/esdl_svc_engine/esdl_binding.cpp
@@ -363,20 +363,7 @@ static void ensureMergeOrderedEsdlTransform(Owned<IPropertyTree> &dest, IPropert
     {
         Owned<IPropertyTreeIterator> children = copy->getElements("*");
         ForEach(*children)
-        {
-            const char *existing = children->query().queryProp("@target");
-            if (existing && *existing)
-            {
-                if (*existing=='.') //support in future so error now so we don't have backward compatability issues
-                {
-                    VStringBuffer errorXpath("unsupported choose xpath*>>%s", existing); //will cause request time xpath error
-                    children->query().setProp("@target", errorXpath);
-                    DBGLOG("ESDL Binding: request transform choose xpath error: %s", existing);
-                }
-                continue;
-            }
-            children->query().setProp("@target", target);
-        }
+            children->query().setProp("@_crtTarget", target); //internal use only attribute
     }
     mergePTree(dest, copy);
 }

--- a/esp/services/esdl_svc_engine/esdl_svc_custom.cpp
+++ b/esp/services/esdl_svc_engine/esdl_svc_custom.cpp
@@ -26,8 +26,8 @@ CEsdlCustomTransformChoose::CEsdlCustomTransformChoose(IPropertyTree * choosewhe
 {
     if (choosewhen)
     {
-        if (choosewhen->hasProp("@target"))
-            target.set(choosewhen->queryProp("@target"));
+        if (choosewhen->hasProp("@_crtTarget"))
+            crtTarget.set(choosewhen->queryProp("@_crtTarget"));
         IPropertyTree * whentree = choosewhen->queryPropTree("xsdl:when"); //should support multiple when statements
         if (whentree)
         {
@@ -214,8 +214,8 @@ void CEsdlCustomTransformChoose::process(IEspContext * context, IPropertyTree *r
 {
     StringBuffer xpath;
 
-    if (target.length())
-        xpath.set(target.str());
+    if (crtTarget.length())
+        xpath.set(crtTarget.str());
     else if (defaultTarget && *defaultTarget)
         xpath.set(defaultTarget);
 
@@ -227,6 +227,7 @@ void CEsdlCustomTransformChoose::process(IEspContext * context, IPropertyTree *r
         xpath.replaceString("{$query}", xpathContext->getVariable("query"));
         xpath.replaceString("{$method}", xpathContext->getVariable("method"));
         xpath.replaceString("{$service}", xpathContext->getVariable("service"));
+        xpath.replaceString("{$request}", xpathContext->getVariable("request"));
 
         reqTarget = origTree->queryPropTree(xpath.str());  //get pointer to the write-able area
         if (!reqTarget)
@@ -330,6 +331,7 @@ void CEsdlCustomTransform::processTransform(IEspContext * context, IPropertyTree
         xpathContext->addVariable("query", tgtcfg->queryProp("@queryname"));
         xpathContext->addVariable("method", mthdef.queryMethodName());
         xpathContext->addVariable("service", srvdef.queryName());
+        xpathContext->addVariable("request", mthdef.queryRequestType());
 
         auto user = context->queryUser();
         if (user)

--- a/esp/services/esdl_svc_engine/esdl_svc_custom.cpp
+++ b/esp/services/esdl_svc_engine/esdl_svc_custom.cpp
@@ -26,7 +26,9 @@ CEsdlCustomTransformChoose::CEsdlCustomTransformChoose(IPropertyTree * choosewhe
 {
     if (choosewhen)
     {
-        IPropertyTree * whentree = choosewhen->queryPropTree("xsdl:when");
+        if (choosewhen->hasProp("@target"))
+            target.set(choosewhen->queryProp("@target"));
+        IPropertyTree * whentree = choosewhen->queryPropTree("xsdl:when"); //should support multiple when statements
         if (whentree)
         {
             StringBuffer testatt;
@@ -110,20 +112,20 @@ void CEsdlCustomTransformChoose::processClauses(IEspContext * context, IProperty
     }
 }
 
-void CEsdlCustomTransformChoose::processChildClauses(IEspContext * context, IPropertyTree *request, IXpathContext * xpathContext,  bool otherwise)
+void CEsdlCustomTransformChoose::processChildClauses(IEspContext * context, IPropertyTree *request, IXpathContext * xpathContext,  bool otherwise, IPropertyTree *origTree)
 {
     if (!otherwise)
     {
         ForEachItemIn(currNestedConditionalIndex, m_childChooseClauses)
         {
-            m_childChooseClauses.item(currNestedConditionalIndex).process(context, request, xpathContext);
+            m_childChooseClauses.item(currNestedConditionalIndex).process(context, request, xpathContext, origTree, nullptr);
         }
     }
     else
     {
         ForEachItemIn(currNestedConditionalIndex, m_childOtherwiseClauses)
         {
-            m_childOtherwiseClauses.item(currNestedConditionalIndex).process(context, request, xpathContext);
+            m_childOtherwiseClauses.item(currNestedConditionalIndex).process(context, request, xpathContext, origTree, nullptr);
         }
     }
 }
@@ -208,14 +210,35 @@ bool CEsdlCustomTransformChoose::evaluate(IXpathContext * xpathContext)
     return evalresp;
 }
 
-void CEsdlCustomTransformChoose::process(IEspContext * context, IPropertyTree *request, IXpathContext * xpathContext)
+void CEsdlCustomTransformChoose::process(IEspContext * context, IPropertyTree *request, IXpathContext * xpathContext, IPropertyTree *origTree, const char *defaultTarget)
 {
+    StringBuffer xpath;
+
+    if (target.length())
+        xpath.set(target.str());
+    else if (defaultTarget && *defaultTarget)
+        xpath.set(defaultTarget);
+
+    IPropertyTree *reqTarget = request;
+
+    if (xpath.length())
+    {
+        //we can use real xpath processing in the future, for now simple substitution is fine
+        xpath.replaceString("{$query}", xpathContext->getVariable("query"));
+        xpath.replaceString("{$method}", xpathContext->getVariable("method"));
+        xpath.replaceString("{$service}", xpathContext->getVariable("service"));
+
+        reqTarget = origTree->queryPropTree(xpath.str());  //get pointer to the write-able area
+        if (!reqTarget)
+            throw MakeStringException(-1, "EsdlCustomTransformChoose::process error getting request target %s", xpath.str());
+    }
+
     bool result = false;
     try
     {
         bool result = evaluate(xpathContext);
-        processClauses(context, request, xpathContext, !result);
-        processChildClauses(context, request, xpathContext, !result);
+        processClauses(context, reqTarget, xpathContext, !result);
+        processChildClauses(context, reqTarget, xpathContext, !result, origTree);
     }
     catch (...)
     {
@@ -363,24 +386,16 @@ void CEsdlCustomTransform::processTransform(IEspContext * context, IPropertyTree
         }
 
         Owned<IPropertyTree> theroot = createPTreeFromXMLString(request.str());
-        StringBuffer xpath = m_target.str();
-        if (!xpath.length())
-        {
+        StringBuffer defaultTarget;
             //This default gives us backward compatibility with only being able to write to the actual request
-            const char *tgtQueryName = tgtcfg->queryProp("@queryname");
-            xpath.setf("soap:Body/%s/%s", tgtQueryName ? tgtQueryName : mthdef.queryMethodName(), mthdef.queryRequestType());
-        }
-        //we can use real xpath processing in the future, for now simple substitution is fine
-        xpath.replaceString("{$query}", tgtcfg->queryProp("@queryname"));
-        xpath.replaceString("{$method}", mthdef.queryMethodName());
-        xpath.replaceString("{$service}", srvdef.queryName());
-        IPropertyTree *thereq = theroot->queryPropTree(xpath.str());  //get pointer to the write-able area
+        const char *tgtQueryName = tgtcfg->queryProp("@queryname");
+        defaultTarget.setf("soap:Body/%s/%s", tgtQueryName ? tgtQueryName : mthdef.queryMethodName(), mthdef.queryRequestType());
+
         ForEachItemIn(currConditionalIndex, m_customTransformClauses)
-        {
-            m_customTransformClauses.item(currConditionalIndex).process(context, thereq, xpathContext);
-        }
+            m_customTransformClauses.item(currConditionalIndex).process(context, theroot, xpathContext, theroot, defaultTarget);
+
         toXML(theroot, request.clear());
 
-        ESPLOG(LogMax,"MODIFIED REQUEST: %s", request.str());
+        ESPLOG(1,"MODIFIED REQUEST: %s", request.str());
     }
 }

--- a/esp/services/esdl_svc_engine/esdl_svc_custom.hpp
+++ b/esp/services/esdl_svc_engine/esdl_svc_custom.hpp
@@ -99,7 +99,7 @@ private:
     CIArrayOf<CEsdlCustomTransformRule> m_otherwiseClauses;
     CIArrayOf<CEsdlCustomTransformChoose> m_childChooseClauses;
     CIArrayOf<CEsdlCustomTransformChoose> m_childOtherwiseClauses;
-    StringAttr target;
+    StringAttr crtTarget;
 
 public:
     IMPLEMENT_IINTERFACE;

--- a/esp/services/esdl_svc_engine/esdl_svc_custom.hpp
+++ b/esp/services/esdl_svc_engine/esdl_svc_custom.hpp
@@ -99,6 +99,7 @@ private:
     CIArrayOf<CEsdlCustomTransformRule> m_otherwiseClauses;
     CIArrayOf<CEsdlCustomTransformChoose> m_childChooseClauses;
     CIArrayOf<CEsdlCustomTransformChoose> m_childOtherwiseClauses;
+    StringAttr target;
 
 public:
     IMPLEMENT_IINTERFACE;
@@ -110,7 +111,7 @@ public:
         DBGLOG("CEsdlCustomTransformClause released!");
 #endif
     }
-    void process(IEspContext * context, IPropertyTree *request, IXpathContext * xpathContext);
+    void process(IEspContext * context, IPropertyTree *request, IXpathContext * xpathContext, IPropertyTree *origTree, const char *defTarget);
 #if defined(_DEBUG)
     void toDBGLog();
 #endif
@@ -124,7 +125,7 @@ private:
     bool evaluate(IXpathContext * xpathContext);
     void processClauses(IPropertyTree *request, IXpathContext * xpathContext, CIArrayOf<CEsdlCustomTransformRule> & m_fieldTransforms);
     void processClauses(IEspContext * context, IPropertyTree *request, IXpathContext * xpathContext, bool otherwise);
-    void processChildClauses(IEspContext * context, IPropertyTree *request, IXpathContext * xpathContext,  bool otherwise);
+    void processChildClauses(IEspContext * context, IPropertyTree *request, IXpathContext * xpathContext,  bool otherwise, IPropertyTree *origTree);
 };
 
 interface IEsdlCustomTransform : extends IInterface


### PR DESCRIPTION
Support target xpath at the xsdl:choose level.  This allows the
choose to reposition the target position in the original xml that
all child setValue and appendValue actions will affect.

Also push the transform level target xpath down to it's child
xsdl:choose level before merging the transforms.  This means the
uniqueness of the target xpaths will be correct after the merge
is done.  Otherwise the transform level xpath can be over ridden
during the merge.

If the choose already has it's own target it will be preserved.

Signed-off-by: Anthony Fishbeck <anthony.fishbeck@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
