### PR TITLE
HPCC-21089 Add bool flag to user descriptor serialize password

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -10366,11 +10366,7 @@ IDFAttributesIterator *CDistributedFileDirectory::getDFAttributesIterator(const 
     mb.append((int)MDFS_ITERATE_FILES).append(wildname).append(recursive).append("").append(includesuper); // "" is legacy
     if (user)
     {
-		Owned<IUserDescriptor> tmpUDesc = createUserDescriptor();
-		StringBuffer userName;
-		user->getUserName(userName);
-		tmpUDesc->set(userName.str(), nullptr);
-		tmpUDesc->serialize(mb);//serialize without password, since it is not checked
+        user->serializeWithoutPassword(mb);
     }
 #ifdef NULL_DALIUSER_STACKTRACE
     else
@@ -10503,11 +10499,7 @@ void CDistributedFileDirectory::setFileAccessed(CDfsLogicalFileName &dlfn,IUserD
     dt.serialize(mb);
     if (user)
     {
-        Owned<IUserDescriptor> tmpUDesc = createUserDescriptor();
-        StringBuffer userName;
-        user->getUserName(userName);
-        tmpUDesc->set(userName.str(), nullptr);
-        tmpUDesc->serialize(mb);//serialize without password, since it is not checked
+        user->serializeWithoutPassword(mb);
     }
 #ifdef NULL_DALIUSER_STACKTRACE
     else
@@ -10548,11 +10540,7 @@ void CDistributedFileDirectory::setFileProtect(CDfsLogicalFileName &dlfn,IUserDe
     mb.append((int)MDFS_SET_FILE_PROTECT).append(lname).append(owner).append(set);
     if (user)
     {
-		Owned<IUserDescriptor> tmpUDesc = createUserDescriptor();
-		StringBuffer userName;
-		user->getUserName(userName);
-		tmpUDesc->set(userName.str(), nullptr);
-		tmpUDesc->serialize(mb);//serialize without password, since it is not checked
+        user->serializeWithoutPassword(mb);
     }
 #ifdef NULL_DALIUSER_STACKTRACE
     else
@@ -10589,11 +10577,7 @@ IPropertyTree *CDistributedFileDirectory::getFileTree(const char *lname, IUserDe
     mb.append(MDFS_GET_FILE_TREE_V2);
     if (user)
     {
-        Owned<IUserDescriptor> tmpUDesc = createUserDescriptor();
-        StringBuffer userName;
-        user->getUserName(userName);
-        tmpUDesc->set(userName.str(), nullptr);
-        tmpUDesc->serialize(mb);//serialize without password, since it is not checked
+        user->serializeWithoutPassword(mb);
     }
 #ifdef NULL_DALIUSER_STACKTRACE
     else
@@ -12469,11 +12453,7 @@ IPropertyTreeIterator *CDistributedFileDirectory::getDFAttributesTreeIterator(co
     mb.append(filters).append(recursive);
     if (user)
     {
-        Owned<IUserDescriptor> tmpUDesc = createUserDescriptor();
-        StringBuffer userName;
-        user->getUserName(userName);
-        tmpUDesc->set(userName.str(), nullptr);
-        tmpUDesc->serialize(mb);//serialize without password, since it is not checked
+        user->serializeWithoutPassword(mb);
     }
 
     if (foreigndali)

--- a/dali/base/dasess.cpp
+++ b/dali/base/dasess.cpp
@@ -938,14 +938,7 @@ public:
         }
 #endif
 
-        {
-            Owned<IUserDescriptor> tmpUDesc = createUserDescriptor();
-            StringBuffer user;
-            udesc->getUserName(user);
-            tmpUDesc->set(user.str(), nullptr);
-            tmpUDesc->serialize(mb);//serialize without password, since it is not checked
-        }
-
+        udesc->serializeWithoutPassword(mb);//serialize user descriptor without password
         mb.append(auditflags);
 
         //Serialize signature. If not provided, compute it
@@ -2111,6 +2104,11 @@ public:
         username.clear();
         passwordenc.clear();
         signature.clear();
+    }
+    void serializeWithoutPassword(MemoryBuffer &mb)
+    {
+        StringBuffer emptyPwd;
+        mb.append(username).append(emptyPwd);
     }
     void serialize(MemoryBuffer &mb)
     {

--- a/dali/base/dasess.hpp
+++ b/dali/base/dasess.hpp
@@ -80,6 +80,7 @@ interface IUserDescriptor: extends serializable
     virtual void set(const char *name,const char *password)=0;
     virtual void set(const char *name,const char *password, const char *_signature)=0;
     virtual void clear()=0;
+    virtual void serializeWithoutPassword(MemoryBuffer &mb)=0;
 };
 
 extern da_decl IUserDescriptor *createUserDescriptor();


### PR DESCRIPTION
Currently if you want to send a user descriptor without a password, you have to
create a new one, copy the old one without the password, and serialize it. This
PR adds a new "serialize" method that can optionally leave out the password when
serializing the user

Signed-off-by: Russ Whitehead <william.whitehead@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [x] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [x] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
