### PR TITLE
HPCC-22175 Potential deadlock on Python when streaming dataset in

### DIFF
--- a/plugins/py3embed/py3embed.cpp
+++ b/plugins/py3embed/py3embed.cpp
@@ -1170,6 +1170,42 @@ protected:
     PythonThreadContext *sharedCtx;
 };
 
+//----------------------------------------------------------------------
+
+// GILBlock ensures the we hold the Python "Global interpreter lock" for the appropriate duration
+
+class GILBlock
+{
+public:
+    GILBlock(PyThreadState * &_state) : state(_state)
+    {
+        PyEval_RestoreThread(state);
+    }
+    ~GILBlock()
+    {
+        state = PyEval_SaveThread();
+    }
+private:
+    PyThreadState * &state;
+};
+
+
+// GILUnblock ensures the we release the Python "Global interpreter lock" for the appropriate duration
+
+class GILUnblock
+{
+public:
+    GILUnblock()
+    {
+        state = PyEval_SaveThread();
+    }
+    ~GILUnblock()
+    {
+        PyEval_RestoreThread(state);
+    }
+private:
+    PyThreadState *state;
+};
 
 //----------------------------------------------------------------------
 
@@ -1193,6 +1229,7 @@ void ECLDatasetIterator_dealloc(PyObject *self)
     ECLDatasetIterator *p = (ECLDatasetIterator *)self;
     if (p->val)
     {
+        GILUnblock b;
         p->val->stop();
         ::Release(p->val);
         p->val = NULL;
@@ -1203,27 +1240,32 @@ void ECLDatasetIterator_dealloc(PyObject *self)
 PyObject* ECLDatasetIterator_iternext(PyObject *self)
 {
     ECLDatasetIterator *p = (ECLDatasetIterator *)self;
+    roxiemem::OwnedConstRoxieRow nextRow;
     if (p->val)
     {
-        roxiemem::OwnedConstRoxieRow nextRow = p->val->ungroupedNextRow();
+        GILUnblock b;
+        nextRow.setown(p->val->ungroupedNextRow());
         if (!nextRow)
         {
             p->val->stop();
             ::Release(p->val);
             p->val = NULL;
         }
-        else
-        {
-            RtlFieldStrInfo dummyField("<row>", NULL, p->typeInfo);
-            PythonNamedTupleBuilder tupleBuilder(NULL, &dummyField);
-            const byte *brow = (const byte *) nextRow.get();
-            p->typeInfo->process(brow, brow, &dummyField, tupleBuilder);
-            return tupleBuilder.getTuple(p->typeInfo);
-        }
     }
-    // If we get here, it's EOF
-    PyErr_SetNone(PyExc_StopIteration);
-    return NULL;
+    if (p->val)
+    {
+        RtlFieldStrInfo dummyField("<row>", NULL, p->typeInfo);
+        PythonNamedTupleBuilder tupleBuilder(NULL, &dummyField);
+        const byte *brow = (const byte *) nextRow.get();
+        p->typeInfo->process(brow, brow, &dummyField, tupleBuilder);
+        return tupleBuilder.getTuple(p->typeInfo);
+    }
+    else
+    {
+        // If we get here, it's EOF
+        PyErr_SetNone(PyExc_StopIteration);
+        return NULL;
+    }
 }
 
 static PyTypeObject ECLDatasetIteratorType =
@@ -1275,22 +1317,6 @@ static PyObject *createECLDatasetIterator(const RtlTypeInfo *_typeInfo, IRowStre
 
 //-----------------------------------------------------
 
-// GILBlock ensures the we hold the Python "Global interpreter lock" for the appropriate duration
-
-class GILBlock
-{
-public:
-    GILBlock(PyThreadState * &_state) : state(_state)
-    {
-        PyEval_RestoreThread(state);
-    }
-    ~GILBlock()
-    {
-        state = PyEval_SaveThread();
-    }
-private:
-    PyThreadState * &state;
-};
 
 void Python3xGlobalState::unregister(const char *key)
 {


### PR DESCRIPTION
If the ECL code delivering data to the stream itself calls Python code, there
is a potential for deadlock.

Release the Python GIL before calling back to ECL, and reacquire it
afterwards.

Signed-off-by: Richard Chapman <rchapman@hpccsystems.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [ ] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [x] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [x] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
Smoketest should cover it. The actual issue has not proved simple to reproduce in a small example.
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
