### PR TITLE
HPCC-20953 Add Connection close header for the last transaction

### DIFF
--- a/esp/bindings/http/platform/httpprot.hpp
+++ b/esp/bindings/http/platform/httpprot.hpp
@@ -48,6 +48,7 @@ private:
     bool m_is_ssl;
     ISecureSocketContext* m_ssctx;
     IPersistentHandler* m_persistentHandler = nullptr;
+    bool m_shouldClose = false;
 public:
     IMPLEMENT_IINTERFACE;
 
@@ -88,6 +89,7 @@ private:
     bool m_is_ssl;
     ISecureSocketContext* m_ssctx;
     IPersistentHandler* m_persistentHandler = nullptr;
+    bool m_shouldClose = false;
 public:
     CHttpThread(ISocket *sock, CEspApplicationPort* apport, bool viewConfig, bool isSSL = false, ISecureSocketContext* ssctx = NULL, IPersistentHandler* persistentHandler = NULL);
     
@@ -96,6 +98,8 @@ public:
 
     virtual void setMaxRequestEntityLength(int len) {m_MaxRequestEntityLength = len;}
     virtual int getMaxRequestEntityLength() { return m_MaxRequestEntityLength; }
+
+    void setShouldClose(bool should) {m_shouldClose = should;}
 };
 
 class esp_http_decl CHttpProtocol : public CEspProtocol
@@ -119,7 +123,7 @@ public:
 
     virtual void init(IPropertyTree * cfg, const char * process, const char * protocol);
 
-    virtual bool notifySelected(ISocket *sock,unsigned selected, IPersistentHandler* persistentHandler) override;
+    virtual bool notifySelected(ISocket *sock,unsigned selected, IPersistentHandler* persistentHandler, bool shouldClose) override;
 //IEspProtocol
     virtual const char * getProtocolName();
 };
@@ -138,7 +142,7 @@ public:
 
     virtual void init(IPropertyTree * cfg, const char * process, const char * protocol);
 
-    virtual bool notifySelected(ISocket *sock,unsigned selected, IPersistentHandler* persistentHandler) override;
+    virtual bool notifySelected(ISocket *sock,unsigned selected, IPersistentHandler* persistentHandler, bool shouldClose) override;
 //IEspProtocol
     virtual const char * getProtocolName();
 };

