### PR TITLE
HPCC-21418 Don't output a line for empty file parts when despraying JSON file

### DIFF
--- a/testing/regress/ecl/key/spray_header_test.xml
+++ b/testing/regress/ecl/key/spray_header_test.xml
@@ -9,3 +9,14 @@
 <Dataset name='Result 4'>
  <Row><Result_4>Pass</Result_4></Row>
 </Dataset>
+<Dataset name='Result 5'>
+</Dataset>
+<Dataset name='Result 6'>
+ <Row><result>Despray Pass</result></Row>
+</Dataset>
+<Dataset name='Result 7'>
+ <Row><result>Spray Pass</result></Row>
+</Dataset>
+<Dataset name='Result 8'>
+ <Row><Result_8>Compare Pass</Result_8></Row>
+</Dataset>

--- a/testing/regress/ecl/spray_test_json.ecl
+++ b/testing/regress/ecl/spray_test_json.ecl
@@ -1,0 +1,264 @@
+/*##############################################################################
+
+    Copyright (C) 2018 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+
+//nohthor
+//class=spray
+
+//version isSmallFile=true,isUnBallanced=false
+//version isSmallFile=true,isUnBallanced=true
+//version isSmallFile=false
+
+import std.system.thorlib;
+import Std.File AS FileServices;
+import $.setup;
+import ^ as root;
+
+
+isSmallFile := #IFDEFINED(root.isSmallFile, true);
+
+isUnBallanced := #IFDEFINED(root.isUnBallanced, false);
+
+dropzonePath := '/var/lib/HPCCSystems/mydropzone/' : STORED('dropzonePath');
+engine := thorlib.platform() : stored('thor');
+prefix := setup.Files(false, false).QueryFilePrefix;
+nodes := thorlib.nodes();
+
+unsigned VERBOSE := 0;
+
+Layout_Person := RECORD
+  UNSIGNED4 PersonID;
+  STRING    FirstName;
+  STRING25  LastName;
+END;
+
+allPeople := DATASET([ {1,'Fred','Smith'},
+                       {2,'Joe','Blow'},
+                       {3,'Jane','Smith'}],Layout_Person);
+
+// One record, object is much larger tha the others. It is testing the
+// split point calculation on multi target environment.
+unBallanced := DATASET([ {1,'Fred','Smith'},
+                       {2,'Joe_012345678901234567890912345678901234567890123456789001234567890123456789','Blow'},
+                       {3,'Jane','Smith'}],Layout_Person);
+
+manyPeople := DATASET(nodes * 100,
+              TRANSFORM({Layout_Person},
+                         SELF.PersonID := COUNTER;
+                         SELF.FirstName := allPeople[(COUNTER-1) % 3 + 1].FirstName;
+                         SELF.LastName := allPeople[(COUNTER-1) % 3 + 1].LastName;
+                        )
+              ,DISTRIBUTED
+              );
+
+#if (isSmallFile)
+    somePeople := if (nodes = 1,
+                        allPeople(LastName = 'Smith'),
+                    #if (isUnBallanced)
+                         unBallanced
+                    #else
+                        allPeople(LastName = 'Blow')
+                    #end
+                    );
+#else
+    somePeople := manyPeople;
+#end
+
+SrcAddrIp := '.';
+File := 'persons';
+OriginalDataFile := prefix + File;
+OriginalDataFile2 := prefix + File + '2';
+
+//  Outputs  ---
+setupPeople := OUTPUT(somePeople,,OriginalDataFile, JSON, OVERWRITE);
+setupPeople2 := OUTPUT(somePeople,,OriginalDataFile2,  JSON('', HEADING('', ''), OPT, TRIM), OVERWRITE);
+
+ClusterName := 'mythor';
+
+desprayRec := RECORD
+   string sourceFile;
+   string destFile;
+   string ip;
+   boolean allowOverwrite;
+   string result;
+   string msg;
+ end;
+
+desprayRec doDespray(desprayRec l) := TRANSFORM
+   SELF.sourceFile := l.sourceFile;
+   SELF.msg := FileServices.fDespray(l.sourceFile
+                                          ,l.ip
+                                          ,destinationPath := l.destFile
+                                          ,ALLOWOVERWRITE := l.allowOverwrite
+                                          );
+   SELF.result := 'Despray Pass';
+   SELF.ip := l.ip;
+   SELF.allowOverwrite := l.allowOverwrite;
+   SELF.destFile := l.destFile;
+ end;
+
+// This should be fine based on valid target file path and SrcAddIp
+DesprayTargetFile1 := dropzonePath + WORKUNIT + '-' + File;
+dst2 := NOFOLD(DATASET([{OriginalDataFile, DesprayTargetFile1, SrcAddrIp, True, '', ''}], desprayRec));
+
+p2 := NOTHOR(PROJECT(NOFOLD(dst2), doDespray(LEFT)));
+
+c2 := CATCH(NOFOLD(p2), ONFAIL(TRANSFORM(desprayRec,
+                                  SELF.sourceFile := OriginalDataFile,
+                                  SELF.destFile := DesprayTargetFile1,
+                                  SELF.ip := SrcAddrIp,
+                                  SELF.allowOverwrite := True,
+                                  SELF.result := 'Fail',
+                                  SELF.msg := FAILMESSAGE
+                                 )));
+#if (VERBOSE = 1)
+     despray := output(c2);
+#else
+     despray := output(c2, {result});
+#end
+
+
+// This should be fine based on valid target file path and SrcAddIp
+DesprayTargetFile2 := dropzonePath + WORKUNIT + '-' + File + '2';
+dst2b := NOFOLD(DATASET([{OriginalDataFile, DesprayTargetFile2, SrcAddrIp, True, '', ''}], desprayRec));
+
+p2b := NOTHOR(PROJECT(NOFOLD(dst2b), doDespray(LEFT)));
+
+c2b := CATCH(NOFOLD(p2b), ONFAIL(TRANSFORM(desprayRec,
+                                  SELF.sourceFile := OriginalDataFile,
+                                  SELF.destFile := DesprayTargetFile2,
+                                  SELF.ip := SrcAddrIp,
+                                  SELF.allowOverwrite := True,
+                                  SELF.result := 'Fail',
+                                  SELF.msg := FAILMESSAGE
+                                 )));
+#if (VERBOSE = 1)
+     despray2 := output(c2b);
+#else
+     despray2 := output(c2b, {result});
+#end
+
+
+
+sprayRec := RECORD
+  string sourceFileName;
+  string targetFileName;
+  string result;
+  string msg;
+end;
+
+//To spray a JSON file we use XML Spray
+sprayRec doSpray(sprayRec l) := TRANSFORM
+    SELF.sourceFileName := l.sourceFileName;
+    SELF.targetFileName := l.targetFileName;
+    SELF.msg := FileServices.fSprayXml(
+                                SOURCEIP := '.',
+                                SOURCEPATH := l.sourceFileName,
+                                SOURCEROWTAG := 'Row',
+                                DESTINATIONGROUP := 'my'+engine,
+                                DESTINATIONLOGICALNAME := l.targetFileName,
+                                TIMEOUT := -1,
+                                ESPSERVERIPPORT := 'http://127.0.0.1:8010/FileSpray',
+                                ALLOWOVERWRITE := true
+                                );
+    self.result := 'Spray Pass';
+end;
+
+
+SprayTargetFileName1 := prefix + 'spray_test';
+dst3 := NOFOLD(DATASET([{DesprayTargetFile1, SprayTargetFileName1, '', ''}], sprayRec));
+
+p3 := NOTHOR(PROJECT(NOFOLD(dst3), doSpray(LEFT)));
+c3 := CATCH(NOFOLD(p3), ONFAIL(TRANSFORM(sprayRec,
+                                  SELF.sourceFileName := DesprayTargetFile1,
+                                  SELF.targetFileName := SprayTargetFileName1,
+                                  SELF.result := 'Spray Fail',
+                                  SELF.msg := FAILMESSAGE
+                                 )));
+#if (VERBOSE = 1)
+    spray := output(c3);
+#else
+    spray := output(c3, {result});
+#end
+
+
+
+SprayTargetFileName2 := prefix + 'spray_test2';
+dst3b := NOFOLD(DATASET([{DesprayTargetFile2, SprayTargetFileName2, '', ''}], sprayRec));
+
+p3b := NOTHOR(PROJECT(NOFOLD(dst3b), doSpray(LEFT)));
+c3b := CATCH(NOFOLD(p3b), ONFAIL(TRANSFORM(sprayRec,
+                                  SELF.sourceFileName := DesprayTargetFile2,
+                                  SELF.targetFileName := SprayTargetFileName2,
+                                  SELF.result := 'Spray Fail',
+                                  SELF.msg := FAILMESSAGE
+                                 )));
+#if (VERBOSE = 1)
+    spray2 := output(c3b);
+#else
+    spray2 := output(c3b, {result});
+#end
+
+
+
+ds := DATASET(SprayTargetFileName1, Layout_Person, JSON('Row'));
+ds2 := DATASET(SprayTargetFileName2, Layout_Person, JSON('Row'));
+
+string compareDatasets(dataset(Layout_Person) ds1, dataset(Layout_Person) ds2) := FUNCTION
+   boolean result := (0 = COUNT(JOIN(ds1, ds2, left.PersonID=right.PersonID, FULL ONLY)));
+   RETURN if(result, 'Compare Pass', 'Fail');
+END;
+
+SEQUENTIAL(
+
+#if (VERBOSE = 1)
+    output(isSmallFile, NAMED('isSmallFile'));
+    output(isUnBallanced, NAMED('isUnBallanced'));
+    output(somePeople, NAMED('somePeople')),
+#end
+
+    setupPeople,
+    despray,
+    spray,
+
+#if (VERBOSE = 1)
+    output(ds, NAMED('ds')),
+#end
+
+    output(compareDatasets(somePeople,ds)),
+
+
+    setupPeople2,
+    despray2,
+    spray2,
+
+#if (VERBOSE = 1)
+    output(ds2, NAMED('ds2')),
+#end
+
+    output(compareDatasets(somePeople,ds2)),
+
+    // Clean-up
+    FileServices.DeleteLogicalFile(OriginalDataFile),
+    FileServices.DeleteExternalFile('.', DesprayTargetFile1),
+    FileServices.DeleteLogicalFile(SprayTargetFileName1),
+
+    FileServices.DeleteLogicalFile(OriginalDataFile2),
+    FileServices.DeleteExternalFile('.', DesprayTargetFile2),
+    FileServices.DeleteLogicalFile(SprayTargetFileName2),
+
+);


### PR DESCRIPTION
Avoid to create partition for empty file parts (contain
only headers and/or part separators) and prevent to store
them into the despray target file.

Extend spray_test_json.ecl to create logical file with empty
headers and json content, despray then spray it back and compare
the sprayed file with the original one.

Re-targeted version of https://github.com/hpcc-systems/HPCC-Platform/pull/12143

Signed-off-by: Attila Vamos <attila.vamos@gmail.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [ ] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [ ] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [ ] I have read the CONTRIBUTORS document.
- [ ] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->
Tested manually and locally executed spray/despray test cases from Regression Suite.
<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
