### PR TITLE
HPCC-21524 Check thor log restarting when retrieving WU thor log

### DIFF
--- a/esp/services/ws_workunits/ws_workunitsAuditLogs.cpp
+++ b/esp/services/ws_workunits/ws_workunitsAuditLogs.cpp
@@ -1439,7 +1439,7 @@ void CWsWorkunitsSoapBindingEx::createAndDownloadWUZAPFile(IEspContext& context,
 
     //CWsWuFileHelper may need ESP's <Directories> settings to locate log files. 
     CWsWuFileHelper helper(directories);
-    response->setContent(helper.createWUZAPFileIOStream(context, cwu, zapInfoReq));
+    response->setContent(helper.createWUZAPFileIOStream(context, cwu, zapInfoReq, getThorSlaveLogThreadPoolSize));
     response->setContentType(HTTP_TYPE_OCTET_STREAM);
     response->send();
 }

--- a/esp/services/ws_workunits/ws_workunitsHelpers.hpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.hpp
@@ -59,6 +59,8 @@ const unsigned AWUS_CACHE_SIZE = 16;
 const unsigned AWUS_CACHE_MIN_DEFAULT = 15;
 const unsigned WUDEFAULT_ZAPEMAILSERVER_PORT = 25;
 
+static const unsigned GET_THOR_SLAVE_LOG_THREAD_POOL_SIZE = 100;
+
 inline bool notEmpty(const char *val){return (val && *val);}
 inline bool isEmpty(const char *val){return (!val || !*val);}
 
@@ -139,8 +141,8 @@ class WsWuInfo
     IEspWUArchiveModule* readArchiveModuleAttr(IPropertyTree& moduleTree, const char* path);
     void readArchiveFiles(IPropertyTree* archiveTree, const char* path, IArrayOf<IEspWUArchiveFile>& files);
     void outputALine(size32_t len, const char* content, MemoryBuffer& outputBuf, IFileIOStream* outIOS);
-    bool readLogLineID(char* linePtr, unsigned long& lineID);
-    void readWorkunitLog(OwnedIFileIOStream ios, MemoryBuffer& buf, const char* outFile);
+    unsigned readLogProcessID(const char* linePtr);
+    void readWorkunitLog(IBufferedFileIOStream* ios, MemoryBuffer& buf, const char* outFile);
 public:
     WsWuInfo(IEspContext &ctx, IConstWorkUnit *cw_) :
       context(ctx), cw(cw_)
@@ -593,6 +595,7 @@ struct CWsWuZAPInfoReq
 class CWsWuFileHelper
 {
     IPropertyTree* directories;
+    unsigned getThorSlaveLogThreadPoolSize = GET_THOR_SLAVE_LOG_THREAD_POOL_SIZE;
 
     void cleanFolder(IFile *folder, bool removeFolder);
     int zipAFolder(const char *folder, const char *passwordReq, const char *zipFileNameWithPath);
@@ -619,8 +622,9 @@ public:
     CWsWuFileHelper(IPropertyTree *_directories) : directories(_directories) {};
 
     void createWUZAPFile(IEspContext &context, Owned<IConstWorkUnit> &cwu, CWsWuZAPInfoReq &request,
-        StringBuffer &zipFileName, StringBuffer &zipFileNameWithPath);
-    IFileIOStream* createWUZAPFileIOStream(IEspContext &context, Owned<IConstWorkUnit> &cwu, CWsWuZAPInfoReq &request);
+        StringBuffer &zipFileName, StringBuffer &zipFileNameWithPath, unsigned _getThorSlaveLogThreadPoolSize);
+    IFileIOStream* createWUZAPFileIOStream(IEspContext &context, Owned<IConstWorkUnit> &cwu,
+        CWsWuZAPInfoReq &request, unsigned _getThorSlaveLogThreadPoolSize);
 
     IFileIOStream* createWUFileIOStream(IEspContext &context, const char *wuid, IArrayOf<IConstWUFileOption> &wuFileOptions,
         CWUFileDownloadOption &downloadOptions, StringBuffer &contentType);
@@ -644,47 +648,31 @@ public:
     void send(const char *body, const void *attachment, size32_t lenAttachment, StringArray &warnings);
 };
 
