### PR TITLE
HPCC-21501 Do not report Roxiemem row leaks on aborted queries

### DIFF
--- a/common/thorhelper/roxierow.cpp
+++ b/common/thorhelper/roxierow.cpp
@@ -683,7 +683,7 @@ protected:
     void testAllocator(IOutputMetaData * meta, roxiemem::RoxieHeapFlags flags, unsigned low, unsigned high, int modify, bool checking)
     {
         CheckingRowAllocatorCache cache;
-        Owned<IRowManager> rm = createRowManager(0, NULL, logctx, &cache);
+        Owned<IRowManager> rm = createRowManager(0, NULL, logctx, &cache, false);
         Owned<IEngineRowAllocator> alloc = checking ? createCrcRoxieRowAllocator(NULL, *rm, meta, 0, 0, flags) : createRoxieRowAllocator(NULL, *rm, meta, 0, 0, flags);
 
         for (unsigned size=low; size <= high; size++)
@@ -740,7 +740,7 @@ protected:
 
     void testChecking()
     {
-        Owned<IRowManager> rm = createRowManager(0, NULL, logctx, NULL);
+        Owned<IRowManager> rm = createRowManager(0, NULL, logctx, NULL, false);
 
         for (unsigned fixedSize=1; fixedSize<64; fixedSize++)
         {
@@ -760,7 +760,7 @@ protected:
     void testAllocatorCache()
     {
         IArrayOf<IOutputMetaData> metas;
-        Owned<IRowManager> rm = createRowManager(0, NULL, logctx, NULL);
+        Owned<IRowManager> rm = createRowManager(0, NULL, logctx, NULL, false);
         class CAllocatorCallback : implements IRowAllocatorMetaActIdCacheCallback
         {
             IRowManager *rm;

--- a/roxie/ccd/ccdactivities.cpp
+++ b/roxie/ccd/ccdactivities.cpp
@@ -3466,7 +3466,7 @@ public:
     virtual IMessagePacker *process()
     {
         MTIME_SECTION(queryActiveTimer(), "CRoxieIndexGroupAggregateActivity ::process");
-        Owned<IRowManager> rowManager = roxiemem::createRowManager(0, NULL, logctx, NULL, true); // MORE - should not really use default limits
+        Owned<IRowManager> rowManager = roxiemem::createRowManager(0, NULL, logctx, NULL, false); // MORE - should not really use default limits
         Owned<IMessagePacker> output = ROQ->createOutputStream(packet->queryHeader(), false, logctx);
 
         unsigned processedBefore = processed;

--- a/roxie/ccd/ccddebug.cpp
+++ b/roxie/ccd/ccddebug.cpp
@@ -1463,7 +1463,7 @@ protected:
         b.append("PROXY"); // MORE - a better log prefix might be good...
         request.serialize(b);
 
-        Owned<IRowManager> rowManager = roxiemem::createRowManager(1, NULL, *logctx, NULL);
+        Owned<IRowManager> rowManager = roxiemem::createRowManager(1, NULL, *logctx, NULL, false);
         Owned<IMessageCollator> mc = ROQ->queryReceiveManager()->createMessageCollator(rowManager, ruid);
 
         Owned<IRoxieQueryPacket> packet = createRoxiePacket(b);

--- a/roxie/ccd/ccdqueue.cpp
+++ b/roxie/ccd/ccdqueue.cpp
@@ -2883,7 +2883,7 @@ public:
     virtual int run()
     {
         Owned<StringContextLogger> logctx = new StringContextLogger("PacketDiscarder");
-        rowManager.setown(roxiemem::createRowManager(1, NULL, *logctx, NULL));
+        rowManager.setown(roxiemem::createRowManager(1, NULL, *logctx, NULL, false));
         mc.setown(ROQ->queryReceiveManager()->createMessageCollator(rowManager, RUID_DISCARD));
         ROQ->queryReceiveManager()->setDefaultCollator(mc);
         while (!aborted)
@@ -3013,7 +3013,7 @@ public:
 
     virtual int run()
     {
-        rowManager.setown(roxiemem::createRowManager(1, NULL, queryDummyContextLogger(), NULL));
+        rowManager.setown(roxiemem::createRowManager(1, NULL, queryDummyContextLogger(), NULL, false));
         mc.setown(ROQ->queryReceiveManager()->createMessageCollator(rowManager, RUID_PING));
         unsigned pingsReceived = 0;
         unsigned pingsElapsed = 0;

--- a/roxie/roxiemem/roxiemem.cpp
+++ b/roxie/roxiemem/roxiemem.cpp
@@ -4333,7 +4333,6 @@ private:
     const IRowAllocatorCache *allocatorCache;
     unsigned __int64 cyclesChecked;       // When we last checked timelimit
     unsigned __int64 cyclesCheckInterval; // How often we need to check timelimit
-    bool ignoreLeaks;
     bool outputOOMReports;
     bool trackMemoryByActivity;
     bool minimizeFootprint;
@@ -4350,7 +4349,7 @@ protected:
     }
 
 public:
-    CChunkingRowManager(memsize_t _memLimit, ITimeLimiter *_tl, const IContextLogger &_logctx, const IRowAllocatorCache *_allocatorCache, bool _ignoreLeaks, bool _outputOOMReports)
+    CChunkingRowManager(memsize_t _memLimit, ITimeLimiter *_tl, const IContextLogger &_logctx, const IRowAllocatorCache *_allocatorCache, bool _outputOOMReports)
         : hugeHeap(this, _logctx, _allocatorCache), logctx(_logctx), allocatorCache(_allocatorCache)
     {
         logctx.Link();
@@ -4381,7 +4380,6 @@ public:
         dataBuffs = 0;
         activeBuffs = NULL;
         dataBuffPages = 0;
-        ignoreLeaks = _ignoreLeaks;
         outputOOMReports = _outputOOMReports;
         minimizeFootprint = false;
         minimizeFootprintCritical = false;
@@ -5236,8 +5234,8 @@ class CGlobalRowManager;
 class CSlaveRowManager : public CChunkingRowManager
 {
 public:
-    CSlaveRowManager(unsigned _slaveId, CGlobalRowManager * _globalManager, memsize_t _memLimit, ITimeLimiter *_tl, const IContextLogger &_logctx, const IRowAllocatorCache *_allocatorCache, bool _ignoreLeaks, bool _outputOOMReports)
-        : CChunkingRowManager(_memLimit, _tl, _logctx, _allocatorCache, _ignoreLeaks, _outputOOMReports), slaveId(_slaveId), globalManager(_globalManager)
+    CSlaveRowManager(unsigned _slaveId, CGlobalRowManager * _globalManager, memsize_t _memLimit, ITimeLimiter *_tl, const IContextLogger &_logctx, const IRowAllocatorCache *_allocatorCache, bool _outputOOMReports)
+        : CChunkingRowManager(_memLimit, _tl, _logctx, _allocatorCache, _outputOOMReports), slaveId(_slaveId), globalManager(_globalManager)
     {
     }
 
@@ -5348,8 +5346,8 @@ class CCallbackRowManager : public CChunkingRowManager
 {
 public:
 
-    CCallbackRowManager(memsize_t _memLimit, ITimeLimiter *_tl, const IContextLogger &_logctx, const IRowAllocatorCache *_allocatorCache, bool _ignoreLeaks, bool _outputOOMReports)
-        : CChunkingRowManager(_memLimit, _tl, _logctx, _allocatorCache, _ignoreLeaks, _outputOOMReports), callbacks(this)
+    CCallbackRowManager(memsize_t _memLimit, ITimeLimiter *_tl, const IContextLogger &_logctx, const IRowAllocatorCache *_allocatorCache, bool _outputOOMReports)
+        : CChunkingRowManager(_memLimit, _tl, _logctx, _allocatorCache, _outputOOMReports), callbacks(this)
     {
     }
 
@@ -5457,15 +5455,15 @@ protected:
 class CGlobalRowManager : public CCallbackRowManager
 {
 public:
-    CGlobalRowManager(memsize_t _memLimit, memsize_t _globalLimit, unsigned _numSlaves, ITimeLimiter *_tl, const IContextLogger &_logctx, const IRowAllocatorCache *_allocatorCache, const IRowAllocatorCache **slaveAllocatorCaches, bool _ignoreLeaks, bool _outputOOMReports)
-        : CCallbackRowManager(_memLimit, _tl, _logctx, _allocatorCache, _ignoreLeaks, _outputOOMReports), numSlaves(_numSlaves)
+    CGlobalRowManager(memsize_t _memLimit, memsize_t _globalLimit, unsigned _numSlaves, ITimeLimiter *_tl, const IContextLogger &_logctx, const IRowAllocatorCache *_allocatorCache, const IRowAllocatorCache **slaveAllocatorCaches, bool _outputOOMReports)
+        : CCallbackRowManager(_memLimit, _tl, _logctx, _allocatorCache, _outputOOMReports), numSlaves(_numSlaves)
     {
         DBGLOG("Create Global/Slave Row Manager %uMB total global can use max %uMB", (unsigned)(_memLimit / 0x100000), (unsigned)(_globalLimit / 0x100000));
         assertex(_globalLimit <= _memLimit);
         globalPageLimit = (unsigned) PAGES(_globalLimit, HEAP_ALIGNMENT_SIZE);
         slaveRowManagers = new CChunkingRowManager * [numSlaves];
         for (unsigned i=0; i < numSlaves; i++)
-            slaveRowManagers[i] = new CSlaveRowManager(i+1, this, _memLimit, _tl, _logctx, slaveAllocatorCaches ? slaveAllocatorCaches[i] : _allocatorCache, _ignoreLeaks, _outputOOMReports);
+            slaveRowManagers[i] = new CSlaveRowManager(i+1, this, _memLimit, _tl, _logctx, slaveAllocatorCaches ? slaveAllocatorCaches[i] : _allocatorCache, _outputOOMReports);
     }
     ~CGlobalRowManager()
     {
@@ -6517,20 +6515,20 @@ void DataBufferBottom::_setDestructorFlag(const void *ptr) { throwUnexpected(); 
 //================================================================================
 //
 
-extern IRowManager *createRowManager(memsize_t memLimit, ITimeLimiter *tl, const IContextLogger &logctx, const IRowAllocatorCache *allocatorCache, bool ignoreLeaks, bool outputOOMReports)
+extern IRowManager *createRowManager(memsize_t memLimit, ITimeLimiter *tl, const IContextLogger &logctx, const IRowAllocatorCache *allocatorCache, bool outputOOMReports)
 {
     if (numDirectBuckets == 0)
         throw MakeStringException(ROXIEMM_HEAP_ERROR, "createRowManager() called before setTotalMemoryLimit()");
 
-    return new CCallbackRowManager(memLimit, tl, logctx, allocatorCache, ignoreLeaks, outputOOMReports);
+    return new CCallbackRowManager(memLimit, tl, logctx, allocatorCache, outputOOMReports);
 }
 
-extern IRowManager *createGlobalRowManager(memsize_t memLimit, memsize_t globalLimit, unsigned numSlaves, ITimeLimiter *tl, const IContextLogger &logctx, const IRowAllocatorCache *allocatorCache, const IRowAllocatorCache **slaveAllocatorCaches, bool ignoreLeaks, bool outputOOMReports)
+extern IRowManager *createGlobalRowManager(memsize_t memLimit, memsize_t globalLimit, unsigned numSlaves, ITimeLimiter *tl, const IContextLogger &logctx, const IRowAllocatorCache *allocatorCache, const IRowAllocatorCache **slaveAllocatorCaches, bool outputOOMReports)
 {
     if (numDirectBuckets == 0)
         throw MakeStringException(ROXIEMM_HEAP_ERROR, "createRowManager() called before setTotalMemoryLimit()");
 
-    return new CGlobalRowManager(memLimit, globalLimit, numSlaves, tl, logctx, allocatorCache, slaveAllocatorCaches, ignoreLeaks, outputOOMReports);
+    return new CGlobalRowManager(memLimit, globalLimit, numSlaves, tl, logctx, allocatorCache, slaveAllocatorCaches, outputOOMReports);
 }
 
 extern void setMemoryStatsInterval(unsigned secs)
@@ -7212,7 +7210,7 @@ protected:
 #endif
         HeapPointerCompressor compressor;
         const unsigned numAllocs = 100;
-        Owned<IRowManager> rm1 = createRowManager(0, NULL, logctx, NULL);
+        Owned<IRowManager> rm1 = createRowManager(0, NULL, logctx, NULL, false);
         memsize_t max = numAllocs * compressor.getSize();
         byte * memory = (byte *)malloc(max + 1);
         void * * ptrs = new void * [numAllocs];
@@ -7234,7 +7232,7 @@ protected:
     }
     void testHuge()
     {
-        Owned<IRowManager> rm1 = createRowManager(0, NULL, logctx, NULL);
+        Owned<IRowManager> rm1 = createRowManager(0, NULL, logctx, NULL, false);
         ReleaseRoxieRow(rm1->allocate(1800000, 0));
         ASSERT(rm1->numPagesAfterCleanup(false)==0); // page should be freed even if force not specified
         ASSERT(rm1->getMemoryUsage()== PAGES(1800000+sizeof(HugeHeaplet), HEAP_ALIGNMENT_SIZE)*HEAP_ALIGNMENT_SIZE);
@@ -7248,7 +7246,7 @@ protected:
         ASSERT(PackedFixedSizeHeaplet::chunkHeaderSize == 4);  // NOTE - this is NOT 8 byte aligned, so can't safely be used to allocate ptr arrays
 
         // Check some alignments
-        Owned<IRowManager> rm1 = createRowManager(0, NULL, logctx, NULL);
+        Owned<IRowManager> rm1 = createRowManager(0, NULL, logctx, NULL, false);
         OwnedRoxieRow rs = rm1->allocate(18, 0);
         OwnedRoxieRow rh = rm1->allocate(1800000, 0);
         ASSERT((((memsize_t) rs.get()) & 0x7) == 0);
@@ -7275,7 +7273,7 @@ protected:
 
     void testRelease()
     {
-        Owned<IRowManager> rm1 = createRowManager(0, NULL, logctx, NULL);
+        Owned<IRowManager> rm1 = createRowManager(0, NULL, logctx, NULL, false);
         ReleaseRoxieRow(rm1->allocate(1000, 0));
         ASSERT(rm1->numPagesAfterCleanup(true)==0);
         ASSERT(rm1->getMemoryUsage()==HEAP_ALIGNMENT_SIZE);
@@ -7292,7 +7290,7 @@ protected:
         ASSERT(rm1->getMemoryUsage()==HEAP_ALIGNMENT_SIZE);
 
 
-        Owned<IRowManager> rm2 = createRowManager(0, NULL, logctx, NULL);
+        Owned<IRowManager> rm2 = createRowManager(0, NULL, logctx, NULL, false);
         ReleaseRoxieRow(rm2->allocate(4000000, 0));
         ASSERT(rm2->numPagesAfterCleanup(true)==0);
         ASSERT(rm2->getMemoryUsage()==PAGES(4000000+sizeof(HugeHeaplet), HEAP_ALIGNMENT_SIZE)*HEAP_ALIGNMENT_SIZE);
@@ -7310,25 +7308,25 @@ protected:
 
         for (unsigned d = 0; d < 50; d++)
         {
-            Owned<IRowManager> rm3 = createRowManager(0, NULL, logctx, NULL);
+            Owned<IRowManager> rm3 = createRowManager(0, NULL, logctx, NULL, false);
             ReleaseRoxieRow(rm3->allocate(HEAP_ALIGNMENT_SIZE - d + 10, 0));
             ASSERT(rm3->numPagesAfterCleanup(true)==0);
         }
 
         // test leak reporting does not crash....
-        Owned<IRowManager> rm4 = createRowManager(0, NULL, logctx, NULL);
+        Owned<IRowManager> rm4 = createRowManager(0, NULL, logctx, NULL, false);
         rm4->allocate(4000000, 0);
         rm4.clear();
 
-        Owned<IRowManager> rm5 = createRowManager(0, NULL, logctx, NULL);
+        Owned<IRowManager> rm5 = createRowManager(0, NULL, logctx, NULL, false);
         rm5->allocate(4000, 0);
         rm5.clear();
     }
 
     void testFixed()
     {
-        Owned<IRowManager> rm1 = createRowManager(0, NULL, logctx, NULL);
-        Owned<IRowManager> rm2 = createRowManager(0, NULL, logctx, NULL);
+        Owned<IRowManager> rm1 = createRowManager(0, NULL, logctx, NULL, false);
+        Owned<IRowManager> rm2 = createRowManager(0, NULL, logctx, NULL, false);
         void *ptrs[20000];
         unsigned i;
         for (i = 0; i < 10000; i++)
@@ -7377,7 +7375,7 @@ protected:
 
     void testMixed()
     {
-        Owned<IRowManager> rm1 = createRowManager(0, NULL, logctx, NULL);
+        Owned<IRowManager> rm1 = createRowManager(0, NULL, logctx, NULL, false);
         void *ptrs[20000];
         unsigned i;
         for (i = 0; i < 10000; i++)
@@ -7399,7 +7397,7 @@ protected:
     }
     void testExhaust()
     {
-        Owned<IRowManager> rm1 = createRowManager(0, NULL, logctx, NULL);
+        Owned<IRowManager> rm1 = createRowManager(0, NULL, logctx, NULL, false);
         rm1->setMemoryLimit(20*HEAP_ALIGNMENT_SIZE);
         try
         {
@@ -7418,7 +7416,7 @@ protected:
     }
     void testCycling()
     {
-        Owned<IRowManager> rm1 = createRowManager(0, NULL, logctx, NULL);
+        Owned<IRowManager> rm1 = createRowManager(0, NULL, logctx, NULL, false);
         rm1->setMemoryLimit(2*1024*1024);
         unsigned i;
         for (i = 0; i < 1000; i++)
@@ -7511,7 +7509,7 @@ protected:
 
     void testAllocSize()
     {
-        Owned<IRowManager> rm = createRowManager(0, NULL, logctx, NULL);
+        Owned<IRowManager> rm = createRowManager(0, NULL, logctx, NULL, false);
         testCapacity(rm, 1);
         testCapacity(rm, 32);
         testCapacity(rm, 32768, PAGES(2 * 32768, (HEAP_ALIGNMENT_SIZE- sizeof(FixedSizeHeaplet))));
@@ -7668,7 +7666,7 @@ protected:
         if (numThreads == 0)
             return;
 
-        Owned<IRowManager> rowManager = createRowManager(0, NULL, logctx, NULL);
+        Owned<IRowManager> rowManager = createRowManager(0, NULL, logctx, NULL, false);
         CountingRowAllocatorCache rowCache;
         void * memory = suballoc_aligned(1, true);
         unsigned heapFlags = 0;
@@ -7708,7 +7706,7 @@ protected:
     void testOldFixedCas()
     {
         CountingRowAllocatorCache rowCache;
-        Owned<IRowManager> rowManager = createRowManager(0, NULL, logctx, &rowCache);
+        Owned<IRowManager> rowManager = createRowManager(0, NULL, logctx, &rowCache, false);
         Owned<IFixedRowHeap> rowHeap = rowManager->createFixedRowHeap(8, ACTIVITY_FLAG_ISREGISTERED|0, RHFhasdestructor|RHFoldfixed);
         Semaphore sem;
         CasAllocatorThread * threads[numCasThreads];
@@ -7722,7 +7720,7 @@ protected:
     {
         CountingRowAllocatorCache rowCache;
         Owned<IFixedRowHeap> rowHeap;
-        Owned<IRowManager> rowManager = createRowManager(0, NULL, logctx, &rowCache);
+        Owned<IRowManager> rowManager = createRowManager(0, NULL, logctx, &rowCache, false);
         //For this test the row heap is assign to a variable that will be destroyed after the manager, to ensure that works.
         rowHeap.setown(rowManager->createFixedRowHeap(8, ACTIVITY_FLAG_ISREGISTERED|0, RHFhasdestructor|flags));
         Semaphore sem;
@@ -7737,7 +7735,7 @@ protected:
     unsigned doTestFixedCas(const char * variant, unsigned flags)
     {
         CountingRowAllocatorCache rowCache;
-        Owned<IRowManager> rowManager = createRowManager(0, NULL, logctx, &rowCache);
+        Owned<IRowManager> rowManager = createRowManager(0, NULL, logctx, &rowCache, false);
         Semaphore sem;
         CasAllocatorThread * threads[numCasThreads];
         for (unsigned i1 = 0; i1 < numCasThreads; i1++)
@@ -7776,7 +7774,7 @@ protected:
     void testGeneralCas()
     {
         CountingRowAllocatorCache rowCache;
-        Owned<IRowManager> rowManager = createRowManager(0, NULL, logctx, &rowCache);
+        Owned<IRowManager> rowManager = createRowManager(0, NULL, logctx, &rowCache, false);
         Semaphore sem;
         CasAllocatorThread * threads[numCasThreads];
         for (unsigned i1 = 0; i1 < numCasThreads; i1++)
@@ -7814,7 +7812,7 @@ protected:
     void testVariableCas()
     {
         CountingRowAllocatorCache rowCache;
-        Owned<IRowManager> rowManager = createRowManager(0, NULL, logctx, &rowCache);
+        Owned<IRowManager> rowManager = createRowManager(0, NULL, logctx, &rowCache, false);
         Semaphore sem;
         CasAllocatorThread * threads[numCasThreads];
         for (unsigned i1 = 0; i1 < numCasThreads; i1++)
@@ -7845,7 +7843,7 @@ protected:
     }
     void testRoundup()
     {
-        Owned<IRowManager> rowManager = createRowManager(1, NULL, logctx, NULL);
+        Owned<IRowManager> rowManager = createRowManager(1, NULL, logctx, NULL, false);
         CChunkingRowManager * managerObject = static_cast<CChunkingRowManager *>(rowManager.get());
         const unsigned maxFrac = firstFractionalHeap;
 
@@ -7897,7 +7895,7 @@ protected:
         //and that row heaps are cleaned up correctly when the row manager is destroyed.
         CountingRowAllocatorCache rowCache;
         Owned<IFixedRowHeap> savedRowHeap;
-        Owned<IRowManager> rowManager = createRowManager(0, NULL, logctx, &rowCache);
+        Owned<IRowManager> rowManager = createRowManager(0, NULL, logctx, &rowCache, false);
         {
             Owned<IFixedRowHeap> rowHeap = rowManager->createFixedRowHeap(8, ACTIVITY_FLAG_ISREGISTERED|0, RHFhasdestructor|RHFunique);
             void * row = rowHeap->allocate();
@@ -7968,7 +7966,7 @@ protected:
     void testReleaseAll()
     {
         CountingRowAllocatorCache rowCache;
-        Owned<IRowManager> rowManager = createRowManager(0, NULL, logctx, &rowCache);
+        Owned<IRowManager> rowManager = createRowManager(0, NULL, logctx, &rowCache, false);
 
         //Test releaseAll on various different heap variants
         testReleaseAll(rowCache, rowManager, RHFhasdestructor|RHFunique);
@@ -7984,7 +7982,7 @@ protected:
     void testCallback(unsigned numPerPage, unsigned pages, unsigned spillPages, double scale, unsigned flags)
     {
         CountingRowAllocatorCache rowCache;
-        Owned<IRowManager> rowManager = createRowManager(0, NULL, logctx, &rowCache);
+        Owned<IRowManager> rowManager = createRowManager(0, NULL, logctx, &rowCache, false);
         rowManager->setMemoryLimit(pages * numCasThreads * HEAP_ALIGNMENT_SIZE, spillPages * numCasThreads * HEAP_ALIGNMENT_SIZE);
         rowManager->setMemoryCallbackThreshold((unsigned)-1);
         rowManager->setCallbackOnThread(true);
@@ -8143,7 +8141,7 @@ protected:
     }
     void testCompacting()
     {
-        Owned<IRowManager> rowManager = createRowManager(0, NULL, logctx, NULL);
+        Owned<IRowManager> rowManager = createRowManager(0, NULL, logctx, NULL, false);
 
         Owned<IFixedRowHeap> rowHeap1 = rowManager->createFixedRowHeap(compactingAllocSize-FixedSizeHeaplet::chunkHeaderSize, 0, 0);
         Owned<IFixedRowHeap> rowHeap2 = rowManager->createFixedRowHeap(compactingAllocSize-PackedFixedSizeHeaplet::chunkHeaderSize, 0, RHFpacked);
@@ -8180,7 +8178,7 @@ protected:
     void testRecursiveCallbacks1()
     {
         const size32_t bigRowSize = HEAP_ALIGNMENT_SIZE * 2 / 3;
-        Owned<IRowManager> rowManager = createRowManager(2 * HEAP_ALIGNMENT_SIZE, NULL, logctx, NULL);
+        Owned<IRowManager> rowManager = createRowManager(2 * HEAP_ALIGNMENT_SIZE, NULL, logctx, NULL, false);
 
         //The lower cost allocator allocates an extra row when it is called to free all its rows.
         //this will only succeed if the higher cost allocator is then called to free its data.
@@ -8194,7 +8192,7 @@ protected:
     void testRecursiveCallbacks2()
     {
         const size32_t bigRowSize = HEAP_ALIGNMENT_SIZE * 2 / 3;
-        Owned<IRowManager> rowManager = createRowManager(2 * HEAP_ALIGNMENT_SIZE, NULL, logctx, NULL);
+        Owned<IRowManager> rowManager = createRowManager(2 * HEAP_ALIGNMENT_SIZE, NULL, logctx, NULL, false);
 
         //Both allocators allocate extra memory when they are requested to free.  Ensure that an exception
         //is thrown instead of the previous stack fault.
@@ -8242,7 +8240,7 @@ protected:
     {
         //Test allocating within the heap when a limit is set on the row manager
         {
-            Owned<IRowManager> rowManager = createRowManager(HEAP_ALIGNMENT_SIZE, NULL, logctx, NULL);
+            Owned<IRowManager> rowManager = createRowManager(HEAP_ALIGNMENT_SIZE, NULL, logctx, NULL, false);
             testFragmentCallbacks(rowManager, 1);
         }
 
@@ -8250,7 +8248,7 @@ protected:
         {
             HeapPreserver preserver;
             adjustHeapSize(HEAP_BITS);
-            Owned<IRowManager> rowManager = createRowManager(0, NULL, logctx, NULL);
+            Owned<IRowManager> rowManager = createRowManager(0, NULL, logctx, NULL, false);
             testFragmentCallbacks(rowManager, HEAP_BITS);
         }
     }
@@ -8263,7 +8261,7 @@ protected:
     {
         //Test with a limit set on the memory manager
         const size32_t bigRowSize = HEAP_ALIGNMENT_SIZE * 2 / 3;
-        Owned<IRowManager> rowManager = createRowManager(1, NULL, logctx, NULL);
+        Owned<IRowManager> rowManager = createRowManager(1, NULL, logctx, NULL, false);
 
         SimpleCallbackBlockAllocator alloc1(rowManager, bigRowSize, 20, 1);
         SimpleCallbackBlockAllocator alloc2(rowManager, bigRowSize, 10, 2);
@@ -8280,7 +8278,7 @@ protected:
     void testCostCallbacks2()
     {
         //Test with no limit set on the memory manager
-        Owned<IRowManager> rowManager = createRowManager(0, NULL, logctx, NULL);
+        Owned<IRowManager> rowManager = createRowManager(0, NULL, logctx, NULL, false);
 
         const memsize_t bigRowSize = HEAP_ALIGNMENT_SIZE * (heapTotalPages * 2 / 3);
         SimpleCallbackBlockAllocator alloc1(rowManager, bigRowSize, 20, 1);
@@ -8308,7 +8306,7 @@ protected:
         for (unsigned i=0; i < numCallbacks; i++)
             callbacks[i] = new TestingRowBuffer(i % numCosts, i % (numCosts * numIds));
 
-        Owned<IRowManager> rowManager = createRowManager(0, NULL, logctx, NULL);
+        Owned<IRowManager> rowManager = createRowManager(0, NULL, logctx, NULL, false);
         unsigned startTime = msTick();
         for (unsigned iter=0; iter < numIter; iter++)
         {
@@ -8341,7 +8339,7 @@ protected:
         const memsize_t allMemoryAlloc = allMemory - halfPage;
         IRowManager * * slaveManagers = new IRowManager * [numSlaves];
         SimpleCallbackBlockAllocator * * allocators = new SimpleCallbackBlockAllocator * [numSlaves];
-        Owned<IRowManager> globalManager = createGlobalRowManager(allMemory, allMemory, numSlaves, NULL, logctx, NULL, NULL, true, false);
+        Owned<IRowManager> globalManager = createGlobalRowManager(allMemory, allMemory, numSlaves, NULL, logctx, NULL, NULL, false);
         for (unsigned i1 = 0; i1 < numSlaves; i1++)
         {
             slaveManagers[i1] = globalManager->querySlaveRowManager(i1);
@@ -8420,7 +8418,7 @@ protected:
     }
     void testResize()
     {
-        Owned<IRowManager> rowManager = createRowManager(0, NULL, logctx, NULL);
+        Owned<IRowManager> rowManager = createRowManager(0, NULL, logctx, NULL, false);
         memsize_t maxMemory = heapTotalPages * HEAP_ALIGNMENT_SIZE;
         memsize_t wasted = 0;
 
@@ -8561,7 +8559,7 @@ protected:
     void testResizeLock()
     {
         ResizeCallback callback;
-        Owned<IRowManager> rowManager = createRowManager(0, NULL, logctx, NULL);
+        Owned<IRowManager> rowManager = createRowManager(0, NULL, logctx, NULL, false);
         callback.rows = (const void * *)rowManager->allocate(1, 0);
         Owned<ReleaseThread> releaser = new ReleaseThread(callback, rowManager);
         Owned<ResizeThread> resizer = new ResizeThread(callback, rowManager);
@@ -8639,7 +8637,7 @@ protected:
         unsigned requestSize = 20;
         unsigned allocSize = 32 + sizeof(void*);
         memsize_t numAlloc = (memorySize / allocSize) * 3 /4;
-        Owned<IRowManager> rowManager = createRowManager(0, NULL, logctx, NULL);
+        Owned<IRowManager> rowManager = createRowManager(0, NULL, logctx, NULL, false);
         void * * rows = (void * *)rowManager->allocate(numAlloc * sizeof(void*), 0);
         unsigned startTime = msTick();
         for (memsize_t i=0; i < numAlloc; i++)
@@ -8660,7 +8658,7 @@ protected:
     void testFragmenting()
     {
         memsize_t requestSize = 32;
-        Owned<IRowManager> rowManager = createRowManager(0, NULL, logctx, NULL);
+        Owned<IRowManager> rowManager = createRowManager(0, NULL, logctx, NULL, false);
         unsigned startTime = msTick();
         void * prev = rowManager->allocate(requestSize, 1);
         try
@@ -8691,7 +8689,7 @@ protected:
     void testDoubleFragmenting()
     {
         memsize_t requestSize = 32;
-        Owned<IRowManager> rowManager = createRowManager(0, NULL, logctx, NULL);
+        Owned<IRowManager> rowManager = createRowManager(0, NULL, logctx, NULL, false);
         unsigned startTime = msTick();
         void * prev1 = rowManager->allocate(requestSize, 1);
         void * prev2 = rowManager->allocate(requestSize, 1);
@@ -8728,7 +8726,7 @@ protected:
     void testResizeFragmenting()
     {
         memsize_t requestSize = 32;
-        Owned<IRowManager> rowManager = createRowManager(0, NULL, logctx, NULL);
+        Owned<IRowManager> rowManager = createRowManager(0, NULL, logctx, NULL, false);
         unsigned startTime = msTick();
         void * prev = rowManager->allocate(requestSize, 1);
         try
@@ -8759,7 +8757,7 @@ protected:
     void testResizeDoubleFragmenting()
     {
         memsize_t requestSize = 32;
-        Owned<IRowManager> rowManager = createRowManager(0, NULL, logctx, NULL);
+        Owned<IRowManager> rowManager = createRowManager(0, NULL, logctx, NULL, false);
         unsigned startTime = msTick();
         void * prev1 = rowManager->allocate(requestSize, 1);
         void * prev2 = rowManager->allocate(requestSize, 1);
@@ -8846,7 +8844,7 @@ protected:
         const unsigned numAllocs = maxAllocs/4;
         const unsigned rowsetSize = numAllocs*4;
         const unsigned releaseSize = numAllocs * 3 / 4;
-        Owned<IRowManager> rowManager = createRowManager(0, NULL, logctx, NULL);
+        Owned<IRowManager> rowManager = createRowManager(0, NULL, logctx, NULL, false);
         const void * * rowset = new const void * [rowsetSize];
         memset(rowset, 0, sizeof(void *) * rowsetSize);
 
@@ -8957,7 +8955,7 @@ protected:
 
     void testHuge()
     {
-        Owned<IRowManager> rowManager = createRowManager(0, NULL, logctx, NULL);
+        Owned<IRowManager> rowManager = createRowManager(0, NULL, logctx, NULL, false);
         void * huge = rowManager->allocate(hugeAllocSize, 1);
         ASSERT(rowManager->numPagesAfterCleanup(true)==16385);
         ReleaseRoxieRow(huge);
@@ -9114,7 +9112,7 @@ protected:
 
     unsigned testSingleSync(size_t numRows, size_t granularity, bool shuffle)
     {
-        Owned<IRowManager> rowManager = createRowManager(0, NULL, logctx, NULL);
+        Owned<IRowManager> rowManager = createRowManager(0, NULL, logctx, NULL, false);
         ConstPointerArray rows;
         createRows(rowManager, numRows, rows, shuffle);
         cycle_t start = get_cycles_now();

--- a/roxie/roxiemem/roxiemem.hpp
+++ b/roxie/roxiemem/roxiemem.hpp
@@ -507,8 +507,8 @@ interface IActivityMemoryUsageMap : public IInterface
     virtual void reportStatistics(IStatisticTarget & target, unsigned detailtarget, const IRowAllocatorCache *allocatorCache) = 0;
 };
 
-extern roxiemem_decl IRowManager *createRowManager(memsize_t memLimit, ITimeLimiter *tl, const IContextLogger &logctx, const IRowAllocatorCache *allocatorCache, bool ignoreLeaks = false, bool outputOOMReports = false);
-extern roxiemem_decl IRowManager *createGlobalRowManager(memsize_t memLimit, memsize_t globalLimit, unsigned numSlaves, ITimeLimiter *tl, const IContextLogger &logctx, const IRowAllocatorCache *allocatorCache, const IRowAllocatorCache **slaveAllocatorCaches, bool ignoreLeaks, bool outputOOMReports);
+extern roxiemem_decl IRowManager *createRowManager(memsize_t memLimit, ITimeLimiter *tl, const IContextLogger &logctx, const IRowAllocatorCache *allocatorCache, bool outputOOMReports);
+extern roxiemem_decl IRowManager *createGlobalRowManager(memsize_t memLimit, memsize_t globalLimit, unsigned numSlaves, ITimeLimiter *tl, const IContextLogger &logctx, const IRowAllocatorCache *allocatorCache, const IRowAllocatorCache **slaveAllocatorCaches, bool outputOOMReports);
 
 // Fixed size aggregated link-counted zero-overhead data Buffer manager
 

--- a/roxie/udplib/uttest.cpp
+++ b/roxie/udplib/uttest.cpp
@@ -174,7 +174,7 @@ public:
     virtual int run()
     {
         Owned<IReceiveManager> rcvMgr = createReceiveManager(7000, 7001, 7002, 7003, multicastIP, udpQueueSize, maxPacketsPerSender, myIndex);
-        Owned<roxiemem::IRowManager> rowMgr = roxiemem::createRowManager(0, NULL, queryDummyContextLogger(), NULL);
+        Owned<roxiemem::IRowManager> rowMgr = roxiemem::createRowManager(0, NULL, queryDummyContextLogger(), NULL, false);
         Owned<IMessageCollator> collator = rcvMgr->createMessageCollator(rowMgr, 1);
         unsigned lastReport = 0;
         unsigned receivedTotal = 0;
@@ -1120,7 +1120,7 @@ int main(int argc, char * argv[] )
     if (modeType & RCV_MODE_BIT) 
     {
         rcvMgr = createReceiveManager(7000, 7001, 7002, 7003, multiCast, 100, 0x7fffffff, myIndex);
-        rowMgr = createRowManager(0, NULL, queryDummyContextLogger(), NULL);
+        rowMgr = createRowManager(0, NULL, queryDummyContextLogger(), NULL, false);
         msgCollA = rcvMgr->createMessageCollator(rowMgr, 100);
         if (destB)
         {

--- a/thorlcr/thorutil/thmem.cpp
+++ b/thorlcr/thorutil/thmem.cpp
@@ -2439,12 +2439,12 @@ CThorAllocator::CThorAllocator(unsigned memLimitMB, unsigned sharedMemLimitMB, u
             slaveAllocators.append(*slaveAllocator);
             slaveAllocatorMetaCaches.append(*slaveAllocator->getAllocatorCache());
         }
-        rowManager.setown(roxiemem::createGlobalRowManager(memLimit, sharedMemLimit, numChannels, NULL, *logctx, allocatorMetaCache, (const roxiemem::IRowAllocatorCache **)slaveAllocatorMetaCaches.getArray(), false, true));
+        rowManager.setown(roxiemem::createGlobalRowManager(memLimit, sharedMemLimit, numChannels, NULL, *logctx, allocatorMetaCache, (const roxiemem::IRowAllocatorCache **)slaveAllocatorMetaCaches.getArray(), true));
         for (unsigned c=0; c<numChannels; c++)
             slaveAllocators.item(c).setRowManager(rowManager->querySlaveRowManager(c));
     }
     else
-        rowManager.setown(roxiemem::createRowManager(memLimit, NULL, *logctx, allocatorMetaCache, false, true));
+        rowManager.setown(roxiemem::createRowManager(memLimit, NULL, *logctx, allocatorMetaCache, true));
 
     rowManager->setMemoryLimit(memLimit, 0==memorySpillAtPercentage ? 0 : memLimit/100*memorySpillAtPercentage);
     const bool paranoid = false;


### PR DESCRIPTION
Only time it's worth reporting leaks is when regression suite checks for them.
Other reports are (a) ignored, (b) misinterpreted, (c) liable to core, or (d)
all of the above.

Signed-off-by: Richard Chapman <rchapman@hpccsystems.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [ ] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
Smoketest should exercise.
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
