### PR TITLE
HPCC-21996 Performance monitor disk majmin lsblk cmd never finishes

### DIFF
--- a/system/jlib/jdebug.cpp
+++ b/system/jlib/jdebug.cpp
@@ -1861,12 +1861,12 @@ void OsDiskInfo::initMajorMinor()
     if (pipe->run("list disks", cmd, nullptr, false, true, true, 8192))
     {
         bool timedout = false;
+        StringBuffer output;
+        Owned<ISimpleReadStream> pipeReader = pipe->getOutputStream();
         // handle when lsblk runs too long
         unsigned exitcode = pipe->wait(2000, timedout);
         if ( (!timedout) && (exitcode == 0) )
         {
-            StringBuffer output;
-            Owned<ISimpleReadStream> pipeReader = pipe->getOutputStream();
             readSimpleStream(output, *pipeReader);
             if (output.length() > 0)
             {
@@ -1882,22 +1882,20 @@ void OsDiskInfo::initMajorMinor()
                         diskMajorMinor.appendUniq(mm);
                     }
                 }
-                return;
             }
+            return;
         }
         if (timedout)
             pipe->abort();
         // log unexpected output, if any
-        StringBuffer output;
-        Owned<ISimpleReadStream> pipeReader = pipe->getOutputStream();
         readSimpleStream(output, *pipeReader);
         if (output.length() > 0)
-            WARNLOG("Pipe: output: %s", output.str());
+            IWARNLOG("Pipe: output: %s", output.str());
         StringBuffer outputErr;
         Owned<ISimpleReadStream> pipeReaderErr = pipe->getErrorStream();
         readSimpleStream(outputErr, *pipeReaderErr);
         if (outputErr.length() > 0)
-            WARNLOG("Pipe: Err output: %s", outputErr.str());
+            IWARNLOG("Pipe: Err output: %s", outputErr.str());
     }
 #endif // __linux__
 }


### PR DESCRIPTION
Add a timeout to the wait() for lsblk pipe command and abort it if it is still running after the timeout.

Signed-off-by: Mark Kelly <mark.kelly@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [ ] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

I started all components with this change using a modified cmd that takes too long and made sure it works as expected.

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