--- a/esp/bindings/http/platform/httpservice.cpp
+++ b/esp/bindings/http/platform/httpservice.cpp
@@ -179,8 +179,8 @@ void checkSetCORSAllowOrigin(CHttpRequest *req, CHttpResponse *resp)
 
 int CEspHttpServer::processRequest()
 {
-    m_request->setPersistentEnabled(m_apport->queryProtocol()->persistentEnabled());
-    m_response->setPersistentEnabled(m_apport->queryProtocol()->persistentEnabled());
+    m_request->setPersistentEnabled(m_apport->queryProtocol()->persistentEnabled() && !shouldClose);
+    m_response->setPersistentEnabled(m_apport->queryProtocol()->persistentEnabled() && !shouldClose);
     try
     {
         if (m_request->receive(NULL)==-1) // MORE - pass in IMultiException if we want to see exceptions (which are not fatal)

--- a/esp/bindings/http/platform/httpservice.hpp
+++ b/esp/bindings/http/platform/httpservice.hpp
@@ -68,6 +68,7 @@ interface IRemoteConnection;
 class CEspHttpServer : implements IHttpServerService, public CInterface
 {
     bool isSSL = false;
+    bool shouldClose = false;
     CriticalSection critDaliSession;
 protected:
     ISocket&                m_socket;
@@ -157,6 +158,7 @@ public:
     virtual const char * getServiceType() {return "HttpServer";};
     bool persistentEligible();
     void setIsSSL(bool _isSSL) { isSSL = _isSSL; };
+    void setShouldClose(bool should) { shouldClose = should; }
 };
 
 

--- a/esp/bindings/http/platform/httptransport.cpp
+++ b/esp/bindings/http/platform/httptransport.cpp
@@ -1817,6 +1817,9 @@ StringBuffer& CHttpRequest::constructHeaderBuffer(StringBuffer& headerbuf, bool 
     if(inclLength && m_content_length > 0)
         headerbuf.append("Content-Length: ").append(m_content_length).append("\r\n");
 
+    if (!m_persistentEnabled)
+        headerbuf.append("Connection: close\r\n");
+
     if(m_cookies.length() > 0)
     {
         headerbuf.append("Cookie: ");

--- a/esp/platform/espprotocol.cpp
+++ b/esp/platform/espprotocol.cpp
@@ -677,7 +677,7 @@ CEspProtocol::~CEspProtocol()
 
 bool CEspProtocol::notifySelected(ISocket *sock,unsigned selected)
 {
-    return notifySelected(sock, selected, nullptr);
+    return notifySelected(sock, selected, nullptr, false);
 }
 
 const char * CEspProtocol::getProtocolName()

--- a/esp/platform/espprotocol.hpp
+++ b/esp/platform/espprotocol.hpp
@@ -194,7 +194,7 @@ public:
     bool getViewConfig(){return m_viewConfig;}
 
     virtual bool notifySelected(ISocket *sock,unsigned selected);
-    virtual bool notifySelected(ISocket *sock,unsigned selected, IPersistentHandler* persistentHandler) override { return false; };
+    virtual bool notifySelected(ISocket *sock,unsigned selected, IPersistentHandler* persistentHandler, bool shouldClose) override { return false; };
 
     //IEspProtocol
     virtual const char * getProtocolName();

--- a/esp/platform/persistent.hpp
+++ b/esp/platform/persistent.hpp
@@ -31,14 +31,14 @@ interface IPersistentHandler : implements IInterface
     virtual void add(ISocket* sock, SocketEndpoint* ep = nullptr) = 0;
     virtual void remove(ISocket* sock) = 0;
     virtual void doneUsing(ISocket* sock, bool keep, unsigned usesOverOne = 0) = 0;
-    virtual Linked<ISocket> getAvailable(SocketEndpoint* ep = nullptr) = 0;
+    virtual Linked<ISocket> getAvailable(SocketEndpoint* ep = nullptr, bool* pShouldClose = nullptr) = 0;
     virtual void stop(bool wait) = 0;
     virtual bool inDoNotReuseList(SocketEndpoint* ep) = 0;
 };
 
 interface IPersistentSelectNotify
 {
-    virtual bool notifySelected(ISocket *sock,unsigned selected, IPersistentHandler* handler) = 0;
+    virtual bool notifySelected(ISocket *sock,unsigned selected, IPersistentHandler* handler, bool shouldClose) = 0;
 };
 
 IPersistentHandler* createPersistentHandler(IPersistentSelectNotify* notify, int maxIdleTime = DEFAULT_MAX_PERSISTENT_IDLE_TIME, int maxReqs = DEFAULT_MAX_PERSISTENT_REQUESTS, PersistentLogLevel loglevel=PersistentLogLevel::PLogMin, bool enableDoNotReuseList=false);


### PR DESCRIPTION
- Add variable "shouldClose" to persistent connection handler methods
  getAvailable and notifySelected to indicate that the current transaction
  is the last one for the connection.
- HTTP server includes "Connection: close" in the response to the client
  for the last transaction.
- HTTP client includes "Connection: close" in the request for the last
  transaction

Signed-off-by: mayx <yanrui.ma@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [x] All new and existing tests passed.
  - [x] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [x] Scalability
  - [x] Performance
  - [x] Security
  - [x] Thread-safety
  - [x] Premature optimization
  - [x] Existing deployed queries will not be broken
  - [x] This change fixes the problem, not just the symptom
  - [x] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [x] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
