### PR TITLE
HPCC-19155 Multiple problems with lazy caching.

### DIFF
--- a/thorlcr/activities/indexread/thindexreadslave.cpp
+++ b/thorlcr/activities/indexread/thindexreadslave.cpp
@@ -252,14 +252,14 @@ public:
 
                 // local key handling
 
-                Owned<IDelayedFile> lfile = queryThor().queryFileCache().lookup(*this, logicalFilename, part);
+                Owned<IFileIO> lazyIFileIO = queryThor().queryFileCache().lookupIFileIO(*this, logicalFilename, part);
 
                 RemoteFilename rfn;
                 part.getFilename(0, rfn);
                 StringBuffer path;
                 rfn.getPath(path); // NB: use for tracing only, IDelayedFile uses IPartDescriptor and any copy
 
-                Owned<IKeyIndex> keyIndex = createKeyIndex(path, crc, *lfile, false, false);
+                Owned<IKeyIndex> keyIndex = createKeyIndex(path, crc, *lazyIFileIO, false, false);
                 Owned<IKeyManager> klManager = createLocalKeyManager(helper->queryDiskRecordSize()->queryRecordAccessor(true), keyIndex, nullptr, helper->hasNewSegmentMonitors());
                 if (localMerge)
                 {

--- a/thorlcr/activities/keyedjoin/thkeyedjoinslave-legacy.cpp
+++ b/thorlcr/activities/keyedjoin/thkeyedjoinslave-legacy.cpp
@@ -1641,8 +1641,9 @@ class CKeyedJoinSlave : public CSlaveActivity, implements IJoinProcessor, implem
 
             IPropertyTree const &props = filePart.queryOwner().queryProperties();
             unsigned publishedFormatCrc = (unsigned)props.getPropInt("@formatCrc", 0);
-            Owned<IDelayedFile> lfile = queryThor().queryFileCache().lookup(*this, indexName, filePart);
-            Owned<IKeyIndex> keyIndex = createKeyIndex(filename, crc, *lfile, false, false);
+            Owned<IFileIO> lazyFileIO = queryThor().queryFileCache().lookupIFileIO(*this, indexName, filePart);
+            Owned<IDelayedFile> delayedFile = createDelayedFile(lazyFileIO);
+            Owned<IKeyIndex> keyIndex = createKeyIndex(filename, crc, *delayedFile, false, false);
             keyIndexes.append(*keyIndex.getClear());
         }
     }
@@ -2044,8 +2045,9 @@ public:
                 unsigned i=0;
                 for(; i<dataParts.ordinality(); i++)
                 {
-                    Owned<IDelayedFile> dFile = queryThor().queryFileCache().lookup(*this, indexName, dataParts.item(i), eexp);
-                    fetchFiles.append(*dFile.getClear());
+                    Owned<IFileIO> lazyFileIO = queryThor().queryFileCache().lookupIFileIO(*this, indexName, dataParts.item(i), eexp);
+                    Owned<IDelayedFile> delayedFile = createDelayedFile(lazyFileIO);
+                    fetchFiles.append(*delayedFile.getClear());
                 }
             }
         }

--- a/thorlcr/graph/thgraph.hpp
+++ b/thorlcr/graph/thgraph.hpp
@@ -1165,8 +1165,10 @@ interface IExpander;
 interface IThorFileCache : extends IInterface
 {
     virtual bool remove(const char *filename) = 0;
-    virtual IDelayedFile *lookup(CActivityBase &activity, const char *logicalFilenae, IPartDescriptor &partDesc, IExpander *expander=NULL) = 0;
+    virtual IFileIO *lookupIFileIO(CActivityBase &activity, const char *logicalFilenae, IPartDescriptor &partDesc, IExpander *expander=nullptr) = 0;
 };
