### PR TITLE
HPCC-21416 Use the standard library from the remote eclccserver

### DIFF
--- a/ecl/eclcc/eclcc.cpp
+++ b/ecl/eclcc/eclcc.cpp
@@ -1553,7 +1553,10 @@ void EclCC::processXmlFile(EclCompileInstance & instance, const char *archiveXML
     //Items first in the list have priority -Dxxx=y overrides all
     processDefinitions(repositories);
     repositories.append(*LINK(pluginsRepository));
-    if (archiveTree->getPropBool("@useLocalSystemLibraries", false)) // Primarily for testing.
+
+    //Default to using the local system libraries so that updates are kept in sync with the plugins
+    bool useLocalSystemLibraries = archiveTree->getPropBool("@useLocalSystemLibraries", true);
+    if (useLocalSystemLibraries)
         repositories.append(*LINK(libraryRepository));
 
     Owned<IFileContents> contents;

--- a/ecl/regress/ecllib.eclxml
+++ b/ecl/regress/ecllib.eclxml
@@ -1,0 +1,54 @@
+<Archive build="internal_7.2.1-closedown0"
+         eclVersion="7.2.1"
+         legacyImport="0"
+         legacyWhen="0">
+ <Query attributePath="_local_directory_.temp"/>
+ <Module key="_local_directory_" name="_local_directory_">
+  <Attribute key="temp"
+             name="temp"
+             sourcePath="/home/gavin/dev/hpcc/ecl/regress/temp.ecl"
+             ts="1553856593000000">
+   &#32;import Std.Str;
+
+output(Str.toUpperCase(&apos;zz&apos;));&#10;
+  </Attribute>
+ </Module>
+ <Module key="std" name="std">
+  <Attribute key="str"
+             name="Str"
+             sourcePath="/home/gavin/dev/hpcc/ecllibrary/std/Str.ecl"
+             ts="1545228834000000">
+EXPORT Str := MODULE
+
+
+/*
+  Since this is primarily a wrapper for a plugin, all the definitions for this standard library
+  module are included in a single file.  Generally I would expect them in individual files.
+  */
+
+IMPORT lib_stringlib;
+
+/**
+ * Return the argument string with all lower case characters converted to upper case.
+ *
+ * @param src           The string that is being converted.
+ */
+
+EXPORT STRING ToUpperCase(STRING src, unsigned newFromParam = 0, unsigned newToParam = -1) := lib_stringlib.StringLib.StringToUpperCase(src, newFromParam, unsigned newToParam);
+
+END;&#10;
+  </Attribute>
+ </Module>
+ <Module flags="5"
+         fullname="/home/gavin/buildr/RelWithDebInfo/libs/libstringlib.so"
+         key="lib_stringlib"
+         name="lib_stringlib"
+         plugin="libstringlib.so"
+         sourcePath="lib_stringlib"
+         ts="1553256631000000"
+         version="STRINGLIB 1.1.14">
+  <Text>export StringLib := SERVICE:fold
+  string StringToUpperCase(const string src) : c,pure,entrypoint=&apos;slStringToUpperCase&apos;;
+END;</Text>
+ </Module>
+</Archive>


### PR DESCRIPTION
Because the ecl standard library is versioned with the platform, the version
of the standard library on the server should be used, rather than the
version in the archive.

Signed-off-by: Gavin Halliday <gavin.halliday@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [ ] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
