### PR TITLE
HPCC-19275 Add 3 WsMachine methods to get disk usages

### DIFF
--- a/common/monitoring/CMakeLists.txt
+++ b/common/monitoring/CMakeLists.txt
@@ -16,3 +16,4 @@
 add_subdirectory (prosysinfo)
 
 Install ( PROGRAMS ${CMAKE_CURRENT_SOURCE_DIR}/preflight DESTINATION sbin COMPONENT Runtime )
+Install ( PROGRAMS ${CMAKE_CURRENT_SOURCE_DIR}/usage DESTINATION sbin COMPONENT Runtime )

--- a/common/monitoring/usage
+++ b/common/monitoring/usage
@@ -1,0 +1,70 @@
+#!/bin/bash
+################################################################################
+#
+#    HPCC SYSTEMS software Copyright (C) 2019 HPCC Systems®.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#################################################################################
+
+declare -a arr1
+declare -a arr2
+declare -a arrDiscPath
+
+if [ "${1:0:1}" == '-' ]; then
+    if [ $# -lt 1 ]; then
+        echo usage: $0 -d=DiskPath[,DiskPath,...]
+        exit 1
+    fi
+
+    for (( i=1;$i<=$#;i=$i+1 )) do
+        case ${!i:0:3} in '-d=')
+                 IFS=, read -a arrDiscPath <<< "${!i:3}";;
+            *)
+                 echo "wrong augument:${!i}";;
+        esac
+    done
+
+    echo "--Start--"
+    if [ "${#arrDiscPath[@]}" ]; then
+        index=0
+        for i in "${arrDiscPath[@]}"; do
+            ok=0
+            dirp=$i
+            until [ $ok = 1 ] ; do
+                if [ -d $dirp ] ; then
+                    ok=1
+                else
+                    dirp=$(dirname $dirp)
+                fi
+            done
+
+            if [ "$dirp" != "/" ] ; then
+                dfout=$(df $dirp | tail -n +2 | awk '{if(NF>=4) print $(NF-3) " " $(NF-2)}')
+                if [ -n "$dfout" ] ; then
+                    arr1[$index]=$(echo $dfout | awk '{print $1}')
+                    arr2[$index]=$(echo $dfout | awk '{print $2}')
+                    if [ "$dirp" != "$i" ] ; then
+                        echo "$i: ${arr1[$index]} ${arr2[$index]} $dirp"
+                    else
+                        echo "$i: ${arr1[$index]} ${arr2[$index]}"
+                    fi
+                fi
+            fi
+
+            index=$((index+1))
+        done
+    fi
+
+    echo "--Finish--"
+    exit 0
+fi

--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -7002,6 +7002,7 @@ class CEnvironmentClusterInfo: implements IConstWUClusterInfo, public CInterface
     StringAttr alias;
     StringAttr serverQueue;
     StringAttr agentQueue;
+    StringAttr agentName;
     StringAttr roxieProcess;
     SocketEndpointArray roxieServers;
     StringAttr thorQueue;
@@ -7096,6 +7097,7 @@ public:
         {
             assertex(!roxie);
             agentQueue.set(getClusterEclAgentQueueName(queue.clear(), name));
+            agentName.set(agent->queryProp("@name"));
         }
         else if (roxie)
             agentQueue.set(getClusterRoxieQueueName(queue.clear(), name));
@@ -7120,6 +7122,11 @@ public:
     IStringVal & getAgentQueue(IStringVal & str) const
     {
         str.set(agentQueue);
+        return str;
+    }
+    IStringVal & getAgentName(IStringVal & str) const
+    {
+        str.set(agentName);
         return str;
     }
     virtual IStringVal & getServerQueue(IStringVal & str) const

--- a/common/workunit/workunit.hpp
+++ b/common/workunit/workunit.hpp
@@ -553,6 +553,7 @@ interface IConstWUClusterInfo : extends IInterface
     virtual unsigned getNumberOfSlaveLogs() const = 0;
     virtual ClusterType getPlatform() const = 0;
     virtual IStringVal & getAgentQueue(IStringVal & str) const = 0;
+    virtual IStringVal & getAgentName(IStringVal & str) const = 0;
     virtual IStringVal & getServerQueue(IStringVal & str) const = 0;
     virtual IStringVal & getRoxieProcess(IStringVal & str) const = 0;
     virtual const StringArray & getThorProcesses() const = 0;

--- a/esp/scm/ws_machine.ecm
+++ b/esp/scm/ws_machine.ecm
@@ -23,6 +23,52 @@ SCMenum ThresholdType
     THRESHOLD_MB
 };
 
