### PR TITLE
HPCC-21418 Don't output a line for empty file parts when despraying JSON file

### DIFF
--- a/dali/ft/filecopy.cpp
+++ b/dali/ft/filecopy.cpp
@@ -1085,7 +1085,9 @@ void FileSprayer::calculateMany2OnePartition()
 {
     LOG(MCdebugProgressDetail, job, "Setting up many2one partition");
     const char *partSeparator = srcFormat.getPartSeparatorString();
+    offset_t partSeparatorLength = ( partSeparator == nullptr ? 0 : strlen(partSeparator));
     offset_t lastContentLength = 0;
+    offset_t contentLength = 0;
     ForEachItemIn(idx, sources)
     {
         FilePartInfo & cur = sources.item(idx);
@@ -1094,7 +1096,7 @@ void FileSprayer::calculateMany2OnePartition()
         setCanAccessDirectly(curFilename);
         if (partSeparator)
         {
-            offset_t contentLength = (cur.size > cur.xmlHeaderLength + cur.xmlFooterLength ? cur.size - cur.xmlHeaderLength - cur.xmlFooterLength : 0);
+            contentLength = (cur.size > cur.xmlHeaderLength + cur.xmlFooterLength  + partSeparatorLength ? cur.size - cur.xmlHeaderLength - cur.xmlFooterLength - partSeparatorLength : 0);
             if (contentLength)
             {
                 if (lastContentLength)
@@ -1106,7 +1108,11 @@ void FileSprayer::calculateMany2OnePartition()
                 lastContentLength = contentLength;
             }
         }
-        partition.append(*new PartitionPoint(idx, 0, cur.headerSize, cur.size, cur.size));
+        else
+            contentLength = (cur.size > cur.headerSize ? cur.size - cur.headerSize : 0);
+
+        if (contentLength)
+            partition.append(*new PartitionPoint(idx, 0, cur.headerSize, cur.size, cur.size));
     }
 
     if (srcFormat.isCsv())

--- a/testing/regress/ecl/key/spray_test_json.xml
+++ b/testing/regress/ecl/key/spray_test_json.xml
@@ -9,3 +9,14 @@
 <Dataset name='Result 4'>
  <Row><Result_4>Compare Pass</Result_4></Row>
 </Dataset>
+<Dataset name='Result 5'>
+</Dataset>
+<Dataset name='Result 6'>
+ <Row><result>Despray Pass</result></Row>
+</Dataset>
+<Dataset name='Result 7'>
+ <Row><result>Spray Pass</result></Row>
+</Dataset>
+<Dataset name='Result 8'>
+ <Row><Result_8>Compare Pass</Result_8></Row>
+</Dataset>


### PR DESCRIPTION

Avoid to create partition for an empty file parts (contain
only headers and/or part separators) and prevent to store
them into the despray target file.

Extend spray_test_json.ecl to create logical file with empty
headers and json content, despray then spray it back and compare
the sprayed file with the original one.

Signed-off-by: Attila Vamos <attila.vamos@gmail.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [ ] The change has been fully tested:
  - [x] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->
Tested manually and locally executed spray/despray testcases from
Regression Suite.
<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