-class CThorSlaveLogFileItem : public CSimpleInterface
-{
-public:
-    CThorSlaveLogFileItem(const char*_groupName, const char*_logDate, const char*_logDir,
-        unsigned _slaveNum, const char*_fileName)
-        : groupName(_groupName), logDate(_logDate), logDir(_logDir), slaveNum(_slaveNum),
-        fileName(_fileName) { };
-
-    StringAttr groupName, logDate, logDir, fileName;
-    unsigned slaveNum;
-};
-
 class CGetThorSlaveLogToFileThreadParam : public CInterface
 {
-    Owned<CThorSlaveLogFileItem> logFile;
     WsWuInfo* wuInfo;
+    unsigned slaveNum;
+    StringAttr groupName, logDate, logDir, fileName;
 
 public:
     IMPLEMENT_IINTERFACE;
 
-    CGetThorSlaveLogToFileThreadParam(WsWuInfo* _wuInfo, CThorSlaveLogFileItem* _logFile)
-        : wuInfo(_wuInfo)
-    {
-        logFile.setown(_logFile);
-    }
+    CGetThorSlaveLogToFileThreadParam(WsWuInfo* _wuInfo, const char*_groupName,
+        const char*_logDate, const char*_logDir, unsigned _slaveNum, const char* _fileName)
+        : wuInfo(_wuInfo), groupName(_groupName), logDate(_logDate), logDir(_logDir),
+          slaveNum(_slaveNum), fileName(_fileName) { };
 
     virtual void doWork()
     {
         MemoryBuffer dummy;
-        wuInfo->getWorkunitThorSlaveLog(logFile->groupName.get(), nullptr, logFile->logDate.str(),
-            logFile->logDir.get(), logFile->slaveNum, dummy, logFile->fileName.get(), false);;
+        wuInfo->getWorkunitThorSlaveLog(groupName.get(), nullptr, logDate.get(),
+            logDir.get(), slaveNum, dummy, fileName.get(), false);;
     }
 };
 
