### PR TITLE
HPCC-21262 Use a more consistent naming convention when regenerating records

### DIFF
--- a/ecl/hql/hqlthql.cpp
+++ b/ecl/hql/hqlthql.cpp
@@ -918,9 +918,9 @@ void HqltHql::toECL(IHqlExpression *expr, StringBuffer &s, bool paren, bool inTy
                     StringBuffer temp;
                     scope.append(NULL);
                     if (expr->isDataset())
-                        temp.appendf("dataset%p ", expr);
+                        temp.appendf("dataset%012" I64F "x ", (__uint64)(memsize_t)expr);
                     else
-                        temp.appendf("dictionary%p ", expr);
+                        temp.appendf("dictionary%012" I64F "x ", (__uint64)(memsize_t)expr);
 #ifdef SHOW_NORMALIZED
                     if (expandProcessed)
                         temp.appendf("[N%p] ", expr->queryNormalizedSelector());
@@ -936,9 +936,9 @@ void HqltHql::toECL(IHqlExpression *expr, StringBuffer &s, bool paren, bool inTy
                     expr->setTransformExtra(expr);
                 }   
                 if (expr->isDataset())
-                    s.appendf("dataset%p", expr);
+                    s.appendf("dataset%012" I64F "x", (__uint64)(memsize_t)expr);
                 else
-                    s.appendf("dictionary%p", expr);
+                    s.appendf("dictionary%012" I64F "x", (__uint64)(memsize_t)expr);
                 if (paren)
                     s.append(')');
                 return;
@@ -992,7 +992,7 @@ void HqltHql::toECL(IHqlExpression *expr, StringBuffer &s, bool paren, bool inTy
 
                     StringBuffer temp;
                     scope.append(NULL);
-                    temp.appendf("alias%p ", expr);
+                    temp.appendf("alias%012" I64F "x ", (__uint64)(memsize_t)expr);
                     temp.append(":= ");
 
                     toECL(expr, temp, false, false, 0, true);
@@ -1003,7 +1003,7 @@ void HqltHql::toECL(IHqlExpression *expr, StringBuffer &s, bool paren, bool inTy
                     insideNewTransform = wasInsideNewTransform;
                     expr->setTransformExtra(expr);
                 }
-                s.appendf("alias%p", expr);
+                s.appendf("alias%012" I64F "x", (__uint64)(memsize_t)expr);
                 if (paren)
                     s.append(')');
                 return;
@@ -1016,7 +1016,7 @@ void HqltHql::toECL(IHqlExpression *expr, StringBuffer &s, bool paren, bool inTy
             {
                 StringBuffer temp;
                 scope.append(NULL);
-                temp.appendf("record%p := ", expr);
+                temp.appendf("record%012" I64F "x := ", (__uint64)(memsize_t)expr);
 
                 toECL(expr, temp, false, false, 0, true);
                 temp.append(";").newline();
@@ -1025,7 +1025,7 @@ void HqltHql::toECL(IHqlExpression *expr, StringBuffer &s, bool paren, bool inTy
                 scope.pop();
                 expr->setTransformExtra(expr);
             }   
-            s.appendf("record%p", expr);
+            s.appendf("record%012" I64F "x", (__uint64)(memsize_t)expr);
             return;
         }
 
@@ -1046,7 +1046,7 @@ void HqltHql::toECL(IHqlExpression *expr, StringBuffer &s, bool paren, bool inTy
                     
                     StringBuffer temp;
                     scope.append(NULL);
-                    temp.appendf("pattern%p := ", expr);
+                    temp.appendf("pattern%012" I64F "x := ", (__uint64)(memsize_t)expr);
 
                     toECL(expr, temp, false, false, 0, true);
                     temp.append(";").newline();
@@ -1055,8 +1055,8 @@ void HqltHql::toECL(IHqlExpression *expr, StringBuffer &s, bool paren, bool inTy
                     scope.pop();
                     insideNewTransform = wasInsideNewTransform;
                     expr->setTransformExtra(expr);
-                }   
-                s.appendf("pattern%p", expr);
+                }
+                s.appendf("pattern%012" I64F "x", (__uint64)(memsize_t)expr);
                 return;
             }
             else if (expandProcessed)

--- a/ecl/hqlcpp/hqlstmt.cpp
+++ b/ecl/hqlcpp/hqlstmt.cpp
@@ -784,54 +784,6 @@ HqlExprAssociation * BuildCtx::queryFirstAssociation(AssocKind searchKind)
 }
 
 
-//Search for an association, but don't allow it to be conditional, or be hidden by the definition of a cursor.
-HqlExprAssociation * BuildCtx::queryFirstCommonAssociation(AssocKind searchKind)
-{
-    HqlStmts * searchStmts = curStmts;
-    unsigned searchMask = searchKind|AssocCursor;
-
-    // search all statements in the tree before this one, to see
-    // if an expression already exists...  If so return the target
-    // of the assignment.
-    for (;;)
-    {
-        if (searchStmts->associationMask & searchMask)
-        {
-            CIArray & defs = searchStmts->defs;
-            ForEachItemInRev(idx, defs)
-            {
-                HqlExprAssociation & cur = (HqlExprAssociation &)defs.item(idx);
-                AssocKind kind = cur.getKind();
-                if (kind == searchKind)
-                    return &cur;
-                if (kind == AssocCursor)
-                    return NULL;
-            }
-        }
-
-        HqlStmt * limitStmt = searchStmts->queryStmt();
-        if (!limitStmt)
-            break;
-        switch (limitStmt->getStmt())
-        {
-        //case quote_compound_stmt:
-        //case quote_compoundopt_stmt,
-        case filter_stmt:
-        case label_stmt:
-        case switch_stmt:
-        case case_stmt:
-        case default_stmt:
-        case break_stmt:
-        case continue_stmt:
-            return NULL;
-        }
-
-        searchStmts = limitStmt->queryContainer();
-    }
-    return NULL;
-}
-
-
 void BuildCtx::walkAssociations(AssocKind searchMask, IAssociationVisitor & visitor)
 {
     HqlStmts * searchStmts = curStmts;

--- a/ecl/hqlcpp/hqlstmt.hpp
+++ b/ecl/hqlcpp/hqlstmt.hpp
@@ -138,7 +138,6 @@ public:
     bool                        isSameLocation(const BuildCtx & other) const;
     HqlExprAssociation *        queryAssociation(IHqlExpression * dataset, AssocKind kind, HqlExprCopyArray * selectors);
     HqlExprAssociation *        queryFirstAssociation(AssocKind kind);
-    HqlExprAssociation *        queryFirstCommonAssociation(AssocKind kind);
     void                        walkAssociations(AssocKind searchMask, IAssociationVisitor & visitor); // Function to walk associations filtered by kind
     HqlExprAssociation *        queryMatchExpr(IHqlExpression * expr);
     bool                        getMatchExpr(IHqlExpression * expr, CHqlBoundExpr & bound);


### PR DESCRIPTION
…records

Signed-off-by: Gavin Halliday <gavin.halliday@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
