### PR TITLE
HPCC-21219 Config tank file limit for ESP logging

### DIFF
--- a/esp/logging/logginglib/LogSerializer.cpp
+++ b/esp/logging/logginglib/LogSerializer.cpp
@@ -61,6 +61,7 @@ void CLogSerializer::Init()
     m_ItemCount     = 0;
     m_fileio        = 0;
     m_file          = 0;
+    fileSize = 0;
 }
 
 CLogSerializer::~CLogSerializer()
@@ -84,6 +85,7 @@ void CLogSerializer::Append(const char* GUID, const char* Data)
     //optimize
     CriticalBlock b(crit);
     m_ItemCount++;
+    fileSize += toWrite.length();
     m_bytesWritten += m_fileio->write(m_bytesWritten, toWrite.length(), toWrite.str());
 }
 
@@ -146,6 +148,7 @@ void CLogSerializer::Close()
 
     m_bytesWritten  = 0;//
     m_ItemCount     = 0;//
+    fileSize        = 0;
 }
 
 void CLogSerializer::Rollover(const char* ClosedPrefix)
@@ -281,6 +284,7 @@ void CLogSerializer::loadAckedLogs(GuidSet& ackedLogs)//
 
             finger+=dataLen;
         }
+        fileSize = finger;
         DBGLOG("Total acks loaded %lu", m_ItemCount);
     }
     catch(IException* ex)

