### PR TITLE
HPCC-21784 Add option to ForeignLogicalFileName to suppress cluster prefix

### DIFF
--- a/docs/EN_US/ECLStandardLibraryReference/SLR-Mods/ForeignLogicalFileName.xml
+++ b/docs/EN_US/ECLStandardLibraryReference/SLR-Mods/ForeignLogicalFileName.xml
@@ -13,6 +13,7 @@
     </indexterm>(</emphasis> <emphasis>filename </emphasis> <emphasis
   role="bold">[,</emphasis> <emphasis>foreigndali </emphasis> <emphasis
   role="bold">] [,</emphasis> <emphasis>absolutepath</emphasis> <emphasis
+  role="bold">] [,</emphasis> <emphasis>omitClusterPrefix</emphasis> <emphasis
   role="bold">] )</emphasis></para>
 
   <informaltable colsep="1" frame="all" rowsep="1">
@@ -44,6 +45,14 @@
           <entry>Optional. A boolean TRUE/FALSE to indicate whether to prepend
           a tilde (~) to the resulting foreign logical file name. If omitted,
           the default is FALSE.</entry>
+        </row>
+
+        <row>
+          <entry><emphasis>omitClusterPreifx</emphasis></entry>
+
+          <entry>Optional. A boolean TRUE/FALSE to indicate whether the target
+          cluster's prefix should automatically be added if 'filename' is a
+          relative logical file name. If omitted, the default is FALSE.</entry>
         </row>
 
         <row>

--- a/ecllibrary/std/File.ecl
+++ b/ecllibrary/std/File.ecl
@@ -149,8 +149,8 @@ EXPORT RenameLogicalFile(varstring oldname, varstring newname, boolean allowOver
  * @param abspath       Should a tilde (~) be prepended to the resulting logical file name.  Defaults to FALSE.
  */
 
-EXPORT varstring ForeignLogicalFileName(varstring name, varstring foreigndali='', boolean abspath=FALSE) :=
-    lib_fileservices.FileServices.ForeignLogicalFileName(name, foreigndali, abspath);
+EXPORT varstring ForeignLogicalFileName(varstring name, varstring foreigndali='', boolean abspath=FALSE, boolean omitClusterPrefix=FALSE) :=
+    lib_fileservices.FileServices.ForeignLogicalFileName(name, foreigndali, abspath, omitClusterPrefix);
 
 /**
  * Returns an encoded logical filename that can be used to refer to a external file.  Examples include directly

--- a/plugins/fileservices/fileservices.hpp
+++ b/plugins/fileservices/fileservices.hpp
@@ -82,6 +82,7 @@ FILESERVICES_API void FILESERVICES_CALL fsSwapSuperFile(IGlobalCodeContext *ctx,
 FILESERVICES_API void FILESERVICES_CALL fsReplaceSuperFile(IGlobalCodeContext *ctx, const char *lsuperfn,const char *lfn,const char *bylfn);
 FILESERVICES_API void FILESERVICES_CALL fsFinishSuperFileTransaction(IGlobalCodeContext *ctx, bool rollback=false);
 FILESERVICES_API char *  FILESERVICES_CALL fsForeignLogicalFileName(ICodeContext *ctx, const char *_lfn,const char *foreigndali,bool abspath);
+FILESERVICES_API char *  FILESERVICES_CALL fsForeignLogicalFileName_v2(ICodeContext *ctx, const char *_lfn,const char *foreigndali,bool abspath,bool omitClusterPrefix);
 FILESERVICES_API char *  FILESERVICES_CALL fsWaitDfuWorkunit(IGlobalCodeContext *ctx, const char *wuid, int timeout, const char * espServerIpPort);
 FILESERVICES_API void FILESERVICES_CALL fsAbortDfuWorkunit(IGlobalCodeContext *ctx, const char *wuid, const char * espServerIpPort);
 FILESERVICES_API void  FILESERVICES_CALL fsMonitorLogicalFileName(ICodeContext *ctx, const char *eventname, const char *_lfn,int shotcount, const char * espServerIpPort);

--- a/testing/regress/ecl/fileservice.ecl
+++ b/testing/regress/ecl/fileservice.ecl
@@ -16,6 +16,7 @@
 ############################################################################## */
 
 import Std.File;
+import Std.Str;
 import $.setup;
 prefix := setup.Files(false, false).QueryFilePrefix;
 
@@ -33,6 +34,11 @@ string compareDatasets(dataset(rec) ds1, dataset(rec) ds2) := FUNCTION
    RETURN if(result, 'Pass', 'Fail');
 END;
 
+RemovePrefix(string lfn, unsigned scopes) := FUNCTION
+  unsigned4 postPrefixPos := Str.Find(lfn, '::', scopes);
+  unsigned4 postScopePos := IF(postPrefixPos=0, 1, postPrefixPos+2); // ensures valid if mismatch
+  return lfn[postScopePos..];
+END;
 
 SEQUENTIAL(
   OUTPUT(ds, , prefix + 'renametest.d00', OVERWRITE),
@@ -47,4 +53,8 @@ SEQUENTIAL(
   File.RenameLogicalFile(prefix + 'renametest.d00', prefix + 'afterrename1.d00', true),
   output(compareDatasets(ds, ds2)),
   File.DeleteLogicalFile(prefix + 'afterrename1.d00'),
+  RemovePrefix(File.ForeignLogicalFileName('somescope::somefilename', '192.168.168.168', true), 3);
+  RemovePrefix(File.ForeignLogicalFileName('somescope::somefilename', '192.168.168.168', false), 3);
+  RemovePrefix(File.ForeignLogicalFileName('somescope::somefilename', '192.168.168.168', true, true), 2);
+  RemovePrefix(File.ForeignLogicalFileName('somescope::somefilename', '192.168.168.168', false, true), 2);
 );

--- a/testing/regress/ecl/key/fileservice.xml
+++ b/testing/regress/ecl/key/fileservice.xml
@@ -14,3 +14,15 @@
 <Dataset name='Result 5'>
  <Row><Result_5>Pass</Result_5></Row>
 </Dataset>
+<Dataset name='Result 6'>
+ <Row><Result_6>somescope::somefilename</Result_6></Row>
+</Dataset>
+<Dataset name='Result 7'>
+ <Row><Result_7>somescope::somefilename</Result_7></Row>
+</Dataset>
+<Dataset name='Result 8'>
+ <Row><Result_8>somescope::somefilename</Result_8></Row>
+</Dataset>
+<Dataset name='Result 9'>
+ <Row><Result_9>somescope::somefilename</Result_9></Row>
+</Dataset>


### PR DESCRIPTION
…refix

Signed-off-by: Jake Smith <jake.smith@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
