### PR TITLE
HPCC-21301 Fix some test differences seen on larger clusters.

### DIFF
--- a/testing/regress/ecl/key/prefetch2.xml
+++ b/testing/regress/ecl/key/prefetch2.xml
@@ -1,10 +1,10 @@
 <Dataset name='Result 1'>
- <Row><word>boy  </word><doc>281474976710888</doc></Row>
- <Row><word>sheep</word><doc>281474976710972</doc></Row>
+ <Row><word>boy  </word><doc>281474976710658</doc></Row>
+ <Row><word>sheep</word><doc>281474976710659</doc></Row>
 </Dataset>
 <Dataset name='Result 2'>
- <Row><word>boy  </word><doc>281474976710888</doc></Row>
- <Row><word>sheep</word><doc>281474976710972</doc></Row>
+ <Row><word>boy  </word><doc>281474976710658</doc></Row>
+ <Row><word>sheep</word><doc>281474976710659</doc></Row>
 </Dataset>
 <Dataset name='Result 3'>
  <Row><word>boy  </word><doc>0</doc></Row>

--- a/testing/regress/ecl/partition.ecl
+++ b/testing/regress/ecl/partition.ecl
@@ -45,7 +45,7 @@ OUTPUT(Files.DG_IntIndex(KEYED(DG_parentId = 1)));
 OUTPUT(Files.DG_IntIndex(KEYED(DG_parentId = 3)));
 OUTPUT(Files.DG_IntIndex(KEYED(DG_parentId = 7)));
 OUTPUT(Files.DG_IntIndex(KEYED(DG_parentId = 22)));
-OUTPUT(Files.DG_IntIndex(KEYED(DG_parentId = 1) OR KEYED(DG_parentId = 22))); // testing key filter that cannot be partitioned
+OUTPUT(SORT(Files.DG_IntIndex(KEYED(DG_parentId = 1) OR KEYED(DG_parentId = 22)), DG_parentId)); // testing key filter that cannot be partitioned
 
 // test partitoned key with keyed join
 inds := DATASET(COUNT(Files.DG_IntIndex), TRANSFORM({unsigned id}, SELF.id := COUNTER-1));

--- a/testing/regress/ecl/prefetch2.ecl
+++ b/testing/regress/ecl/prefetch2.ecl
@@ -26,6 +26,7 @@ useTranslation := #IFDEFINED(root.useTranslation, false);
 //--- end of version configuration ---
 
 #option ('layoutTranslation', useTranslation);
+#onwarning(4523, ignore);
 
 import $.setup;
 import setup.TS;
@@ -40,12 +41,12 @@ END;
 
 outrec trans1(in L) := TRANSFORM
   SELF.word := L.word;
-  SELF.doc := SORTED(Files.getSearchSuperIndex()(KEYED(kind = TS.kindType.TextEntry),keyed(word = l.word)), doc)[1].doc;
+  SELF.doc := SORT(Files.getSearchSuperIndex()(KEYED(kind = TS.kindType.TextEntry),keyed(word = l.word)), doc)[1].doc;
 END;
 
 outrec trans2(in L) := TRANSFORM
   SELF.word := L.word;
-  SELF.doc := SORTED(Files.getSearchSuperIndex()(KEYED(kind = TS.kindType.TextEntry),keyed(word = 'gobbledegook'+l.word)), doc)[1].doc;
+  SELF.doc := SORT(Files.getSearchSuperIndex()(KEYED(kind = TS.kindType.TextEntry),keyed(word = 'gobbledegook'+l.word)), doc)[1].doc;
 END;
 
 outrec trans3(in L) := TRANSFORM


### PR DESCRIPTION
Larger cluster configurations exposed issues with a couple of
the regression tests, that produced inconsistent results,
depending on the size of the cluster (e.g. due to ordering issues).

Signed-off-by: Jake Smith <jake.smith@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
