### PR TITLE
HPCC-21993 support Ubuntu 19.04

### DIFF
--- a/cmake_modules/dependencies/disco.cmake
+++ b/cmake_modules/dependencies/disco.cmake
@@ -1,0 +1,6 @@
+# Ubuntu 19.04
+SET_DEPENDENCIES ( CPACK_DEBIAN_PACKAGE_DEPENDS g++ openssh-client openssh-server expect rsync libapr1 python psmisc curl )
+
+if(SPARK)
+    SET_DEPENDENCIES ( CPACK_DEBIAN_PACKAGE_DEPENDS "openjdk-11-jdk" )
+endif(SPARK)


### PR DESCRIPTION
Add dependencies for Ubuntu 19.04
Signed-off-by: Xiaoming Wang <xiaoming.wang@lexisnexi.com> 

@Michael-Gardner please review.

Test build: http://10.240.32.243/job/CE-7.2.x-disco-test/