--- a/esp/logging/logginglib/LogSerializer.hpp
+++ b/esp/logging/logginglib/LogSerializer.hpp
@@ -33,6 +33,7 @@ class CLogSerializer : public CInterface
 {
     __int64 m_bytesWritten;
     unsigned long m_ItemCount;//
+    unsigned long fileSize;//
     CriticalSection crit;
 protected:
     IFile* m_file;
@@ -63,6 +64,7 @@ public:
     void SafeRollover(const char* Directory,const char* NewFileName,const char* Prefix, const char* ClosedPrefix);
 
     unsigned long getItemCount() const { return m_ItemCount; }//
+    unsigned long getFileSize() const { return fileSize; }//
     static StringBuffer& extractFileName(const char* fullName, StringBuffer& fileName);//
     virtual void loadSendLogs(GuidSet& ACKSet, GuidMap& MissedLogs, unsigned long& total_missed);//
     virtual void loadAckedLogs(GuidSet& ReceiveMap);//

--- a/esp/logging/logginglib/logthread.cpp
+++ b/esp/logging/logginglib/logthread.cpp
@@ -26,7 +26,6 @@ const char* const PropMaxLogQueueLength = "MaxLogQueueLength";
 const char* const PropQueueSizeSignal = "QueueSizeSignal";
 const char* const PropMaxTriesRS = "MaxTriesRS";
 const char* const PropFailSafe = "FailSafe";
-const char* const PropFailSafeLogsDir = "FailSafeLogsDir";
 
 #define     MaxLogQueueLength   500000 //Write a warning into log when queue length is greater than 500000
 #define     QueueSizeSignal     10000 //Write a warning into log when queue length is increased by 10000
@@ -65,13 +64,8 @@ CLogThread::CLogThread(IPropertyTree* _cfg , const char* _service, const char* _
     maxLogRetries = _cfg->getPropInt(PropMaxTriesRS, DefaultMaxTriesRS);
     ensureFailSafe = _cfg->getPropBool(PropFailSafe);
     if(ensureFailSafe)
-    {
-        const char * logsDir = _cfg->queryProp(PropFailSafeLogsDir);
-        if (!logsDir || !*logsDir)
-            logsDir = "./FailSafeLogs";
+        logFailSafe.setown(createFailSafeLogger(_cfg, _service, _agentName));
 
-        logFailSafe.setown(createFailSafeLogger(_service, _agentName, logsDir));
-    }
     time_t tNow;
     time(&tNow);
     localtime_r(&tNow, &m_startTime);

--- a/initfiles/componentfiles/configxml/@temp/CMakeLists.txt
+++ b/initfiles/componentfiles/configxml/@temp/CMakeLists.txt
@@ -23,6 +23,7 @@ FOREACH ( iFILES
     ${CMAKE_CURRENT_SOURCE_DIR}/roxiePlugins.xsl
     ${CMAKE_CURRENT_SOURCE_DIR}/esp_service_DynamicESDL.xsl
     ${CMAKE_CURRENT_SOURCE_DIR}/esp_logging_transid.xsl
+    ${CMAKE_CURRENT_SOURCE_DIR}/esp_logging_agent_basic.xsl
     ${CMAKE_CURRENT_SOURCE_DIR}/esp_service_wslogging.xsl
     ${CMAKE_CURRENT_SOURCE_DIR}/logging_agent.xsl
     ${CMAKE_CURRENT_SOURCE_DIR}/wslogserviceespagent.xsl

--- a/initfiles/componentfiles/configxml/@temp/esp_logging_agent_basic.xsl
+++ b/initfiles/componentfiles/configxml/@temp/esp_logging_agent_basic.xsl
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+################################################################################
+#    HPCC SYSTEMS software Copyright (C) 2019 HPCC Systems®.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+################################################################################
+-->
+
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xml:space="default"
+xmlns:set="http://exslt.org/sets" exclude-result-prefixes="set">
+
+  <xsl:template name="EspLoggingAgentBasic">
+    <xsl:param name="agentNode"/>
+    <xsl:if test="string($agentNode/@FailSafe) != ''">
+        <FailSafe><xsl:value-of select="$agentNode/@FailSafe"/></FailSafe>
+    </xsl:if>
+    <xsl:if test="string($agentNode/@FailSafeLogsDir) != ''">
+        <FailSafeLogsDir><xsl:value-of select="$agentNode/@FailSafeLogsDir"/></FailSafeLogsDir>
+    </xsl:if>
+    <xsl:if test="string($agentNode/@MaxLogQueueLength) != ''">
+        <MaxLogQueueLength><xsl:value-of select="$agentNode/@MaxLogQueueLength"/></MaxLogQueueLength>
+    </xsl:if>
+    <xsl:if test="string($agentNode/@MaxTriesGTS) != ''">
+        <MaxTriesGTS><xsl:value-of select="$agentNode/@MaxTriesGTS"/></MaxTriesGTS>
+    </xsl:if>
+    <xsl:if test="string($agentNode/@MaxTriesRS) != ''">
+        <MaxTriesRS><xsl:value-of select="$agentNode/@MaxTriesRS"/></MaxTriesRS>
+    </xsl:if>
+    <xsl:if test="string($agentNode/@QueueSizeSignal) != ''">
+        <QueueSizeSignal><xsl:value-of select="$agentNode/@QueueSizeSignal"/></QueueSizeSignal>
+    </xsl:if>
+    <xsl:if test="string($agentNode/@SafeRolloverThreshold) != ''">
+        <SafeRolloverThreshold><xsl:value-of select="$agentNode/@SafeRolloverThreshold"/></SafeRolloverThreshold>
+    </xsl:if>
+  </xsl:template>
+</xsl:stylesheet>

--- a/initfiles/componentfiles/configxml/@temp/logging_agent.xsl
+++ b/initfiles/componentfiles/configxml/@temp/logging_agent.xsl
@@ -20,6 +20,7 @@
 
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xml:space="default"
 xmlns:set="http://exslt.org/sets">
+    <xsl:import href="esp_logging_agent_basic.xsl"/>
     <xsl:import href="esp_logging_transid.xsl"/>
 
     <xsl:template name="LogSourceMap">
@@ -90,28 +91,6 @@ xmlns:set="http://exslt.org/sets">
         </xsl:if>
     </xsl:template>
 
-    <xsl:template name="LogBasic">
-        <xsl:param name="agentNode"/>
-        <xsl:if test="string($agentNode/@FailSafe) != ''">
-            <FailSafe><xsl:value-of select="$agentNode/@FailSafe"/></FailSafe>
-        </xsl:if>
-        <xsl:if test="string($agentNode/@FailSafeLogsDir) != ''">
-            <FailSafeLogsDir><xsl:value-of select="$agentNode/@FailSafeLogsDir"/></FailSafeLogsDir>
-        </xsl:if>
-        <xsl:if test="string($agentNode/@MaxLogQueueLength) != ''">
-            <MaxLogQueueLength><xsl:value-of select="$agentNode/@MaxLogQueueLength"/></MaxLogQueueLength>
-        </xsl:if>
-        <xsl:if test="string($agentNode/@MaxTriesGTS) != ''">
-            <MaxTriesGTS><xsl:value-of select="$agentNode/@MaxTriesGTS"/></MaxTriesGTS>
-        </xsl:if>
-        <xsl:if test="string($agentNode/@MaxTriesRS) != ''">
-            <MaxTriesRS><xsl:value-of select="$agentNode/@MaxTriesRS"/></MaxTriesRS>
-        </xsl:if>
-        <xsl:if test="string($agentNode/@QueueSizeSignal) != ''">
-            <QueueSizeSignal><xsl:value-of select="$agentNode/@QueueSizeSignal"/></QueueSizeSignal>
-        </xsl:if>
-    </xsl:template>
-
     <xsl:template name="CassandraLoggingAgent">
         <xsl:param name="agentName"/>
         <xsl:param name="agentNode"/>
@@ -127,7 +106,7 @@ xmlns:set="http://exslt.org/sets">
         <LogAgent name="{$agentName}" type="LogAgent" services="{$Services}" plugin="cassandralogagent">
             <Cassandra server="{$agentNode/@serverIP}" dbUser="{$agentNode/@userName}" dbPassWord="{$agentNode/@userPassword}" dbName="{$agentNode/@ksName}"/>
 
-            <xsl:call-template name="LogBasic">
+            <xsl:call-template name="EspLoggingAgentBasic">
                 <xsl:with-param name="agentNode" select="$agentNode"/>
             </xsl:call-template>
             <xsl:call-template name="TransactionSeed">
@@ -187,7 +166,7 @@ xmlns:set="http://exslt.org/sets">
                 <xsl:with-param name="agentNode" select="$agentNode"/>
             </xsl:call-template>
 
-            <xsl:call-template name="LogBasic">
+            <xsl:call-template name="EspLoggingAgentBasic">
                 <xsl:with-param name="agentNode" select="$agentNode"/>
             </xsl:call-template>
             <xsl:call-template name="LogSourceMap">

--- a/initfiles/componentfiles/configxml/@temp/wslogserviceespagent.xsl
+++ b/initfiles/componentfiles/configxml/@temp/wslogserviceespagent.xsl
@@ -20,6 +20,7 @@
 
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xml:space="default"
 xmlns:set="http://exslt.org/sets">
+    <xsl:import href="esp_logging_agent_basic.xsl"/>
     <xsl:import href="esp_logging_transid.xsl"/>
 
     <xsl:template name="WsLogServiceESPAgent" type="DefaultLoggingAgent">
@@ -48,24 +49,9 @@ xmlns:set="http://exslt.org/sets">
         </xsl:variable>
         <LogAgent name="{$agentName}" type="LogAgent" services="{$Services}" plugin="wslogserviceespagent">
             <LoggingServer url="{$loggingServerUrl}" user="{$loggingServer/@User}" password="{$loggingServer/@Password}"/>
-            <xsl:if test="string($agentNode/@FailSafe) != ''">
-                <FailSafe><xsl:value-of select="$agentNode/@FailSafe"/></FailSafe>
-            </xsl:if>
-            <xsl:if test="string($agentNode/@FailSafeLogsDir) != ''">
-                <FailSafeLogsDir><xsl:value-of select="$agentNode/@FailSafeLogsDir"/></FailSafeLogsDir>
-            </xsl:if>
-            <xsl:if test="string($agentNode/@MaxLogQueueLength) != ''">
-                <MaxLogQueueLength><xsl:value-of select="$agentNode/@MaxLogQueueLength"/></MaxLogQueueLength>
-            </xsl:if>
-            <xsl:if test="string($agentNode/@MaxTriesGTS) != ''">
-                <MaxTriesGTS><xsl:value-of select="$agentNode/@MaxTriesGTS"/></MaxTriesGTS>
-            </xsl:if>
-            <xsl:if test="string($agentNode/@MaxTriesRS) != ''">
-                <MaxTriesRS><xsl:value-of select="$agentNode/@MaxTriesRS"/></MaxTriesRS>
-            </xsl:if>
-            <xsl:if test="string($agentNode/@QueueSizeSignal) != ''">
-                <QueueSizeSignal><xsl:value-of select="$agentNode/@QueueSizeSignal"/></QueueSizeSignal>
-            </xsl:if>
+            <xsl:call-template name="EspLoggingAgentBasic">
+                <xsl:with-param name="agentNode" select="$agentNode"/>
+            </xsl:call-template>
             <xsl:if test="string($agentNode/@TransactionSeedType) != ''">
                 <TransactionSeedType><xsl:value-of select="$agentNode/@TransactionSeedType"/></TransactionSeedType>
             </xsl:if>

--- a/initfiles/componentfiles/configxml/cassandraloggingagent.xsd
+++ b/initfiles/componentfiles/configxml/cassandraloggingagent.xsd
@@ -112,6 +112,13 @@
           </xs:appinfo>
         </xs:annotation>
       </xs:attribute>
+      <xs:attribute name="SafeRolloverThreshold" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:appinfo>
+            <tooltip>The threshold to switch to a new tank file: a number of requests or file size (xBytes, xMBs, etc).</tooltip>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:attribute>
       <xs:attribute name="logSourcePath" type="xs:string" use="required">
         <xs:annotation>
           <xs:appinfo>

--- a/initfiles/componentfiles/configxml/esploggingagent.xsd
+++ b/initfiles/componentfiles/configxml/esploggingagent.xsd
@@ -107,6 +107,13 @@
           </xs:appinfo>
         </xs:annotation>
       </xs:attribute>
+      <xs:attribute name="SafeRolloverThreshold" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:appinfo>
+            <tooltip>The threshold to switch to a new tank file: a number of requests or file size (xBytes, xMBs, etc).</tooltip>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:attribute>
       <xs:attribute name="MaxTransIDLength" type="xs:nonNegativeInteger" use="optional">
         <xs:annotation>
           <xs:appinfo>


### PR DESCRIPTION
1. Add new safeRolloverReqThreshold to CLogFailSafe which
controls how many logging requests in a tank file. Its
default value is DEFAULT_SAFE_ROLLOVER_THRESHOLD;
2. Add new safeRolloverSizeThreshold to CLogFailSafe which
controls tank file size.
3. Pass setting tree to CLogFailSafe so that >1 settings
(including the tank file limit) may be read.
4. Add SafeRolloverThreshold to the xsd files for esp logging
agents;
5. Move multiple existing settings to new esp_logging_agent_
basic.xsl so that the code may be shared by all esp logging
agents;
6. Read and use SafeRolloverThreshold setting to rollover tank
files.

Signed-off-by: wangkx <kevin.wang@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
