### PR TITLE
HPCC-21373 Use INTERNAL_READ_NEXT_TOKEN to reduce lexer recursion

### DIFF
--- a/ecl/hql/hqllex.l
+++ b/ecl/hql/hqllex.l
@@ -79,7 +79,7 @@ int HqlLex::lookupIdentifierToken(YYSTYPE & returnToken, HqlLex * lexer, bool lo
         if (lexer->macroParms->getProp(str(name), macroval))
         {
             lexer->pushText(macroval.str());
-            return lexer->yyLex(returnToken, lookup, activeState);
+            return INTERNAL_READ_NEXT_TOKEN;
         }
     }
     
@@ -325,14 +325,14 @@ xpathseq      ([^}\r\n])+
                         if (lexer->macroGathering || lexer->skipNesting)
                             return SKIPPED;
                         lexer->doError(returnToken, true); 
-                        return lexer->yyLex(returnToken, lookup, activeState);
+                        return INTERNAL_READ_NEXT_TOKEN;
                     }
 #WARNING            {
                         setupdatepos; 
                         if (lexer->macroGathering || lexer->skipNesting)
                             return SKIPPED;
                         lexer->doError(returnToken, false); 
-                        return lexer->yyLex(returnToken, lookup, activeState); 
+                        return INTERNAL_READ_NEXT_TOKEN;
                     }
 #FOR                {
                         setupdatepos; 
@@ -345,7 +345,7 @@ xpathseq      ([^}\r\n])+
                             return SKIPPED;
                         }
                         lexer->doFor(returnToken, false); 
-                        return lexer->yyLex(returnToken, lookup, activeState); 
+                        return INTERNAL_READ_NEXT_TOKEN;
                     }
 #FORALL             {
                         setupdatepos; 
@@ -358,7 +358,7 @@ xpathseq      ([^}\r\n])+
                             return SKIPPED;
                         }
                         lexer->doFor(returnToken, true); 
-                        return lexer->yyLex(returnToken, lookup, activeState); 
+                        return INTERNAL_READ_NEXT_TOKEN;
                     }
 #LOOP               {
                         setupdatepos; 
@@ -371,7 +371,7 @@ xpathseq      ([^}\r\n])+
                             return SKIPPED;
                         }
                         lexer->doLoop(returnToken); 
-                        return lexer->yyLex(returnToken, lookup, activeState); 
+                        return INTERNAL_READ_NEXT_TOKEN;
                     }
 #BREAK              {
                         setupdatepos; 
@@ -393,77 +393,77 @@ xpathseq      ([^}\r\n])+
                             return SKIPPED;
                         }
                         lexer->doIf(returnToken, false);
-                        return lexer->yyLex(returnToken, lookup, activeState); 
+                        return INTERNAL_READ_NEXT_TOKEN;
                     }
 #EXPAND             {
                         setupdatepos; 
                         if (lexer->skipNesting || lexer->macroGathering)
                             return SKIPPED; 
                         lexer->doExpand(returnToken); 
-                        return lexer->yyLex(returnToken, lookup, activeState); 
+                        return INTERNAL_READ_NEXT_TOKEN;
                     }
 #DECLARE            { 
                         setupdatepos; 
                         if (lexer->skipNesting || lexer->macroGathering)
                             return SKIPPED; 
                         lexer->doDeclare(returnToken); 
-                        return lexer->yyLex(returnToken, lookup, activeState); 
+                        return INTERNAL_READ_NEXT_TOKEN;
                     }
 #SET                { 
                         setupdatepos; 
                         if (lexer->skipNesting || lexer->macroGathering)
                             return SKIPPED; 
                         lexer->doSet(returnToken, false); 
-                        return lexer->yyLex(returnToken, lookup, activeState); 
+                        return INTERNAL_READ_NEXT_TOKEN;
                     }
 #TRACE              { 
                         setupdatepos; 
                         if (lexer->skipNesting || lexer->macroGathering)
                             return SKIPPED; 
                         lexer->doTrace(returnToken); 
