### PR TITLE
HPCC-21406 Fix translate AlwaysECL problems with projected formats

### DIFF
--- a/common/thorhelper/thorcommon.cpp
+++ b/common/thorhelper/thorcommon.cpp
@@ -2113,7 +2113,12 @@ ITranslator *getTranslators(const char *tracing, unsigned expectedCrc, IOutputMe
     Owned<const IKeyTranslator> keyedTranslator;
     if (getTranslators(translator, &keyedTranslator, tracing, expectedCrc, expectedFormat, publishedCrc, publishedFormat, projectedCrc, projectedFormat, mode))
     {
-        if (!publishedFormat)
+        if (RecordTranslationMode::AlwaysECL == mode)
+        {
+            publishedFormat = expectedFormat;
+            publishedCrc = expectedCrc;
+        }
+        else if (!publishedFormat)
             publishedFormat = expectedFormat;
         class CTranslator : public CSimpleInterfaceOf<ITranslator>
         {

--- a/ecl/hthor/hthor.cpp
+++ b/ecl/hthor/hthor.cpp
@@ -8024,6 +8024,8 @@ CHThorDiskReadBaseActivity::CHThorDiskReadBaseActivity(IAgentContext &_agent, un
     helper.setCallback(this);
     expectedDiskMeta = helper.queryDiskRecordSize();
     projectedDiskMeta = helper.queryProjectedDiskRecordSize();
+    actualDiskMeta.set(helper.queryDiskRecordSize()->querySerializedDiskMeta());
+
     if (_node)
     {
         const char *recordTranslationModeHintText = _node->queryProp("hint[@name='layoutTranslation']/@value");
@@ -8054,6 +8056,30 @@ void CHThorDiskReadBaseActivity::ready()
     partNum = (unsigned)-1;
 
     resolve();
+
+    unsigned expectedCrc = helper.getDiskFormatCrc();
+    unsigned projectedCrc = helper.getProjectedFormatCrc();
+    unsigned actualCrc = expectedCrc;
+    IDistributedFile *dFile = nullptr;
+    if (ldFile)
+        dFile = ldFile->queryDistributedFile();  // Null for local file usage
+    if (dFile)
+    {
+        IPropertyTree &props = dFile->queryAttributes();
+        Owned<IOutputMetaData> publishedMeta = getDaliLayoutInfo(props);
+        if (publishedMeta)
+        {
+            actualDiskMeta.setown(publishedMeta.getClear());
+            actualCrc = props.getPropInt("@formatCrc");
+        }
+    }
+    translators.setown(::getTranslators("hthor-diskread", expectedCrc, expectedDiskMeta, actualCrc, actualDiskMeta, projectedCrc, projectedDiskMeta, getLayoutTranslationMode()));
+    if (translators)
+    {
+        translator = &translators->queryTranslator();
+        keyedTranslator = translators->queryKeyedTranslator();
+        actualDiskMeta.set(&translators->queryActualFormat());
+    }
 }
 
 void CHThorDiskReadBaseActivity::stop()
@@ -8150,7 +8176,6 @@ void CHThorDiskReadBaseActivity::gatherInfo(IFileDescriptor * fileDesc)
         grouped = ((helper.getFlags() & TDXgrouped) != 0);
     }
 
-    actualDiskMeta.set(helper.queryDiskRecordSize()->querySerializedDiskMeta());
     calcFixedDiskRecordSize();
     if (fileDesc)
     {
@@ -8223,8 +8248,6 @@ bool CHThorDiskReadBaseActivity::openNext()
     localOffset = 0;
     saveOpenExc.clear();
     actualFilter.clear();
-    unsigned expectedCrc = helper.getDiskFormatCrc();
-    unsigned projectedCrc = helper.getProjectedFormatCrc();
 
     if (dfsParts||ldFile)
     {
@@ -8250,16 +8273,6 @@ bool CHThorDiskReadBaseActivity::openNext()
                 }
             }
 
-            unsigned actualCrc = 0;
-            if (dFile)
-            {
-                IPropertyTree &props = dFile->queryAttributes();
-                actualDiskMeta.setown(getDaliLayoutInfo(props));
-                actualCrc = props.getPropInt("@formatCrc");
-            }
-            if (!actualDiskMeta)
-                actualDiskMeta.set(expectedDiskMeta->querySerializedDiskMeta());
-            keyedTranslator.setown(createKeyTranslator(actualDiskMeta->queryRecordAccessor(true), expectedDiskMeta->queryRecordAccessor(true)));
             if (keyedTranslator && keyedTranslator->needsTranslate())
                 keyedTranslator->translate(actualFilter, fieldFilters);
             else
@@ -8342,8 +8355,13 @@ bool CHThorDiskReadBaseActivity::openNext()
 
                             Owned<IFile> iFile = createIFile(rfilename);
 
+                            // remote side does projection/translation/filtering
                             actualDiskMeta.set(projectedDiskMeta);
                             expectedDiskMeta = projectedDiskMeta;
+                            translators.clear();
+                            translator = nullptr;
+                            keyedTranslator = nullptr;
+
                             actualFilter.clear();
                             inputfileio.setown(remoteFileIO.getClear());
                             if (inputfileio)
@@ -8412,27 +8430,6 @@ bool CHThorDiskReadBaseActivity::openNext()
                 }
             }
 
-            //Check if the file requires translation, but translation is disabled
-            if (actualCrc && expectedCrc && (actualCrc != expectedCrc) && (getLayoutTranslationMode()==RecordTranslationMode::None))
-            {
-                IOutputMetaData * expectedDiskMeta = helper.queryDiskRecordSize();
-                throwTranslationError(actualDiskMeta->queryRecordAccessor(true), expectedDiskMeta->queryRecordAccessor(true), logicalFileName.str());
-            }
-
-            //The projected format will often not match the expected format, and if it differs it must be translated
-            if (projectedCrc && actualCrc != projectedCrc)
-                translator.setown(createRecordTranslator(projectedDiskMeta->queryRecordAccessor(true), actualDiskMeta->queryRecordAccessor(true)));
-
-            if (translator && translator->needsTranslate())
-            {
-                if (!translator->canTranslate())
-                    throw MakeStringException(0, "Untranslatable key layout mismatch reading file %s", logicalFileName.str());
-            }
-            else
-            {
-                translator.clear();
-                keyedTranslator.clear();
-            }
             calcFixedDiskRecordSize();
             if (dfsParts)
                 dfsParts->next();
@@ -8480,22 +8477,6 @@ bool CHThorDiskReadBaseActivity::openNext()
                 saveOpenExc.setown(E);
         }
 