-class CGetThorSlaveLogToFileThread : public CInterface, implements IPooledThread
+class CGetThorSlaveLogToFileThread : public CSimpleInterfaceOf<IPooledThread>
 {
 public:
-    IMPLEMENT_IINTERFACE;
-
-    CGetThorSlaveLogToFileThread() {};
-
     virtual void init(void* _param) override
     {
         param.setown((CGetThorSlaveLogToFileThreadParam*)_param);

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -437,6 +437,9 @@ void CWsWorkunitsEx::init(IPropertyTree *cfg, const char *process, const char *s
     Owned<CClusterQueryStateThreadFactory> threadFactory = new CClusterQueryStateThreadFactory();
     clusterQueryStatePool.setown(createThreadPool("CheckAndSetClusterQueryState Thread Pool", threadFactory, NULL,
             cfg->getPropInt(xpath.str(), CHECK_QUERY_STATUS_THREAD_POOL_SIZE)));
+
+    xpath.setf("Software/EspProcess[@name=\"%s\"]/EspService[@name=\"%s\"]/GetThorSlaveLogThreadPoolSize", process, service);
+    getThorSlaveLogThreadPoolSize = cfg->getPropInt(xpath, GET_THOR_SLAVE_LOG_THREAD_POOL_SIZE);
 }
 
 void CWsWorkunitsEx::refreshValidClusters()
@@ -4716,7 +4719,7 @@ bool CWsWorkunitsEx::onWUCreateZAPInfo(IEspContext &context, IEspWUCreateZAPInfo
         StringBuffer zipFileName, zipFileNameWithPath;
         //CWsWuFileHelper may need ESP's <Directories> settings to locate log files. 
         CWsWuFileHelper helper(directories);
-        helper.createWUZAPFile(context, cwu, zapInfoReq, zipFileName, zipFileNameWithPath);
+        helper.createWUZAPFile(context, cwu, zapInfoReq, zipFileName, zipFileNameWithPath, getThorSlaveLogThreadPoolSize);
 
         //Download ZIP file to user
         Owned<IFile> f = createIFile(zipFileNameWithPath.str());

--- a/esp/services/ws_workunits/ws_workunitsService.hpp
+++ b/esp/services/ws_workunits/ws_workunitsService.hpp
@@ -342,6 +342,7 @@ private:
     Owned<IPropertyTree> directories;
     int maxRequestEntityLength;
     Owned<IThreadPool> clusterQueryStatePool;
+    unsigned getThorSlaveLogThreadPoolSize = GET_THOR_SLAVE_LOG_THREAD_POOL_SIZE;
 
 public:
     QueryFilesInUse filesInUse;
@@ -361,6 +362,12 @@ public:
         VStringBuffer xpath("Software/EspProcess[@name=\"%s\"]/EspBinding[@name=\"%s\"]/BatchWatch", process, name);
         batchWatchFeaturesOnly = cfg->getPropBool(xpath.str(), false);
         directories.set(cfg->queryPropTree("Software/Directories"));
+
+        xpath.setf("Software/EspProcess[@name=\"%s\"]/EspBinding[@name=\"%s\"]/service", process, name);
+        const char *service = cfg->queryProp(xpath);
+
+        xpath.setf("Software/EspProcess[@name=\"%s\"]/EspService[@name=\"%s\"]/GetThorSlaveLogThreadPoolSize", process, service);
+        getThorSlaveLogThreadPoolSize = cfg->getPropInt(xpath, GET_THOR_SLAVE_LOG_THREAD_POOL_SIZE);
     }
 
     virtual void getNavigationData(IEspContext &context, IPropertyTree & data)
@@ -392,6 +399,7 @@ private:
     bool batchWatchFeaturesOnly;
     CWsWorkunitsEx *wswService;
     Owned<IPropertyTree> directories;
+    unsigned getThorSlaveLogThreadPoolSize = GET_THOR_SLAVE_LOG_THREAD_POOL_SIZE;
 };
 
 void deploySharedObject(IEspContext &context, StringBuffer &wuid, const char *filename, const char *cluster, const char *name, const MemoryBuffer &obj, const char *dir, const char *xml=NULL);

--- a/initfiles/componentfiles/configxml/@temp/esp_service_WsSMC.xsl
+++ b/initfiles/componentfiles/configxml/@temp/esp_service_WsSMC.xsl
@@ -230,6 +230,9 @@ This is required by its binding with ESP service '<xsl:value-of select="$espServ
             <xsl:if test="string(@clusterQueryStateThreadPoolSize) != ''">
                 <ClusterQueryStateThreadPoolSize><xsl:value-of select="@clusterQueryStateThreadPoolSize"/></ClusterQueryStateThreadPoolSize>
             </xsl:if>
+            <xsl:if test="string(@GetThorSlaveLogThreadPoolSize) != ''">
+                <GetThorSlaveLogThreadPoolSize><xsl:value-of select="@GetThorSlaveLogThreadPoolSize"/></GetThorSlaveLogThreadPoolSize>
+            </xsl:if>
             <xsl:if test="string(@AWUsCacheTimeout) != ''">
                 <AWUsCacheMinutes><xsl:value-of select="@AWUsCacheTimeout"/></AWUsCacheMinutes>
             </xsl:if>

--- a/initfiles/componentfiles/configxml/espsmcservice.xsd.in
+++ b/initfiles/componentfiles/configxml/espsmcservice.xsd.in
@@ -173,6 +173,13 @@
                     </xs:appinfo>
                 </xs:annotation>
             </xs:attribute>
+            <xs:attribute name="GetThorSlaveLogThreadPoolSize" type="xs:nonNegativeInteger" use="optional">
+                <xs:annotation>
+                    <xs:appinfo>
+                        <tooltip>Thread pool size for getting thor slave logs.</tooltip>
+                    </xs:appinfo>
+                </xs:annotation>
+            </xs:attribute>
             <xs:attribute name="enableLogDaliConnection" type="xs:boolean" use="optional" default="false">
                 <xs:annotation>
                     <xs:appinfo>

--- a/system/jlib/jfile.cpp
+++ b/system/jlib/jfile.cpp
@@ -2535,7 +2535,7 @@ size32_t CFileIOStream::write(size32_t len, const void * data)
 //---------------------------------------------------------------------------
 
 
-class CBufferedFileIOStreamBase : public CBufferedIOStreamBase, implements IFileIOStream
+class CBufferedFileIOStreamBase : public CBufferedIOStreamBase, implements IBufferedFileIOStream
 {
 protected:
     virtual offset_t directSize() = 0;
@@ -2611,6 +2611,11 @@ public:
     size32_t read(size32_t len, void * data)
     {
         return CBufferedIOStreamBase::doread(len, data);
+    }
+
+    bool readLine(bool keepCRLF, StringBuffer & outBuffer)
+    {
+        return CBufferedIOStreamBase::readLineFromBuffer(keepCRLF, outBuffer);
     }
 
     size32_t write(size32_t len, const void * data)
@@ -4202,6 +4207,13 @@ IFileIOStream * createBufferedAsyncIOStream(IFileAsyncIO * io, unsigned bufsize)
     if (bufsize == (unsigned)-1)
         bufsize = DEFAULT_BUFFER_SIZE*2;
     return new CBufferedAsyncIOStream(io, bufsize);
+}
+
+IBufferedFileIOStream * createBufferedFileIOStream(IFileIO * io, unsigned bufsize)
+{
+    if (bufsize == (unsigned)-1)
+        bufsize = DEFAULT_BUFFER_SIZE;
+    return new CBufferedFileIOStream(io, bufsize);
 }
 
 IReadSeq *createReadSeq(IFileIOStream * stream, offset_t offset, size32_t size)

--- a/system/jlib/jfile.hpp
+++ b/system/jlib/jfile.hpp
@@ -213,6 +213,11 @@ interface IFileIOStream : extends IIOStream
     virtual offset_t tell() = 0;
 };
 
