### PR TITLE
HPCC-21758 Make StringBuffer constructors explicit

### DIFF
--- a/common/environment/environment.cpp
+++ b/common/environment/environment.cpp
@@ -2318,7 +2318,7 @@ extern ENVIRONMENT_API void closeEnvironment()
 
 extern ENVIRONMENT_API unsigned long readSizeSetting(const char * sizeStr, const unsigned long defaultSize)
 {
-    StringBuffer buf = sizeStr;
+    StringBuffer buf(sizeStr);
     buf.trim();
 
     if (buf.isEmpty())

--- a/common/remote/rmtssh.cpp
+++ b/common/remote/rmtssh.cpp
@@ -64,7 +64,7 @@ class CFRunSSH: public CInterface, implements IFRunSSH
 
 
 
-    StringBuffer expandCmd(StringBuffer &cmdbuf, unsigned nodenum, unsigned treefrom)
+    StringBuffer &expandCmd(StringBuffer &cmdbuf, unsigned nodenum, unsigned treefrom)
     {
         const char *cp=cmd.get();
         if (!cp)

--- a/common/roxiecommlib/roxiecommunicationclient.cpp
+++ b/common/roxiecommlib/roxiecommunicationclient.cpp
@@ -59,9 +59,9 @@ protected:
     SocketEndpoint ep;
     unsigned roxieTimeout;
 
-    IPropertyTree *sendRoxieControlQuery(const StringBuffer &xml, bool deployAll, const char *remoteRoxieIP = NULL)
+    IPropertyTree *sendRoxieControlQuery(const char *xml, bool deployAll, const char *remoteRoxieIP = NULL)
     {
-        unsigned len = xml.length();
+        unsigned len = strlen(xml);
         size32_t sendlen = len;
         _WINREV(sendlen);
         Owned<ISocket> sock = getRoxieSocket(remoteRoxieIP);
@@ -70,7 +70,7 @@ protected:
                 throw MakeStringException(GET_LOCK_FAILURE, "Request Failed! All roxie nodes unable to process this request at this time.  Roxie is busy - possibly in the middle of another deployment.  Try again later, if problem persists, make sure all nodes are running");
 
         sock->write(&sendlen, sizeof(sendlen));
-        sock->write(xml.str(), len);
+        sock->write(xml, len);
         StringBuffer response;
         for (;;)
         {
@@ -98,9 +98,9 @@ protected:
     }
 
 
-    const char *sendRoxieOnDemandQuery(const StringBuffer &xml, SCMStringBuffer &response, bool deployAll, const char *remoteRoxieIP = NULL)
+    const char *sendRoxieOnDemandQuery(const char *xml, SCMStringBuffer &response, bool deployAll, const char *remoteRoxieIP = NULL)
     {
-        unsigned len = xml.length();
+        unsigned len = strlen(xml);
         size32_t sendlen = len;
         _WINREV(sendlen);
         Owned<ISocket> sock = getRoxieSocket(remoteRoxieIP);
@@ -109,7 +109,7 @@ protected:
                 throw MakeStringException(GET_LOCK_FAILURE, "Request Failed! All roxie nodes unable to process this request at this time.  Roxie is busy - possibly in the middle of another deployment.  Try again later, if problem persists, make sure all nodes are running");
 
         sock->write(&sendlen, sizeof(sendlen));
-        sock->write(xml.str(), len);
+        sock->write(xml, len);
 
         Owned<IException> exception;
         for (;;)

--- a/common/thorhelper/thorcommon.hpp
+++ b/common/thorhelper/thorcommon.hpp
@@ -102,14 +102,14 @@ inline bool TestRwFlag(unsigned flags, RowReaderWriterFlags flag) { return 0 != 
 
 #define COMP_MASK (rw_compress|rw_compressblkcrc|rw_fastlz|rw_lzw|rw_lz4)
 #define COMP_TYPE_MASK (rw_fastlz|rw_lzw|rw_lz4)
-inline void setCompFlag(const StringBuffer compStr, unsigned &flags)
+inline void setCompFlag(const char *compStr, unsigned &flags)
 {
     flags &= ~COMP_TYPE_MASK;
-    if (compStr.length())
+    if (!isEmptyString(compStr))
     {
-        if (0 == stricmp("FLZ", compStr.str()))
+        if (0 == stricmp("FLZ", compStr))
             flags |= rw_fastlz;
-        else if (0 == stricmp("LZ4", compStr.str()))
+        else if (0 == stricmp("LZ4", compStr))
             flags |= rw_lz4;
         else // not specifically FLZ or LZ4 so set to LZW (or rowdif)
             flags |= rw_lzw;
@@ -130,14 +130,14 @@ inline unsigned getCompMethod(unsigned flags)
     return compMethod;
 }
 
-inline unsigned getCompMethod(const StringBuffer compStr)
+inline unsigned getCompMethod(const char *compStr)
 {
     unsigned compMethod = COMPRESS_METHOD_LZW;
-    if (compStr.length())
+    if (!isEmptyString(compStr))
     {
-        if (0 == stricmp("FLZ", compStr.str()))
+        if (0 == stricmp("FLZ", compStr))
             compMethod = COMPRESS_METHOD_FASTLZ;
-        else if (0 == stricmp("LZ4", compStr.str()))
+        else if (0 == stricmp("LZ4", compStr))
             compMethod = COMPRESS_METHOD_LZ4;
     }
     else // default is LZ4

--- a/common/thorhelper/thorsoapcall.cpp
+++ b/common/thorhelper/thorsoapcall.cpp
@@ -611,7 +611,7 @@ interface IWSCAsyncFor: public IInterface
     virtual int readHttpResponse(StringBuffer &response, ISocket *socket) = 0;
     virtual void processResponse(Url &url, StringBuffer &response, ColumnProvider * meta) = 0;
 
-    virtual StringBuffer getResponsePath() = 0;
+    virtual const char *getResponsePath() = 0;
     virtual ConstPointerArray & getInputRows() = 0;
     virtual IWSCHelper * getMaster() = 0;
     virtual IEngineRowAllocator * getOutputAllocator() = 0;
@@ -1559,7 +1559,7 @@ private:
             if (master->httpHeaders.isEmpty() && master->httpHeaderName.get() && master->httpHeaderValue.get())
             {
                 //backward compatibility
-                StringBuffer hdr = master->httpHeaderName.get();
+                StringBuffer hdr(master->httpHeaderName.get());
                 hdr.append(": ").append(master->httpHeaderValue);
                 if (soapTraceLevel > 6 || master->logXML)
                     master->logctx.CTXLOG("SOAPCALL: Adding HTTP Header(%s)", hdr.str());
@@ -2110,7 +2110,7 @@ public:
             }
         }
     }
-    inline virtual StringBuffer getResponsePath() { return responsePath; }
+    inline virtual const char *getResponsePath() { return responsePath; }
     inline virtual ConstPointerArray & getInputRows() { return inputRows; }
     inline virtual CWSCHelper * getMaster() { return master; }
     inline virtual IEngineRowAllocator * getOutputAllocator() { return outputAllocator; }

--- a/common/workunit/pkgimpl.hpp
+++ b/common/workunit/pkgimpl.hpp
@@ -83,7 +83,7 @@ protected:
 
     virtual IPropertyTreeIterator *lookupElements(const char *xpath1, const char *xpath2) const = 0;
 
-    inline StringBuffer makeSuperFileXPath(StringBuffer &xpath, const char *superFileName) const
+    inline StringBuffer &makeSuperFileXPath(StringBuffer &xpath, const char *superFileName) const
     {
         superFileName = skipForeign(superFileName);
         return xpath.append("SuperFile[@id='").appendLower(strlen(superFileName), superFileName).append("']");

--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -5440,7 +5440,7 @@ public:
                     const StringArray& values = orFilter->queryValues();
                     ForEachItemIn(i, values)
                     {
-                        StringBuffer path = xPath.get();
+                        StringBuffer path(xPath.get());
                         const char* value = values.item(i);
                         if (!isEmptyString(value))
                         {
@@ -7221,7 +7221,7 @@ public:
             getRoxieProcessServers(roxie, roxieServers);
             clusterWidth = roxieServers.length();
             ldapUser.set(roxie->queryProp("@ldapUser"));
-            StringBuffer encPassword = roxie->queryProp("@ldapPassword");
+            StringBuffer encPassword (roxie->queryProp("@ldapPassword"));
             if (encPassword.length())
                 decrypt(ldapPassword, encPassword);
             const char *redundancyMode = roxie->queryProp("@slaveConfig");
@@ -7385,7 +7385,7 @@ extern WORKUNIT_API void getDFUServerQueueNames(StringArray &ret, const char *pr
     Owned<IEnvironmentFactory> factory = getEnvironmentFactory(true);
     Owned<IConstEnvironment> env = factory->openEnvironment();
 
-    StringBuffer xpath = "Software/DfuServerProcess";
+    StringBuffer xpath ("Software/DfuServerProcess");
     if (!isEmptyString(process))
         xpath.appendf("[@name=\"%s\"]", process);
 
@@ -9296,7 +9296,7 @@ bool CLocalWorkUnit::getFieldUsageArray(StringArray & filenames, StringArray & c
     {    
         Owned<IConstWUFileUsage> file = files->get();
 
-        StringBuffer filename = file->queryName();
+        StringBuffer filename(file->queryName());
         size32_t length = filename.length();
         
         if (length == 0)

--- a/dali/daliadmin/daliadmin.cpp
+++ b/dali/daliadmin/daliadmin.cpp
@@ -3031,7 +3031,7 @@ static void migrateFiles(const char *srcGroup, const char *tgtGroup, const char 
             try
             {
                 bool doCommit = false;
-                StringBuffer _tgtClusterGroupText = tgtClusterGroupText;
+                StringBuffer _tgtClusterGroupText(tgtClusterGroupText);
 
                 Owned<IFileDescriptor> fileDesc = deserializeFileDescriptorTree(&root, &queryNamedGroupStore());
                 unsigned numClusters = fileDesc->numClusters();

--- a/dali/dfu/dfurunkdp.cpp
+++ b/dali/dfu/dfurunkdp.cpp
@@ -30,23 +30,6 @@
 
 #define FULL_TRACE
 
-static StringBuffer appendb32(StringBuffer &out,unsigned v)
-{
-    if (out.length())
-        out.append('_');
-    while (v) {
-        byte b = (byte)(v%32);
-        v /= 32;
-        if (b<26)
-            out.append((char)(b+'a'));
-        else
-            out.append((char)(b-26+'0'));
-    }
-    return out;
-}
-
-
-
 class CDKDPitem : public CInterface
 {
     SocketEndpoint ep;

--- a/dali/sasha/saarch.cpp
+++ b/dali/sasha/saarch.cpp
@@ -283,7 +283,7 @@ void WUiterate(ISashaCommand *cmd, const char *mask)
                 cmd->addId(wuid);
             else
             {
-                StringBuffer output = wuTree->queryName();
+                StringBuffer output(wuTree->queryName());
                 //Append more into the output.
                 setWUDataTree(wuTree, output);
                 cmd->addId(output.str());

--- a/deployment/configenv/xml_jlibpt/ComponentFromXSD.cpp
+++ b/deployment/configenv/xml_jlibpt/ComponentFromXSD.cpp
@@ -51,7 +51,7 @@ ComponentFromXSD::~ComponentFromXSD()
 }
 
 void ComponentFromXSD::CreateAttributeFromSchema(IPropertyTree& attr,
-     StringBuffer compName, const char* childElementName)
+     const char *compName, const char* childElementName)
 {
   StringBuffer attrname;
   StringBuffer strBuf;
@@ -128,7 +128,7 @@ void ComponentFromXSD::CreateAttributeFromSchema(IPropertyTree& attr,
 }
 
 void ComponentFromXSD::AddAttributeFromSchema(IPropertyTree& schemaNode,
-       StringBuffer elemName, StringBuffer& compName, const char* childElementName)
+       const char *elemName, StringBuffer& compName, const char* childElementName)
 {
   CreateAttributeFromSchema(schemaNode, compName,  childElementName);
 }
@@ -422,7 +422,7 @@ void ComponentFromXSD::setCompTree(const char* buildSetName, IPropertyTree* pTre
 }
 
 void ComponentFromXSD::getValueForTypeInXSD(IPropertyTree& attr,
-       StringBuffer compName, StringBuffer& wizDefVal)
+       const char *compName, StringBuffer& wizDefVal)
 {
   StringBuffer tempPath;
   const char* type = attr.queryProp("@type");
@@ -449,7 +449,7 @@ void ComponentFromXSD::getValueForTypeInXSD(IPropertyTree& attr,
     }
     else if (!strcmp(attr.queryProp(tempPath.str()), "$processname"))
     {
-      tempPath.clear().appendf("Software/%s[1]/@name",compName.str());
+      tempPath.clear().appendf("Software/%s[1]/@name",compName);
       wizDefVal.clear().append(m_pEnv->queryProp(tempPath.str()));
     }
     else if(!strcmp(attr.queryProp(tempPath.str()), "$hthorcluster"))
@@ -473,7 +473,7 @@ void ComponentFromXSD::getValueForTypeInXSD(IPropertyTree& attr,
     else
     {
       wizDefVal.clear().append(attr.queryProp(tempPath.str()));
-      tempPath.clear().appendf("Software/%s[1]/@buildSet", compName.str());
+      tempPath.clear().appendf("Software/%s[1]/@buildSet", compName);
       if (m_pEnv->queryProp(tempPath.str()))
       {
         SWProcess * swp = (SWProcess *)m_eh->getEnvSWComp(m_buildSetName.str());

--- a/deployment/configenv/xml_jlibpt/ComponentFromXSD.hpp
+++ b/deployment/configenv/xml_jlibpt/ComponentFromXSD.hpp
@@ -37,9 +37,9 @@ class ComponentFromXSD
    ~ComponentFromXSD();
 
   void CreateAttributeFromSchema(IPropertyTree& attr,
-         StringBuffer compName, const char* childElementName);
+         const char * compName, const char* childElementName);
   void AddAttributeFromSchema(IPropertyTree& schemaNode,
-         StringBuffer elemName, StringBuffer& compName, const char* childElementName);
+         const char *elemName, StringBuffer& compName, const char* childElementName);
   void AddAttributesFromSchema(IPropertyTree* pSchema,
          StringBuffer& compName, const char* childElementName);
   void ProcessElementSchemaNode(IPropertyTree* pElement,
@@ -50,7 +50,7 @@ class ComponentFromXSD
   void setCompTree(const char* buildSetName,  IPropertyTree* pTree, IPropertyTree* schemaTree, bool allSubTypes);
   void setWizardFlag(bool flag) { m_wizFlag = flag; }
   void setGenerateOptional(bool flag) { m_genOptional = flag; }
-  void getValueForTypeInXSD(IPropertyTree& attr, StringBuffer compName, StringBuffer& wizDefVal);
+  void getValueForTypeInXSD(IPropertyTree& attr, const char *compName, StringBuffer& wizDefVal);
 
 private:
 

--- a/deployment/configenv/xml_jlibpt/ConfigEnv.cpp
+++ b/deployment/configenv/xml_jlibpt/ConfigEnv.cpp
@@ -71,7 +71,7 @@ void ConfigEnv::create(IPropertyTree *params)
      int roxieNodes=1, thorNodes=1, slavesPerNode=1, supportNodes=1,
          espNodes=1, thorChannelsPerSlave=1, roxieChannelsPerSlave=1;
      bool roxieOnDemand = true;
-     MapStringTo<StringBuffer> dirMap;
+     MapStringTo<StringAttr, const char *> dirMap;
      Owned<IPropertyTree> pCfg = createPTreeFromXMLFile(ESP_CONFIG_PATH);
      StringArray arrAssignIPRanges;
      StringArray arrBuildSetWithAssignedIPs;

--- a/deployment/configenv/xml_jlibpt/SWComponentBase.cpp
+++ b/deployment/configenv/xml_jlibpt/SWComponentBase.cpp
@@ -67,7 +67,7 @@ IPropertyTree * SWComponentBase::addComponent(IPropertyTree *params)
 
   IPropertyTree * envTree = m_envHelper->getEnvTree();
 
-  StringBuffer deployable  = m_pBuildSet->queryProp("@" TAG_DEPLOYABLE);
+  const char *deployable  = m_pBuildSet->queryProp("@" TAG_DEPLOYABLE);
 
   IPropertyTree * pt = NULL;
 

--- a/deployment/configgen/main.cpp
+++ b/deployment/configgen/main.cpp
@@ -390,7 +390,7 @@ int processRequest(const char* in_cfgname, const char* out_dirname, const char* 
   {
     //first, build a map of all ldapServer/IP
     StringBuffer sb1,sb2;
-    typedef MapStringTo<StringBuffer> strMap;
+    typedef MapStringTo<StringAttr, const char *> strMap;
     strMap ldapServers;
     {
       xPath.appendf("Software/%s/", XML_TAG_LDAPSERVERPROCESS);
@@ -430,7 +430,7 @@ int processRequest(const char* in_cfgname, const char* out_dirname, const char* 
         //If this is ldap server name, lookup and add its IP address
         if (0==strcmp(attrs->queryName(), "@name"))
         {
-          StringBuffer * ldapIP = ldapServers.getValue(attrs->queryValue());
+          StringAttr * ldapIP = ldapServers.getValue(attrs->queryValue());
           if (ldapIP)
           {
             out.appendf("@ldapAddress,%s\n",ldapIP->str());

--- a/deployment/deploy/DeployTask.cpp
+++ b/deployment/deploy/DeployTask.cpp
@@ -1938,12 +1938,12 @@ public:
    virtual IDeploymentCallback& getCallback() const { return *m_pCallback; }
 
 private:
-  char* getMD5Checksum(StringBuffer filename, char* digestStr)
+  char* getMD5Checksum(const char *filename, char* digestStr)
   {
-      if (filename.length() < 1)
+      if (isEmptyString(filename))
           return NULL;
 
-    if (!checkFileExists(filename.str()))
+      if (!checkFileExists(filename))
           return NULL;
 
       OwnedIFile ifile = createIFile(filename);

--- a/deployment/deploy/DeploymentEngine.hpp
+++ b/deployment/deploy/DeploymentEngine.hpp
@@ -248,10 +248,10 @@ protected:
    virtual void siteCertificate(IPropertyTree& process, const char *instanceName, const char *outputFile);
 #endif
 
-   StringBuffer getHostRoot(const char* computer, const char* dir, bool bIgnoreDepToFolder=false) const;
-   StringBuffer getHostDir(IPropertyTree& node, bool bIgnoreDepToFolder=false);
-   StringBuffer getDeployDir(IPropertyTree& node);
-   StringBuffer getLocalDir(IPropertyTree& node) const;
+   StringBuffer &getHostRoot(StringBuffer &hostRoot, const char* computer, const char* dir, bool bIgnoreDepToFolder=false) const;
+   StringBuffer &getHostDir(StringBuffer &hostDir, IPropertyTree& node, bool bIgnoreDepToFolder=false);
+   StringBuffer &getDeployDir(StringBuffer &deployDir, IPropertyTree& node);
+   StringBuffer &getLocalDir(StringBuffer &localDir, IPropertyTree& node) const;
    const char *queryDirectory(IPropertyTree& node, StringBuffer& dir) const;
 
    void connectToHost(IPropertyTree& node, const char* dir=NULL);

--- a/deployment/deploy/configgenengine.cpp
+++ b/deployment/deploy/configgenengine.cpp
@@ -343,7 +343,11 @@ int CConfigGenEngine::determineInstallFiles(IPropertyTree& processNode, CInstall
 void CConfigGenEngine::deployInstance(IPropertyTree& instanceNode, bool useTempDir)
 {
     StringAttr hostDir(m_outDir);
-    StringAttr destDir(useTempDir ? getDeployDir(instanceNode).str() : hostDir.get());
+    StringBuffer destDir;
+    if (useTempDir)
+        getDeployDir(destDir, instanceNode);
+    else
+        destDir.set(hostDir.get());
     
     const char* pszHostDir = hostDir.get();
     if (pszHostDir && *pszHostDir==PATHSEPCHAR && *(pszHostDir+1)==PATHSEPCHAR)

--- a/deployment/deploy/dalideploymentengine.cpp
+++ b/deployment/deploy/dalideploymentengine.cpp
@@ -70,7 +70,8 @@ void CDaliDeploymentEngine::copyInstallFiles(IPropertyTree& instanceNode, const 
    if ((m_deployFlags & DEFLAGS_CONFIGFILES) && computer && *computer)
    {
       // Create dalisds.xml is not already exists
-      StringBuffer hostRoot(getHostRoot(computer, NULL));
+      StringBuffer hostRoot;
+      getHostRoot(hostRoot, computer, NULL);
 
       const char* dir = m_process.queryProp("@dataPath");
       if (!dir || !*dir)

--- a/deployment/deployutils/computerpicker.cpp
+++ b/deployment/deployutils/computerpicker.cpp
@@ -180,10 +180,10 @@ bool CComputerPicker::GetUsage(const char* szComputer, StringBuffer& sUsage,
 
           if (bIncludeComponentType)
           {
-            StringBuffer sType = GetComponentTypeForPrefix(chPrefix);
             //if (!sType.IsEmpty())
             if (sUsage.length() > 0)
             {
+              const char * sType = GetComponentTypeForPrefix(chPrefix);
               sUsage.append(sType);
               sUsage.append(" - ");
             }

--- a/deployment/deployutils/configenvhelper.cpp
+++ b/deployment/deployutils/configenvhelper.cpp
@@ -179,7 +179,7 @@ bool CConfigEnvHelper::addRoxieServers(const char* xmlArg)
     if (!pFarm->hasProp("@aclName"))
       pFarm->addProp("@aclName", "");
 
-    StringBuffer dataDir = pFarm->queryProp(XML_ATTR_LEVEL);
+    StringBuffer dataDir(pFarm->queryProp(XML_ATTR_LEVEL)); // MORE - this is dead code - variable never used
   }
   else
   {

--- a/deployment/deployutils/deployutils.cpp
+++ b/deployment/deployutils/deployutils.cpp
@@ -58,13 +58,13 @@ bool schemaNodeHasAttributeGroups(IPropertyTree* pNode)
   return itAttrGr->first() && itAttrGr->isValid();
 }
 
-bool writeToFile(const char* fileName, StringBuffer sb)
+bool writeToFile(const char* fileName, const char * sb)
 {
   StringBuffer jsName(fileName);
   recursiveCreateDirectoryForFile(fileName);
   Owned<IFile> pFile = createIFile(jsName);
   Owned<IFileIO> pFileIO = pFile->open(IFOcreaterw);
-  pFileIO->write(0, sb.length(), sb.str());
+  pFileIO->write(0, strlen(sb), sb);
 
   return true;
 }
@@ -573,7 +573,7 @@ public:
         }
       }
 
-      void CreateAttributeFromSchema(IPropertyTree& attr, StringBuffer compName, const char* tabName, const char* childElementName)
+      void CreateAttributeFromSchema(IPropertyTree& attr, const char *compName, const char* tabName, const char* childElementName)
       {
         StringBuffer attrname;
         StringBuffer combovalues;
@@ -605,7 +605,7 @@ public:
             value.clear().append(attr.queryProp("./xs:annotation/xs:appinfo/autogenforwizard"));
             if(!strcmp(value.str(),"1"))
             {
-                    getValueForTypeInXSD(attr, compName, wizDefVal);  
+              getValueForTypeInXSD(attr, compName, wizDefVal);
             }
           }
           else
@@ -624,7 +624,7 @@ public:
         IPropertyTree* pField = NULL;
         if (m_pDefTree)
         {
-          IPropertyTree* pProcess = m_pDefTree->queryPropTree(compName.str());
+          IPropertyTree* pProcess = m_pDefTree->queryPropTree(compName);
 
           if (!pProcess)
             pProcess = m_pDefTree->addPropTree(compName, createPTree());
@@ -716,7 +716,7 @@ public:
 
               if (childElementName && i == 1 && m_splitterTabName.length())
               {
-                setNameInCompTabArray(m_splitterTabName, compName.str());
+                setNameInCompTabArray(m_splitterTabName, compName);
                 m_columns.appendf("tabCols['%s'][%d] = '_%s';", m_splitterTabName.str(), m_numAttrs, tabName);
               }
             }
@@ -729,7 +729,7 @@ public:
             {
               m_columns.appendf("tabCols['%s'][%d] = '%s';", getRealTabName(tabName), 0, caption? caption:attr.queryProp(XML_ATTR_NAME));
 
-              setNameInCompTabArray(m_splitterTabName, compName.str());
+              setNameInCompTabArray(m_splitterTabName, compName);
               m_columns.appendf("tabCols['%s'][%d] = '_%s';", m_splitterTabName.str(), m_numAttrs, tabName);
             }
           }
@@ -1169,8 +1169,8 @@ public:
       }
 
       void AddAttributeFromSchema(IPropertyTree& schemaNode, 
-        StringBuffer elemName, 
-        StringBuffer& compName, 
+        const char * elemName,
+        const char *compName,
         const char* tabName,
         const char* childElementName)
       {
@@ -1178,7 +1178,7 @@ public:
       }
 
       void AddAttributesFromSchema(IPropertyTree* pSchema,
-        StringBuffer& compName,
+        const char *compName,
         const char* tabName,
         const char* childElementName)
       {
@@ -1506,7 +1506,7 @@ public:
         CloneArray(tabNameArray, m_tabNameArray);
       }
 
-      void getDefnPropTree(IPropertyTree* pTree, StringBuffer xpathDefn)
+      void getDefnPropTree(IPropertyTree* pTree, const char * xpathDefn)
       {
         m_pDefTree = pTree;
         m_xpathDefn.clear().append(xpathDefn);
@@ -1548,7 +1548,7 @@ public:
         m_wizard.set(ptr);
       }
 
-      void getValueForTypeInXSD(IPropertyTree& attr, StringBuffer compName, StringBuffer& wizDefVal)
+      void getValueForTypeInXSD(IPropertyTree& attr, const char *compName, StringBuffer& wizDefVal)
       {
         StringBuffer tempPath;
         const char* type = attr.queryProp("@type");
@@ -1581,7 +1581,7 @@ public:
            }
            else if(!strcmp(attr.queryProp(tempPath.str()), "$processname"))
            {
-              tempPath.clear().appendf("Software/%s[1]/@name",compName.str());
+              tempPath.clear().appendf("Software/%s[1]/@name",compName);
               wizDefVal.clear().append(m_pEnv->queryProp(tempPath.str()));
            }
            else if(!strcmp(attr.queryProp(tempPath.str()), "$hthorcluster"))
@@ -1605,7 +1605,7 @@ public:
            else
            {
              wizDefVal.clear().append(attr.queryProp(tempPath.str()));
-             tempPath.clear().appendf("Software/%s[1]/@buildSet", compName.str());
+             tempPath.clear().appendf("Software/%s[1]/@buildSet", compName);
              if(m_pEnv->queryProp(tempPath.str()))
              {
                if(m_wizard->getNumOfNodes(m_pEnv->queryProp(tempPath.str())) > 1)
@@ -2883,7 +2883,7 @@ const char* getUniqueName(const IPropertyTree* pEnv, StringBuffer& sName, const 
   //if the name ends in _N (where N is a number) then ignore _N to avoid duplicating
   //number suffix as in _N_M
   //
-  StringBuffer sPrefix = sName;
+  StringBuffer sPrefix(sName);
   const char* pdx = strrchr(sName.str(), '_');
   if (pdx)
   {
@@ -2928,7 +2928,7 @@ const char* getUniqueName2(const IPropertyTree* pEnv, StringBuffer& sName, const
   //if the name ends in _N (where N is a number) then ignore _N to avoid duplicating
   //number suffix as in _N_M
   //
-  StringBuffer sPrefix = sName;
+  StringBuffer sPrefix(sName);
   const char* pdx = strrchr(sName.str(), '_');
   if (pdx)
   {
@@ -3140,7 +3140,7 @@ bool ensureUniqueName(const IPropertyTree* pEnv, IPropertyTree* pParentNode, con
 const char* expandXPath(StringBuffer& xpath, IPropertyTree* pNode, IPropertyTree* pParentNode, int position)
 {
   StringBuffer xpathOut;
-  StringBuffer subxpath = strpbrk(xpath.str(), "/=");
+  StringBuffer subxpath(strpbrk(xpath.str(), "/="));
   if (!strcmp(subxpath.str(), ".."))
   {
     int skip = 2;
@@ -3165,7 +3165,7 @@ const char* expandXPath(StringBuffer& xpath, IPropertyTree* pNode, IPropertyTree
   return xpath;
 }
 
-bool xsltTransform(const StringBuffer& xml, const char* sheet, IProperties *params, StringBuffer& ret)
+bool xsltTransform(const char *xml, const char* sheet, IProperties *params, StringBuffer& ret)
 {
   if (!checkFileExists(sheet))
     throw MakeStringException(-1, "Could not find stylesheet %s",sheet);
@@ -3173,7 +3173,7 @@ bool xsltTransform(const StringBuffer& xml, const char* sheet, IProperties *para
   Owned<IXslProcessor> proc  = getXslProcessor();
   Owned<IXslTransform> trans = proc->createXslTransform();
 
-  trans->setXmlSource(xml.str(), xml.length());
+  trans->setXmlSource(xml, strlen(xml));
   trans->loadXslFromFile(sheet);
 
   if (params)
@@ -3459,7 +3459,7 @@ void formIPList(const char* ip, StringArray& formattedIpList)
 }
 
 void buildEnvFromWizard(const char * wizardXml, const char* service,IPropertyTree* cfg, StringBuffer& envXml, StringArray& arrBuildSetWithAssignedIPs,
-                StringArray& arrAssignedIPs, MapStringTo<StringBuffer>* dirMap)
+                StringArray& arrAssignedIPs, MapStringTo<StringAttr, const char *>* dirMap)
 {
   if(wizardXml && *wizardXml)
   {

--- a/deployment/deployutils/deployutils.hpp
+++ b/deployment/deployutils/deployutils.hpp
@@ -73,12 +73,12 @@ extern DEPLOYUTILS_API bool handleThorTopologyOp(IPropertyTree* pEnv, const char
 extern DEPLOYUTILS_API void addComponentToEnv(IPropertyTree* pEnv, const char* buildSet, StringBuffer& sbNewName, IPropertyTree* pCompTree);
 extern DEPLOYUTILS_API bool onChangeAttribute(const IPropertyTree* pEnv, IConstEnvironment* pConstEnv, const char* attrName, IPropertyTree* pOnChange, IPropertyTree*& pNode, IPropertyTree* pParentNode, 
                                               int position, const char* szNewValue, const char* prevValue, const char* buildset);
-extern DEPLOYUTILS_API bool xsltTransform(const StringBuffer& xml, const char* sheet, IProperties *params, StringBuffer& ret);
+extern DEPLOYUTILS_API bool xsltTransform(const char *xml, const char* sheet, IProperties *params, StringBuffer& ret);
 extern DEPLOYUTILS_API void UpdateRefAttributes(IPropertyTree* pEnv, const char* szPath, const char* szAttr, const char* szOldVal, const char* szNewVal);
 extern DEPLOYUTILS_API bool ensureUniqueName(const IPropertyTree* pEnv, IPropertyTree* pParentNode, const char* szText);
 extern DEPLOYUTILS_API void addInstanceToCompTree(const IPropertyTree* pEnvRoot,const IPropertyTree* pInstance,StringBuffer& dups,StringBuffer& resp, IConstEnvironment* pConstEnv);
 extern DEPLOYUTILS_API void formIPList(const char* ip, StringArray& formattedIpList);
-extern DEPLOYUTILS_API void buildEnvFromWizard(const char * xml, const char* service,IPropertyTree* cfg, StringBuffer& envXml, StringArray& arrBuildSetWithAssignedIPs, StringArray& arrAssignedIPs, MapStringTo<StringBuffer>* dirMap=NULL);
+extern DEPLOYUTILS_API void buildEnvFromWizard(const char * xml, const char* service,IPropertyTree* cfg, StringBuffer& envXml, StringArray& arrBuildSetWithAssignedIPs, StringArray& arrAssignedIPs, MapStringTo<StringAttr, const char *>* dirMap=NULL);
 extern DEPLOYUTILS_API void runScript(StringBuffer& output, StringBuffer& errMsg, const char* pathToScript);
 extern DEPLOYUTILS_API bool validateIPS(const char* ipAddressList);
 extern DEPLOYUTILS_API void getSummary(const IPropertyTree* pEnvRoot, StringBuffer& respXmlStr , bool prepareLink);

--- a/deployment/deployutils/wizardInputs.cpp
+++ b/deployment/deployutils/wizardInputs.cpp
@@ -30,7 +30,7 @@
 #define STANDARD_CONFIGXMLDIR COMPONENTFILES_DIR"/configxml/"
 #define STANDARD_CONFIG_DIR CONFIG_DIR
 
-CInstDetails::CInstDetails(StringBuffer compName, const StringArray &ipAssigned) : m_compName(compName)
+CInstDetails::CInstDetails(const char * compName, const StringArray &ipAssigned) : m_compName(compName)
 {
     m_ipAssigned.clear();
 
@@ -45,7 +45,7 @@ CInstDetails::CInstDetails(StringBuffer compName, const StringArray &ipAssigned)
 //---------------------------------------------------------------------------
 CWizardInputs::CWizardInputs(const char* xmlArg,const char *service, 
                              IPropertyTree * cfg, 
-                             MapStringTo<StringBuffer>* dirMap,
+                             MapStringTo<StringAttr, const char *>* dirMap,
                              StringArray &arrBuildSetsWithAssignedIPs,
                              StringArray &arrAssignedIPs): m_service(service),
                              m_cfg(cfg), m_overrideDirs(dirMap), m_roxieOnDemand(true),
@@ -457,7 +457,7 @@ bool CWizardInputs::applyOverlappingRules(const char* compName,const char* build
   return assignedIP;
 }
 
-count_t CWizardInputs::getNumOfInstForIP(StringBuffer ip)
+count_t CWizardInputs::getNumOfInstForIP(const char * ip)
 {
   count_t cnt = 0;
   HashIterator ips(m_compIpMap);
@@ -620,7 +620,7 @@ void CWizardInputs::generateSoftwareTree(IPropertyTree* pNewEnvTree)
       ForEach(iter)
       {
         IMapping &cur = iter.query();
-        StringBuffer* dirvalue = m_overrideDirs->mapToValue(&cur);
+        StringAttr* dirvalue = m_overrideDirs->mapToValue(&cur);
         const char * key = (const char*)cur.getKey();
         xpath.clear().appendf(XML_TAG_SOFTWARE"/Directories/Category[@name='%s']", key);
         if (!strcmp(key, "log"))
@@ -673,10 +673,10 @@ void CWizardInputs::generateSoftwareTree(IPropertyTree* pNewEnvTree)
   }
 }
 
-void CWizardInputs::addInstanceToTree(IPropertyTree* pNewEnvTree, StringBuffer attrName, const char* processName, const char* buildSetName, const char* instName)
+void CWizardInputs::addInstanceToTree(IPropertyTree* pNewEnvTree, const char * attrName, const char* processName, const char* buildSetName, const char* instName)
 {
   StringBuffer sb, sbl, compName, xpath, nodeName;
-  xpath.clear().appendf("./%s/%s[%s=\"%s\"]", XML_TAG_HARDWARE, XML_TAG_COMPUTER, XML_ATTR_NETADDRESS, attrName.str());
+  xpath.clear().appendf("./%s/%s[%s=\"%s\"]", XML_TAG_HARDWARE, XML_TAG_COMPUTER, XML_ATTR_NETADDRESS, attrName);
   IPropertyTree* pHardTemp = pNewEnvTree->queryPropTree(xpath.str());
   if(pHardTemp)
     nodeName.clear().append(pHardTemp->queryProp("./" XML_ATTR_NAME));//NodeName
@@ -1210,7 +1210,7 @@ void CWizardInputs::addComponentToSoftware(IPropertyTree* pNewEnvTree, IProperty
   const char* buildSetName = pBuildSet->queryProp(XML_ATTR_NAME);
   const char* xsdFileName = pBuildSet->queryProp(XML_ATTR_SCHEMA);
   const char* processName = pBuildSet->queryProp(XML_ATTR_PROCESS_NAME);
-  StringBuffer deployable = pBuildSet->queryProp("@" TAG_DEPLOYABLE);
+  StringBuffer deployable(pBuildSet->queryProp("@" TAG_DEPLOYABLE));
   unsigned numOfIpNeeded = 1;
 
  if (!hasBaseInstantRequested())

--- a/deployment/deployutils/wizardInputs.hpp
+++ b/deployment/deployutils/wizardInputs.hpp
@@ -45,17 +45,17 @@ class CInstDetails : public CInterface, implements IInterface
 {
   public: 
     CInstDetails(){};
-    CInstDetails(StringBuffer compName, StringBuffer ipAssigned):m_compName(compName)
+    CInstDetails(const char * compName, const char * ipAssigned):m_compName(compName)
     {
-      m_ipAssigned.append(ipAssigned.str());
+      m_ipAssigned.append(ipAssigned);
     }
-    CInstDetails(StringBuffer compName, const StringArray &ipAssigned);
+    CInstDetails(const char * compName, const StringArray &ipAssigned);
 
     virtual ~CInstDetails(){};
 
     IMPLEMENT_IINTERFACE;
     StringArray& getIpAssigned() { return m_ipAssigned;}
-    StringBuffer getCompName() { return m_compName; }
+    StringBuffer &getCompName() { return m_compName; }
     void setParams(const char* compName, const char* value)
     {
       m_compName.clear().append(compName);
@@ -79,7 +79,7 @@ class CWizardInputs : public CInterface, implements IInterface
 {
 // Construction
 public:
-  CWizardInputs(const char* xmlArg, const char* service, IPropertyTree* cfg, MapStringTo<StringBuffer>* dirMap, StringArray &arrBuildSetsWithAssignedIPs, StringArray &arrAssignedIPs);
+  CWizardInputs(const char* xmlArg, const char* service, IPropertyTree* cfg, MapStringTo<StringAttr, const char *>* dirMap, StringArray &arrBuildSetsWithAssignedIPs, StringArray &arrAssignedIPs);
   virtual ~CWizardInputs(); 
   
   void setEnvironment();
@@ -87,9 +87,9 @@ public:
   void setWizardRules();
   CInstDetails* getServerIPMap(const char* compName, const char* buildSetName,const IPropertyTree* pEnvTree, unsigned numOfNode = 1);
   bool applyOverlappingRules(const char* compName, const char* buildSetName, unsigned startpos, StringArray* pIpAddrMap);
-  count_t getNumOfInstForIP(StringBuffer ip);
+  count_t getNumOfInstForIP(const char * ip);
   void generateSoftwareTree(IPropertyTree* pTree);
-  void addInstanceToTree(IPropertyTree* pTree, StringBuffer attrName, const char* processName, const char* buildSetName, const char* instName);
+  void addInstanceToTree(IPropertyTree* pTree, const char *attrName, const char* processName, const char* buildSetName, const char* instName);
   void getDefaultsForWizard(IPropertyTree* pTree);
   void addRoxieThorClusterToEnv(IPropertyTree* pNewEnvTree, CInstDetails* pInstDetails, const char* buildSetName, bool genRoxieOnDemand = false);
   unsigned getCntForAlreadyAssignedIPS(const char* buildsetName);
@@ -152,6 +152,6 @@ private:
    StringBuffer m_roxieAgentRedType;
    Owned<IPropertyTree> m_buildSetTree;
    Owned<IProperties> m_algProp;
-   MapStringTo<StringBuffer>* m_overrideDirs;
+   MapStringTo<StringAttr, const char *>* m_overrideDirs;
 };
 #endif // !defined(WIZARDINPUTS_HPP__INCLUDED_)

--- a/deployment/envgen/main.cpp
+++ b/deployment/envgen/main.cpp
@@ -127,7 +127,7 @@ int main(int argc, char** argv)
   StringBuffer ipAddrs;
   int roxieNodes=1, thorNodes=1, slavesPerNode=1, supportNodes=1, espNodes=1, thorChannelsPerSlave=1, roxieChannelsPerSlave=1;
   bool roxieOnDemand = true;
-  MapStringTo<StringBuffer> dirMap;
+  MapStringTo<StringAttr, const char *> dirMap;
   StringArray overrides;
   StringBufferArray arrXPaths;
   StringBufferArray arrAttrib;

--- a/ecl/agentexec/agentexec.cpp
+++ b/ecl/agentexec/agentexec.cpp
@@ -206,7 +206,7 @@ int CEclAgentExecutionServer::executeWorkunit(const char * wuid)
     command.append("start_eclagent");
 #endif
 
-    StringBuffer cmdLine = command;
+    StringBuffer cmdLine(command);
     cmdLine.append(" WUID=").append(wuid).append(" DALISERVERS=").append(daliServers);
 
     DWORD runcode;

--- a/ecl/ecl-package/ecl-package.cpp
+++ b/ecl/ecl-package/ecl-package.cpp
@@ -984,7 +984,7 @@ public:
                     IPropertyTree *querynode = ensurePTree(filetree, info.item(0));
                     if (querynode)
                     {
-                        StringBuffer category = (info.length()>=3) ? info.item(2) : "required";
+                        StringBuffer category((info.length()>=3) ? info.item(2) : "required");
                         IPropertyTree *cat = ensurePTree(querynode, category.toLowerCase());
                         if (cat)
                             ensurePTree(cat, info.item(1));

--- a/ecl/eclcmd/eclcmd_core.cpp
+++ b/ecl/eclcmd/eclcmd_core.cpp
@@ -1930,7 +1930,7 @@ public:
         EclCmdURL eclCmdURL("WsWorkunits", !streq(optServer, ".") ? optServer : "localhost", optPort, optSSL, urlTail.str());
 
         //Create CURL command
-        StringBuffer curlCommand = "curl -v -X post";
+        StringBuffer curlCommand("curl -v -X post");
         if (!optUsername.isEmpty())
         {
             curlCommand.append(" -u ").append(optUsername.get());

--- a/esp/bindings/SOAP/Platform/soapparam.cpp
+++ b/esp/bindings/SOAP/Platform/soapparam.cpp
@@ -353,7 +353,7 @@ void SoapAttachString::marshall(IRpcMessage &rpc_call, const char *tagname, cons
 
 void SoapAttachString::toJSON(IEspContext *ctx, StringBuffer &s, const char *tagname)
 {
-    appendJSONValue(s, tagname, value);
+    appendJSONValue(s, tagname, value.str());
 }
 
 void SoapAttachString::toXML(IEspContext *ctx, StringBuffer &s, const char *tagname, const char *prefix, bool encode)

--- a/esp/bindings/SOAP/client/soapclient.cpp
+++ b/esp/bindings/SOAP/client/soapclient.cpp
@@ -177,7 +177,7 @@ int CSoapClient::postRequest(const char* contenttype, const char* soapaction, IR
     int retstatus = soap_response->get_status();
     if(retstatus != SOAP_OK)
     {
-        StringBuffer errmsg = "SOAP error";
+        const char * errmsg = "SOAP error";
 
         if(retstatus == SOAP_CLIENT_ERROR)
             errmsg = "SOAP client error";
@@ -191,7 +191,7 @@ int CSoapClient::postRequest(const char* contenttype, const char* soapaction, IR
             errmsg = "SOAP request type error";
         else if(retstatus == SOAP_AUTHENTICATION_ERROR)
             errmsg = "SOAP authentication error";
-
+        StringBuffer errStr(errmsg);
         const char *errText = soap_response->get_err();
         if (errText && *errText)
         {
@@ -204,16 +204,16 @@ int CSoapClient::postRequest(const char* contenttype, const char* soapaction, IR
                     const char *endString = strchr(faultString, ']');
                     if (endString)
                     {
-                        errmsg.clear().append(endString-faultString, faultString);
+                        errStr.clear().append(endString-faultString, faultString);
                         errText = nullptr;
                     }
                 }
             }
             if (errText)
-                errmsg.appendf("[%s]", errText);
+                errStr.appendf("[%s]", errText);
         }
 
-        throw MakeStringException(retstatus, "%s", errmsg.str());
+        throw MakeStringException(retstatus, "%s", errStr.str());
     }
 
 #if defined(DEBUG_HTTP_)

--- a/esp/bindings/SOAP/ws_ecl_client/ws_ecl_client_bind.hpp
+++ b/esp/bindings/SOAP/ws_ecl_client/ws_ecl_client_bind.hpp
@@ -76,7 +76,7 @@ public:
     void setRequestId(unsigned long reqId){m_request_id = reqId;}
     void setClientValue(unsigned long cv){m_client_value = cv;}
     
-    void setHttpMessage(StringBuffer message){message.swapWith(m_HttpMessage);}
+    void setHttpMessage(const char *message){ m_HttpMessage.set(message);}
     const char* getHttpMessage(StringBuffer &message)
     {
         message.append(m_HttpMessage);
@@ -87,7 +87,7 @@ public:
             return NULL;
     }
 
-    void setStatusMessage(StringBuffer message){message.swapWith(m_StatusMessage);}
+    void setStatusMessage(const char *message){ m_StatusMessage.set(message);}
     const char* getStatusMessage(StringBuffer &message)
     {
         message.append(m_StatusMessage);
@@ -127,7 +127,7 @@ public:
             {
                 StringBuffer buf;
                 buf.append(eptr - sptr, sptr);
-                m_ResultsXML = buf;
+                m_ResultsXML->set(buf);
             }
         }   
 

--- a/esp/bindings/http/platform/httpbinding.cpp
+++ b/esp/bindings/http/platform/httpbinding.cpp
@@ -1135,7 +1135,7 @@ static void filterXmlBySchema(StringBuffer& in, StringBuffer& schema, const char
         type = sp->queryElementType(name);
         if (!type)
         {
-            StringBuffer method = name;
+            StringBuffer method(name);
             if (method.length() > 7)
                 method.setLength(method.length()-7);
             type = sp->queryElementType(method);

--- a/esp/bindings/http/platform/httpservice.cpp
+++ b/esp/bindings/http/platform/httpservice.cpp
@@ -1596,7 +1596,7 @@ void CEspHttpServer::sendLockResponse(bool lock, bool error, const char* msg)
 
 void CEspHttpServer::sendGetAuthTypeResponse(EspAuthRequest& authReq, const char* authType)
 {
-    StringBuffer authTypeStr = authType;
+    StringBuffer authTypeStr(authType);
     if (authTypeStr.isEmpty())
     {
         switch (authReq.authBinding->getDomainAuthType())
@@ -2035,7 +2035,7 @@ void CEspHttpServer::askUserLogin(EspAuthRequest& authReq, const char* msg)
     readCookie(SESSION_START_URL_COOKIE, urlCookie);
     if (urlCookie.isEmpty())
     {
-        StringBuffer sessionStartURL = authReq.httpPath;
+        StringBuffer sessionStartURL(authReq.httpPath);
         if (authReq.requestParams && authReq.requestParams->hasProp("__querystring"))
             sessionStartURL.append("?").append(authReq.requestParams->queryProp("__querystring"));
         if (!sessionStartURL.isEmpty() && streq(sessionStartURL.str(), "/WsSMC/"))
@@ -2178,7 +2178,7 @@ unsigned CEspHttpServer::readCookie(const char* cookieName)
     CEspCookie* sessionIDCookie = m_request->queryCookie(cookieName);
     if (sessionIDCookie)
     {
-        StringBuffer sessionIDStr = sessionIDCookie->getValue();
+        StringBuffer sessionIDStr(sessionIDCookie->getValue());
         if (sessionIDStr.length())
             return atoi(sessionIDStr.str());
     }

--- a/esp/bindings/http/platform/httptransport.cpp
+++ b/esp/bindings/http/platform/httptransport.cpp
@@ -732,7 +732,7 @@ void CHttpMessage::logMessage(const char* message, const char* prefix, const cha
     }
 
     RegExpr auth(find, true);
-    StringBuffer messageToLog = message;
+    StringBuffer messageToLog(message);
     if (auth.find(messageToLog.str()))
         auth.replace(replace, messageToLog.length() + strlen(replace) - strlen(find));
 
@@ -1947,7 +1947,7 @@ bool CHttpRequest::readUploadFileName(CMimeMultiPart* mimemultipart, StringBuffe
     return (fileName.length() > 0);
 }
 
-IFile* CHttpRequest::createUploadFile(StringBuffer netAddress, const char* filePath, StringBuffer& fileName)
+IFile* CHttpRequest::createUploadFile(const char * netAddress, const char* filePath, StringBuffer& fileName)
 {
     StringBuffer name(fileName), tmpFileName;
     char* str = (char*) name.reverse().str();
@@ -1963,7 +1963,7 @@ IFile* CHttpRequest::createUploadFile(StringBuffer netAddress, const char* fileP
 
     RemoteFilename rfn;
     SocketEndpoint ep;
-    ep.set(netAddress.str());
+    ep.set(netAddress);
     rfn.setPath(ep, tmpFileName.str());
 
     return createIFile(rfn);
@@ -2011,7 +2011,7 @@ void CHttpRequest::readUploadFileContent(StringArray& fileNames, StringArray& fi
     return;
 }
 
-int CHttpRequest::readContentToFiles(StringBuffer netAddress, StringBuffer path, StringArray& fileNames)
+int CHttpRequest::readContentToFiles(const char * netAddress, const char * path, StringArray& fileNames)
 {
     const char* contentType = m_content_type.get();
     if (!contentType || !*contentType)
@@ -2076,7 +2076,7 @@ int CHttpRequest::readContentToFiles(StringBuffer netAddress, StringBuffer path,
             break;
 
         StringBuffer fileNameWithPath;
-        fileNameWithPath.appendf("%s/%s", path.str(), fileName.str());
+        fileNameWithPath.appendf("%s/%s", path, fileName.str());
         file->rename(fileNameWithPath.str());
 
         if (!foundAnotherFile)

--- a/esp/bindings/http/platform/httptransport.ipp
+++ b/esp/bindings/http/platform/httptransport.ipp
@@ -348,8 +348,8 @@ public:
 
     bool readContentToBuffer(MemoryBuffer& fileContent, __int64& bytesNotRead);
     bool readUploadFileName(CMimeMultiPart* mimemultipart, StringBuffer& fileName, MemoryBuffer& contentBuffer, __int64& bytesNotRead);
-    IFile* createUploadFile(StringBuffer netAddress, const char* filePath, StringBuffer& fileName);
-    virtual int readContentToFiles(StringBuffer netAddress, StringBuffer path, StringArray& fileNames);
+    IFile* createUploadFile(const char *netAddress, const char* filePath, StringBuffer& fileName);
+    virtual int readContentToFiles(const char * netAddress, const char * path, StringArray& fileNames);
     virtual void readUploadFileContent(StringArray& fileNames, StringArray& files);
 };
 

--- a/esp/logging/loggingagent/espserverloggingagent/loggingagent.cpp
+++ b/esp/logging/loggingagent/espserverloggingagent/loggingagent.cpp
@@ -235,7 +235,7 @@ void CESPServerLoggingAgent::resetTransSeed(CTransIDBuilder *builder, const char
         int statusCode = getTransactionSeed(groupName, transactionSeed, statusMessage);
         if (!transactionSeed.length() || (statusCode != 0))
         {
-            StringBuffer msg = "Failed to get Transaction Seed for ";
+            StringBuffer msg("Failed to get Transaction Seed for ");
             msg.append(groupName).append(". statusCode: ").append(statusCode);
             if (!statusMessage.isEmpty())
                 msg.append(", ").append(statusMessage.str());

--- a/esp/logging/logginglib/LogFailSafe.cpp
+++ b/esp/logging/logginglib/LogFailSafe.cpp
@@ -80,7 +80,7 @@ CLogFailSafe::~CLogFailSafe()
 
 void CLogFailSafe::readCfg(IPropertyTree* cfg)
 {
-    StringBuffer safeRolloverThreshold = cfg->queryProp(PropSafeRolloverThreshold);
+    StringBuffer safeRolloverThreshold(cfg->queryProp(PropSafeRolloverThreshold));
     if (!safeRolloverThreshold.isEmpty())
         readSafeRolloverThresholdCfg(safeRolloverThreshold);
 
@@ -287,9 +287,9 @@ void CLogFailSafe::Add(const char* GUID,IInterface& pIn, CLogRequestInFile* reqI
     Add(GUID, dataStr, reqInFile);
 }
 
-void CLogFailSafe::Add(const char* GUID, const StringBuffer& strContents, CLogRequestInFile* reqInFile)
+void CLogFailSafe::Add(const char* GUID, const char *strContents, CLogRequestInFile* reqInFile)
 {
-    VStringBuffer dataStr("<cache>%s</cache>", strContents.str());
+    VStringBuffer dataStr("<cache>%s</cache>", strContents);
 
     if (safeRolloverSizeThreshold <= 0)
     {
@@ -339,7 +339,7 @@ void CLogFailSafe::RollOldLogs()
 {
     ForEachItemIn(i, oldLogs)
     {
-        StringBuffer fileName = oldLogs.item(i);
+        StringBuffer fileName(oldLogs.item(i));
         Owned<IFile> file = createIFile(fileName);
         fileName.replaceString(logFileExt, rolloverFileExt);
         file->rename(fileName.str());

--- a/esp/logging/logginglib/LogFailSafe.hpp
+++ b/esp/logging/logginglib/LogFailSafe.hpp
@@ -32,7 +32,7 @@ const char* const DefaultFailSafeLogsDir = "./FailSafeLogs";
 
 interface ILogFailSafe : IInterface
 {
-    virtual void Add(const char*, const StringBuffer& strContents, CLogRequestInFile* reqInFile)=0;//
+    virtual void Add(const char*, const char *strContents, CLogRequestInFile* reqInFile)=0;//
     virtual void Add(const char*,IInterface& pIn, CLogRequestInFile* reqInFile)=0;
     virtual StringBuffer& GenerateGUID(StringBuffer& GUID,const char* seed="") = 0;
     virtual void AddACK(const char* GUID)=0;
@@ -84,7 +84,7 @@ public:
 
     virtual ~CLogFailSafe();
     StringBuffer& GenerateGUID(StringBuffer& GUID,const char* seed="");
-    virtual void Add(const char*, const StringBuffer& strContents, CLogRequestInFile* reqInFile);//
+    virtual void Add(const char*, const char *strContents, CLogRequestInFile* reqInFile);//
     virtual void Add(const char*,IInterface& pIn, CLogRequestInFile* reqInFile);
     virtual void AddACK(const char* GUID);
     virtual void RollCurrentLog();

--- a/esp/logging/logginglib/LogSerializer.cpp
+++ b/esp/logging/logginglib/LogSerializer.cpp
@@ -206,7 +206,7 @@ void CLogSerializer::splitLogRecord(MemoryBuffer& rawdata, StringBuffer& GUID, S
 bool CLogSerializer::readLogRequest(CLogRequestInFile* logRequestInFile, StringBuffer& logRequest)
 {
     //Open the file if exists.
-    StringBuffer fileName = logRequestInFile->getFileName();
+    StringBuffer fileName(logRequestInFile->getFileName());
     Owned<IFile> file = createIFile(fileName);
     Owned<IFileIO> fileIO = file->open(IFOread);
     if (!fileIO)

--- a/esp/logging/logginglib/loggingagentbase.cpp
+++ b/esp/logging/logginglib/loggingagentbase.cpp
@@ -66,7 +66,7 @@ bool CLogContentFilter::readLogFilters(IPropertyTree* cfg, unsigned groupID)
     ForEach(*filters)
     {
         IPropertyTree &filter = filters->query();
-        StringBuffer value = filter.queryProp("@value");
+        StringBuffer value(filter.queryProp("@value"));
         if (!value.length())
             continue;
 
@@ -357,7 +357,7 @@ bool CDBLogAgentBase::getTransactionSeed(IEspGetTransactionSeedRequest& req, IEs
         throw MakeStringException(EspLoggingErrors::GetTransactionSeedFailed, "%s: no getTransactionSeed service configured", agentName.get());
 
     bool bRet = false;
-    StringBuffer appName = req.getApplication();
+    StringBuffer appName(req.getApplication());
     appName.trim();
     if (appName.length() == 0)
         appName = defaultTransactionApp.get();
@@ -490,12 +490,12 @@ bool CDBLogAgentBase::buildUpdateLogStatement(IPropertyTree* logRequest, const c
     {
         CLogField& logField = logFields.item(i);
 
-        StringBuffer colName = logField.getMapTo();
+        StringBuffer colName(logField.getMapTo());
         bool* found = handledFields.getValue(colName.str());
         if (found && *found)
             continue;
 
-        StringBuffer path = logField.getName();
+        StringBuffer path(logField.getName());
         if (path.charAt(path.length() - 1) == ']')
         {//Attr filter. Separate the last [] from the path.
             const char* pTr = path.str();
@@ -577,7 +577,7 @@ void CDBLogAgentBase::addMissingFields(CIArrayOf<CLogField>& logFields, BoolHash
         bool* found = handledFields.getValue(colName);
         if (found && *found)
             continue;
-        StringBuffer value = logField.getDefault();
+        StringBuffer value(logField.getDefault());
         if (!value.isEmpty())
             addField(logField, colName, value, fields, values);
     }

--- a/esp/platform/espcache.cpp
+++ b/esp/platform/espcache.cpp
@@ -226,7 +226,7 @@ ESPCacheResult ESPMemCached::get(const char* groupID, const char* cacheID, Strin
     if (value)
         out.set(value);
 
-    StringBuffer msg = "'Get' request failed - ";
+    StringBuffer msg("'Get' request failed - ");
     if (rc == MEMCACHED_NOTFOUND)
         msg.append("(cacheID: '").append(cacheID).append("') ");
     assertOnError(rc, msg.str());
@@ -286,7 +286,7 @@ void ESPMemCached::assertPool()
 {
     if (!pool)
     {
-        StringBuffer msg = "ESPMemCached: Failed to instantiate server pool with:";
+        StringBuffer msg("ESPMemCached: Failed to instantiate server pool with:");
         msg.newline().append(options);
         ESPLOG(LogNormal, "%s", msg.str());
     }

--- a/esp/platform/espprotocol.cpp
+++ b/esp/platform/espprotocol.cpp
@@ -368,7 +368,7 @@ void CEspApplicationPort::buildNavTreeXML(IPropertyTree* navtree, StringBuffer& 
         //If no one asks for this position, pick one from the itemsGroup1
         if (!foundOne && (positionInGroup1 < itemCountInGroup1))
         {
-            StringBuffer itemXML = itemsGroup1.item(positionInGroup1);
+            StringBuffer itemXML(itemsGroup1.item(positionInGroup1));
             xmlBuf.append(itemXML.str());
             positionInGroup1++;
         }
@@ -379,7 +379,7 @@ void CEspApplicationPort::buildNavTreeXML(IPropertyTree* navtree, StringBuffer& 
     //Check any item left inside the itemsGroup1 and append it into the xml
     while (positionInGroup1 < itemCountInGroup1)
     {
-        StringBuffer itemXML = itemsGroup1.item(positionInGroup1);
+        StringBuffer itemXML(itemsGroup1.item(positionInGroup1));
         xmlBuf.append(itemXML.str());
         positionInGroup1++;
     }

--- a/esp/platform/tokenserialization.hpp
+++ b/esp/platform/tokenserialization.hpp
@@ -46,12 +46,6 @@
 class TokenSerializer
 {
 public:
-    // Produce a buffer suitable for use by the serialize method. Used by
-    // template methods that do not inherently know the buffer type.
-    StringBuffer makeBuffer() const
-    {
-        return StringBuffer();
-    }
 
     // Write any type of data to a given text buffer. There must be an
     // overloaded operator << to insert the value type into the buffer type.

--- a/esp/platform/txsummary.hpp
+++ b/esp/platform/txsummary.hpp
@@ -87,8 +87,8 @@ private:
 
     struct Entry
     {
-        StringBuffer key;
-        StringBuffer value;
+        StringAttr key;
+        StringAttr value;
     };
 
     using Entries = std::list<Entry>;
@@ -107,7 +107,7 @@ private:
 template <typename TValue, typename TSuffix, class TSerializer>
 inline bool CTxSummary::append(const char* key, const TValue& value, const TSuffix& suffix, const TSerializer& serializer)
 {
-    auto buffer = serializer.makeBuffer();
+    StringBuffer buffer;
     serializer.serialize(value, buffer);
     serializer.serialize(suffix, buffer);
     return append(key, serializer.str(buffer));
@@ -117,7 +117,7 @@ inline bool CTxSummary::append(const char* key, const TValue& value, const TSuff
 template <typename TValue, typename TSuffix, class TSerializer>
 inline bool CTxSummary::set(const char* key, const TValue& value, const TSuffix& suffix, const TSerializer& serializer)
 {
-    auto buffer = serializer.makeBuffer();
+    StringBuffer buffer;
     serializer.serialize(value, buffer);
     serializer.serialize(suffix, buffer);
     return set(key, serializer.str(buffer));

--- a/esp/services/WsDeploy/WsDeployService.cpp
+++ b/esp/services/WsDeploy/WsDeployService.cpp
@@ -3963,8 +3963,8 @@ bool CWsDeployFileInfo::handleAttributeAdd(IEspContext &context, IEspHandleAttri
 
   IPropertyTree* pSetting = &iter->query();
   Owned<IPropertyTree> pEnvRoot = getEnvTree(context, &req.getReqInfo());
-  StringBuffer xpath =  pSetting->queryProp(XML_ATTR_PARAMS);
-  StringBuffer attribName = pSetting->queryProp(XML_ATTR_ATTRIB);
+  StringBuffer xpath(pSetting->queryProp(XML_ATTR_PARAMS));
+  StringBuffer attribName(pSetting->queryProp(XML_ATTR_ATTRIB));
 
   if (attribName.length() == 0)
     throw MakeStringException(-1,"Attribute name can't be empty!");
@@ -3997,7 +3997,7 @@ bool CWsDeployFileInfo::handleAttributeDelete(IEspContext &context, IEspHandleAt
 
   IPropertyTree* pSetting = &iter->query();
   Owned<IPropertyTree> pEnvRoot = &m_Environment->getPTree();
-  StringBuffer xpath2 =  pSetting->queryProp("@params");
+  StringBuffer xpath2(pSetting->queryProp("@params"));
   IPropertyTree* pComp = pEnvRoot->queryPropTree(xpath2.str());
 
   if (pComp == NULL)
@@ -4302,7 +4302,7 @@ bool CWsDeployFileInfo::handleComponentCopy(IPropertyTree *pComponents, IPropert
     }
 
     const char* compType = pComp.queryProp(XML_ATTR_COMPTYPE);
-    StringBuffer sbNewName = compName;
+    StringBuffer sbNewName(compName);
 
     xpath.clear().appendf("%s", compType);
     getUniqueName(pEnvRoot2, sbNewName, xpath.str(), XML_TAG_SOFTWARE);
@@ -5703,7 +5703,8 @@ void CWsDeployFileInfo::generateGraph(IEspContext &context, IConstWsDeployReqInf
   }
 
   m_pGraphXml.set(new SCMStringBuffer());
-  xsltTransform(m_pEnvXml->str(), StringBuffer(getCFD()).append("xslt/graph_env.xslt").str(), NULL, m_pGraphXml->s);
+  StringBuffer buf;
+  xsltTransform(m_pEnvXml->str(), buf.append(getCFD()).append("xslt/graph_env.xslt").str(), NULL, m_pGraphXml->s);
 }
 
 //---------------------------------------------------------------------------

--- a/esp/services/espcontrol/ws_espcontrolservice.cpp
+++ b/esp/services/espcontrol/ws_espcontrolservice.cpp
@@ -68,7 +68,7 @@ void CWSESPControlEx::init(IPropertyTree *cfg, const char *process, const char *
     ForEach(*it)
     {
         IPropertyTree& authDomain = it->query();
-        StringBuffer name = authDomain.queryProp("@domainName");
+        StringBuffer name(authDomain.queryProp("@domainName"));
         if (name.isEmpty())
             name.set("default");
         sessionTimeoutMinutesMap.setValue(name.str(), authDomain.getPropInt("@sessionTimeoutMinutes", 0));
@@ -272,7 +272,7 @@ bool CWSESPControlEx::onSessionInfo(IEspContext& context, IEspSessionInfoRequest
         }
 #endif
 
-        StringBuffer id = req.getID();
+        StringBuffer id(req.getID());
         if (id.trim().isEmpty())
             throw MakeStringException(ECLWATCH_INVALID_INPUT, "ID not specified.");
 

--- a/esp/services/ws_access/ws_accessService.cpp
+++ b/esp/services/ws_access/ws_accessService.cpp
@@ -295,7 +295,7 @@ bool Cws_accessEx::getNewFileScopePermissions(ISecManager* secmgr, IEspResourceA
     CLdapSecManager* ldapsecmgr = (CLdapSecManager*)secmgr;
     while (newResources.ordinality())
     {
-        StringBuffer namebuf = newResources.item(0);
+        StringBuffer namebuf(newResources.item(0));
         try
         {
             IArrayOf<CPermission> permissions;
@@ -382,7 +382,7 @@ bool Cws_accessEx::setNewFileScopePermissions(ISecManager* secmgr, IEspResourceA
 
         ForEachItemIn(y, newResources)
         {
-            StringBuffer namebuf = newResources.item(y);
+            StringBuffer namebuf(newResources.item(y));
             paction.m_rname.clear().append(namebuf.str());
             ldapsecmgr->changePermission(paction);
         }
@@ -1819,7 +1819,7 @@ bool Cws_accessEx::onResourceQuery(IEspContext &context, IEspResourceQueryReques
             }
         }
 
-        StringBuffer nameReq = req.getName();
+        StringBuffer nameReq(req.getName());
         const char* prefix = req.getPrefix();
         if (!nameReq.length() && req.getRtitle() && !stricmp(req.getRtitle(), "CodeGenerator Permission"))
             nameReq.set(prefix);
@@ -1997,7 +1997,7 @@ bool Cws_accessEx::onResourceAdd(IEspContext &context, IEspResourceAddRequest &r
                 StringBuffer retmsg;
                 ForEachItemIn(y, newResources)
                 {
-                    StringBuffer namebuf = newResources.item(y);
+                    StringBuffer namebuf(newResources.item(y));
                     if (retmsg.length() < 1)
                         retmsg.append(namebuf);
                     else
@@ -2129,7 +2129,7 @@ void Cws_accessEx::addResourcePermission(const char *name, int type, int allows,
     if (isEmptyString(name))
         return;
 
-    StringBuffer nameIn = name;
+    StringBuffer nameIn(name);
     Owned<IEspResourcePermission> permission = createResourcePermission();
     permission->setAccount_name(name);
     permission->setEscaped_account_name(nameIn.replaceString("\'", "\\\'").str());
@@ -4385,7 +4385,7 @@ bool Cws_accessEx::onFilePermission(IEspContext &context, IEspFilePermissionRequ
                 access = SecAccess_None;
                 ForEachItemIn(y, scopes)
                 {
-                    StringBuffer namebuf = scopes.item(y);
+                    StringBuffer namebuf(scopes.item(y));
                     try
                     {
                         IArrayOf<CPermission> permissions;

--- a/esp/services/ws_dfu/ws_dfuService.cpp
+++ b/esp/services/ws_dfu/ws_dfuService.cpp
@@ -221,7 +221,7 @@ bool CWsDfuEx::onDFUSearch(IEspContext &context, IEspDFUSearchRequest & req, IEs
         ForEachItemIn(k1, clusters1)
         {
             IEspTpCluster& cluster = clusters1.item(k1);
-            StringBuffer slaveName = cluster.getName();
+            StringBuffer slaveName(cluster.getName());
             dfuclusters.append(slaveName.str());
         }
 
@@ -848,7 +848,7 @@ bool CWsDfuEx::setSpaceItemByOwner(IArrayOf<IEspSpaceItem>& SpaceItems64, const 
     return true;
 }
 
-bool CWsDfuEx::createSpaceItemsByDate(IArrayOf<IEspSpaceItem>& SpaceItems, StringBuffer interval, unsigned& yearFrom,
+bool CWsDfuEx::createSpaceItemsByDate(IArrayOf<IEspSpaceItem>& SpaceItems, const char *interval, unsigned& yearFrom,
     unsigned& monthFrom, unsigned& dayFrom, unsigned& yearTo, unsigned& monthTo, unsigned& dayTo)
 {
     if (!stricmp(interval, COUNTBY_YEAR))
@@ -986,11 +986,11 @@ bool CWsDfuEx::createSpaceItemsByDate(IArrayOf<IEspSpaceItem>& SpaceItems, Strin
     return true;
 }
 
-bool CWsDfuEx::setSpaceItemByDate(IArrayOf<IEspSpaceItem>& SpaceItems, StringBuffer interval, StringBuffer mod, const char*logicalName, __int64 size)
+bool CWsDfuEx::setSpaceItemByDate(IArrayOf<IEspSpaceItem>& SpaceItems, const char * interval, const char * mod, const char*logicalName, __int64 size)
 {
     unsigned year, month, day;
     CDateTime wuTime;
-    wuTime.setString(mod.str(),NULL,true);
+    wuTime.setString(mod,NULL,true);
     wuTime.getDate(year, month, day, true);
 
     StringBuffer name;
@@ -1129,7 +1129,7 @@ int CWsDfuEx::superfileAction(IEspContext &context, const char* action, const ch
             msgHead.appendf("%s: Superfile:%s, Subfile(s): ", action, superfile);
 
         unsigned filesInMsgBuf = 0;
-        StringBuffer msgBuf = msgHead;
+        StringBuffer msgBuf(msgHead);
         for(unsigned i = 0; i < num; i++)
         {
             subfileArray.append((char*) subfiles.item(i));
@@ -1411,7 +1411,8 @@ bool CWsDfuEx::DFUDeleteFiles(IEspContext &context, IEspDFUArrayActionRequest &r
         userdesc->set(username, context.queryPassword(), context.querySignature());
     }
 
-    StringBuffer returnStr, auditStr = (",FileAccess,WsDfu,DELETED,");
+    StringBuffer returnStr;
+    StringBuffer auditStr(",FileAccess,WsDfu,DELETED,");
     IArrayOf<IEspDFUActionInfo> actionResults;
 
     StringArray superFiles, failedFiles;
@@ -1447,7 +1448,7 @@ bool CWsDfuEx::onDFUArrayAction(IEspContext &context, IEspDFUArrayActionRequest 
         double version = context.getClientVersion();
         if (version > 1.03)
         {
-            StringBuffer backToPage = req.getBackToPage();
+            StringBuffer backToPage(req.getBackToPage());
             if (backToPage.length() > 0)
             {
                 const char* oldStr = "&";
@@ -1581,7 +1582,7 @@ bool CWsDfuEx::onDFUDefFile(IEspContext &context,IEspDFUDefFileRequest &req, IEs
         resp.setDefFile(buff);
 
         //set the type
-        StringBuffer type = "text/";
+        StringBuffer type("text/");
         if (format == CDFUDefFileFormat_xml)
             type.append("xml");
         else
@@ -2106,7 +2107,7 @@ void CWsDfuEx::doGetFileDetails(IEspContext &context, IUserDescriptor *udesc, co
         }
         FileDetails.setProtectList(protectList);
     }
-    StringBuffer strDesc = df->queryAttributes().queryProp("@description");
+    StringBuffer strDesc(df->queryAttributes().queryProp("@description"));
     if (description)
     {
         DistributedFilePropertyLock lock(df);
@@ -2339,7 +2340,7 @@ void CWsDfuEx::doGetFileDetails(IEspContext &context, IUserDescriptor *udesc, co
             ForEachItemIn(k, roxieclusters)
             {
                 IEspTpCluster& r_cluster = roxieclusters.item(k);
-                StringBuffer sName = r_cluster.getName();
+                StringBuffer sName(r_cluster.getName());
                 if (FindInStringArray(clusters, sName.str()))
                 {
                     fromRoxieCluster = true;
@@ -3010,7 +3011,7 @@ void CWsDfuEx::getAPageOfSortedLogicalFile(IEspContext &context, IUserDescriptor
     ForEachItemIn(k, roxieclusters)
     {
         IEspTpCluster& cluster = roxieclusters.item(k);
-        StringBuffer sName = cluster.getName();
+        StringBuffer sName(cluster.getName());
         roxieClusterNames.append(sName.str());
     }
 
@@ -3324,8 +3325,8 @@ void CWsDfuEx::getAPageOfSortedLogicalFile(IEspContext &context, IUserDescriptor
         addToQueryStringFromInt(basicQuery, "FileSizeTo", req.getFileSizeTo());
     }
 
-    StringBuffer ParametersForFilters = basicQuery;
-    StringBuffer ParametersForPaging = basicQuery;
+    StringBuffer ParametersForFilters(basicQuery);
+    StringBuffer ParametersForPaging(basicQuery);
 
     addToQueryStringFromInt(ParametersForFilters, "PageSize",pagesize);
     addToQueryStringFromInt(ParametersForPaging, "PageSize", pagesize);
@@ -3372,7 +3373,7 @@ void CWsDfuEx::getAPageOfSortedLogicalFile(IEspContext &context, IUserDescriptor
         resp.setSortby(sortBy);
         resp.setDescending(descending);
 
-        StringBuffer strbuf = sortBy;
+        StringBuffer strbuf(sortBy);
         strbuf.append("=");
         String str1(strbuf.str());
         String str(basicQuery.str());
@@ -3762,7 +3763,7 @@ void CWsDfuEx::setDFUQueryResponse(IEspContext &context, unsigned totalFiles, St
         addToQueryStringFromInt(queryReq, "FileSizeTo", req.getFileSizeTo());
     }
 
-    StringBuffer queryReqNoPageSize = queryReq;
+    StringBuffer queryReqNoPageSize(queryReq);
     addToQueryStringFromInt(queryReq, "PageSize", pageSize);
     resp.setFilters(queryReq.str());
 
@@ -4790,13 +4791,13 @@ bool CWsDfuEx::onDFUGetFileMetaData(IEspContext &context, IEspDFUGetFileMetaData
 
     try
     {
-        StringBuffer fileNameStr = req.getLogicalFileName();
+        StringBuffer fileNameStr(req.getLogicalFileName());
         const char* fileName = fileNameStr.trim().str();
         if (!fileName || !*fileName)
             throw MakeStringException(ECLWATCH_INVALID_INPUT, "CWsDfuEx::onDFUGetFileMetaData: LogicalFileName not set");
 
         const char* cluster = NULL;
-        StringBuffer clusterNameStr = req.getClusterName();
+        StringBuffer clusterNameStr(req.getClusterName());
         if (clusterNameStr.trim().length() > 0)
             cluster = clusterNameStr.str();
 
@@ -5274,16 +5275,16 @@ void CWsDfuEx::readColumnsForDisplay(StringBuffer& schemaText, StringArray& colu
     return;
 }
 
-void CWsDfuEx::mergeSchema(IRelatedBrowseFile * file, StringBuffer& schemaText, StringBuffer schemaText2,
+void CWsDfuEx::mergeSchema(IRelatedBrowseFile * file, StringBuffer& schemaText, const char * schemaText2,
                                     StringArray& columnsDisplay, StringArray& columnsDisplayType, StringArray& columnsHide)
 {
     if (schemaText.length() < 1)
         return;
-    if (schemaText2.length() < 1)
+    if (isEmptyString(schemaText2))
         return;
 
     Owned<IPropertyTree> schema = createPTreeFromXMLString(schemaText.str());
-    Owned<IPropertyTree> schema2 = createPTreeFromXMLString(schemaText2.str());
+    Owned<IPropertyTree> schema2 = createPTreeFromXMLString(schemaText2);
     if (!schema || !schema2)
         return;
 
@@ -5493,15 +5494,15 @@ void CWsDfuEx::mergeDataRow(StringBuffer& newRow, int depth, IPropertyTreeIterat
     return;
 }
 
-void CWsDfuEx::mergeDataRow(StringBuffer& newRow, StringBuffer dataRow1, StringBuffer dataRow2, StringArray& columnsHide)
+void CWsDfuEx::mergeDataRow(StringBuffer& newRow, const char * dataRow1, const char * dataRow2, StringArray& columnsHide)
 {
-    if (dataRow1.length() < 1)
+    if (isEmptyString(dataRow1))
         return;
-    if (dataRow2.length() < 1)
+    if (isEmptyString(dataRow2))
         return;
 
-    Owned<IPropertyTree> data1 = createPTreeFromXMLString(dataRow1.str());
-    Owned<IPropertyTree> data2 = createPTreeFromXMLString(dataRow2.str());
+    Owned<IPropertyTree> data1 = createPTreeFromXMLString(dataRow1);
+    Owned<IPropertyTree> data2 = createPTreeFromXMLString(dataRow2);
     if (!data1 || !data2)
         return;
 
@@ -5668,7 +5669,7 @@ int CWsDfuEx::browseRelatedFileDataSet(double version, IRelatedBrowseFile * file
                     for (unsigned ii = 0; ii<dataSetOutput0.length(); ii++)
                     {
                         StringBuffer text0;
-                        StringBuffer text1 = dataSetOutput0.item(ii);
+                        StringBuffer text1(dataSetOutput0.item(ii));
                         if (text1.length() > 0)
                         {
                             mergeDataRow(text0, text, text1, columnsHide);
@@ -5851,7 +5852,7 @@ int CWsDfuEx::GetIndexData(IEspContext &context, bool bSchemaOnly, const char* i
         dataSetText.newline();
         for (unsigned i = 0; i<dataSetOutput.length(); i++)
         {
-            StringBuffer text0 = dataSetOutput.item(i);
+            StringBuffer text0(dataSetOutput.item(i));
             if (text0.length() > 0)
             {
                 dataSetText.append(text0);
@@ -6211,7 +6212,7 @@ bool CWsDfuEx::onDFUFileCreate(IEspContext &context, IEspDFUFileCreateRequest &r
         const char *fileName = requestBase.getName();
         const char *clusterName = requestBase.getCluster();
         const char *recordDefinition = req.getECLRecordDefinition();
-        StringBuffer requestId = requestBase.getJobId();
+        StringBuffer requestId(requestBase.getJobId());
         unsigned expirySecs = requestBase.getExpirySeconds();
         bool returnTextResponse = true;
 
@@ -6237,7 +6238,7 @@ bool CWsDfuEx::onDFUFileCreate(IEspContext &context, IEspDFUFileCreateRequest &r
 
         CDfsLogicalFileName lfn;
         lfn.set(fileName);
-        StringBuffer normalizedFileName = lfn.get();
+        StringBuffer normalizedFileName(lfn.get());
 
         checkLogicalName(normalizedFileName, userDesc, false, true, false, nullptr);
 
@@ -6245,7 +6246,7 @@ bool CWsDfuEx::onDFUFileCreate(IEspContext &context, IEspDFUFileCreateRequest &r
         StringBuffer groupName;
         Owned<IGroup> group = getDFUFileIGroup(clusterName, clusterType, clusterTypeEx, req.getPartLocations(), groupName);
 
-        StringBuffer tempFileName = normalizedFileName;
+        StringBuffer tempFileName(normalizedFileName);
         tempFileName.append(DFUFileCreate_FileNamePostfix);
 
         //create FileId
@@ -6308,7 +6309,7 @@ bool CWsDfuEx::onDFUFileCreateV2(IEspContext &context, IEspDFUFileCreateV2Reques
         const char *clusterName = req.getCluster();
         const char *recordDefinition = req.getECLRecordDefinition();
         unsigned expirySecs = req.getExpirySeconds();
-        StringBuffer requestId = req.getRequestId();
+        StringBuffer requestId(req.getRequestId());
         bool returnTextResponse = req.getReturnTextResponse();
 
         if (isEmptyString(fileName))
@@ -6341,11 +6342,11 @@ bool CWsDfuEx::onDFUFileCreateV2(IEspContext &context, IEspDFUFileCreateV2Reques
 
         CDfsLogicalFileName lfn;
         lfn.set(fileName);
-        StringBuffer normalizedFileName = lfn.get();
+        StringBuffer normalizedFileName(lfn.get());
 
         checkLogicalName(normalizedFileName, userDesc, false, true, false, nullptr);
 
-        StringBuffer tempFileName = normalizedFileName;
+        StringBuffer tempFileName(normalizedFileName);
         tempFileName.append(".").append(dfuCreateUniqId++); // avoid potential clash if >1 creating file. One will succeed at publish time.
         tempFileName.append(DFUFileCreate_FileNamePostfix);
 
@@ -6469,7 +6470,7 @@ bool CWsDfuEx::onDFUFilePublish(IEspContext &context, IEspDFUFilePublishRequest 
                 fileDesc->queryProperties().setPropBool("@blockCompressed", true);
         }
 
-        StringBuffer newFileName = normalizeTempFileName;
+        StringBuffer newFileName(normalizeTempFileName);
         const char *start = newFileName;
         const char *pos = start + (newFileName.length() - postFixLen);
         const char *startPos = pos;

--- a/esp/services/ws_dfu/ws_dfuService.hpp
+++ b/esp/services/ws_dfu/ws_dfuService.hpp
@@ -198,11 +198,11 @@ private:
     void doGetFileDetails(IEspContext &context, IUserDescriptor* udesc, const char *name,const char *cluster,
         const char *querySet, const char *query, const char *description, bool includeJsonTypeInfo, bool includeBinTypeInfo,
         CDFUChangeProtection protect, IEspDFUFileDetail& FileDetails);
-    bool createSpaceItemsByDate(IArrayOf<IEspSpaceItem>& SpaceItems, StringBuffer interval, unsigned& yearFrom,
+    bool createSpaceItemsByDate(IArrayOf<IEspSpaceItem>& SpaceItems, const char * interval, unsigned& yearFrom,
         unsigned& monthFrom, unsigned& dayFrom, unsigned& yearTo, unsigned& monthTo, unsigned& dayTo);
     bool setSpaceItemByScope(IArrayOf<IEspSpaceItem>& SpaceItems64, const char*scopeName, const char*logicalName, __int64 size);
     bool setSpaceItemByOwner(IArrayOf<IEspSpaceItem>& SpaceItems64, const char *owner, const char *logicalName, __int64 size);
-    bool setSpaceItemByDate(IArrayOf<IEspSpaceItem>& SpaceItems, StringBuffer interval, StringBuffer mod, const char*logicalName, __int64 size);
+    bool setSpaceItemByDate(IArrayOf<IEspSpaceItem>& SpaceItems, const char * interval, const char *mod, const char*logicalName, __int64 size);
     bool findPositionToAdd(const char *datetime, const __int64 size, const int numNeeded, const unsigned orderType,
                        IArrayOf<IEspDFULogicalFile>& LogicalFiles, int& addToPos, bool& reachLimit);
     __int64 findPositionByParts(const __int64 parts, bool decsend, IArrayOf<IEspDFULogicalFile>& LogicalFiles);
@@ -223,10 +223,10 @@ private:
     void setRootFilter(INewResultSet* result, const char* filterBy, IResultSetFilter* filter, bool disableUppercaseTranslation = true);
     void getMappingColumns(IRelatedBrowseFile * file, bool isPrimary, UnsignedArray& cols);
     void readColumnsForDisplay(StringBuffer& schemaText, StringArray& columnsDisplay, StringArray& columnsDisplayType);
-    void mergeSchema(IRelatedBrowseFile * file, StringBuffer& schemaText, StringBuffer schemaText2,
+    void mergeSchema(IRelatedBrowseFile * file, StringBuffer& schemaText, const char * schemaText2,
         StringArray& columnsDisplay, StringArray& columnsDisplayType, StringArray& columnsHide);
     void mergeDataRow(StringBuffer& newRow, int depth, IPropertyTreeIterator* it, StringArray& columnsHide, StringArray& columnsUsed);
-    void mergeDataRow(StringBuffer& newRow, StringBuffer dataRow1, StringBuffer dataRow2, StringArray& columnsHide);
+    void mergeDataRow(StringBuffer& newRow, const char * dataRow1, const char * dataRow2, StringArray& columnsHide);
     void browseRelatedFileSchema(IRelatedBrowseFile * file, const char* parentName, unsigned depth, StringBuffer& schemaText,
         StringArray& columnsDisplay, StringArray& columnsDisplayType, StringArray& columnsHide);
     int browseRelatedFileDataSet(double version, IRelatedBrowseFile * file, const char* parentName, unsigned depth, __int64 start, __int64& count, __int64& read,

--- a/esp/services/ws_ecl/ws_ecl_wuinfo.cpp
+++ b/esp/services/ws_ecl/ws_ecl_wuinfo.cpp
@@ -279,7 +279,7 @@ void WsEclWuInfo::addOutputSchemas(StringBuffer &schemas, IConstWUResultIterator
         getSchemaFromResult(s, results->query());
         SCMStringBuffer resultName;
         results->query().getResultName(resultName);
-        StringBuffer sname =resultName.s.str();
+        StringBuffer sname(resultName.s.str());
         sname.replace(' ', '_');
         int seq = results->query().getResultSequence();
         schemas.appendf("<%s sequence=\"%d\" name=\"%s\" sname=\"%s\">%s</%s>", tag, seq, resultName.str(), sname.str(), s.str(), tag);
@@ -296,7 +296,7 @@ void WsEclWuInfo::addInputSchemas(StringBuffer &schemas, IConstWUResultIterator 
             getSchemaFromResult(s, results->query());
             SCMStringBuffer resultName;
             results->query().getResultName(resultName);
-            StringBuffer sname =resultName.s.str();
+            StringBuffer sname(resultName.s.str());
             sname.replace(' ', '_');
 
             int seq = results->query().getResultSequence();

--- a/esp/services/ws_esdlconfig/ws_esdlconfigservice.cpp
+++ b/esp/services/ws_esdlconfig/ws_esdlconfigservice.cpp
@@ -533,7 +533,7 @@ bool CWsESDLConfigEx::onPublishESDLBinding(IEspContext &context, IEspPublishESDL
 
                         if (def)
                         {
-                            StringBuffer defid = def->queryProp("@id");
+                            StringBuffer defid(def->queryProp("@id"));
                             msg.appendf("\nFetched ESDL Biding definition declaration: '%s'.", defid.str());
                             resp.updateESDLBinding().updateDefinition().setId(defid);
                             resp.updateESDLBinding().updateDefinition().setName(def->queryProp("@name"));
@@ -843,7 +843,7 @@ bool CWsESDLConfigEx::onConfigureESDLBindingMethod(IEspContext &context, IEspCon
                                 IPropertyTree * def = esdlbindingtree->queryPropTree("Definition[1]");
                                 if (def)
                                 {
-                                    StringBuffer defid = def->queryProp("@id");
+                                    StringBuffer defid(def->queryProp("@id"));
                                     msg.appendf("\nFetched ESDL Biding definition declaration: '%s'.", defid.str());
                                     resp.updateESDLBinding().updateDefinition().setId(defid);
                                     resp.updateESDLBinding().updateDefinition().setName(def->queryProp("@name"));
@@ -1119,7 +1119,7 @@ bool CWsESDLConfigEx::onGetESDLBinding(IEspContext &context, IEspGetESDLBindingR
         {
             if (!esdlBindId || !*esdlBindId)
             {
-                StringBuffer espPort = req.getEspPort();
+                StringBuffer espPort(req.getEspPort());
                 StringBuffer msg;
                 StringBuffer serviceName;
                 if (espProcName.length() == 0 || (espBindingName.length() == 0 && espPort.length() == 0))
@@ -1151,7 +1151,7 @@ bool CWsESDLConfigEx::onGetESDLBinding(IEspContext &context, IEspGetESDLBindingR
 
                 if (def)
                 {
-                    StringBuffer defid = def->queryProp("@id");
+                    StringBuffer defid(def->queryProp("@id"));
                     msg.appendf("\nFetched ESDL Biding definition declaration: '%s'.", defid.str());
                     resp.updateESDLBinding().updateDefinition().setId(defid);
                     resp.updateESDLBinding().updateDefinition().setName(def->queryProp("@name"));
@@ -1475,7 +1475,7 @@ bool CWsESDLConfigEx::onGetESDLDefinition(IEspContext &context, IEspGetESDLDefin
 
     context.ensureFeatureAccess(FEATURE_URL, SecAccess_Read, ECLWATCH_ROXIE_QUERY_ACCESS_DENIED, "WsESDLConfigEx::GetESDLDefinition: Permission denied.");
 
-    StringBuffer id = req.getId();
+    StringBuffer id(req.getId());
     StringBuffer definition;
     const char* serviceName = req.getServiceName();
 
@@ -1722,7 +1722,7 @@ bool CWsESDLConfigEx::onListDESDLEspBindings(IEspContext &context, IEspListDESDL
                     {
                         IPropertyTree * def = esdlbindingtree->queryPropTree("Definition[1]");
 
-                        StringBuffer defid = def->queryProp("@id");
+                        StringBuffer defid(def->queryProp("@id"));
                         msg.appendf("\nFetched ESDL Biding definition declaration: '%s'.", defid.str());
                         desdlespbinding->updateESDLBinding().updateDefinition().setId(defid);
                         desdlespbinding->updateESDLBinding().updateDefinition().setName(def->queryProp("@name"));

--- a/esp/services/ws_fs/ws_fsBinding.hpp
+++ b/esp/services/ws_fs/ws_fsBinding.hpp
@@ -47,7 +47,7 @@ public:
 
     virtual void getNavigationData(IEspContext &context, IPropertyTree & data)
     {
-        StringBuffer path = "/WsSMC/NotInCommunityEdition?form_";
+        StringBuffer path("/WsSMC/NotInCommunityEdition?form_");
         if (m_portalURL.length() > 0)
             path.appendf("&EEPortal=%s", m_portalURL.str());
 

--- a/esp/services/ws_fs/ws_fsService.cpp
+++ b/esp/services/ws_fs/ws_fsService.cpp
@@ -926,7 +926,7 @@ bool CFileSprayEx::onGetDFUWorkunits(IEspContext &context, IEspGetDFUWorkunits &
     {
         context.ensureFeatureAccess(DFU_WU_URL, SecAccess_Read, ECLWATCH_DFU_WU_ACCESS_DENIED, "Access to DFU workunit is denied.");
 
-        StringBuffer wuidStr = req.getWuid();
+        StringBuffer wuidStr(req.getWuid());
         const char* wuid = wuidStr.trim().str();
         if (wuid && *wuid && looksLikeAWuid(wuid, 'D'))
             return getOneDFUWorkunit(context, wuid, resp);
@@ -1203,7 +1203,7 @@ bool CFileSprayEx::onGetDFUWorkunits(IEspContext &context, IEspGetDFUWorkunits &
             if (req.getDescending())
                 resp.setDescending(req.getDescending());
 
-            StringBuffer strbuf = req.getSortby();
+            StringBuffer strbuf(req.getSortby());
             strbuf.append("=");
             String str1(strbuf.str());
             String str(basicQuery.str());
@@ -1331,13 +1331,13 @@ void CFileSprayEx::getInfoFromSasha(IEspContext &context, const char *sashaServe
             info->setStateMessage(state);
         if (timeStarted && *timeStarted)
         {
-            StringBuffer startStr = timeStarted;
+            StringBuffer startStr(timeStarted);
             startStr.replace('T', ' ');
             info->setTimeStarted(startStr.str());
         }
         if (timeStopped && *timeStopped)
         {
-            StringBuffer stopStr = timeStopped;
+            StringBuffer stopStr(timeStopped);
             stopStr.replace('T', ' ');
             info->setTimeStopped(stopStr.str());
         }
@@ -1633,7 +1633,7 @@ bool CFileSprayEx::onDFUWorkunitsAction(IEspContext &context, IEspDFUWorkunitsAc
                             "Sasha (%s) took too long to respond from: Restore workunit %s.",
                             sashaAddress.str(), wuid);
                     {
-                        StringBuffer reply = "Restore ID: ";
+                        StringBuffer reply("Restore ID: ");
                         if (!cmd->getId(0, reply))
                             throw MakeStringException(ECLWATCH_CANNOT_UPDATE_WORKUNIT, "Failed to get ID.");
                         res->setResult(reply.str());
@@ -2189,7 +2189,7 @@ bool CFileSprayEx::onReplicate(IEspContext &context, IEspReplicate &req, IEspRep
         Owned<IDFUWorkUnitFactory> factory = getDFUWorkUnitFactory();
         Owned<IDFUWorkUnit> wu = factory->createWorkUnit();
 
-        StringBuffer jobname = "Replicate: ";
+        StringBuffer jobname("Replicate: ");
         jobname.append(srcname);
         wu->setJobName(jobname.str());
         setDFUServerQueueReq(req.getDFUServerQueue(), wu);
@@ -3287,7 +3287,7 @@ bool CFileSprayEx::onDeleteDropZoneFiles(IEspContext &context, IEspDeleteDropZon
 
             try
             {
-                StringBuffer fileToDelete = path;
+                StringBuffer fileToDelete(path);
                 fileToDelete.append(file);
 
                 rfn.setPath(ep, fileToDelete.str());
@@ -3304,7 +3304,7 @@ bool CFileSprayEx::onDeleteDropZoneFiles(IEspContext &context, IEspDeleteDropZon
                 eMsg = e->errorMessage(eMsg);
                 e->Release();
 
-                StringBuffer failedMsg = "Failed: ";
+                StringBuffer failedMsg("Failed: ");
                 failedMsg.append(eMsg);
                 res->setResult(failedMsg.str());
             }

--- a/esp/services/ws_machine/ws_machineService.cpp
+++ b/esp/services/ws_machine/ws_machineService.cpp
@@ -495,7 +495,7 @@ void Cws_machineEx::addProcessData(CMachineData* machine, const char* processTyp
     if (!machine)
         return;
 
-    StringBuffer pathStr = path;
+    StringBuffer pathStr(path);
     if (pathStr.length() > 0)
     {
         char pathSep = machine->getPathSep();
@@ -531,7 +531,7 @@ void Cws_machineEx::addProcessData(CMachineData* machine, const char* processTyp
         if (!name || streq(name, "."))
             continue;
 
-        StringBuffer processName = name;
+        StringBuffer processName(name);
         processName.toLowerCase().replaceString(".exe", "");
         if (processName.length() < 1)
             continue;
@@ -814,10 +814,11 @@ void Cws_machineEx::getProcesses(IConstEnvironment* constEnv, IPropertyTree* env
                 continue;
             }
 
-            StringBuffer netAddress, configNetAddress = ip;
+            StringBuffer netAddress;
+            StringBuffer configNetAddress(ip);
             if (!streq(ip, "."))
             {
-                netAddress.append(ip);
+                netAddress.set(ip);
             }
             else
             {
@@ -1581,7 +1582,7 @@ void Cws_machineEx::setMachineInfo(IEspContext& context, CMachineInfoThreadParam
         int len = additionalProcessFilters.length();
         for (int i=0; i<len; i++)
         {
-            StringBuffer processName = additionalProcessFilters.item(i);
+            StringBuffer processName(additionalProcessFilters.item(i));
             processName.toLowerCase().replaceString(".exe", "");
             if (processName.length() > 0)
                 additionalProcesses.insert(processName.str());
@@ -1810,7 +1811,7 @@ void Cws_machineEx::enumerateRunningProcesses(CMachineInfoThreadParam* pParam, C
         const char* pName = processInfo.getDescription();
         if (pParam->m_machineData.getOS() == MachineOsW2K)
         {
-            StringBuffer sName = pName;
+            StringBuffer sName(pName);
             pName = sName.toLowerCase().replaceString(".exe", "").str();
             if (!dependencies.empty())
                 dependencies.erase(pName);
@@ -1840,7 +1841,7 @@ void Cws_machineEx::enumerateRunningProcesses(CMachineInfoThreadParam* pParam, C
                     const char* pch = strchr(pPath, ' ');
                     if (pch)
                     {
-                        StringBuffer sPath = pPath;
+                        StringBuffer sPath(pPath);
                         sPath.setLength( pch - pPath );
                         pPath = sPath.str();
                     }
@@ -3069,7 +3070,7 @@ void Cws_machineEx::buildComponentUsageCacheID(StringBuffer& id, IArrayOf<IConst
     ForEachItemIn(i, componentList)
     {
         IConstComponent& component = componentList.item(i);
-        StringBuffer str = component.getType();
+        StringBuffer str(component.getType());
         if (str.isEmpty())
             throw MakeStringException(ECLWATCH_INVALID_INPUT, "Empty Component Type");
         str.append(":").append(component.getName());

--- a/esp/services/ws_sql/SQL2ECL/ECLEngine.cpp
+++ b/esp/services/ws_sql/SQL2ECL/ECLEngine.cpp
@@ -150,10 +150,10 @@ void ECLEngine::generateCreateAndLoad(HPCCSQLTreeWalker * sqlobj, StringBuffer &
         StringBuffer sourceFileName;
         sourceFileName.set(sqlobj->getSourceDataTableName()).trim();
 
-        StringBuffer landingZoneIP = sqlobj->getLandingZoneIp();
+        StringBuffer landingZoneIP(sqlobj->getLandingZoneIp());
         if (landingZoneIP.length())
         {
-            StringBuffer landingZonePath = sqlobj->getLandingZonePath();
+            StringBuffer landingZonePath(sqlobj->getLandingZonePath());
             if (landingZonePath.length())
             {
                 addPathSepChar(landingZonePath);
@@ -182,7 +182,7 @@ void ECLEngine::generateCreateAndLoad(HPCCSQLTreeWalker * sqlobj, StringBuffer &
 
 void ECLEngine::generateSelectECL(HPCCSQLTreeWalker * selectsqlobj, StringBuffer & out)
 {
-    StringBuffer latestDS = "TblDS0";
+    StringBuffer latestDS("TblDS0");
 
     Owned<IProperties> eclEntities = createProperties(true);
     Owned<IProperties> eclDSSourceMapping = createProperties(true);
@@ -461,7 +461,7 @@ void ECLEngine::generateSelectECL(HPCCSQLTreeWalker * selectsqlobj, StringBuffer
 
 void ECLEngine::generateConstSelectDataset(HPCCSQLTreeWalker * selectsqlobj, IProperties* eclEntities,  const IArrayOf<ISQLExpression> & expectedcolumns, const char * datasource)
 {
-    StringBuffer datasetStructSB = "DATASET([{ ";
+    StringBuffer datasetStructSB("DATASET([{ ");
 
     ForEachItemIn(i, expectedcolumns)
     {
@@ -478,7 +478,7 @@ void ECLEngine::generateConstSelectDataset(HPCCSQLTreeWalker * selectsqlobj, IPr
 
 void ECLEngine::generateSelectStruct(HPCCSQLTreeWalker * selectsqlobj, IProperties* eclEntities,  const IArrayOf<ISQLExpression> & expectedcolumns, const char * datasource)
 {
-    StringBuffer selectStructSB = "SelectStruct := RECORD\n";
+    StringBuffer selectStructSB("SelectStruct := RECORD\n");
 
     ForEachItemIn(i, expectedcolumns)
     {
@@ -560,7 +560,7 @@ void ECLEngine::generateSelectStruct(HPCCSQLTreeWalker * selectsqlobj, IProperti
 
                         for (int j = 0; j < funccols->length(); j++)
                         {
-                            StringBuffer paramname = funccols->item(j).getName();
+                            StringBuffer paramname(funccols->item(j).getName());
                             selectStructSB.append(", ");
                             selectStructSB.append(paramname);
                         }

--- a/esp/services/ws_sql/SQL2ECL/ECLFunction.hpp
+++ b/esp/services/ws_sql/SQL2ECL/ECLFunction.hpp
@@ -102,7 +102,7 @@ public:
 
         if (funcname && strlen(funcname)>0)
         {
-            StringBuffer fnnameupper = funcname;
+            StringBuffer fnnameupper(funcname);
 
             if (eclfuncstable.count(fnnameupper.toUpperCase().str()))
                 return  eclfuncstable.find(fnnameupper.toUpperCase().str())->second;

--- a/esp/services/ws_sql/SQL2ECL/HPCCFile.cpp
+++ b/esp/services/ws_sql/SQL2ECL/HPCCFile.cpp
@@ -73,7 +73,7 @@ bool HPCCFile::getFileRecDef(StringBuffer & out, const char * structname, const 
         ForEachItemIn(rowindex, this->columns)
         {
            out.append(recordindent);
-           out.append(this->columns.item(rowindex).toEclRecString().str());
+           this->columns.item(rowindex).toEclRecString(out);
            out.append(";");
            out.append(linedelimiter);
         }
@@ -109,7 +109,7 @@ bool HPCCFile::getFileRecDefwithIndexpos(HPCCColumnMetaData * fieldMetaData, Str
         ForEachItemIn(rowindex, this->columns)
         {
            out.append("\t");
-           out.append(this->columns.item(rowindex).toEclRecString().str());
+           this->columns.item(rowindex).toEclRecString(out);
            out.append(";");
            out.append("\n");
         }
@@ -129,7 +129,7 @@ bool HPCCFile::getFileRecDefwithIndexpos(HPCCColumnMetaData * fieldMetaData, Str
 
 bool HPCCFile::setFileColumns(const char * eclString)
 {
-    StringBuffer text = eclString;
+    StringBuffer text(eclString);
 
     MultiErrorReceiver errs;
     OwnedHqlExpr record = parseQuery(text.str(), &errs);

--- a/esp/services/ws_sql/SQL2ECL/HPCCFile.hpp
+++ b/esp/services/ws_sql/SQL2ECL/HPCCFile.hpp
@@ -121,7 +121,7 @@ public:
             return HPCCFileFormatUnknown;
         else
         {
-            StringBuffer toUpper = formatstr;
+            StringBuffer toUpper(formatstr);
             toUpper.trim().toUpperCase();
 
             if (strcmp(toUpper.str(), "FLAT")==0)

--- a/esp/services/ws_sql/SQL2ECL/HPCCSQLTreeWalker.cpp
+++ b/esp/services/ws_sql/SQL2ECL/HPCCSQLTreeWalker.cpp
@@ -766,7 +766,7 @@ void HPCCSQLTreeWalker::createAndLoadStatementTreeWalker(pANTLR3_BASE_TREE clsql
                                     sourceDataType.append((char *)sourcetypechild->toString(sourcetypechild)->chars);
                                     sourceDataType.append(" = ");
                                     sourcetypechild = (pANTLR3_BASE_TREE)(loadPartIthChild->getChild(loadPartIthChild, ++sourcetypechildindex));
-                                    StringBuffer value = (char *)sourcetypechild->toString(sourcetypechild)->chars;
+                                    StringBuffer value((char *)sourcetypechild->toString(sourcetypechild)->chars);
                                     trimSingleQuotes(value);
                                     sourceDataType.append(value.str());
 

--- a/esp/services/ws_sql/SQL2ECL/SQLColumn.hpp
+++ b/esp/services/ws_sql/SQL2ECL/SQLColumn.hpp
@@ -150,9 +150,8 @@ public:
 #endif
     }
 
-    StringBuffer toEclRecString()
+    StringBuffer &toEclRecString(StringBuffer &result)
     {
-        StringBuffer result;
         result.append(this->columnType.str());
         result.append(" ");
         result.append(this->columnName.str());

--- a/esp/services/ws_sql/ws_sqlService.cpp
+++ b/esp/services/ws_sql/ws_sqlService.cpp
@@ -895,7 +895,7 @@ bool CwssqlEx::onExecuteSQL(IEspContext &context, IEspExecuteSQLRequest &req, IE
         }
 
         StringBuffer xmlparams;
-        StringBuffer normalizedSQL = parsedSQL->getNormalizedSQL();
+        StringBuffer normalizedSQL(parsedSQL->getNormalizedSQL());
 
         normalizedSQL.append(" | --TC=").append(cluster);
         if (username.length() > 0)
@@ -1373,7 +1373,7 @@ bool CwssqlEx::onPrepareSQL(IEspContext &context, IEspPrepareSQLRequest &req, IE
         }
 
         StringBuffer xmlparams;
-        StringBuffer normalizedSQL = parsedSQL->getNormalizedSQL();
+        StringBuffer normalizedSQL(parsedSQL->getNormalizedSQL());
         normalizedSQL.append(" | --TC=").append(cluster);
         if (username.length() > 0)
             normalizedSQL.append("--USER=").append(username.str());
@@ -1690,7 +1690,7 @@ bool CwssqlEx::onCreateTableAndLoad(IEspContext &context, IEspCreateTableAndLoad
         if (!lzIP || !*lzIP)
             throw MakeStringException(-1, "WsSQL::CreateTableAndLoad: Error: LandingZone IP cannot be empty if targeting a landing zone file.");
 
-        StringBuffer lzPath = datasource.getLandingZonePath();
+        StringBuffer lzPath(datasource.getLandingZonePath());
 
         if (!lzPath.length())
             throw MakeStringException(-1, "WsSQL::CreateTableAndLoad: Error: Landingzone path cannot be empty.");
@@ -1813,7 +1813,7 @@ bool CwssqlEx::onCreateTableAndLoad(IEspContext &context, IEspCreateTableAndLoad
 
     bool overwrite = req.getOverwrite();
 
-    StringBuffer formatnamefull = formatname;
+    StringBuffer formatnamefull(formatname);
     IArrayOf<IConstDataTypeParam> & formatparams = format.getParams();
     int formatparamscount = formatparams.length();
     if (formatparamscount > 0 )

--- a/esp/services/ws_topology/ws_topologyService.cpp
+++ b/esp/services/ws_topology/ws_topologyService.cpp
@@ -491,7 +491,7 @@ bool CWsTopologyEx::isLineTerminator(const char* dataPtr, const size32_t dataSiz
     return false;
 }
 
-bool CWsTopologyEx::readLogLineID(char* linePtr, unsigned long& lineID)
+bool CWsTopologyEx::readLogLineID(const char* linePtr, unsigned long& lineID)
 {
     char *epTr;
     lineID = strtoul(linePtr, &epTr, 16);
@@ -520,11 +520,11 @@ bool CWsTopologyEx::readLogTime(char* pTr, int start, int length, CDateTime& dt)
     return bRet;
 }
 
-bool CWsTopologyEx::findTimestampAndLT(StringBuffer logname, IFile* rFile, ReadLog& readLogReq, CDateTime& latestLogTime)
+bool CWsTopologyEx::findTimestampAndLT(const char *logname, IFile* rFile, ReadLog& readLogReq, CDateTime& latestLogTime)
 {
     OwnedIFileIO rIO = rFile->openShared(IFOread,IFSHfull);
     if (!rIO)
-        throw MakeStringException(ECLWATCH_CANNOT_OPEN_FILE,"Cannot read file %s.",logname.str());
+        throw MakeStringException(ECLWATCH_CANNOT_OPEN_FILE,"Cannot read file %s.",logname);
 
     size32_t fileSize = (size32_t) rFile->size();
     size32_t readSize = 64000;
@@ -535,7 +535,7 @@ bool CWsTopologyEx::findTimestampAndLT(StringBuffer logname, IFile* rFile, ReadL
     StringBuffer dataBuffer;
     size32_t bytesRead = rIO->read(0, readSize, dataBuffer.reserve(readSize));
     if (bytesRead != readSize)
-        throw MakeStringException(ECLWATCH_CANNOT_READ_FILE, "Failed to read file %s.", logname.str());
+        throw MakeStringException(ECLWATCH_CANNOT_READ_FILE, "Failed to read file %s.", logname);
 
     char* pTr = (char*) dataBuffer.str();
     readLogReq.ltBytes = findLineTerminator(pTr, bytesRead);
@@ -553,7 +553,7 @@ bool CWsTopologyEx::findTimestampAndLT(StringBuffer logname, IFile* rFile, ReadL
     {
         bytesRead = rIO->read(fileSize - readSize, readSize, dataBuffer.clear().reserve(readSize));
         if (bytesRead != readSize)
-            throw MakeStringException(ECLWATCH_CANNOT_READ_FILE, "Failed to read file %s.", logname.str());
+            throw MakeStringException(ECLWATCH_CANNOT_READ_FILE, "Failed to read file %s.", logname);
         pTr = (char*) dataBuffer.str();
     }
 
@@ -606,8 +606,9 @@ char* CWsTopologyEx::readALogLine(char* dataPtr, size32_t& bytesRemaining, unsig
     return pTr;
 }
 
-void CWsTopologyEx::addALogLine(offset_t& readFrom, unsigned& locationFlag, StringBuffer dataRow, ReadLog& readLogReq, StringArray& returnbuff)
+void CWsTopologyEx::addALogLine(offset_t& readFrom, unsigned& locationFlag, const char * dataRow, ReadLog& readLogReq, StringArray& returnbuff)
 {
+    size_t len = strlen(dataRow);
     if (readLogReq.filterType == GLOFirstNRows)
     {
         locationFlag = 1; //enter the area to be retrieved
@@ -626,34 +627,34 @@ void CWsTopologyEx::addALogLine(offset_t& readFrom, unsigned& locationFlag, Stri
     else
     {
         unsigned long rowID;
-        if (!readLogLineID((char*)dataRow.str(), rowID)) //row id (and timestamp) not found in this log line
+        if (!readLogLineID(dataRow, rowID)) //row id (and timestamp) not found in this log line
         {
             if (locationFlag > 0)
                 returnbuff.append(dataRow);
-            readFrom += dataRow.length();
+            readFrom += len;
             return;
         }
 
         StringBuffer str;
-        str.append(dataRow.str(), 20, 8); //Read time
+        str.append(dataRow, 20, 8); //Read time
         if (readLogReq.endDate.length() > 0 && strcmp(str.str(), readLogReq.endDate.str()) > 0)
             locationFlag = 2; //out of the area to be retrieved
         else if (readLogReq.startDate.length() > 1 && strcmp(str.str(), readLogReq.startDate.str()) < 0)
-            readFrom += dataRow.length(); //skip this line
+            readFrom += len; //skip this line
         else
         {
             returnbuff.append(dataRow);
             if ((locationFlag < 1) && (readLogReq.filterType == GLOTimeRange))
                 readLogReq.pageFrom = readFrom;
 
-            readFrom += dataRow.length();
+            readFrom += len;
             locationFlag = 1; //enter the area to be retrieved
         }
     }
     return;
 }
 
-void CWsTopologyEx::readLogFileToArray(StringBuffer logname, OwnedIFileIO rIO, ReadLog& readLogReq, StringArray& returnbuf)
+void CWsTopologyEx::readLogFileToArray(const char *logname, OwnedIFileIO rIO, ReadLog& readLogReq, StringArray& returnbuf)
 {
     bool firstChuck = true;
     bool lastChuck = false;
@@ -699,7 +700,7 @@ void CWsTopologyEx::readLogFileToArray(StringBuffer logname, OwnedIFileIO rIO, R
             dataBuffer.append(logLine.str());
         size32_t nRead = rIO->read(readFrom, readSize, dataBuffer.reserve(readSize));
         if (nRead != readSize)
-            throw MakeStringException(ECLWATCH_CANNOT_READ_FILE, "Failed to read file %s.", logname.str());
+            throw MakeStringException(ECLWATCH_CANNOT_READ_FILE, "Failed to read file %s.", logname);
 
         logLineFrom = readFrom;
         readFrom += nRead;
@@ -726,18 +727,18 @@ void CWsTopologyEx::readLogFileToArray(StringBuffer logname, OwnedIFileIO rIO, R
     return;
 }
 
-void CWsTopologyEx::readLogFile(StringBuffer logname, IFile* rFile, ReadLog& readLogReq, StringBuffer& returnbuff)
+void CWsTopologyEx::readLogFile(const char *logname, IFile* rFile, ReadLog& readLogReq, StringBuffer& returnbuff)
 {
     OwnedIFileIO rIO = rFile->openShared(IFOread,IFSHfull);
     if (!rIO)
-        throw MakeStringException(ECLWATCH_CANNOT_OPEN_FILE,"Cannot read file %s.",logname.str());
+        throw MakeStringException(ECLWATCH_CANNOT_OPEN_FILE,"Cannot read file %s.", logname);
 
     if ((readLogReq.filterType == GLOFirstPage) || (readLogReq.filterType == GLOLastPage) || (readLogReq.filterType == GLOGoToPage)) //by page number
     {
         size32_t fileSize = (size32_t) (readLogReq.pageTo - readLogReq.pageFrom);
         size32_t nRead = rIO->read(readLogReq.pageFrom, fileSize, returnbuff.reserve(fileSize));
         if (nRead != fileSize)
-            throw MakeStringException(ECLWATCH_CANNOT_READ_FILE, "Failed to read file %s.", logname.str());
+            throw MakeStringException(ECLWATCH_CANNOT_READ_FILE, "Failed to read file %s.", logname);
     }
     else
     {
@@ -745,7 +746,7 @@ void CWsTopologyEx::readLogFile(StringBuffer logname, IFile* rFile, ReadLog& rea
         readLogFileToArray(logname, rIO, readLogReq, logLines);
         ForEachItemIn(i, logLines)
         {
-            StringBuffer logLine = logLines.item(i);
+            StringBuffer logLine(logLines.item(i));
             if ((!readLogReq.reverse && (readLogReq.filterType != 5)) ||
                 (readLogReq.reverse && (readLogReq.filterType == 5)))
                 returnbuff.append(logLine.str());

--- a/esp/services/ws_topology/ws_topologyService.hpp
+++ b/esp/services/ws_topology/ws_topologyService.hpp
@@ -94,15 +94,15 @@ private:
     void getThorLog(const char *cluster,MemoryBuffer& returnbuff);
     //void getThorLog(StringBuffer logname,StringBuffer& returnbuff);
     int loadFile(const char* fname, int& len, unsigned char* &buf, bool binary=true);
-    void readLogFile(StringBuffer logname, IFile* pFile, ReadLog& readLogReq, StringBuffer& returnbuff);
-    void readLogFileToArray(StringBuffer logname, OwnedIFileIO rIO, ReadLog& readLogReq, StringArray& returnbuff);
-    bool readLogLineID(char* pTr, unsigned long& lineID);
+    void readLogFile(const char * logname, IFile* pFile, ReadLog& readLogReq, StringBuffer& returnbuff);
+    void readLogFileToArray(const char * logname, OwnedIFileIO rIO, ReadLog& readLogReq, StringArray& returnbuff);
+    bool readLogLineID(const char* pTr, unsigned long& lineID);
     bool readLogTime(char* pTr, int start, int length, CDateTime& dt);
-    bool findTimestampAndLT(StringBuffer logname, IFile* pFile, ReadLog& readLogReq, CDateTime& latestLogTime);
+    bool findTimestampAndLT(const char * logname, IFile* pFile, ReadLog& readLogReq, CDateTime& latestLogTime);
     unsigned findLineTerminator(const char* dataPtr, const size32_t dataSize);
     bool isLineTerminator(const char* dataPtr, const size32_t dataSize, unsigned ltLength);
     char* readALogLine(char* dataPtr, size32_t& dataSize, unsigned ltLength, StringBuffer& logLine, bool& hasLineTerminator);
-    void addALogLine(offset_t& readFrom, unsigned& locationFlag, StringBuffer dataRow, ReadLog& readLogReq, StringArray& returnbuff);
+    void addALogLine(offset_t& readFrom, unsigned& locationFlag, const char *dataRow, ReadLog& readLogReq, StringArray& returnbuff);
     void readTpLogFileRequest(IEspContext &context, const char* fileName, IFile* rFile, IEspTpLogFileRequest  &req, ReadLog& readLogReq);
     void setTpLogFileResponse(IEspContext &context, ReadLog& readLogReq, const char* fileName,
                                          const char* fileType, StringBuffer& returnbuf, IEspTpLogFileResponse &resp);

--- a/esp/services/ws_workunits/ws_workunitsAuditLogs.cpp
+++ b/esp/services/ws_workunits/ws_workunitsAuditLogs.cpp
@@ -1380,7 +1380,7 @@ void streamJobQueueListResponse(IEspContext &context, const char *cluster, const
 
 void logWUClusterJobESPCall(const char* method, const char* cluster, const char* from, const char* to)
 {
-    StringBuffer logMsg = method;
+    StringBuffer logMsg(method);
     if (notEmpty(cluster))
         logMsg.appendf(" cluster %s,", cluster);
     if (notEmpty(from))
@@ -1674,7 +1674,7 @@ bool CWsWorkunitsEx::onWUClusterJobQueueLOG(IEspContext &context,IEspWUClusterJo
         SecAccessFlags accessOthers;
         getUserWuAccessFlags(context, accessOwn, accessOthers, true);
 
-        StringBuffer logMsg = "WUClusterJobQueueLOG: ";
+        StringBuffer logMsg("WUClusterJobQueueLOG: ");
         CDateTime fromTime;
         if(notEmpty(req.getStartDate()))
         {
@@ -1798,8 +1798,8 @@ bool CWsWorkunitsEx::onWUGetThorJobList(IEspContext &context, IEspWUGetThorJobLi
         maxJobsToReturn = defaultMaxJobsInWUGetJobListResponse;
 
     CDateTime queryAuditLogFrom, queryAuditLogTo;
-    StringBuffer startDate = req.getStartDate();
-    StringBuffer endDate = req.getEndDate();
+    StringBuffer startDate(req.getStartDate());
+    StringBuffer endDate(req.getEndDate());
     if (!startDate.isEmpty())
     {
         if (startDate.length() == 10)
@@ -2119,8 +2119,8 @@ bool CWsWorkunitsEx::onWUGetThorJobQueue(IEspContext &context, IEspWUGetThorJobQ
         getUserWuAccessFlags(context, accessOwn, accessOthers, true);
 
         const char *cluster = req.getCluster();
-        StringBuffer startDate = req.getStartDate();
-        StringBuffer endDate = req.getEndDate();
+        StringBuffer startDate(req.getStartDate());
+        StringBuffer endDate(req.getEndDate());
         unsigned maxJobQueueItemsToReturn = req.getMaxJobQueueItemsToReturn();
         if (maxJobQueueItemsToReturn == 0)
             maxJobQueueItemsToReturn = defaultMaxJobQueueItemsInWUGetJobQueueResponse;

--- a/esp/services/ws_workunits/ws_workunitsHelpers.cpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.cpp
@@ -1130,7 +1130,7 @@ unsigned WsWuInfo::getWorkunitThorLogInfo(IArrayOf<IEspECLHelpFile>& helpers, IE
                 }
 
                 ppStr += 12;
-                StringBuffer logDate = ppStr;
+                StringBuffer logDate(ppStr);
                 logDate.setLength(10);
 
                 Owned<IEspThorLogInfo> thorLog = createThorLogInfo("","");
@@ -1202,7 +1202,7 @@ unsigned WsWuInfo::getWorkunitThorLogInfo(IArrayOf<IEspECLHelpFile>& helpers, IE
 
                 const char* pProcessName = ppStr + logDir.length();
                 char sep = pProcessName[0];
-                StringBuffer processName = pProcessName + 1;
+                StringBuffer processName(pProcessName + 1);
                 ppStr = strchr(pProcessName + 1, sep);
                 if (!ppStr)
                 {
@@ -1214,7 +1214,7 @@ unsigned WsWuInfo::getWorkunitThorLogInfo(IArrayOf<IEspECLHelpFile>& helpers, IE
                 StringBuffer groupName;
                 getClusterThorGroupName(groupName, processName.str());
 
-                StringBuffer logDate = ppStr + 12;
+                StringBuffer logDate(ppStr + 12);
                 logDate.setLength(10);
 
                 Owned<IEspThorLogInfo> thorLog = createThorLogInfo("","");
@@ -2064,7 +2064,7 @@ void WsWuInfo::getWorkunitThorSlaveLog(const char *groupName, const char *ipAddr
             slaveIPAddress.append(ipAddress);
         else
         {
-            StringBuffer ipAddressStr = ipAddress;
+            StringBuffer ipAddressStr(ipAddress);
             ipAddressStr.setLength(portPtr - ipAddress);
             slaveIPAddress.append(ipAddressStr.str());
         }
@@ -3267,7 +3267,7 @@ void WsWuHelpers::submitWsWorkunit(IEspContext& context, const char *wuid, const
     Owned<IConstWorkUnit> cw = factory->openWorkUnit(wuid);
     if(!cw)
         throw MakeStringException(ECLWATCH_CANNOT_OPEN_WORKUNIT,"Cannot open workunit %s.",wuid);
-    return submitWsWorkunit(context, cw, cluster, snapshot, maxruntime, compile, resetWorkflow, resetVariables, paramXml, variables, debugs, applications);
+    submitWsWorkunit(context, cw, cluster, snapshot, maxruntime, compile, resetWorkflow, resetVariables, paramXml, variables, debugs, applications);
 }
 
 
@@ -3510,7 +3510,7 @@ void CWsWuFileHelper::createThorSlaveLogfile(Owned<IConstWorkUnit>& cwu, WsWuInf
                 continue;
             }
             ppStr += 12;
-            StringBuffer logDate = ppStr;
+            StringBuffer logDate(ppStr);
             logDate.setLength(10);
 
             for (unsigned i = 0; i < numberOfSlaveLogs; i++)
@@ -3785,7 +3785,7 @@ IFileIOStream* CWsWuFileHelper::createWUZAPFileIOStream(IEspContext& context, Ow
     {
         CWsWuEmailHelper emailHelper(request.emailFrom.str(), request.emailTo.str(), request.emailServer.str(), request.port);
 
-        StringBuffer subject = request.emailSubject.str();
+        StringBuffer subject(request.emailSubject.str());
         if (subject.isEmpty())
             subject.append(request.wuid.str()).append(" ZAP Report");
         emailHelper.setSubject(subject.str());
@@ -3957,7 +3957,7 @@ void CWsWuFileHelper::readWUFile(const char* wuid, const char* workingFolder, Ws
         break;
     case CWUFileType_XML:
     {
-        StringBuffer name  = item.getName();
+        StringBuffer name(item.getName());
         if (!name.isEmpty())
         {
             const char *tail=pathTail(name.str());

--- a/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
+++ b/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
@@ -454,7 +454,7 @@ IPropertyTreeIterator *QueryFilesInUse::findQueriesUsingFile(const char *target,
 
 bool CWsWorkunitsEx::onWUCopyLogicalFiles(IEspContext &context, IEspWUCopyLogicalFilesRequest &req, IEspWUCopyLogicalFilesResponse &resp)
 {
-    StringBuffer wuid = req.getWuid();
+    StringBuffer wuid(req.getWuid());
     WsWuHelpers::checkAndTrimWorkunit("WUCopyLogicalFiles", wuid);
 
     Owned<IWorkUnitFactory> factory = getWorkUnitFactory(context.querySecManager(), context.queryUser());
@@ -811,7 +811,7 @@ bool CWsWorkunitsEx::isQuerySuspended(const char* query, IConstWUClusterInfo *cl
 
 bool CWsWorkunitsEx::onWUPublishWorkunit(IEspContext &context, IEspWUPublishWorkunitRequest & req, IEspWUPublishWorkunitResponse & resp)
 {
-    StringBuffer wuid = req.getWuid();
+    StringBuffer wuid(req.getWuid());
     WsWuHelpers::checkAndTrimWorkunit("WUPublishWorkunit", wuid);
 
     Owned<IWorkUnitFactory> factory = getWorkUnitFactory(context.querySecManager(), context.queryUser());
@@ -2471,7 +2471,7 @@ public:
     }
     void cloneQueryRemote(IPropertyTree *query, bool makeActive)
     {
-        StringBuffer wuid = query->queryProp("Wuid");
+        StringBuffer wuid(query->queryProp("Wuid"));
         if (!wuid.length())
             return;
         const char *queryName = query->queryProp("Name");
@@ -3198,7 +3198,7 @@ bool CWsWorkunitsEx::onWUUpdateQueryEntry(IEspContext& context, IEspWUUpdateQuer
         if (!tree)
             throw MakeStringException(ECLWATCH_QUERYSET_NOT_FOUND, "Query %s not found", query.str());
 
-        StringBuffer comment = req.getComment();
+        StringBuffer comment(req.getComment());
         if (comment.isEmpty())
             tree->removeProp("@comment");
         else
@@ -3251,7 +3251,7 @@ bool CWsWorkunitsEx::onWUGetNumFileToCopy(IEspContext& context, IEspWUGetNumFile
 
     try
     {
-        StringBuffer clusterName = req.getClusterName();
+        StringBuffer clusterName(req.getClusterName());
         if (clusterName.isEmpty())
             throw MakeStringException(ECLWATCH_CANNOT_RESOLVE_CLUSTER_NAME, "Cluster not specified");
 

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -117,7 +117,7 @@ bool doAction(IEspContext& context, StringArray& wuids, CECLWUActions action, IP
     const char* strAction = (action < NumOfECLWUActionNames) ? ECLWUActionNames[action] : "Unknown Action";
     for(aindex_t i=0; i<wuids.length();i++)
     {
-        StringBuffer wuidStr = wuids.item(i);
+        StringBuffer wuidStr(wuids.item(i));
         const char* wuid = wuidStr.trim().str();
         if (isEmpty(wuid))
         {
@@ -513,7 +513,7 @@ bool CWsWorkunitsEx::onWUUpdate(IEspContext &context, IEspWUUpdateRequest &req, 
 {
     try
     {
-        StringBuffer wuid = req.getWuid();
+        StringBuffer wuid(req.getWuid());
         WsWuHelpers::checkAndTrimWorkunit("WUUpdate", wuid);
 
         ensureWsWorkunitAccess(context, wuid.str(), SecAccess_Write);
@@ -815,7 +815,7 @@ bool CWsWorkunitsEx::onWUResubmit(IEspContext &context, IEspWUResubmitRequest &r
         IArrayOf<IEspResubmittedWU> resubmittedWUs;
         for(aindex_t i=0; i<req.getWuids().length();i++)
         {
-            StringBuffer requestWuid = req.getWuids().item(i);
+            StringBuffer requestWuid(req.getWuids().item(i));
             WsWuHelpers::checkAndTrimWorkunit("WUResubmit", requestWuid);
 
             ensureWsWorkunitAccess(context, requestWuid.str(), SecAccess_Write);
@@ -919,7 +919,7 @@ bool CWsWorkunitsEx::onWUSchedule(IEspContext &context, IEspWUScheduleRequest &r
 {
     try
     {
-        StringBuffer wuid = req.getWuid();
+        StringBuffer wuid(req.getWuid());
         WsWuHelpers::checkAndTrimWorkunit("WUSchedule", wuid);
 
         const char* cluster = req.getCluster();
@@ -974,7 +974,7 @@ bool CWsWorkunitsEx::onWUSubmit(IEspContext &context, IEspWUSubmitRequest &req, 
 {
     try
     {
-        StringBuffer wuid = req.getWuid();
+        StringBuffer wuid(req.getWuid());
         WsWuHelpers::checkAndTrimWorkunit("WUSubmit", wuid);
 
         const char *cluster = req.getCluster();
@@ -1041,7 +1041,7 @@ bool CWsWorkunitsEx::onWURun(IEspContext &context, IEspWURunRequest &req, IEspWU
         if (notEmpty(cluster) && !isValidCluster(cluster))
             throw MakeStringException(ECLWATCH_INVALID_CLUSTER_NAME, "Invalid cluster name: %s", cluster);
 
-        StringBuffer wuidStr = req.getWuid();
+        StringBuffer wuidStr(req.getWuid());
         const char* runWuid = wuidStr.trim().str();
         StringBuffer wuid;
 
@@ -1114,7 +1114,7 @@ bool CWsWorkunitsEx::onWUFullResult(IEspContext &context, IEspWUFullResultReques
 {
     try
     {
-        StringBuffer wuid = req.getWuid();
+        StringBuffer wuid(req.getWuid());
         WsWuHelpers::checkAndTrimWorkunit("WUFullResult", wuid);
 
         ErrorSeverity severity = checkGetExceptionSeverity(req.getExceptionSeverity());
@@ -1167,7 +1167,7 @@ bool CWsWorkunitsEx::onWUWaitCompiled(IEspContext &context, IEspWUWaitRequest &r
 {
     try
     {
-        StringBuffer wuid = req.getWuid();
+        StringBuffer wuid(req.getWuid());
         WsWuHelpers::checkAndTrimWorkunit("WUWaitCompiled", wuid);
         ensureWsWorkunitAccess(context, wuid.str(), SecAccess_Full);
         PROGLOG("WUWaitCompiled: %s", wuid.str());
@@ -1190,7 +1190,7 @@ bool CWsWorkunitsEx::onWUWaitComplete(IEspContext &context, IEspWUWaitRequest &r
 {
     try
     {
-        StringBuffer wuid = req.getWuid();
+        StringBuffer wuid(req.getWuid());
         WsWuHelpers::checkAndTrimWorkunit("WUWaitComplete", wuid);
         ensureWsWorkunitAccess(context, wuid.str(), SecAccess_Full);
         PROGLOG("WUWaitComplete: %s", wuid.str());
@@ -1207,7 +1207,7 @@ bool CWsWorkunitsEx::onWUCDebug(IEspContext &context, IEspWUDebugRequest &req, I
 {
     try
     {
-        StringBuffer wuid = req.getWuid();
+        StringBuffer wuid(req.getWuid());
         WsWuHelpers::checkAndTrimWorkunit("WUCDebug", wuid);
         ensureWsWorkunitAccess(context, wuid.str(), SecAccess_Full);
         PROGLOG("WUCDebug: %s", wuid.str());
@@ -1547,7 +1547,7 @@ bool CWsWorkunitsEx::onWUInfo(IEspContext &context, IEspWUInfoRequest &req, IEsp
 {
     try
     {
-        StringBuffer wuid = req.getWuid();
+        StringBuffer wuid(req.getWuid());
         WsWuHelpers::checkAndTrimWorkunit("WUInfo", wuid);
 
         double version = context.getClientVersion();
@@ -1672,7 +1672,7 @@ bool CWsWorkunitsEx::onWUInfoDetails(IEspContext &context, IEspWUInfoRequest &re
 
 bool CWsWorkunitsEx::onWUResultView(IEspContext &context, IEspWUResultViewRequest &req, IEspWUResultViewResponse &resp)
 {
-    StringBuffer wuid = req.getWuid();
+    StringBuffer wuid(req.getWuid());
     WsWuHelpers::checkAndTrimWorkunit("WUResultView", wuid);
 
     ensureWsWorkunitAccess(context, wuid.str(), SecAccess_Read);
@@ -2520,7 +2520,7 @@ bool CWsWorkunitsEx::onWUQuery(IEspContext &context, IEspWUQueryRequest & req, I
 {
     try
     {
-        StringBuffer wuidStr = req.getWuid();
+        StringBuffer wuidStr(req.getWuid());
         const char* wuid = wuidStr.trim().str();
 
         if (req.getType() && strieq(req.getType(), "archived workunits"))
@@ -2956,7 +2956,7 @@ bool CWsWorkunitsEx::onWUFile(IEspContext &context,IEspWULogFileRequest &req, IE
 {
     try
     {
-        StringBuffer wuidStr = req.getWuid();
+        StringBuffer wuidStr(req.getWuid());
         const char* wuidIn = wuidStr.trim().str();
         if (wuidIn && *wuidIn)
         {
@@ -3180,7 +3180,7 @@ bool CWsWorkunitsEx::onWUResultBin(IEspContext &context,IEspWUResultBinRequest &
 {
     try
     {
-        StringBuffer wuidStr = req.getWuid();
+        StringBuffer wuidStr(req.getWuid());
         const char* wuidIn = wuidStr.trim().str();
         if (wuidIn && *wuidIn)
         {
@@ -3334,7 +3334,7 @@ bool CWsWorkunitsEx::onWUResultSummary(IEspContext &context, IEspWUResultSummary
 {
     try
     {
-        StringBuffer wuid = req.getWuid();
+        StringBuffer wuid(req.getWuid());
         WsWuHelpers::checkAndTrimWorkunit("WUResultSummary", wuid);
 
         Owned<IWorkUnitFactory> factory = getWorkUnitFactory(context.querySecManager(), context.queryUser());
@@ -3369,7 +3369,7 @@ bool CWsWorkunitsEx::onWUResult(IEspContext &context, IEspWUResultRequest &req, 
 {
     try
     {
-        StringBuffer wuidStr = req.getWuid();
+        StringBuffer wuidStr(req.getWuid());
         const char* wuid = wuidStr.trim().str();
         if (wuid && *wuid)
         {
@@ -3712,7 +3712,7 @@ bool CWsWorkunitsEx::onWUListLocalFileRequired(IEspContext& context, IEspWUListL
 {
     try
     {
-        StringBuffer wuid = req.getWuid();
+        StringBuffer wuid(req.getWuid());
         WsWuHelpers::checkAndTrimWorkunit("WUListLocalFileRequired", wuid);
 
         ensureWsWorkunitAccess(context, wuid.str(), SecAccess_Read);
@@ -3812,7 +3812,7 @@ bool CWsWorkunitsEx::onWUAddLocalFileToWorkunit(IEspContext& context, IEspWUAddL
 {
     try
     {
-        StringBuffer wuid = req.getWuid();
+        StringBuffer wuid(req.getWuid());
         WsWuHelpers::checkAndTrimWorkunit("WUAddLocalFileToWorkunit", wuid);
         ensureWsWorkunitAccess(context, wuid.str(), SecAccess_Write);
         resp.setWuid(wuid.str());
@@ -3904,12 +3904,12 @@ bool CWsWorkunitsEx::onWUGetGraphNameAndTypes(IEspContext &context,IEspWUGetGrap
 {
     try
     {
-        StringBuffer wuid = req.getWuid();
+        StringBuffer wuid(req.getWuid());
         WsWuHelpers::checkAndTrimWorkunit("WUGraphQuery", wuid);
         ensureWsWorkunitAccess(context, wuid.str(), SecAccess_Read);
         PROGLOG("WUGetGraphNameAndTypes: %s", wuid.str());
 
-        StringBuffer type = req.getType();
+        StringBuffer type(req.getType());
         WUGraphType graphType = GraphTypeAny;
         if (type.trim().length())
             graphType = getGraphTypeFromString(type.str());
@@ -3931,7 +3931,7 @@ bool CWsWorkunitsEx::onWUProcessGraph(IEspContext &context,IEspWUProcessGraphReq
 {
     try
     {
-        StringBuffer wuid = req.getWuid();
+        StringBuffer wuid(req.getWuid());
         WsWuHelpers::checkAndTrimWorkunit("WUProcessGraph", wuid);
 
         Owned<IWorkUnitFactory> factory = getWorkUnitFactory(context.querySecManager(), context.queryUser());
@@ -4027,7 +4027,7 @@ bool CWsWorkunitsEx::onWUGetGraph(IEspContext& context, IEspWUGetGraphRequest& r
 {
     try
     {
-        StringBuffer wuid = req.getWuid();
+        StringBuffer wuid(req.getWuid());
         WsWuHelpers::checkAndTrimWorkunit("WUGetGraph", wuid);
 
         Owned<IWorkUnitFactory> factory = getWorkUnitFactory(context.querySecManager(), context.queryUser());
@@ -4089,7 +4089,7 @@ bool CWsWorkunitsEx::onWUDetails(IEspContext &context, IEspWUDetailsRequest &req
 {
     try
     {
-        StringBuffer wuid = req.getWUID();
+        StringBuffer wuid(req.getWUID());
         WsWuHelpers::checkAndTrimWorkunit("WUDetails", wuid);
 
         PROGLOG("WUDetails: %s", wuid.str());
@@ -4245,7 +4245,7 @@ bool CWsWorkunitsEx::onWUGraphInfo(IEspContext &context,IEspWUGraphInfoRequest &
 {
     try
     {
-        StringBuffer wuid = req.getWuid();
+        StringBuffer wuid(req.getWuid());
         WsWuHelpers::checkAndTrimWorkunit("WUGraphInfo", wuid);
 
         Owned<IWorkUnitFactory> factory = getWorkUnitFactory(context.querySecManager(), context.queryUser());
@@ -4274,7 +4274,7 @@ bool CWsWorkunitsEx::onWUGVCGraphInfo(IEspContext &context,IEspWUGVCGraphInfoReq
 {
     try
     {
-        StringBuffer wuid = req.getWuid();
+        StringBuffer wuid(req.getWuid());
         WsWuHelpers::checkAndTrimWorkunit("WUGVCGraphInfo", wuid);
 
         Owned<IWorkUnitFactory> factory = getWorkUnitFactory(context.querySecManager(), context.queryUser());
@@ -4314,7 +4314,7 @@ bool CWsWorkunitsEx::onWUGraphTiming(IEspContext &context, IEspWUGraphTimingRequ
 {
     try
     {
-        StringBuffer wuid = req.getWuid();
+        StringBuffer wuid(req.getWuid());
         WsWuHelpers::checkAndTrimWorkunit("WUGraphTiming", wuid);
 
         Owned<IWorkUnitFactory> factory = getWorkUnitFactory(context.querySecManager(), context.queryUser());
@@ -4756,7 +4756,7 @@ bool CWsWorkunitsEx::onWUGetZAPInfo(IEspContext &context, IEspWUGetZAPInfoReques
 {
     try
     {
-        StringBuffer wuid = req.getWUID();
+        StringBuffer wuid(req.getWUID());
         WsWuHelpers::checkAndTrimWorkunit("WUGetZAPInfo", wuid);
 
         Owned<IWorkUnitFactory> factory = getWorkUnitFactory(context.querySecManager(), context.queryUser());
@@ -4917,7 +4917,7 @@ bool CWsWorkunitsEx::onWUGetStats(IEspContext &context, IEspWUGetStatsRequest &r
         if (!req.getCreateDescriptions_isNull())
             createDescriptions = req.getCreateDescriptions();
 
-        StringBuffer wuid = req.getWUID();
+        StringBuffer wuid(req.getWUID());
         PROGLOG("WUGetStats: %s", wuid.str());
 
         IArrayOf<IEspWUStatisticItem> statistics;
@@ -5241,7 +5241,7 @@ void CWsWorkunitsEx::deployEclDefinition(IEspContext &context, const char *targe
 void CWsWorkunitsEx::publishEclDefinition(IEspContext &context, const char *target,  const char *eclDefinition,
     int msToWait, IEspWUEclDefinitionActionRequest &req, IArrayOf<IConstWUEclDefinitionActionResult> &results)
 {
-    StringBuffer priorityReq = req.getPriority();
+    StringBuffer priorityReq(req.getPriority());
     if (priorityReq.trim().length() && !isValidPriorityValue(priorityReq.str()))
     {
         VStringBuffer msg("Invalid Priority: %s", priorityReq.str());
@@ -5249,7 +5249,7 @@ void CWsWorkunitsEx::publishEclDefinition(IEspContext &context, const char *targ
         return;
     }
 
-    StringBuffer memoryLimitReq = req.getMemoryLimit();
+    StringBuffer memoryLimitReq(req.getMemoryLimit());
     if (memoryLimitReq.trim().length() && !isValidMemoryValue(memoryLimitReq.str()))
     {
         VStringBuffer msg("Invalid MemoryLimit: %s", memoryLimitReq.str());
@@ -5275,9 +5275,9 @@ void CWsWorkunitsEx::publishEclDefinition(IEspContext &context, const char *targ
     }
 
     //Do publish now
-    StringBuffer comment = req.getComment();
-    StringBuffer remoteDali = req.getRemoteDali();
-    StringBuffer sourceProcess = req.getSourceProcess();
+    StringBuffer comment(req.getComment());
+    StringBuffer remoteDali(req.getRemoteDali());
+    StringBuffer sourceProcess(req.getSourceProcess());
     int timeLimit = req.getTimeLimit();
     int warnTimeLimit = req.getWarnTimeLimit();
 
@@ -5349,7 +5349,7 @@ bool CWsWorkunitsEx::onWUEclDefinitionAction(IEspContext &context, IEspWUEclDefi
 
         ensureWsCreateWorkunitAccess(context);
 
-        StringBuffer target = req.getTarget();
+        StringBuffer target(req.getTarget());
         if (target.trim().isEmpty())
             throw MakeStringException(ECLWATCH_INVALID_INPUT,"Target not defined in onWUEclDefinitionAction.");
 
@@ -5358,7 +5358,7 @@ bool CWsWorkunitsEx::onWUEclDefinitionAction(IEspContext &context, IEspWUEclDefi
         int msToWait = req.getMsToWait();
         for (aindex_t i = 0; i < eclDefinitions.length(); i++)
         {
-            StringBuffer eclDefinitionName = eclDefinitions.item(i);
+            StringBuffer eclDefinitionName(eclDefinitions.item(i));
             if (eclDefinitionName.trim().isEmpty())
                 WARNLOG("Empty ECL Definition name in WUEclDefinitionAction request");
             else if (action == CEclDefinitionActions_SyntaxCheck)

--- a/esp/services/ws_workunits/ws_wudetails.cpp
+++ b/esp/services/ws_workunits/ws_wudetails.cpp
@@ -76,7 +76,8 @@ private:
     public:
         void add(WuAttr attr, const char *value)
         {
-            AttribValuePair tmp(attr,"");
+            AttribValuePair tmp;
+            tmp.first = attr;
 
             auto cur = find(attribValuePairs.begin(), attribValuePairs.end(), tmp);
             if (cur!=attribValuePairs.end())

--- a/esp/tools/soapplus/EspLogDeserializer.cpp
+++ b/esp/tools/soapplus/EspLogDeserializer.cpp
@@ -170,7 +170,7 @@ static void LoadMethodMappings()
                 printf( "Syntax error in EspMethods.txt at line %d: ", lineno++);
             else
             {
-                StringBuffer method = strArray.item(0);
+                StringBuffer method(strArray.item(0));
                 method.trim();
 
                 if (ord > 1)

--- a/plugins/cassandra/cassandrawu.cpp
+++ b/plugins/cassandra/cassandrawu.cpp
@@ -497,7 +497,7 @@ public:
         unsigned numItems = 0;
         ForEach(*attrs)
         {
-            StringBuffer key = attrs->queryName();
+            StringBuffer key(attrs->queryName());
             key.append('@');
             if (strstr(name, key) == NULL)
                 numItems++;
@@ -509,7 +509,7 @@ public:
                 CassandraCollection collection(cass_collection_new(CASS_COLLECTION_TYPE_MAP, numItems));
                 ForEach(*attrs)
                 {
-                    StringBuffer key = attrs->queryName();
+                    StringBuffer key(attrs->queryName());
                     key.append('@');
                     if (strstr(name, key) == NULL)
                     {
@@ -3526,6 +3526,7 @@ public:
                         merger->addPostFilter(*new PostFilter(field, fv, true)); // Wildcards on ECL are trailing and leading - no way to do remotely
                     else
                         goodFilters.append(*new PostFilter(field, fv, false)); // A hard filter on exact ecl match is possible but very unlikely
+                    break;
                 default:
                     UNSUPPORTED("Workunit filter criteria");
                 }

--- a/plugins/kafka/kafka.cpp
+++ b/plugins/kafka/kafka.cpp
@@ -82,7 +82,7 @@ namespace KafkaPlugin
 
             ForEach(*props)
             {
-                StringBuffer key = props->getPropKey();
+                StringBuffer key(props->getPropKey());
 
                 key.trim();
 
@@ -612,10 +612,8 @@ namespace KafkaPlugin
         return new KafkaStreamedDataset(this, allocator, traceLevel, maxRecords);
     }
 
-    StringBuffer Consumer::offsetFilePath() const
+    StringBuffer &Consumer::offsetFilePath(StringBuffer &offsetPath) const
     {
-        StringBuffer offsetPath;
-
         offsetPath.append(topic.c_str());
         offsetPath.append("-");
         offsetPath.append(partitionNum);
@@ -641,7 +639,8 @@ namespace KafkaPlugin
             // we left off; NOTE:  librdkafka does not clean the topic name
             // or consumer group name when constructing this path
             // (which is actually a security concern), so we can't clean, either
-            StringBuffer offsetPath = offsetFilePath();
+            StringBuffer offsetPath;
+            offsetFilePath(offsetPath);
 
             std::ofstream outFile(offsetPath.str(), std::ofstream::trunc);
             outFile << offset;
@@ -655,7 +654,8 @@ namespace KafkaPlugin
 
     void Consumer::initFileOffsetIfNotExist() const
     {
-        StringBuffer offsetPath = offsetFilePath();
+        StringBuffer offsetPath;
+        offsetFilePath(offsetPath);
 
         if (!checkFileExists(offsetPath.str()))
         {

--- a/plugins/kafka/kafka.hpp
+++ b/plugins/kafka/kafka.hpp
@@ -275,10 +275,11 @@ extern "C++"
                 KafkaStreamedDataset* getMessageDataset(IEngineRowAllocator* allocator, __int64 maxRecords = 1);
 
                 /**
-                 * @return  StringBuffer object containing the path to this
-                 *          consumer's offset file
+                 * @param offsetPath  StringBuffer object to contain the path to this
+                 *                    consumer's offset file
+                 * @return            Reference to pass-in buffer
                  */
-                StringBuffer offsetFilePath() const;
+                StringBuffer &offsetFilePath(StringBuffer &offsetPath) const;
 
                 /**
                  * Commits the given offset to storage so we can pick up

--- a/plugins/logging/logging.cpp
+++ b/plugins/logging/logging.cpp
@@ -66,18 +66,18 @@ LOGGING_API void LOGGING_CALL logDbgLog(unsigned srcLen, const char * src)
 
 LOGGING_API char *  LOGGING_CALL logGetGlobalId(ICodeContext *ctx)
 {
-    StringBuffer ret = ctx->queryContextLogger().queryGlobalId();
+    StringBuffer ret(ctx->queryContextLogger().queryGlobalId());
     return ret.detach();
 }
 
 LOGGING_API char *  LOGGING_CALL logGetLocalId(ICodeContext *ctx)
 {
-    StringBuffer ret = ctx->queryContextLogger().queryLocalId();
+    StringBuffer ret(ctx->queryContextLogger().queryLocalId());
     return ret.detach();
 }
 
 LOGGING_API char *  LOGGING_CALL logGetCallerId(ICodeContext *ctx)
 {
-    StringBuffer ret = ctx->queryContextLogger().queryCallerId();
+    StringBuffer ret(ctx->queryContextLogger().queryCallerId());
     return ret.detach();
 }

--- a/plugins/memcached/memcachedplugin.cpp
+++ b/plugins/memcached/memcachedplugin.cpp
@@ -244,7 +244,7 @@ template<class type> void MemCachedPlugin::MCached::get(ICodeContext * ctx, cons
     else
         value.setown(memcached_get(connection, key, strlen(key), &returnLength, &flag, &rc));
 
-    StringBuffer keyMsg = "'Get<type>' request failed - ";
+    StringBuffer keyMsg("'Get<type>' request failed - ");
     assertOnError(rc, appendIfKeyNotFoundMsg(rc, key, keyMsg));
     reportKeyTypeMismatch(ctx, key, flag, eclType);
 
@@ -267,7 +267,7 @@ template<class type> void MemCachedPlugin::MCached::get(ICodeContext * ctx, cons
     else
         value.setown(memcached_get(connection, key, strlen(key), &returnLength, &flag, &rc));
 
-    StringBuffer keyMsg = "'Get<type>' request failed - ";
+    StringBuffer keyMsg("'Get<type>' request failed - ");
     assertOnError(rc, appendIfKeyNotFoundMsg(rc, key, keyMsg));
     reportKeyTypeMismatch(ctx, key, flag, eclType);
 
@@ -286,7 +286,7 @@ void MemCachedPlugin::MCached::getVoidPtrLenPair(ICodeContext * ctx, const char 
     else
         value.setown(memcached_get(connection, key, strlen(key), &returnValueLength, &flag, &rc));
 
-    StringBuffer keyMsg = "'Get<type>' request failed - ";
+    StringBuffer keyMsg("'Get<type>' request failed - ");
     assertOnError(rc, appendIfKeyNotFoundMsg(rc, key, keyMsg));
     reportKeyTypeMismatch(ctx, key, flag, eclType);
 
@@ -340,7 +340,7 @@ void MemCachedPlugin::MCached::assertPool()
 {
     if (!pool)
     {
-        StringBuffer msg = "Memcached Plugin: Failed to instantiate server pool with:";
+        StringBuffer msg("Memcached Plugin: Failed to instantiate server pool with:");
         msg.newline().append(options);
         rtlFail(0, msg.str());
     }

--- a/rtl/eclrtl/rtlformat.cpp
+++ b/rtl/eclrtl/rtlformat.cpp
@@ -1251,7 +1251,7 @@ void CommonCSVWriter::outputBeginNested(const char* fieldName, bool simpleNested
             unsigned rowCount = item->getRowCount();
             if (rowCount > 0)
             {//Starting from the second result row, the NextRowIDs of every children are reset based on the last result row.
-                StringBuffer path = currentParentXPath;
+                StringBuffer path(currentParentXPath);
                 path.setLength(path.length() - 1);
                 setChildrenNextRowID(path.str(), getChildrenMaxNextRowID(path.str()));
             }
@@ -1375,13 +1375,13 @@ void CommonCSVWriter::outputHeadersToBuffer()
 //Go through every children to find out MaxColumnID.
 unsigned CommonCSVWriter::getChildrenMaxColumnID(CCSVItem* item, unsigned& maxColumnID)
 {
-    StringBuffer path = item->getParentXPath();
+    StringBuffer path(item->getParentXPath());
     path.append(item->getName());
 
     StringArray& names = item->getChildrenNames();
     ForEachItemIn(i, names)
     {
-        StringBuffer childPath = path;
+        StringBuffer childPath(path);
         childPath.append("/").append(names.item(i));
         CCSVItem* childItem = csvItems.getValue(childPath.str());
         if (!childItem)
@@ -1419,7 +1419,7 @@ CCSVItem* CommonCSVWriter::getParentCSVItem()
     if (currentParentXPath.isEmpty())
         return NULL;
 
-    StringBuffer path = currentParentXPath;
+    StringBuffer path(currentParentXPath);
     path.setLength(path.length() - 1);
     return csvItems.getValue(path.str());
 }
@@ -1494,7 +1494,7 @@ void CommonCSVWriter::addColumnToRow(CIArrayOf<CCSVRow>& rows, unsigned rowID, u
 void CommonCSVWriter::setParentItemRowEmpty(CCSVItem* item, bool empty)
 {
     item->setCurrentRowEmpty(empty);
-    StringBuffer parentXPath = item->getParentXPath();
+    StringBuffer parentXPath(item->getParentXPath());
     if (parentXPath.isEmpty())
         return;
     //If this item is not empty, its parent is not empty.
@@ -1515,7 +1515,7 @@ void CommonCSVWriter::addCSVHeader(const char* name, const char* type, bool isNe
     headerItem->setColumnID(headerColumnID);
     headerItem->setNestedLayer(nestedHeaderLayerID);
     headerItem->setParentXPath(currentParentXPath.str());
-    StringBuffer xPath = currentParentXPath;
+    StringBuffer xPath(currentParentXPath);
     xPath.append(name);
     csvItems.setValue(xPath.str(), headerItem);
 
@@ -1555,12 +1555,12 @@ unsigned CommonCSVWriter::getChildrenMaxNextRowID(const char* path)
         return item->getNextRowID();
 
     unsigned maxRowID = item->getNextRowID();
-    StringBuffer basePath = path;
+    StringBuffer basePath(path);
     basePath.append("/");
     StringArray& names = item->getChildrenNames();
     ForEachItemIn(i, names)
     {
-        StringBuffer childPath = basePath;
+        StringBuffer childPath(basePath);
         childPath.append(names.item(i));
         unsigned rowID = getChildrenMaxNextRowID(childPath.str());
         if (rowID > maxRowID)
@@ -1584,7 +1584,7 @@ void CommonCSVWriter::setChildrenNextRowID(const char* path, unsigned rowID)
     StringArray& names = item->getChildrenNames();
     ForEachItemIn(i, names)
     {
-        StringBuffer childPath = path;
+        StringBuffer childPath(path);
         childPath.append("/").append(names.item(i));
         CCSVItem* childItem = csvItems.getValue(childPath.str());
         if (!childItem)

--- a/services/runagent/frunssh.cpp
+++ b/services/runagent/frunssh.cpp
@@ -70,7 +70,7 @@ int main( int argc, char *argv[] )
         const StringArray & strArray = runssh->getReplyText();
         const UnsignedArray & unsArray = runssh->getReply();
         for(unsigned i = 0;i < unsArray.ordinality();i++) {
-            StringBuffer buf = strArray.item(i);
+            StringBuffer buf(strArray.item(i));
             // strip newlines off end of string buf
             if (buf.length() && (buf.charAt(buf.length()-1)) == '\n') {
                 buf.setLength(buf.length()-1);

--- a/system/jlib/jcomp.cpp
+++ b/system/jlib/jcomp.cpp
@@ -710,7 +710,8 @@ bool CppCompiler::doLink()
     DWORD runcode = 0;
     if (verbose)
         UERRLOG("%s", expanded.str());
-    StringBuffer logFile = StringBuffer(coreName).append("_link.log.tmp");
+    StringBuffer logFile(coreName);
+    logFile.append("_link.log.tmp");
     logFiles.append(logFile);
 
     bool ret;

--- a/system/jlib/jptree.cpp
+++ b/system/jlib/jptree.cpp
@@ -4635,7 +4635,7 @@ restart:
             if ('<' == nextChar)
                 error("Unmatched close tag encountered");
         }
-        StringBuffer completeTagname = tagName;
+        StringBuffer completeTagname(tagName);
         if (ignoreNameSpaces)
         {
             const char *colon;
@@ -7507,7 +7507,7 @@ IPropertyTree *createPTreeFromHttpParameters(const char *nameWithAttrs, IPropert
     Owned<IPropertyIterator> iter = parameters->getIterator();
     ForEach(*iter)
     {
-        StringBuffer key = iter->getPropKey();
+        StringBuffer key(iter->getPropKey());
         if (!key.length() || key.charAt(key.length()-1)=='!')
             continue;
         if (skipLeadingDotParameters && key.charAt(0)=='.')

--- a/system/jlib/jsocket.cpp
+++ b/system/jlib/jsocket.cpp
@@ -6337,7 +6337,7 @@ bool IpSubNet::test(const IpAddress &ip) const
     return false;
 }
 
-StringBuffer IpSubNet::getNetText(StringBuffer &text) const
+StringBuffer &IpSubNet::getNetText(StringBuffer &text) const
 {
     char tmp[INET6_ADDRSTRLEN];
     const char *res  = ::isIp4(net) ? _inet_ntop(AF_INET, &net[3], tmp, sizeof(tmp))
@@ -6345,7 +6345,7 @@ StringBuffer IpSubNet::getNetText(StringBuffer &text) const
     return text.append(res);
 }
 
-StringBuffer IpSubNet::getMaskText(StringBuffer &text) const
+StringBuffer &IpSubNet::getMaskText(StringBuffer &text) const
 {
     char tmp[INET6_ADDRSTRLEN];
     // isIp4(net) is correct here
@@ -6383,7 +6383,7 @@ bool setPreferredSubnet(const char *ip,const char *mask)
         return false;
 }
 
-StringBuffer lookupHostName(const IpAddress &ip,StringBuffer &ret)
+StringBuffer &lookupHostName(const IpAddress &ip,StringBuffer &ret)
 {
 // not a common routine (no Jlib function!) only support IPv4 initially
     unsigned ipa;

--- a/system/jlib/jsocket.hpp
+++ b/system/jlib/jsocket.hpp
@@ -189,8 +189,8 @@ public:
     bool set(const char *_net,const char *_mask); // _net NULL means match everything
                                                   // _mask NULL means match exact
     bool test(const IpAddress &ip) const;
-    StringBuffer getNetText(StringBuffer &text) const;
-    StringBuffer getMaskText(StringBuffer &text) const;
+    StringBuffer &getNetText(StringBuffer &text) const;
+    StringBuffer &getMaskText(StringBuffer &text) const;
     bool isNull() const;
     bool operator==(IpSubNet const &other) const
     {
@@ -611,7 +611,7 @@ extern jlib_decl IBufferedSocket* createBufferedSocket(ISocket* socket);
 extern jlib_decl IpSubNet &queryPreferredSubnet(); // preferred subnet when resolving multiple NICs
 extern jlib_decl bool setPreferredSubnet(const char *ip,const char *mask); // also resets cached host IP
 
-extern jlib_decl StringBuffer lookupHostName(const IpAddress &ip,StringBuffer &ret);
+extern jlib_decl StringBuffer &lookupHostName(const IpAddress &ip,StringBuffer &ret);
 
 extern jlib_decl bool isInterfaceIp(const IpAddress &ip, const char *ifname);
 extern jlib_decl bool getInterfaceIp(IpAddress &ip, const char *ifname);

--- a/system/jlib/jstring.hpp
+++ b/system/jlib/jstring.hpp
@@ -35,14 +35,14 @@ class jlib_decl StringBuffer
 {
     enum { InternalBufferSize = 16 };
 public:
-    StringBuffer();
-    StringBuffer(String & value);
-    StringBuffer(const char *value);
-    StringBuffer(StringBuffer && value);
-    StringBuffer(size_t len, const char *value);
-    StringBuffer(const StringBuffer & value);
+    explicit StringBuffer();
+    explicit StringBuffer(String & value);
+    explicit StringBuffer(const char *value);
+    explicit StringBuffer(StringBuffer && value);
+    explicit StringBuffer(size_t len, const char *value);
+    explicit StringBuffer(const StringBuffer & value);
     explicit StringBuffer(bool useInternal);
-    StringBuffer(char value);
+    explicit StringBuffer(char value);
     ~StringBuffer();
 
     inline size32_t length() const                      { return (size32_t)curLen; }
@@ -501,51 +501,61 @@ inline StringBuffer &appendJSONStringValue(StringBuffer& s, const char *name, co
     return appendJSONStringValue(s, name, (size32_t)(value ? strlen(value) : 0), value, encode, quoted);
 }
 
-template <typename type>
-inline StringBuffer &appendJSONValue(StringBuffer& s, const char *name, type value)
-{
-    appendJSONNameOrDelimit(s, name);
-    return s.append(value);
-}
-
-//specialization
-template <>
 inline StringBuffer &appendJSONValue(StringBuffer& s, const char *name, bool value)
 {
     appendJSONNameOrDelimit(s, name);
     return s.append((value) ? "true" : "false");
 }
 
-template <>
 inline StringBuffer &appendJSONValue(StringBuffer& s, const char *name, const char *value)
 {
     return appendJSONStringValue(s, name, value, true);
 }
 
-template <>
 inline StringBuffer &appendJSONValue(StringBuffer& s, const char *name, long value)
 {
     appendJSONNameOrDelimit(s, name);
     return s.appendlong(value);
 }
 
-template <>
+inline StringBuffer &appendJSONValue(StringBuffer& s, const char *name, __int64 value)
+{
+    appendJSONNameOrDelimit(s, name);
+    return s.append(value);
+}
+
+inline StringBuffer &appendJSONValue(StringBuffer& s, const char *name, unsigned __int64 value)
+{
+    appendJSONNameOrDelimit(s, name);
+    return s.append(value);
+}
+
 inline StringBuffer &appendJSONValue(StringBuffer& s, const char *name, double value)
 {
     return ::appendJSONRealValue(s, name, value);
 }
 
-template <>
 inline StringBuffer &appendJSONValue(StringBuffer& s, const char *name, float value)
 {
     return ::appendJSONRealValue(s, name,  value);
 }
 
-template <>
 inline StringBuffer &appendJSONValue(StringBuffer& s, const char *name, unsigned long value)
 {
     appendJSONNameOrDelimit(s, name);
     return s.appendulong(value);
+}
+
+inline StringBuffer &appendJSONValue(StringBuffer& s, const char *name, int value)
+{
+    appendJSONNameOrDelimit(s, name);
+    return s.append(value);
+}
+
+inline StringBuffer &appendJSONValue(StringBuffer& s, const char *name, unsigned value)
+{
+    appendJSONNameOrDelimit(s, name);
+    return s.append(value);
 }
 
 template <typename TValue>

--- a/system/jlib/jutil.cpp
+++ b/system/jlib/jutil.cpp
@@ -2280,7 +2280,7 @@ jlib_decl StringBuffer& decodeUrlUseridPassword(StringBuffer& out, const char* i
 }
 
 
-StringBuffer jlib_decl passwordInput(const char* prompt, StringBuffer& passwd)
+jlib_decl StringBuffer &  passwordInput(const char* prompt, StringBuffer& passwd)
 {
 #ifdef _WIN32
     printf("%s", prompt);

--- a/system/jlib/jutil.hpp
+++ b/system/jlib/jutil.hpp
@@ -350,7 +350,7 @@ public:
     const char* str() { return m_buffer.str(); }
 };
 
-extern jlib_decl StringBuffer passwordInput(const char* prompt, StringBuffer& passwd);
+extern jlib_decl StringBuffer & passwordInput(const char* prompt, StringBuffer& passwd);
 
 /**
  * Return a reference to a shared IProperties object representing the environment.conf settings.

--- a/system/security/plugins/htpasswdSecurity/htpasswdSecurity.cpp
+++ b/system/security/plugins/htpasswdSecurity/htpasswdSecurity.cpp
@@ -170,7 +170,7 @@ protected:
 		if (!apr_initialized)
 			initAPR();
 		loadPwds();//reload password file if modified
-		StringBuffer *encPW = userMap.getValue(user.str());
+		StringAttr *encPW = userMap.getValue(user.str());
 		if (encPW && encPW->length())
 		{
 			apr_status_t rc = apr_password_validate(sec_user.credentials().getPassword(), encPW->str());
@@ -301,7 +301,7 @@ private:
 					if (NULL == colon)
 						throw MakeStringException(-1, "htpasswd Password file appears malformed");
 					*colon = (char)NULL;
-					userMap.setValue(next, colon+1);//username, enctypted password
+					userMap.setValue(next, colon+1);//username, encrypted password
 					next = strtok_r(NULL, seps, &saveptr);
 				} while (next);
 			}
@@ -318,12 +318,12 @@ private:
 
 
 private:
-	mutable CriticalSection crit;
-	StringBuffer    pwFile;
-	CDateTime       pwFileLastMod;
+    mutable CriticalSection crit;
+    StringBuffer    pwFile;
+    CDateTime       pwFileLastMod;
 	bool            apr_initialized;
-	MapStringTo<StringBuffer> userMap;
-	apr_md5_ctx_t 	md5_ctx;
+    MapStringTo<StringAttr, const char *> userMap;
+    apr_md5_ctx_t   md5_ctx;
 };
 
 extern "C"

--- a/testing/unittests/dalitests.cpp
+++ b/testing/unittests/dalitests.cpp
@@ -1471,7 +1471,7 @@ static void setupDFS(const IContextLogger &logctx, const char *scope, unsigned s
 
     logctx.CTXLOG("Cleaning up '%s' scope", bufScope.str());
     for (unsigned i=1; i<=supersToDel; i++) {
-        StringBuffer super = bufScope;
+        StringBuffer super(bufScope);
         super.append("::super").append(i);
         if (dir.exists(super.str(),user,false,true))
             ASSERT(dir.removeEntry(super.str(), user) && "Can't remove super-file");
@@ -1481,7 +1481,7 @@ static void setupDFS(const IContextLogger &logctx, const char *scope, unsigned s
     for (unsigned i=1; i<=subsToCreate; i++) {
         StringBuffer name;
         name.append("sub").append(i);
-        StringBuffer sub = bufScope;
+        StringBuffer sub(bufScope);
         sub.append("::").append(name);
 
         // Remove first

--- a/tools/esdlcmd-xml/esdl2xml.hpp
+++ b/tools/esdlcmd-xml/esdl2xml.hpp
@@ -63,7 +63,7 @@ public:
             if (optRecursive && hc.includes)
             {
                 StringBuffer subfile;
-                StringBuffer srcDir = hc.getSrcDir();
+                StringBuffer srcDir(hc.getSrcDir());
 
                 IncludeInfo * ii;
                 for (ii=hc.includes;ii;ii=ii->next)

--- a/tools/esdlcmd/esdlcmd_monitor.cpp
+++ b/tools/esdlcmd/esdlcmd_monitor.cpp
@@ -929,7 +929,7 @@ public:
 
     IPropertyTree *checkExtractNestedResponseType(IPropertyTree *depTree, IPropertyTree *respType, StringBuffer &respTypeName)
     {
-        StringBuffer typeName = respType->queryProp("@name");
+        StringBuffer typeName(respType->queryProp("@name"));
         if (typeName.length()<=2)
             return respType;
         if (!streq(typeName.str()+ typeName.length()-2, "Ex"))
@@ -993,7 +993,7 @@ public:
         if (!espRespTree)
             throw( MakeStringException(0, "Esdl Response type '%s' definition not found", esp_resp_type.str()));
 
-        StringBuffer resp_type = esp_resp_type.get();
+        StringBuffer resp_type(esp_resp_type.get());
         if (resp_type.length()>2 && resp_type.charAt(resp_type.length()-2)=='E' && resp_type.charAt(resp_type.length()-1)=='x')
             resp_type.setLength(resp_type.length()-2);
 


### PR DESCRIPTION
Catches places where a stringbuffer is passed or returned by value, 99% of
which are either accidental or ill-advised.

Also means you can no longer use StringBuffer x = "xxx"; which is perhaps
unfortunate and required a few changes.

Signed-off-by: Richard Chapman <rchapman@hpccsystems.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [x] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [ ] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Testing:
Compiled, Smoketest, OBT
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