-        //A spill file - actual will always equal expected, so keyed translator will never be used.
-        keyedTranslator.clear();
-
-        //The projected format will often not match the expected format, and if it differs it must be translated
-        translator.clear();
-        if (projectedCrc != expectedCrc)
-            translator.setown(createRecordTranslator(projectedDiskMeta->queryRecordAccessor(true), actualDiskMeta->queryRecordAccessor(true)));
-
-        if (translator && translator->needsTranslate())
-        {
-            assertex(translator->canTranslate());
-        }
-        else
-        {
-            translator.clear();
-        }
         partNum++;
         if (checkOpenedFile(file.str(), NULL))
         {

--- a/ecl/hthor/hthor.ipp
+++ b/ecl/hthor/hthor.ipp
@@ -2263,8 +2263,9 @@ protected:
     StringAttr logicalFileName;
     StringArray subfileLogicalFilenames;
     Owned<ISuperFileDescriptor> superfile;
-    Owned<const IDynamicTransform> translator;
-    Owned<const IKeyTranslator> keyedTranslator;
+    const IDynamicTransform *translator = nullptr;
+    const IKeyTranslator *keyedTranslator = nullptr;
+    Owned<ITranslator> translators;
     IPointerArrayOf<IOutputMetaData> actualLayouts;  // Do we need to keep more than one?
     IConstArrayOf<IFieldFilter> fieldFilters;  // These refer to the expected layout
     RowFilter actualFilter;               // This refers to the actual disk layout


### PR DESCRIPTION
Signed-off-by: Jake Smith <jake.smith@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