+interface IBufferedFileIOStream : extends IFileIOStream
+{
+    virtual bool readLine(bool keepCRLF, StringBuffer & outBuffer) = 0;
+};
+
 interface IDiscretionaryLock: extends IInterface
 {
     virtual bool lock(bool exclusive=true, unsigned timeout=INFINITE) = 0; // overrides previous setting
@@ -275,6 +280,7 @@ extern jlib_decl IFileIO * createIORange(IFileIO * file, offset_t header, offset
 extern jlib_decl IFileIOStream * createIOStream(IFileIO * file);        // links argument
 extern jlib_decl IFileIOStream * createBufferedIOStream(IFileIO * file, unsigned bufsize=(unsigned)-1);// links argument
 extern jlib_decl IFileIOStream * createBufferedAsyncIOStream(IFileAsyncIO * file, unsigned bufsize=(unsigned)-1);// links argument
+extern jlib_decl IBufferedFileIOStream * createBufferedFileIOStream(IFileIO * file, unsigned bufsize=(unsigned)-1);// links argument
 
 // Useful for commoning up file and string based processing
 extern jlib_decl IFileIO * createIFileI(unsigned len, const void * buffer);     // input only...

--- a/system/jlib/jutil.cpp
+++ b/system/jlib/jutil.cpp
@@ -1466,7 +1466,7 @@ void JBASE32_Decode(const char *bi,StringBuffer &out)
 }
 
 
-static void DelimToStringArray(const char *csl, StringArray &dst, const char *delim, bool deldup, bool trimSpaces)
+static void DelimToStringArray(const char *csl, StringArray &dst, const char *delim, bool deldup, bool trimSpaces, unsigned maxNumItems)
 {
     if (!csl)
         return;
@@ -1511,20 +1511,22 @@ static void DelimToStringArray(const char *csl, StringArray &dst, const char *de
         }
         else
             dst.append(str.str());
+        if ((maxNumItems > 0) && (maxNumItems == dst.ordinality()))
+            break;
         if (!*e)
             break;
         s = e+1;
     }
 }
 
-void StringArray::appendList(const char *list, const char *delim, bool trimSpaces)
+void StringArray::appendList(const char *list, const char *delim, bool trimSpaces, unsigned maxNumItems)
 {
-    DelimToStringArray(list, *this, delim, false, trimSpaces);
+    DelimToStringArray(list, *this, delim, false, trimSpaces, maxNumItems);
 }
 
-void StringArray::appendListUniq(const char *list, const char *delim, bool trimSpaces)
+void StringArray::appendListUniq(const char *list, const char *delim, bool trimSpaces, unsigned maxNumItems)
 {
-    DelimToStringArray(list, *this, delim, true, trimSpaces);
+    DelimToStringArray(list, *this, delim, true, trimSpaces, maxNumItems);
 }
 
 StringBuffer &StringArray::getString(StringBuffer &ret, const char *delim)

--- a/system/jlib/jutil.hpp
+++ b/system/jlib/jutil.hpp
@@ -231,9 +231,9 @@ class jlib_decl StringArray : public ArrayOf<const char *, const char *, StringP
     typedef ArrayOf<const char *, const char *, StringPointerArrayMapper> PARENT;
 public:
     // Appends a list in a string delimited by 'delim'
-    void appendList(const char *list, const char *delim, bool trimSpaces = true);
+    void appendList(const char *list, const char *delim, bool trimSpaces = true, unsigned maxNumItems = 0);//maxNumItems = 0: no limit
     // Appends a list in a string delimited by 'delim' without duplicates
-    void appendListUniq(const char *list, const char *delim, bool trimSpaces = true);
+    void appendListUniq(const char *list, const char *delim, bool trimSpaces = true, unsigned maxNumItems = 0);
     StringBuffer &getString(StringBuffer &ret, const char *delim); // get CSV string of array contents
     void sortAscii(bool nocase=false);
     void sortAsciiReverse(bool nocase=false);


### PR DESCRIPTION
If thor master/slave is restarted before a WU is finished, the
"Finished wuid=..." will not be in thor log. The existing code
for retrieving WU thor log only uses the "Finished wuid=..." to
find out the end of the WU thor log. In this fix, we also check
the thor log restarting (by checking log ID) for the end of the
WU thor log.

Also adding code to retrieve WU thor logs using a thread pool
for a better performance.

Signed-off-by: wangkx <kevin.wang@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