+
+extern graph_decl IDelayedFile *createDelayedFile(IFileIO *iFileIO);
 
 class graph_decl CThorResourceBase : implements IThorResource, public CInterface
 {

--- a/thorlcr/graph/thgraphslave.cpp
+++ b/thorlcr/graph/thgraphslave.cpp
@@ -1934,7 +1934,7 @@ IActivityReplicatedFile *createEnsurePrimaryPartFile(const char *logicalFilename
 ///////////////
 
 class CFileCache;
-class CLazyFileIO : public CInterface
+class CLazyFileIO : public CSimpleInterfaceOf<IFileIO>
 {
     CFileCache &cache;
     Owned<IActivityReplicatedFile> repFile;
@@ -1944,6 +1944,7 @@ class CLazyFileIO : public CInterface
     CRuntimeStatisticCollection fileStats;
     CriticalSection crit;
     Owned<IFileIO> iFileIO; // real IFileIO
+    CActivityBase *activity = nullptr;
 
     IFileIO *getFileIO()
     {
@@ -1956,24 +1957,40 @@ class CLazyFileIO : public CInterface
         return iFileIO.getClear();
     }
 public:
-    IMPLEMENT_IINTERFACE;
-
     CLazyFileIO(CFileCache &_cache, const char *_filename, IActivityReplicatedFile *_repFile, bool _compressed, IExpander *_expander)
         : cache(_cache), filename(_filename), repFile(_repFile), compressed(_compressed), expander(_expander), fileStats(diskLocalStatistics)
     {
     }
+    void setActivity(CActivityBase *_activity)
+    {
+        activity = _activity;
+    }
     IFileIO *getOpenFileIO(CActivityBase &activity);
     const char *queryFindString() const { return filename.get(); } // for string HT
-    void close()
+// IFileIO impl.
+    virtual size32_t read(offset_t pos, size32_t len, void * data) override
     {
+        Owned<IFileIO> iFileIO = getOpenFileIO(*activity);
+        return iFileIO->read(pos, len, data);
+    }
+    virtual offset_t size() override
+    {
+        Owned<IFileIO> iFileIO = getOpenFileIO(*activity);
+        return iFileIO->size();
+    }
+    virtual void close() override
+    {
+        /* NB: clears CLazyFileIO's ownership of the underlying IFileIO, there will be disposed on exit of this function if no other references,
+         * and as a result will close the underlying file handle or remote connection.
+         * There can be concurrent threads and theoretically other threads could be in some of the other CLazyFileIO methods and still have
+         * references to the underlying iFileIO, in which case the last thread referencing it will release, dispose and close handle.
+         * But given that we are in probably here via purgeOldest(), then it is very unlikely that there is an active read at this time.
+         */
         Owned<IFileIO> openiFileIO = getClearFileIO();
         if (openiFileIO)
-        {
-            openiFileIO->close();
             mergeStats(fileStats, openiFileIO);
-        }
     }
-    unsigned __int64 getStatistic(StatisticKind kind)
+    virtual unsigned __int64 getStatistic(StatisticKind kind) override
     {
         switch (kind)
         {
@@ -1987,99 +2004,39 @@ public:
         unsigned __int64 openValue = openiFileIO ? openiFileIO->getStatistic(kind) : 0;
         return openValue + fileStats.getStatisticValue(kind);
     }
+    virtual size32_t write(offset_t pos, size32_t len, const void * data) override
+    {
+        throwUnexpectedX("CDelayedFileWrapper::write() called for a cached IFileIO object");
+    }
+    virtual offset_t appendFile(IFile *file,offset_t pos=0,offset_t len=(offset_t)-1) override
+    {
+        throwUnexpectedX("CDelayedFileWrapper::appendFile() called for a cached IFileIO object");
+    }
+    virtual void setSize(offset_t size) override
+    {
+        throwUnexpectedX("CDelayedFileWrapper::setSize() called for a cached IFileIO object");
+    }
+    virtual void flush() override
+    {
+        throwUnexpectedX("CDelayedFileWrapper::flush() called for a cached IFileIO object");
+    }
 };
 
-class CFileCache : public CInterface, implements IThorFileCache
+class CFileCache : public CSimpleInterfaceOf<IThorFileCache>
 {
     OwningStringSuperHashTableOf<CLazyFileIO> files;
-    CICopyArrayOf<CLazyFileIO> openFiles;
+    ICopyArrayOf<CLazyFileIO> openFiles;
     unsigned limit, purgeN;
     CriticalSection crit;
 
-    class CDelayedFileWapper : public CSimpleInterfaceOf<IDelayedFile>, implements IFileIO
-    {
-        typedef CSimpleInterfaceOf<IDelayedFile> PARENT;
-
-        CFileCache &cache;
-        CActivityBase &activity;
-        Linked<CLazyFileIO> lFile;
-        CriticalSection crit;
-
-    public:
-        IMPLEMENT_IINTERFACE_USING(PARENT);
-
-        CDelayedFileWapper(CFileCache &_cache, CActivityBase &_activity, CLazyFileIO &_lFile) : cache(_cache), activity(_activity), lFile(&_lFile) { }
-
-        ~CDelayedFileWapper()
-        {
-            cache.remove(lFile->queryFindString());
-        }
-        // IDelayedFile impl.
-        virtual IMemoryMappedFile *getMappedFile() override { return nullptr; }
-        virtual IFileIO *getFileIO() override
-        {
-            // NB: lFile needs an activity to open fileIO
-            return lFile->getOpenFileIO(activity);
-        }
-        // IFileIO impl.
-        virtual size32_t read(offset_t pos, size32_t len, void * data) override
-        {
-            Owned<IFileIO> iFileIO = lFile->getOpenFileIO(activity);
-            return iFileIO->read(pos, len, data);
-        }
-        virtual offset_t size() override
-        {
-            Owned<IFileIO> iFileIO = lFile->getOpenFileIO(activity);
-            return iFileIO->size();
-        }
-        virtual size32_t write(offset_t pos, size32_t len, const void * data) override
-        {
-            Owned<IFileIO> iFileIO = lFile->getOpenFileIO(activity);
-            return iFileIO->write(pos, len, data);
-        }
-        virtual offset_t appendFile(IFile *file,offset_t pos=0,offset_t len=(offset_t)-1) override
-        {
-            Owned<IFileIO> iFileIO = lFile->getOpenFileIO(activity);
-            return iFileIO->appendFile(file, pos, len);
-        }
-        virtual void setSize(offset_t size) override
-        {
-            Owned<IFileIO> iFileIO = lFile->getOpenFileIO(activity);
-            iFileIO->setSize(size);
-        }
-        virtual void flush() override
-        {
-            Owned<IFileIO> iFileIO = lFile->getOpenFileIO(activity);
-            iFileIO->flush();
-        }
-        virtual void close() override
-        {
-            lFile->close();
-        }
-        virtual unsigned __int64 getStatistic(StatisticKind kind) override
-        {
-            return lFile->getStatistic(kind);
-        }
-    };
-
     void purgeOldest()
     {
+        // NB: called in crit
         // will be ordered oldest first.
-        unsigned count = 0;
-        CICopyArrayOf<CLazyFileIO> toClose;
-        ForEachItemIn(o, openFiles)
-        {
-            CLazyFileIO &lFile = openFiles.item(o);
-            toClose.append(lFile);
-            if (++count>=purgeN) // crude for now, just remove oldest N
-                break;
-        }
-        ForEachItemIn(r, toClose)
-        {
-            CLazyFileIO &lFile = toClose.item(r);
-            lFile.close();
-            openFiles.zap(lFile);
-        }
+        dbgassertex(purgeN >= openFiles.ordinality()); // purgeOldest() should not be called unless >= limit, and purgeN always >= limit.
+        for (unsigned i=0; i<purgeN; i++)
+            openFiles.item(i).close();
+        openFiles.removen(0, purgeN);
     }
     bool _remove(const char *filename)
     {
@@ -2090,8 +2047,6 @@ class CFileCache : public CInterface, implements IThorFileCache
         return true;
     }
 public:
-    IMPLEMENT_IINTERFACE;
-
     CFileCache(unsigned _limit) : limit(_limit)
     {
         assertex(limit);
@@ -2099,7 +2054,6 @@ public:
         if (purgeN > limit) purgeN=limit; // why would it be, but JIC.
         PROGLOG("FileCache: limit = %d, purgeN = %d", limit, purgeN);
     }
-
     void opening(CLazyFileIO &lFile)
     {
         CriticalBlock b(crit);
@@ -2108,34 +2062,46 @@ public:
             purgeOldest(); // will close purgeN
             assertex(openFiles.ordinality() < limit);
         }
+        // NB: moves to end if already in openFiles, meaning head of openFiles are oldest used
         openFiles.zap(lFile);
         openFiles.append(lFile);
     }
-
 // IThorFileCache impl.
-    virtual bool remove(const char *filename)
+    virtual bool remove(const char *filename) override
     {
         CriticalBlock b(crit);
         return _remove(filename);
     }
-    virtual IDelayedFile *lookup(CActivityBase &activity, const char *logicalFilename, IPartDescriptor &partDesc, IExpander *expander)
+    virtual IFileIO *lookupIFileIO(CActivityBase &activity, const char *logicalFilename, IPartDescriptor &partDesc, IExpander *expander) override
     {
         StringBuffer filename;
         RemoteFilename rfn;
         partDesc.getFilename(0, rfn);
         rfn.getPath(filename);
         CriticalBlock b(crit);
-        Linked<CLazyFileIO> file = files.find(filename.str());
+        CLazyFileIO *file = files.find(filename.str());
         if (!file)
         {
             Owned<IActivityReplicatedFile> repFile = createEnsurePrimaryPartFile(logicalFilename, &partDesc);
             bool compressed = partDesc.queryOwner().isCompressed();
-            file.setown(new CLazyFileIO(*this, filename.str(), repFile.getClear(), compressed, expander));
+            file = new CLazyFileIO(*this, filename.str(), repFile.getClear(), compressed, expander);
+            files.replace(* file); // NB: files HT owns
+
+            /* NB: there will be 1 CLazyFileIO per physical file part name
+             * They will be linked by multiple lookups
+             *
+             * When the file cache hits the limit, it will calll CLazyFileIO.close()
+             * This does not actually close the file, but releases CLazyFileIO's underlying real IFileIO
+             * Each active CLazyFileIO file op. has a link to the underlying IFileIO.
+             * Meaning, that only when there are no active ops. and close() has exited, is the underlying
+             * real IFileIO actually freed and the file handle closed.
+             */
         }
-        files.replace(*LINK(file));
-        return new CDelayedFileWapper(*this, activity, *file); // to avoid circular dependency and allow destruction to remove from cache
+        file->setActivity(&activity); // an activity needed by IActivityReplicatedFile, mainly for logging purposes.
+        return LINK(file);
     }
 };
+
 ////
 IFileIO *CLazyFileIO::getOpenFileIO(CActivityBase &activity)
 {
@@ -2159,6 +2125,35 @@ IFileIO *CLazyFileIO::getOpenFileIO(CActivityBase &activity)
 IThorFileCache *createFileCache(unsigned limit)
 {
     return new CFileCache(limit);
+}
+
+IDelayedFile *createDelayedFile(IFileIO *iFileIO)
+{
+    /* NB: all this serves to do, is to create IDelayedFile shell
+     * It does not implement the delay itself, the CLazyFileIO it links to does that.
+     * However a IDelayedFile is expected/used by some jhtree mechanism, as a further
+     * delayed route before invoking key loads.
+     */
+
+    class CDelayedFileWrapper : public CSimpleInterfaceOf<IDelayedFile>
+    {
+        Linked<IFileIO> lFile;
+
+    public:
+        CDelayedFileWrapper(IFileIO *_lFile) : lFile(_lFile) { }
+        ~CDelayedFileWrapper()
+        {
+        }
+        // IDelayedFile impl.
+        virtual IMemoryMappedFile *getMappedFile() override { return nullptr; }
+        virtual IFileIO *getFileIO() override
+        {
+            return lFile.getLink();
+        }
+    };
+
+    // NB: CLazyFileIO can't implement IDelayedFile, purely because it's method would cause circular links
+    return new CDelayedFileWrapper(iFileIO);
 }
 
 /*


### PR DESCRIPTION
When the limit is exceeded, it could cause indexes that used
that lazy cache to fail dealing with a file that had been closed.
Resulting in a checked_pread error (if local), or a
RFSERR_InvalidFileIOHandle if dealing with a remote file.

It could also cause a crash, if multiple uses of the same
physical file raced in and out of the cache and were then removed
after use, due to a bug in the handling of the objects during
removal from the cache.

Signed-off-by: Jake Smith <jake.smith@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [ ] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

Tested extensively with fileCacheLimit set to 1, with a custom query that runs lots of KJ's for a while that force the part in the cache to constantly swap.
Also ran valgrind with 1 of these queries to check for issues and/or leaks.

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