-                        return lexer->yyLex(returnToken, lookup, activeState); 
+                        return INTERNAL_READ_NEXT_TOKEN;
                     }
 #EXPORT             { 
                         setupdatepos; 
                         if (lexer->skipNesting || lexer->macroGathering)
                             return SKIPPED; 
                         lexer->doExport(returnToken, false); 
-                        return lexer->yyLex(returnToken, lookup, activeState); 
+                        return INTERNAL_READ_NEXT_TOKEN;
                     }
 #EXPORTXML              { 
                         setupdatepos; 
                         if (lexer->skipNesting || lexer->macroGathering)
                             return SKIPPED; 
                         lexer->doExport(returnToken, true); 
-                        return lexer->yyLex(returnToken, lookup, activeState); 
+                        return INTERNAL_READ_NEXT_TOKEN;
                     }
 #MANGLE             { 
                         setupdatepos; 
                         if (lexer->skipNesting || lexer->macroGathering)
                             return SKIPPED; 
                         lexer->doMangle(returnToken, false); 
-                        return lexer->yyLex(returnToken, lookup, activeState); 
+                        return INTERNAL_READ_NEXT_TOKEN;
                     }
 #DEMANGLE           { 
                         setupdatepos; 
                         if (lexer->skipNesting || lexer->macroGathering)
                             return SKIPPED; 
                         lexer->doMangle(returnToken, true); 
-                        return lexer->yyLex(returnToken, lookup, activeState); 
+                        return INTERNAL_READ_NEXT_TOKEN;
                     }
 #APPLY              { 
                         setupdatepos; 
                         if (lexer->skipNesting || lexer->macroGathering)
                             return SKIPPED; 
                         lexer->doApply(returnToken); 
-                        return lexer->yyLex(returnToken, lookup, activeState); 
+                        return INTERNAL_READ_NEXT_TOKEN;
                     }
 #APPEND             {
                         setupdatepos; 
                         if (lexer->skipNesting || lexer->macroGathering)
                             return SKIPPED; 
                         lexer->doSet(returnToken, true); 
-                        return lexer->yyLex(returnToken, lookup, activeState); 
+                        return INTERNAL_READ_NEXT_TOKEN;
                     }
 #CONSTANT           { 
                         setupdatepos;
@@ -476,7 +476,7 @@ xpathseq      ([^}\r\n])+
                         if (lexer->skipNesting || lexer->macroGathering)
                             return SKIPPED; 
                         lexer->doDefined(returnToken);
-                        return lexer->yyLex(returnToken, lookup, activeState); 
+                        return INTERNAL_READ_NEXT_TOKEN;
                     }
 #ELSE               {
                         setupdatepos;
@@ -513,7 +513,7 @@ xpathseq      ([^}\r\n])+
                         if (lexer->skipNesting || lexer->macroGathering)
                             return SKIPPED; 
                         lexer->doGetDataType(returnToken); 
-                        return lexer->yyLex(returnToken, lookup, activeState); 
+                        return INTERNAL_READ_NEXT_TOKEN;
                     }
 
 #INMODULE           {
@@ -521,14 +521,14 @@ xpathseq      ([^}\r\n])+
                         if (lexer->skipNesting || lexer->macroGathering)
                             return SKIPPED; 
                         lexer->doInModule(returnToken); 
-                        return lexer->yyLex(returnToken, lookup, activeState); 
+                        return INTERNAL_READ_NEXT_TOKEN;
                     }
 #ISVALID            {
                         setupdatepos; 
                         if (lexer->skipNesting || lexer->macroGathering)
                             return SKIPPED; 
                         lexer->doIsValid(returnToken); 
-                        return lexer->yyLex(returnToken, lookup, activeState); 
+                        return INTERNAL_READ_NEXT_TOKEN;
                     }
 #ISDEFINED          {
                         setupdatepos; 
@@ -537,12 +537,12 @@ xpathseq      ([^}\r\n])+
                         bool defined = lexer->doIsDefined(returnToken);
 //                      RETURNHARD(defined ? TOK_TRUE : TOK_FALSE);
                         lexer->pushText(defined ? "true" : "false");
