### PR TITLE
HPCC-21220 Allow explicit selection of config content sent to roxie

### DIFF
--- a/esp/services/esdl_svc_engine/esdl_svc_engine.cpp
+++ b/esp/services/esdl_svc_engine/esdl_svc_engine.cpp
@@ -39,6 +39,70 @@ CEsdlSvcEngineSoapBindingEx::CEsdlSvcEngineSoapBindingEx(IPropertyTree* cfg, con
 {
 }
 
+IPropertyTree *createContextMethodConfig(IPropertyTree *methodConfig)
+{
+    const char *include = "*";
+    if (methodConfig->hasProp("@contextInclude"))
+        include = methodConfig->queryProp("@contextInclude");
+    const char *remove = "Transforms|xsdl:CustomRequestTransform";
+    if (methodConfig->hasProp("@contextRemove"))
+        remove = methodConfig->queryProp("@contextRemove");
+    const char *removeAttrs = "@contextInclude|@contextRemove|@contextAttRemove";
+    if (methodConfig->hasProp("@contextAttRemove"))
+        removeAttrs = methodConfig->queryProp("@contextAttRemove");
+
+    Owned<IPropertyTree> contextConfig;
+    if (include && !streq(include, "*"))
+    {
+        contextConfig.setown(createPTree("Method", ipt_ordered));
+        Owned<IAttributeIterator> aiter = methodConfig->getAttributes(); //for now include all attributes
+        ForEach (*aiter)
+            contextConfig->addProp(aiter->queryName(), aiter->queryValue());
+
+        if (*include) //if *include==0 we should have an empty tree
+        {
+            StringArray xpaths;
+            xpaths.appendListUniq(include, "|", true); //don't supported quoted | for now
+            ForEachItemIn(pos, xpaths)
+            {
+                Owned<IPropertyTreeIterator> toInclude = methodConfig->getElements(xpaths.item(pos));
+                ForEach(*toInclude)
+                    contextConfig->addPropTree(toInclude->query().queryName(), LINK(&toInclude->query()));
+            }
+        }
+    }
+    if (remove && *remove)
+    {
+        if (!contextConfig)
+            contextConfig.setown(createPTreeFromIPT(methodConfig, ipt_ordered));
+        if (contextConfig->hasChildren())
+        {
+            StringArray xpaths;
+            xpaths.appendListUniq(remove, "|", true); //don't supported quoted | for now
+            ForEachItemIn(pos, xpaths)
+            {
+                Owned<IPropertyTreeIterator> toRemove = contextConfig->getElements(xpaths.item(pos));
+                ForEach(*toRemove)
+                    contextConfig->removeTree(&toRemove->query());
+            }
+        }
+    }
+
+    if (removeAttrs && *removeAttrs)
+    {
+        if (!contextConfig)
+            contextConfig.setown(createPTreeFromIPT(methodConfig, ipt_ordered));
+        StringArray xpaths;
+        xpaths.appendListUniq(removeAttrs, "|", true); //don't supported quoted | for now
+        ForEachItemIn(pos, xpaths)
+            contextConfig->removeProp(xpaths.item(pos));
+    }
+
+    if (contextConfig)
+        return contextConfig.getClear();
+    return LINK(methodConfig); //no copy, nothing changed
+}
+
 IPropertyTree *CEsdlSvcEngine::createTargetContext(IEspContext &context, IPropertyTree *tgtcfg, IEsdlDefService &srvdef, IEsdlDefMethod &mthdef, IPropertyTree *req_pt)
 {
     Owned<IPropertyTree> localCtx(createPTreeFromIPT(m_service_ctx, ipt_none));
@@ -48,8 +112,12 @@ IPropertyTree *CEsdlSvcEngine::createTargetContext(IEspContext &context, IProper
     localCtx->setProp("Row/Common/ESP/ServiceName", context.queryServiceName(""));
     //removing this entry since the Row/Common/ESP/Config/Method tree should have an attribute @name
     //localCtx->setProp("Row/Common/ESP/MethodName", mthdef.queryMethodName());
-    ensurePTree(localCtx, "Row/Common/ESP/Config");
-    localCtx->addPropTree("Row/Common/ESP/Config/Method", LINK(tgtcfg));
+    Owned<IPropertyTree> config = createContextMethodConfig(tgtcfg);
+    if (config && (config->hasChildren() || config->getAttributes()->count()>0))
+    {
+        ensurePTree(localCtx, "Row/Common/ESP/Config");
+        localCtx->addPropTree("Row/Common/ESP/Config/Method", config.getClear());
+    }
     return localCtx.getLink();
 }
 

--- a/esp/services/esdl_svc_engine/esdl_svc_engine.cpp
+++ b/esp/services/esdl_svc_engine/esdl_svc_engine.cpp
@@ -105,17 +105,18 @@ IPropertyTree *createContextMethodConfig(IPropertyTree *methodConfig)
 
 bool skipContextConfig(IPropertyTree *cfg)
 {
-    if (!cfg->getPropBool("@contextConfig", true)) //explicitly disabled
+    const char *elRemove = cfg->queryProp("@contextRemove");
+    if (elRemove && streq(elRemove, ".")) //remove entire node
         return true;
 
     const char *elInclude = cfg->queryProp("@contextInclude");
-    const char *elRemove = cfg->queryProp("@contextRemove");
     const char *attRemove = cfg->queryProp("@contextAttRemove");
 
     bool noElIncluded = elInclude && !*elInclude; //empty xpath
-    bool allElRemoved = (elRemove && streq(elRemove, "*"));
-    bool allAttRemoved = (attRemove && streq(attRemove, "*"));
+    bool allElRemoved = (elRemove && streq(elRemove, "*"));  //remove all child elements
+    bool allAttRemoved = (attRemove && streq(attRemove, "*")); //remove top level attributes (affects root node only)
 
+    //note that @contextRemove="." is equivalent to (@contextRemove="*" and @contextAttRemove="*") because the empty root tag is removed
     return (allAttRemoved && (noElIncluded || allElRemoved));
 }
 

--- a/esp/services/esdl_svc_engine/esdl_svc_engine.cpp
+++ b/esp/services/esdl_svc_engine/esdl_svc_engine.cpp
@@ -93,7 +93,21 @@ IPropertyTree *createContextMethodConfig(IPropertyTree *methodConfig)
         if (!contextConfig)
             contextConfig.setown(createPTreeFromIPT(methodConfig, ipt_ordered));
         StringArray xpaths;
-        xpaths.appendListUniq(removeAttrs, "|", true); //don't supported quoted | for now
+        StringBuffer temp;
+        if (streq(removeAttrs, "*"))
+        {
+            Owned<IAttributeIterator> attrs = contextConfig->getAttributes();
+            ForEach(*attrs)
+            {
+                if (!temp.isEmpty())
+                    temp.append('|');
+                temp.append(attrs->queryName());
+            }
+            removeAttrs=temp.str();
+        }
+
+        xpaths.appendListUniq(removeAttrs, "|", true); //don't support quoted | for now
+
         ForEachItemIn(pos, xpaths)
             contextConfig->removeProp(xpaths.item(pos));
     }


### PR DESCRIPTION
With the introduction of request transforms the dynamic configuration of
methods gets quite large.  What gets added to the request context config
section should be much more explicit so that we are not wasting bandwidth.

Signed-off-by: Anthony Fishbeck <anthony.fishbeck@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
