### PR TITLE
HPCC-21951 Use Basedn name to get Basedn in ESP ws_access, etc

### DIFF
--- a/esp/scm/ws_access.ecm
+++ b/esp/scm/ws_access.ecm
@@ -442,10 +442,11 @@ ESPresponse BasednsResponse
 
 ESPrequest ResourcesRequest
 {
-    string basedn;
-    string rtype;
-    string rtitle;
+    [depr_ver("1.14")] string basedn;
+    [depr_ver("1.14")] string rtype;
+    [depr_ver("1.14")] string rtitle;
     string templatename;
+    [min_ver("1.14")] BasednName;
     string prefix;
     string searchinput;
 };
@@ -466,23 +467,24 @@ ESPstruct ScopeScanStatusStruct
 
 ESPresponse ResourcesResponse
 {
-    string basedn;
-    string rtype;
-    string rtitle;
+    [depr_ver("1.14")] string basedn;
+    [depr_ver("1.14")] string rtype;
+    [depr_ver("1.14")] string rtitle;
     ESParray<ESPstruct Resource, Resource> Resources;
 
     string default_basedn;
     string default_name;
-    string prefix;
+    [depr_ver("1.14")] string prefix;
     [min_ver("1.05")] bool toomany;
     [min_ver("1.08")] ESPstruct ScopeScanStatusStruct scopeScansStatus;
 };
 
 ESPrequest [nil_remove] ResourceQueryRequest
 {
-    string basedn;
-    string rtype;
-    string rtitle;
+    [depr_ver("1.14")] string basedn;
+    [depr_ver("1.14")] string rtype;
+    [depr_ver("1.14")] string rtitle;
+    [min_ver("1.14")] BasednName;
     string prefix;
     string Name;
     unsigned PageSize;
@@ -518,9 +520,10 @@ ESPresponse ResourceAddInputResponse
 
 ESPrequest ResourceAddRequest
 {
-    string basedn;
-    string rtype;
-    string rtitle;
+    [depr_ver("1.14")] string basedn;
+    [depr_ver("1.14")] string rtype;
+    [depr_ver("1.14")] string rtitle;
+    [min_ver("1.14")] BasednName;
     string name;
     string description;
     string prefix;
@@ -528,10 +531,10 @@ ESPrequest ResourceAddRequest
 
 ESPresponse ResourceAddResponse
 {
-    string basedn;
-    string rtype;
-    string rtitle;
-    string prefix;
+    [depr_ver("1.14")] string basedn;
+    [depr_ver("1.14")] string rtype;
+    [depr_ver("1.14")] string rtitle;
+    [depr_ver("1.14")] string prefix;
 
     int retcode;
     string retmsg;
@@ -539,9 +542,10 @@ ESPresponse ResourceAddResponse
 
 ESPrequest ResourceDeleteRequest
 {
-    string basedn;
-    string rtype;
-    string rtitle;
+    [depr_ver("1.14")] string basedn;
+    [depr_ver("1.14")] string rtype;
+    [depr_ver("1.14")] string rtitle;
+    [min_ver("1.14")] BasednName;
     string prefix;
     ESParray<string> names;
     int DoUpdate(0);
@@ -549,10 +553,10 @@ ESPrequest ResourceDeleteRequest
 
 ESPresponse ResourceDeleteResponse
 {
-    string basedn;
-    string rtype;
-    string rtitle;
-    string prefix;
+    [depr_ver("1.14")] string basedn;
+    [depr_ver("1.14")] string rtype;
+    [depr_ver("1.14")] string rtitle;
+    [depr_ver("1.14")] string prefix;
 
     int retcode;
     string retmsg;
@@ -560,10 +564,11 @@ ESPresponse ResourceDeleteResponse
 
 ESPrequest ResourcePermissionsRequest
 {
-    string basedn;
-    string rtype;
+    [depr_ver("1.14")] string basedn;
+    [depr_ver("1.14")] string rtype;
     string name;
-    string rtitle;
+    [min_ver("1.14")] BasednName;
+    [depr_ver("1.14")] string rtitle;
     string prefix;
 };
 
@@ -584,19 +589,20 @@ ESPstruct ResourcePermission
 
 ESPresponse ResourcePermissionsResponse
 {
-    string basedn;
-    string rtype;
-    string name;
-    string rtitle;
-    string prefix;
+    [depr_ver("1.14")] string basedn;
+    [depr_ver("1.14")] string rtype;
+    [depr_ver("1.14")] string name;
+    [depr_ver("1.14")] string rtitle;
+    [depr_ver("1.14")] string prefix;
     ESParray<ESPstruct ResourcePermission, Permission> Permissions;
 };
 
 ESPrequest [nil_remove] ResourcePermissionQueryRequest
 {
-    string basedn;
-    string rtype;
-    string rtitle;
+    [depr_ver("1.14")] string basedn;
+    [depr_ver("1.14")] string rtype;
+    [depr_ver("1.14")] string rtitle;
+    [min_ver("1.14")] BasednName;
     string prefix;
     string Name;
     ESPenum AccountTypeReq AccountType;
@@ -817,10 +823,11 @@ ESPresponse PermissionsResetInputResponse
 
 ESPrequest PermissionsResetRequest
 {
-    string basedn;
-    string rtype;
-    string rname;
-    string rtitle;
+    [min_ver("1.14")] BasednName;
+    [depr_ver("1.14")] string basedn;
+    [depr_ver("1.14")] string rtype;
+    [depr_ver("1.14")] string rname; //Not used
+    [depr_ver("1.14")] string rtitle;
     string prefix;
     ESParray<string> names;
 
@@ -839,11 +846,11 @@ ESPrequest PermissionsResetRequest
 
 ESPresponse PermissionsResetResponse
 {
-    string basedn;
-    string rtype;
-    string rname;
-    string rtitle;
-    string prefix;
+    [depr_ver("1.14")] string basedn;
+    [depr_ver("1.14")] string rtype;
+    [depr_ver("1.14")] string rname;
+    [depr_ver("1.14")] string rtitle;
+    [depr_ver("1.14")] string prefix;
 
     int retcode;
     string retmsg;
@@ -887,10 +894,10 @@ ESPresponse DisableScopeScansResponse
 
 ESPrequest PermissionActionRequest
 {
-    string basedn;
-    string rtype;
+    [depr_ver("1.14")] string basedn;
+    [depr_ver("1.14")] string rtype;
     string rname;
-    string rtitle;
+    [depr_ver("1.14")] string rtitle;
     string prefix;
     string action;
 
@@ -913,12 +920,12 @@ ESPrequest PermissionActionRequest
 
 ESPresponse PermissionActionResponse
 {
-    string basedn;
-    string rtype;
-    string rname;
-    string rtitle;
-    string prefix;
-   [min_ver("1.01")] string AccountName;
+    [depr_ver("1.14")] string basedn;
+    [depr_ver("1.14")] string rtype;
+    [depr_ver("1.14")] string rname;
+    [depr_ver("1.14")] string rtitle;
+    [depr_ver("1.14")] string prefix;
+    [min_ver("1.01")] string AccountName;
     [min_ver("1.01")] bool IsGroup;
 
     int retcode;
@@ -978,7 +985,7 @@ ESPresponse [nil_remove] UserAccountExportResponse
     [http_content("application/octet-stream")] binary Result;
 };
 
-ESPservice [version("1.13"), auth_feature("NONE"), exceptions_inline("./smc_xslt/exceptions.xslt")] ws_access
+ESPservice [version("1.14"), auth_feature("NONE"), exceptions_inline("./smc_xslt/exceptions.xslt")] ws_access
 {
     ESPmethod [client_xslt("/esp/xslt/access_users.xslt")] Users(UserRequest, UserResponse);
     ESPmethod [client_xslt("/esp/xslt/access_useredit.xslt")] UserEdit(UserEditRequest, UserEditResponse);
@@ -1004,7 +1011,7 @@ ESPservice [version("1.13"), auth_feature("NONE"), exceptions_inline("./smc_xslt
     ESPmethod [client_xslt("/esp/xslt/access_resources.xslt")] Resources(ResourcesRequest, ResourcesResponse);
     ESPmethod [client_xslt("/esp/xslt/access_resourceadd.xslt")] ResourceAdd(ResourceAddRequest, ResourceAddResponse);
     ESPmethod [client_xslt("/esp/xslt/access_resourcedelete.xslt")] ResourceDelete(ResourceDeleteRequest, ResourceDeleteResponse);
-    ESPmethod [client_xslt("/esp/xslt/access_resourceaddinput.xslt")] ResourceAddInput(ResourceAddInputRequest, ResourceAddInputResponse);
+    ESPmethod [depr_ver("1.14"), client_xslt("/esp/xslt/access_resourceaddinput.xslt")] ResourceAddInput(ResourceAddInputRequest, ResourceAddInputResponse);
 
     ESPmethod [min_ver("1.10")] QueryViews(QueryViewsRequest, QueryViewsResponse);
     ESPmethod [min_ver("1.10")] AddView(AddViewRequest, AddViewResponse);
@@ -1018,11 +1025,11 @@ ESPservice [version("1.13"), auth_feature("NONE"), exceptions_inline("./smc_xslt
     ESPmethod [min_ver("1.10")] QueryUserViewColumns(QueryUserViewColumnsRequest, QueryUserViewColumnsResponse);
 
     ESPmethod [client_xslt("/esp/xslt/access_permissions.xslt")] ResourcePermissions(ResourcePermissionsRequest, ResourcePermissionsResponse);
-    ESPmethod [client_xslt("/esp/xslt/access_permissionaddinput.xslt")] PermissionAddInput(PermissionAddRequest, PermissionAddResponse);
+    ESPmethod [depr_ver("1.14"), client_xslt("/esp/xslt/access_permissionaddinput.xslt")] PermissionAddInput(PermissionAddRequest, PermissionAddResponse);
     ESPmethod [client_xslt("/esp/xslt/access_permissionchange.xslt")] PermissionAction(PermissionActionRequest, PermissionActionResponse);
     ESPmethod [client_xslt("/esp/xslt/access_accountpermissions.xslt")] AccountPermissions(AccountPermissionsRequest, AccountPermissionsResponse);
     ESPmethod [client_xslt("/esp/xslt/access_filepermission.xslt")] FilePermission(FilePermissionRequest, FilePermissionResponse);
-    ESPmethod [client_xslt("/esp/xslt/access_permissionresetinput.xslt")] PermissionsResetInput(PermissionsResetInputRequest, PermissionsResetInputResponse);
+    ESPmethod [depr_ver("1.14"), client_xslt("/esp/xslt/access_permissionresetinput.xslt")] PermissionsResetInput(PermissionsResetInputRequest, PermissionsResetInputResponse);
     ESPmethod [client_xslt("/esp/xslt/access_permissionsreset.xslt")] PermissionsReset(PermissionsResetRequest, PermissionsResetResponse);
     ESPmethod [client_xslt("/esp/xslt/access_clearpermissionscache.xslt")] ClearPermissionsCache(ClearPermissionsCacheRequest, ClearPermissionsCacheResponse);
     ESPmethod QueryScopeScansEnabled(QueryScopeScansEnabledRequest, QueryScopeScansEnabledResponse);

--- a/esp/services/ws_access/ws_accessService.hpp
+++ b/esp/services/ws_access/ws_accessService.hpp
@@ -68,11 +68,12 @@ class Cws_accessEx : public Cws_access
     SecResourceType str2type(const char* rtstr);
 
     void setBasedns(IEspContext &context);
-    const char* getBaseDN(IEspContext &context, const char* rtype, StringBuffer& baseDN);
+    void getBasednReq(IEspContext &context, const char* name, const char* basedn,
+        const char* rType, const char* rTitle, IEspDnStruct* dn);
     bool permissionAddInputOnResource(IEspContext &context, IEspPermissionAddRequest &req, IEspPermissionAddResponse &resp);
     bool permissionAddInputOnAccount(IEspContext &context, const char* accountName, IEspPermissionAddRequest &req, IEspPermissionAddResponse &resp);
-    bool getNewFileScopePermissions(ISecManager* secmgr, IEspResourceAddRequest &req, StringBuffer& existingResource, StringArray& newResources);
-    bool setNewFileScopePermissions(ISecManager* secmgr, IEspResourceAddRequest &req, StringBuffer& existingResource, StringArray& newResources);
+    bool getNewFileScopePermissions(ISecManager* secmgr, const char* name, IEspDnStruct* req, StringBuffer& existingResource, StringArray& newResources);
+    bool setNewFileScopePermissions(ISecManager* secmgr, IEspDnStruct* req, StringBuffer& existingResource, StringArray& newResources);
     bool permissionsReset(CLdapSecManager* ldapsecmgr, const char* basedn, const char* rtype, const char* prefix,
         const char* resourceName, ACT_TYPE accountType, const char* accountName,
         bool allow_access, bool allow_read, bool allow_write, bool allow_full,


### PR DESCRIPTION
1. The ws_access service only returns LDAP Basedn for Permissions
request;
2. Basedn name (not the Basedn itself) is used to identify a
Basedn in other ws_access requests;
3. The ws_access does not echo Basedn rtype, rtitle, prefix, etc;
4. Depreciate the PermissionsResetInput, PermissionAddInput, and
ResourceAddInput methods which were used only for legacy ECLWatch;
5. Fix 1 bug in the PermissionsReset method. For example, if the
Userarray contains 'user1,user2', the existing code only resets
the permssions for the user1;
6. Clean some code.

Signed-off-by: wangkx <kevin.wang@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