+ESPStruct [nil_remove] DiskUsage
+{
+    string Name;
+    string Path;
+    string Description;
+    int64 InUse;
+    int64 Available;
+    int PercentAvailable;
+};
+
+ESPStruct [nil_remove] MachineUsage
+{
+    string Name;
+    string NetAddress;
+    string Description;
+    ESParray<ESPstruct DiskUsage> DiskUsages;
+};
+
+ESPStruct [nil_remove] Component
+{
+    string Type;
+    string Name;
+};
+
+ESPStruct [nil_remove] ComponentUsage
+{
+    string Type;
+    string Name;
+    string Description;
+    ESParray<ESPstruct MachineUsage> MachineUsages;
+};
+
+ESPStruct [nil_remove] TargetClusterUsage
+{
+    string Name;
+    string Description;
+    ESParray<ESPstruct ComponentUsage> ComponentUsages;
+};
+
+ESPStruct [nil_remove] NodeGroupUsage
+{
+    string Name;
+    string Description;
+    ESParray<ESPstruct ComponentUsage> ComponentUsages;
+};
+
 ESPrequest GetMachineInfoRequest
 {
     ESParray<string> Addresses;
@@ -367,8 +413,38 @@ ESPresponse [encode(0), nil_remove, exceptions_inline] UpdateComponentStatusResp
     string Status;
 };
 
+ESPrequest [nil_remove] GetComponentUsageRequest
+{
+    ESParray<ESPstruct Component> Components;
+};
+
+ESPresponse [encode(0), nil_remove, exceptions_inline] GetComponentUsageResponse 
+{
+    ESParray<ESPstruct ComponentUsage> ComponentUsages;
+};
+
+ESPrequest [nil_remove] GetTargetClusterUsageRequest
+{
+    ESParray<string> TargetClusters;
+};
+
+ESPresponse [encode(0), nil_remove, exceptions_inline] GetTargetClusterUsageResponse 
+{
+    ESParray<ESPstruct TargetClusterUsage> TargetClusterUsages;
+};
+
+ESPrequest [nil_remove] GetNodeGroupUsageRequest
+{
+    ESParray<string> NodeGroups;
+};
+
+ESPresponse [encode(0), nil_remove, exceptions_inline] GetNodeGroupUsageResponse 
+{
+    ESParray<ESPstruct NodeGroupUsage> NodeGroupUsages;
+};
+
 //-------- service ---------
-ESPservice [auth_feature("DEFERRED"), version("1.13")] ws_machine
+ESPservice [auth_feature("DEFERRED"), version("1.14")] ws_machine
 {
     ESPmethod [resp_xsl_default("./smc_xslt/clusterprocesses.xslt"), exceptions_inline("./smc_xslt/exceptions.xslt")]
        GetTargetClusterInfo(GetTargetClusterInfoRequest, GetTargetClusterInfoResponse);
@@ -381,6 +457,10 @@ ESPservice [auth_feature("DEFERRED"), version("1.13")] ws_machine
 
     ESPmethod GetComponentStatus(GetComponentStatusRequest, GetComponentStatusResponse);
     ESPmethod UpdateComponentStatus(UpdateComponentStatusRequest, UpdateComponentStatusResponse);
+
+    ESPmethod [min_ver("1.14")] GetComponentUsage(GetComponentUsageRequest, GetComponentUsageResponse);
+    ESPmethod [min_ver("1.14")] GetTargetClusterUsage(GetTargetClusterUsageRequest, GetTargetClusterUsageResponse);
+    ESPmethod [min_ver("1.14")] GetNodeGroupUsage(GetNodeGroupUsageRequest, GetNodeGroupUsageResponse);
 
     ESPmethod [resp_xsl_default("./smc_xslt/ws_machine/metrics.xslt"), exceptions_inline("./smc_xslt/exceptions.xslt")] 
        GetMetrics(MetricsRequest, MetricsResponse);

--- a/esp/smc/SMCLib/TpWrapper.hpp
+++ b/esp/smc/SMCLib/TpWrapper.hpp
@@ -120,6 +120,7 @@ using std::string;
 #define eqHoleControlProcess    "HoleControlProcess"
 #define eqHoleCollatorProcess   "HoleCollatorProcess"
 #define eqHoleStandbyProcess    "HoleStandbyProcess"
+#define eqRoxieServerProcess    "RoxieServerProcess"
 
 #define SDS_LOCK_TIMEOUT 30000
 


### PR DESCRIPTION
1. GetComponentUsage
Input: a list of HPCC components with name and type; if no
component is specified, the disk usages for all related
HPCC components (thor, roxie, dali, eclagent, sasha, and
dropzone) are returned.
Output: Disk usages for each log/data/mirror drive on each
machine used by each component.

2. GetTargetClusterUsage
Input: a list of HPCC TargetCluster name; if no target
cluster is specified, the disk usages for all target
clusters are returned.
Output: Disk usages for each log/data/mirror drive on each
machine used by each TargetCluster.

3. GetNodeGroupUsage
Input: a list of HPCC NodeGroup name; if no node group is
specified, the disk usages for all related node groups
(thor and hthor) are returned.
Output: Disk usages for each log/data/mirror drive on each
machine used by each NodeGroup.

Signed-off-by: wangkx <kevin.wang@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
