### PR TITLE
HPCC-21647 Improve error messages when command to sasha fails

### DIFF
--- a/esp/services/ws_fs/ws_fsService.cpp
+++ b/esp/services/ws_fs/ws_fsService.cpp
@@ -780,9 +780,10 @@ bool CFileSprayEx::GetArchivedDFUWorkunits(IEspContext &context, IEspGetDFUWorku
 
     if (!cmd->send(sashaserver))
     {
-        StringBuffer msg;
-        msg.appendf("Cannot connect to archive server at %s",sashaAddress.str());
-        throw MakeStringException(ECLWATCH_CANNOT_CONNECT_ARCHIVE_SERVER, "%s", msg.str());
+        StringBuffer url;
+        throw MakeStringException(ECLWATCH_CANNOT_CONNECT_ARCHIVE_SERVER,
+            "Sasha (%s) took too long to respond from: Get archived workUnits.",
+            ep.getUrlStr(url).str());
     }
 
     IArrayOf<IEspDFUWorkunit> results;
@@ -1249,8 +1250,10 @@ void CFileSprayEx::getInfoFromSasha(IEspContext &context, const char *sashaServe
     Owned<INode> node = createINode(ep);
     if (!cmd->send(node,1*60*1000))
     {
-        DBGLOG("Cannot connect to Sasha server at %s",sashaServer);
-        throw MakeStringException(ECLWATCH_CANNOT_CONNECT_ARCHIVE_SERVER,"Cannot connect to archive server at %s.",sashaServer);
+        StringBuffer url;
+        throw MakeStringException(ECLWATCH_CANNOT_CONNECT_ARCHIVE_SERVER,
+            "Sasha (%s) took too long to respond from: Get information for %s.",
+            ep.getUrlStr(url).str(), wuid);
     }
     if (cmd->numIds()==0)
     {
@@ -1626,7 +1629,9 @@ bool CFileSprayEx::onDFUWorkunitsAction(IEspContext &context, IEspDFUWorkunitsAc
                 case CDFUWUActions_Restore:
                     cmd->addId(wuid);
                     if (!cmd->send(node,1*60*1000))
-                        throw MakeStringException(ECLWATCH_CANNOT_CONNECT_ARCHIVE_SERVER,"Cannot connect to archive server at %s.",sashaAddress.str());
+                        throw MakeStringException(ECLWATCH_CANNOT_CONNECT_ARCHIVE_SERVER,
+                            "Sasha (%s) took too long to respond from: Restore workunit %s.",
+                            sashaAddress.str(), wuid);
                     {
                         StringBuffer reply = "Restore ID: ";
                         if (!cmd->getId(0, reply))

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -153,7 +153,9 @@ bool doAction(IEspContext& context, StringArray& wuids, CECLWUActions action, IP
 
                     StringBuffer s;
                     if (!cmd->send(node, 1*60*1000))
-                        throw MakeStringException(ECLWATCH_CANNOT_CONNECT_ARCHIVE_SERVER,"Cannot connect to Archive server at %s.", ep.getUrlStr(s).str());
+                        throw MakeStringException(ECLWATCH_CANNOT_CONNECT_ARCHIVE_SERVER,
+                            "Sasha (%s) took too long to respond from: Restore workunit %s.",
+                            ep.getUrlStr(s).str(), wuid);
 
                     if (cmd->numIds()==0)
                         throw MakeStringException(ECLWATCH_CANNOT_UPDATE_WORKUNIT,"Could not Archive/restore %s",wuid);
@@ -1459,8 +1461,9 @@ bool getWsWuInfoFromSasha(IEspContext &context, SocketEndpoint &ep, const char* 
     if (!cmd->send(node, 1*60*1000))
     {
         StringBuffer url;
-        DBGLOG("Could not connect to Sasha server at %s", ep.getUrlStr(url).str());
-        throw MakeStringException(ECLWATCH_CANNOT_CONNECT_ARCHIVE_SERVER,"Cannot connect to archive server at %s.", url.str());
+        throw MakeStringException(ECLWATCH_CANNOT_CONNECT_ARCHIVE_SERVER,
+            "Sasha (%s) took too long to respond from: Get information for %s.",
+            ep.getUrlStr(url).str(), wuid);
     }
 
     if (cmd->numIds()==0)
@@ -2416,9 +2419,10 @@ public:
             setSashaCommandLW(reqLW, cmd);
         if (!cmd->send(sashaserver))
         {
-            StringBuffer msg("Cannot connect to archive server at ");
-            sashaserver->endpoint().getUrlStr(msg);
-            throw MakeStringException(ECLWATCH_CANNOT_CONNECT_ARCHIVE_SERVER, "%s", msg.str());
+            StringBuffer url;
+            throw MakeStringException(ECLWATCH_CANNOT_CONNECT_ARCHIVE_SERVER,
+                "Sasha (%s) took too long to respond from: Get archived workUnits.",
+                ep.getUrlStr(url).str());
         }
 
         numberOfWUsReturned = cmd->numIds();
@@ -3103,7 +3107,9 @@ IPropertyTree *getArchivedWorkUnitProperties(const char *wuid, bool dfuWU)
     if (dfuWU)
         cmd->setDFU(true);
     if (!cmd->send(node, 1*60*1000))
-        throw MakeStringException(ECLWATCH_CANNOT_CONNECT_ARCHIVE_SERVER,"Cannot connect to Archive server at %s.", ep.getUrlStr(tmp).str());
+        throw MakeStringException(ECLWATCH_CANNOT_CONNECT_ARCHIVE_SERVER,
+            "Sasha (%s) took too long to respond from: Get workUnit properties for %s.",
+            ep.getUrlStr(tmp).str(), wuid);
 
     if ((cmd->numIds() < 1) || (cmd->numResults() < 1))
         return nullptr;


### PR DESCRIPTION
Signed-off-by: wangkx <kevin.wang@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
