### PR TITLE
HPCC-21626 Change fastlz routines, to consistenly use size32_t

### DIFF
--- a/system/jlib/jflz.cpp
+++ b/system/jlib/jflz.cpp
@@ -107,9 +107,9 @@ typedef unsigned short flzuint16;
 typedef unsigned int   flzuint32;
 
 /* prototypes */
-//int fastlz_compress(const void* input, int length, void* output);
-//int fastlz_compress_level(int level, const void* input, int length, void* output);
-//int fastlz_decompress(const void* input, int length, void* output, int maxout);
+//size32_t fastlz_compress(const void* input, size32_t length, void* output);
+//size32_t fastlz_compress_level(int level, const void* input, size32_t length, void* output);
+//size32_t fastlz_decompress(const void* input, size32_t length, void* output, size32_t maxout);
 
 #define MAX_COPY       32
 #define MAX_LEN       264  /* 256 + 8 */
@@ -136,8 +136,8 @@ typedef const flzuint8* HTAB_T[HASH_SIZE];
 #undef FASTLZ_DECOMPRESSOR
 #define FASTLZ_COMPRESSOR fastlz1_compress
 #define FASTLZ_DECOMPRESSOR fastlz1_decompress
-static FASTLZ_INLINE int FASTLZ_COMPRESSOR(const void* input, int length, void* output, HTAB_T &htab);
-static FASTLZ_INLINE int FASTLZ_DECOMPRESSOR(const void* input, int length, void* output, int maxout);
+static FASTLZ_INLINE size32_t FASTLZ_COMPRESSOR(const void* input, size32_t length, void* output, HTAB_T &htab);
+static FASTLZ_INLINE size32_t FASTLZ_DECOMPRESSOR(const void* input, size32_t length, void* output, size32_t maxout);
 #include "jflz.cpp"
 
 #undef FASTLZ_LEVEL
@@ -151,8 +151,8 @@ static FASTLZ_INLINE int FASTLZ_DECOMPRESSOR(const void* input, int length, void
 #undef FASTLZ_DECOMPRESSOR
 #define FASTLZ_COMPRESSOR fastlz2_compress
 #define FASTLZ_DECOMPRESSOR fastlz2_decompress
-static FASTLZ_INLINE int FASTLZ_COMPRESSOR(const void* input, int length, void* output, HTAB_T &htab);
-static FASTLZ_INLINE int FASTLZ_DECOMPRESSOR(const void* input, int length, void* output, int maxout);
+static FASTLZ_INLINE size32_t FASTLZ_COMPRESSOR(const void* input, size32_t length, void* output, HTAB_T &htab);
+static FASTLZ_INLINE size32_t FASTLZ_DECOMPRESSOR(const void* input, size32_t length, void* output, size32_t maxout);
 #include "jflz.cpp"
 
 #define FASTLZ__JLIBCOMPRESSOR 1
@@ -188,7 +188,7 @@ size32_t fastlz_decompress(const void* input, size32_t length, void* output, siz
   return 0;
 }
 
-int fastlz_compress_level(int level, const void* input, size32_t length, void* output)
+size32_t fastlz_compress_level(int level, const void* input, size32_t length, void* output)
 {
   MemoryAttr ma;
   HTAB_T *ht = (HTAB_T *)ma.allocate(sizeof(HTAB_T)); // HTAB_T too big for stack really
@@ -202,7 +202,7 @@ int fastlz_compress_level(int level, const void* input, size32_t length, void* o
 
 #else /* !defined(FASTLZ_COMPRESSOR) && !defined(FASTLZ_DECOMPRESSOR) */
 
-static FASTLZ_INLINE int FASTLZ_COMPRESSOR(const void* input, int length, void* output, HTAB_T &htab)
+static FASTLZ_INLINE size32_t FASTLZ_COMPRESSOR(const void* input, size32_t length, void* output, HTAB_T &htab)
 {
   const flzuint8* ip = (const flzuint8*) input;
   const flzuint8* ip_bound = ip + length - 2;
@@ -455,7 +455,7 @@ static FASTLZ_INLINE int FASTLZ_COMPRESSOR(const void* input, int length, void* 
   return op - (flzuint8*)output;
 }
 
-static FASTLZ_INLINE int FASTLZ_DECOMPRESSOR(const void* input, int length, void* output, int maxout)
+static FASTLZ_INLINE size32_t FASTLZ_DECOMPRESSOR(const void* input, size32_t length, void* output, size32_t maxout)
 {
   const flzuint8* ip = (const flzuint8*) input;
   const flzuint8* ip_limit  = ip + length;
@@ -636,7 +636,7 @@ class jlib_decl CFastLZCompressor : public CFcmpCompressor
         }
         size32_t *cmpsize = (size32_t *)(outbuf+outlen);
         byte *out = (byte *)(cmpsize+1);
-        *cmpsize = (size32_t)fastlz_compress(inbuf, (int)toflush, out, ht);
+        *cmpsize = fastlz_compress(inbuf, toflush, out, ht);
         if (*cmpsize<toflush)
         {
             *(size32_t *)outbuf += toflush;
@@ -706,7 +706,7 @@ void fastLZCompressToBuffer(MemoryBuffer & out, size32_t len, const void * src)
     out.append(len);
     DelayedMarker<size32_t> cmpSzMarker(out);
     void *cmpData = out.reserve(len+fastlzSlack(len));
-    size32_t sz = (len>16)?fastlz_compress(src, (int)len, cmpData):16;
+    size32_t sz = (len>16)?fastlz_compress(src, len, cmpData):16;
     if (sz>=len)
     {
         sz = len;


### PR DESCRIPTION
Without this change, these routines could be called with
values larger than 2^31 (e.g outlen) and fail.

Signed-off-by: Jake Smith <jake.smith@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
