### PR TITLE
HPCC-21479 Dali Timestamp Error

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -5299,6 +5299,28 @@ protected:
         }
     }
 
+    void addPropIfCommon(IPropertyTree &target, const char *prop, const char *value)
+    {
+        bool ok = true;
+        // add attributes that are common
+        for (unsigned i=1; i<subfiles.ordinality(); i++)
+        {
+            IDistributedFile &file = subfiles.item(i);
+            IDistributedSuperFile *sFile = file.querySuperFile();
+            if (!sFile || sFile->numSubFiles(true)) // skip empty super files
+            {
+                const char *otherValue = file.queryAttributes().queryProp(prop);
+                if (!otherValue || !streq(otherValue, value))
+                {
+                    ok = false;
+                    break;
+                }
+            }
+        }
+        if (ok)
+            target.setProp(prop, value);
+    }
+
 public:
 
     virtual void checkFormatAttr(IDistributedFile *sub, const char* exprefix="") override
@@ -5427,26 +5449,17 @@ public:
                         const char *v = ait->queryValue();
                         if (!v)
                             continue;
-                        bool ok = true;
-                        // add attributes that are common
-                        for (unsigned i=1;i<subfiles.ordinality();i++)
-                        {
-                            IDistributedFile &file = subfiles.item(i);
-                            IDistributedSuperFile *sFile = file.querySuperFile();
-                            if (!sFile || sFile->numSubFiles(true)) // skip empty super files
-                            {
-                                const char *p = file.queryAttributes().queryProp(name);
-                                if (!p||(strcmp(p,v)!=0))
-                                {
-                                    ok = false;
-                                    break;
-                                }
-                            }
-                        }
-                        if (ok)
-                            at->setProp(name,v);
+                        addPropIfCommon(*at, name, v);
                     }
                 }
+                MemoryBuffer mb;
+                if (getRecordLayout(mb, "_record_layout"))
+                    at->setPropBin("_record_layout", mb.length(), mb.bufferBase());
+                if (getRecordLayout(mb, "_rtlType"))
+                    at->setPropBin("_rtlType", mb.length(), mb.bufferBase());
+                const char *ecl = file.queryAttributes().queryProp("ECL");
+                if (!isEmptyString(ecl))
+                    addPropIfCommon(*at, "ECL", ecl);
             }
             unsigned np = file.numParts();
             if (0 == width)

--- a/ecl/hthor/hthor.cpp
+++ b/ecl/hthor/hthor.cpp
@@ -8248,6 +8248,13 @@ bool CHThorDiskReadBaseActivity::openNext()
     localOffset = 0;
     saveOpenExc.clear();
     actualFilter.clear();
+    if (translators)
+    {
+        /* if previous part was remotely accessed, the format used (actualDiskMeta), became the projected meta
+         * reset here, in case this next part is access locally, in which case the published or expect meta is needed
+         */
+        actualDiskMeta.set(&translators->queryActualFormat());
+    }
 
     if (dfsParts||ldFile)
     {
@@ -8357,8 +8364,6 @@ bool CHThorDiskReadBaseActivity::openNext()
 
                             // remote side does projection/translation/filtering
                             actualDiskMeta.set(projectedDiskMeta);
-                            expectedDiskMeta = projectedDiskMeta;
-                            translators.clear();
                             translator = nullptr;
                             keyedTranslator = nullptr;
 

--- a/initfiles/componentfiles/configxml/dali.xsd
+++ b/initfiles/componentfiles/configxml/dali.xsd
@@ -409,6 +409,13 @@
         </xs:appinfo>
       </xs:annotation>
     </xs:attribute>
+    <xs:attribute name="allowedClockVariance" use="optional" type="xs:string" default="5">
+      <xs:annotation>
+        <xs:appinfo>
+          <tooltip>Maximum number of seconds that client clocks can vary from Dali clock, used when checking permissions request digital signature.</tooltip>
+        </xs:appinfo>
+      </xs:annotation>
+    </xs:attribute>
     <xs:attribute name="checkScopeScans" type="xs:boolean" use="optional" default="true">
       <xs:annotation>
         <xs:appinfo>

--- a/initfiles/componentfiles/configxml/dali.xsl
+++ b/initfiles/componentfiles/configxml/dali.xsl
@@ -240,7 +240,7 @@
         </xsl:element>
         <xsl:if test="string(@ldapServer) != ''">
           <xsl:element name="ldapSecurity">
-            <xsl:copy-of select="@ldapProtocol | @authMethod | @maxConnections | @workunitsBasedn | @filesDefaultUser | @filesDefaultPassword | @reqSignatureExpiry"/>
+            <xsl:copy-of select="@ldapProtocol | @authMethod | @maxConnections | @workunitsBasedn | @filesDefaultUser | @filesDefaultPassword | @reqSignatureExpiry | @allowedClockVariance"/>
             <xsl:variable name="ldapServerName" select="@ldapServer"/>
             <xsl:attribute name="filesBasedn">
                 <xsl:value-of select="/Environment/Software/LDAPServerProcess[@name=$ldapServerName]/@filesBasedn"/>

--- a/system/jlib/jtime.cpp
+++ b/system/jlib/jtime.cpp
@@ -365,6 +365,13 @@ void CDateTime::adjustTime(int deltaMins)
     set(simple);
 }
 
+void CDateTime::adjustTimeSecs(int deltaSecs)
+{
+    time_t simple = getSimple();
+    simple += deltaSecs;
+    set(simple);
+}
+
 void CDateTime::getDate(unsigned & year, unsigned & month, unsigned & day, bool local) const
 {
     if(local)

--- a/system/jlib/jtime.hpp
+++ b/system/jlib/jtime.hpp
@@ -88,6 +88,7 @@ public:
     void setTimeString(char const * str, char const * * end = NULL, bool local = false); // Leaves the date alone, sets to the time given as hh:mm:ss[.nnnnnnnnn]
     void setNow();
     void adjustTime(int deltaMins);
+    void adjustTimeSecs(int deltaSecs);
 
     void getDate(unsigned & year, unsigned & month, unsigned & day, bool local = false) const;
     void getTime(unsigned & hour, unsigned & minute, unsigned & second, unsigned & nano, bool local = false) const;


### PR DESCRIPTION
Because clocks are not synchronized between all notes in a cluster, sometimes
a permissions request to Dali will appear to be "from the future." This PR
implements a new configuration "allowedClockVariance" key, which allows
the admin to specify the max number of seconds that a clock can be out of
sync, either plus or minus

Signed-off-by: Russ Whitehead <william.whitehead@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [x] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
