### PR TITLE
HPCC-21850 Fix a couple of potential issues coercing dataset types

### DIFF
--- a/ecl/hql/hqlgram.hpp
+++ b/ecl/hql/hqlgram.hpp
@@ -722,8 +722,8 @@ public:
     void checkRecordTypesMatch(IHqlExpression *ds1, IHqlExpression *ds2, const attribute & errpos);
     int checkRecordTypesSimilar(IHqlExpression *left, IHqlExpression *right, const ECLlocation & errPos, unsigned maxFields = (unsigned)-1);
     bool checkRecordCreateTransform(HqlExprArray & assigns, IHqlExpression *leftExpr, IHqlExpression *leftSelect, IHqlExpression *rightExpr, IHqlExpression *rightSelect, const ECLlocation & errPos);
-    IHqlExpression * checkEnsureRecordsMatch(IHqlExpression * left, IHqlExpression * right, const ECLlocation & errPos, bool rightIsRow);
-    void ensureMapToRecordsMatch(OwnedHqlExpr & recordExpr, HqlExprArray & args, const attribute & errpos, bool isRow);
+    IHqlExpression * checkEnsureRecordsMatch(IHqlExpression * left, IHqlExpression * right, const ECLlocation & errPos, type_t rightType);
+    void ensureMapToRecordsMatch(OwnedHqlExpr & recordExpr, HqlExprArray & args, const attribute & errpos, type_t rightType);
     void checkRecordIsValid(const attribute &atr, IHqlExpression *record);
     void checkValidRecordMode(IHqlExpression * dataset, attribute & atr, attribute & modeatr);
     void checkValidCsvRecord(const attribute & errpos, IHqlExpression * record);

--- a/ecl/hql/hqlgram.y
+++ b/ecl/hql/hqlgram.y
@@ -7450,7 +7450,7 @@ dataSetOrRowList
                         {
                             OwnedHqlExpr lhs = $1.getExpr();
                             OwnedHqlExpr rhs = $3.getExpr();
-                            OwnedHqlExpr normRhs = parser->checkEnsureRecordsMatch(lhs, rhs, $2.pos, rhs->isDatarow());
+                            OwnedHqlExpr normRhs = parser->checkEnsureRecordsMatch(lhs, rhs, $2.pos, rhs->queryType()->getTypeCode());
                             $$.setExpr(createComma(lhs.getClear(), normRhs.getClear()), $1);
                         }
     ;
@@ -7776,7 +7776,7 @@ simpleDataRow
                             OwnedHqlExpr elseExpr = $5.getExpr();
                             $3.unwindCommaList(args);
 
-                            parser->ensureMapToRecordsMatch(elseExpr, args, $5, true);
+                            parser->ensureMapToRecordsMatch(elseExpr, args, $5, type_row);
 
                             args.append(*elseExpr.getClear());
                             OwnedHqlExpr expr = createRow(no_map, args);
@@ -7790,7 +7790,7 @@ simpleDataRow
                             parser->endList(args);
                             parser->checkCaseForDuplicates(args, $6);
 
-                            parser->ensureMapToRecordsMatch(elseExpr, args, $8, true);
+                            parser->ensureMapToRecordsMatch(elseExpr, args, $8, type_row);
 
                             args.add(*$3.getExpr(),0);
                             args.append(*elseExpr.getClear());
@@ -9398,7 +9398,7 @@ simpleDataSet
                             HqlExprArray args;
                             OwnedHqlExpr elseExpr = $5.getExpr();
                             $3.unwindCommaList(args);
-                            parser->ensureMapToRecordsMatch(elseExpr, args, $5, false);
+                            parser->ensureMapToRecordsMatch(elseExpr, args, $5, type_table);
                             args.append(*elseExpr.getClear());
                             OwnedHqlExpr expr = createDataset(no_map, args);
                             $$.setExpr(foldConstantMapExpr(expr), $1);
@@ -9413,7 +9413,7 @@ simpleDataSet
                             else
                                 elseExpr.setown(createDataset(no_null, LINK(queryNullRecord())));
 
-                            parser->ensureMapToRecordsMatch(elseExpr, args, $3, false);
+                            parser->ensureMapToRecordsMatch(elseExpr, args, $3, type_table);
                             args.append(*elseExpr.getClear());
                             OwnedHqlExpr expr = createDataset(no_map, args);
                             $$.setExpr(foldConstantMapExpr(expr), $1);
@@ -9426,7 +9426,7 @@ simpleDataSet
                             parser->endList(args);
                             parser->checkCaseForDuplicates(args, $6);
 
-                            parser->ensureMapToRecordsMatch(elseExpr, args, $8, false);
+                            parser->ensureMapToRecordsMatch(elseExpr, args, $8, type_table);
 
                             args.add(*$3.getExpr(),0);
                             args.append(*elseExpr.getClear());
@@ -9445,7 +9445,7 @@ simpleDataSet
                                 elseDs.setown(createDataset(no_null, LINK(queryNullRecord())));
                             parser->checkCaseForDuplicates(args, $6);
 
-                            parser->ensureMapToRecordsMatch(elseDs, args, $6, false);
+                            parser->ensureMapToRecordsMatch(elseDs, args, $6, type_table);
 
                             args.add(*$3.getExpr(),0);
                             args.append(*elseDs.getClear());
@@ -9482,7 +9482,7 @@ simpleDataSet
                                     {
                                         if (parser->lookupCtx.queryParseContext().expandCallsWhenBound && (isGrouped(cur) != isGrouped(compareDs)))
                                             parser->reportError(ERR_GROUPING_MISMATCH, $1, "Branches of the condition have different grouping");
-                                        OwnedHqlExpr mapped = parser->checkEnsureRecordsMatch(compareDs, cur, $5.pos, false);
+                                        OwnedHqlExpr mapped = parser->checkEnsureRecordsMatch(compareDs, cur, $5.pos, type_table);
                                         if (mapped != cur)
                                             args.replace(*mapped.getClear(), idx);
                                     }


### PR DESCRIPTION
Signed-off-by: Gavin Halliday <gavin.halliday@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