-                        return lexer->yyLex(returnToken, lookup, activeState);
+                        return INTERNAL_READ_NEXT_TOKEN;
                     }
 #LINE               {
                         setupdatepos;
                         lexer->doLine(returnToken);
-                        return lexer->yyLex(returnToken, lookup, activeState); 
+                        return INTERNAL_READ_NEXT_TOKEN;
                     }
 #LINK               {
                         setupdatepos;
@@ -582,7 +582,7 @@ xpathseq      ([^}\r\n])+
                             return SKIPPED; 
                         }
                         lexer->doUniqueName(returnToken); 
-                        return lexer->yyLex(returnToken, lookup, activeState); 
+                        return INTERNAL_READ_NEXT_TOKEN;
                     }
 #WORKUNIT           { 
                         setupdatepos;
@@ -603,11 +603,11 @@ __LINE__            {
                     }
 #REGION[^\n]*       { 
                         updatepos1;
-                        return INTERNAL_READ_NEXT_TOKEN; 
+                        return INTERNAL_READ_NEXT_TOKEN;
                     }
 #ENDREGION          {
                         updatepos1;
-                        return INTERNAL_READ_NEXT_TOKEN; 
+                        return INTERNAL_READ_NEXT_TOKEN;
                     }
 #END                { 
 //Place #END last so the specialised versions are hit first
@@ -625,7 +625,7 @@ __LINE__            {
                         StringBuffer msg("Unknown # command: ");
                         msg.append(CUR_TOKEN_TEXT);
                         lexer->reportError(returnToken, ERR_TMPLT_UNKNOWNCOMMAND, "%s", msg.str());
-                        return lexer->yyLex(returnToken, lookup, activeState); 
+                        return INTERNAL_READ_NEXT_TOKEN;
                     }
         
 ABS                 { RETURNSYM(ABS); }
@@ -1053,7 +1053,7 @@ __TARGET_PLATFORM__ { RETURNSYM(__TARGET_PLATFORM__); }
                         if (lexer->skipNesting || lexer->macroGathering)
                             return SKIPPED;
                         lexer->doPreprocessorLookup(returnToken, false, 0);
-                        return lexer->yyLex(returnToken, lookup, activeState); 
+                        return INTERNAL_READ_NEXT_TOKEN;
                     };
 
 {percent}'{alphanumcolon}*'{percent} {
@@ -1061,14 +1061,14 @@ __TARGET_PLATFORM__ { RETURNSYM(__TARGET_PLATFORM__); }
                         if (lexer->skipNesting || lexer->macroGathering)
                             return SKIPPED;
                         lexer->doPreprocessorLookup(returnToken, true, 1);
-                        return lexer->yyLex(returnToken, lookup, activeState); 
+                        return INTERNAL_READ_NEXT_TOKEN;
                     };
 {percent}\{{xpathseq}\}{percent} {
                         setupdatepos;
                         if (lexer->skipNesting || lexer->macroGathering)
                             return SKIPPED;
                         lexer->doPreprocessorLookup(returnToken, false, 1);
-                        return lexer->yyLex(returnToken, lookup, activeState); 
+                        return INTERNAL_READ_NEXT_TOKEN;
                     };
 
 {percent}'\{{xpathseq}\}'{percent} {
@@ -1076,7 +1076,7 @@ __TARGET_PLATFORM__ { RETURNSYM(__TARGET_PLATFORM__); }
                         if (lexer->skipNesting || lexer->macroGathering)
                             return SKIPPED;
                         lexer->doPreprocessorLookup(returnToken, true, 2);
-                        return lexer->yyLex(returnToken, lookup, activeState); 
+                        return INTERNAL_READ_NEXT_TOKEN;
                     };
 INTEGER{digit}+ { 
                       setupdatepos; 


### PR DESCRIPTION
Signed-off-by: Gavin Halliday <gavin.halliday@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [x] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
