### PR TITLE
HPCC-20914 Log why extra log line is added to ESP log

### DIFF
--- a/esp/bindings/http/platform/httpservice.cpp
+++ b/esp/bindings/http/platform/httpservice.cpp
@@ -73,7 +73,12 @@ CEspHttpServer::~CEspHttpServer()
                 if (paramStr && *paramStr)
                     logStr.appendf("?%s", paramStr);
 
-                DBGLOG("Request[%s]", logStr.str());
+                if (ctx->queryHasException())
+                    DBGLOG("Log request due to exception. Request[%s]", logStr.str());
+                else
+                    DBGLOG("Log request due to long processing time: %u seconds. Request[%s]",
+                        (unsigned) (ctx->queryProcessingTime() * 0.001), logStr.str());
+
                 if (m_request->isSoapMessage())
                 {
                     StringBuffer requestStr;

--- a/esp/bindings/http/platform/httpservice.cpp
+++ b/esp/bindings/http/platform/httpservice.cpp
@@ -64,7 +64,7 @@ CEspHttpServer::~CEspHttpServer()
             //has been logged and it should not be logged here.
             ctx->setProcessingTime();
             if ((ctx->queryHasException() || (ctx->queryProcessingTime() > getSlowProcessingTime())) &&
-                !getEspLogRequests() && (getEspLogLevel() <= LogNormal))
+                (getEspLogRequests() == LogRequestsWithIssuesOnly))
             {
                 StringBuffer logStr;
                 logStr.appendf("%s %s", m_request->queryMethod(), m_request->queryPath());
@@ -74,9 +74,9 @@ CEspHttpServer::~CEspHttpServer()
                     logStr.appendf("?%s", paramStr);
 
                 if (ctx->queryHasException())
-                    DBGLOG("Log request due to exception. Request[%s]", logStr.str());
+                    DBGLOG("Request with exception. Request[%s]", logStr.str());
                 else
-                    DBGLOG("Log request due to long processing time: %u seconds. Request[%s]",
+                    DBGLOG("Request with long processing time: %u seconds. Request[%s]",
                         (unsigned) (ctx->queryProcessingTime() * 0.001), logStr.str());
 
                 if (m_request->isSoapMessage())

--- a/esp/bindings/http/platform/httptransport.cpp
+++ b/esp/bindings/http/platform/httptransport.cpp
@@ -630,7 +630,7 @@ int CHttpMessage::receive(bool alwaysReadContent, IMultiException *me)
             DBGLOG("length of content read = %d", m_content.length());
     }
 
-    if (getEspLogRequests() || getEspLogLevel()>LogNormal)
+    if (getEspLogRequests() == LogRequestsAlways)
         logMessage(LOGCONTENT, "HTTP content received:\n");
     return 0;
 }
@@ -802,7 +802,7 @@ int CHttpMessage::send()
     int retcode = 0;
 
     // If m_content is empty but m_content_stream is set, the stream will not be logged here.
-    if (getEspLogResponses() || getEspLogLevel(queryContext())>LogNormal)
+    if (getEspLogResponses())
     {
         logMessage(headers.str(), "Sending out HTTP headers:\n", "Authorization:[~\r\n]*", "Authorization: (hidden)");
         if(m_content_length > 0 && m_content.length() > 0)
@@ -1897,7 +1897,7 @@ int CHttpRequest::processHeaders(IMultiException *me)
         lenread = m_bufferedsocket->readline(oneline, MAX_HTTP_HEADER_LEN + 1, me);
     }
 
-    if (getEspLogRequests() || getEspLogLevel()>LogNormal)
+    if (getEspLogRequests() == LogRequestsAlways)
         logMessage(LOGHEADERS, "HTTP request headers received:\n");
 
     if(m_content_length > 0 && m_MaxRequestEntityLength > 0 && m_content_length > m_MaxRequestEntityLength && (!isUpload(false)))
@@ -2447,7 +2447,7 @@ int CHttpResponse::receive(bool alwaysReadContent, IMultiException *me)
             DBGLOG("length of content read = %d", m_content.length());
     }
     
-    if ((getEspLogRequests() || getEspLogLevel()>LogNormal))
+    if (getEspLogRequests() == LogRequestsAlways)
         logMessage(LOGCONTENT, "HTTP response content received:\n");
     return 0;
 

--- a/esp/platform/espcfg.cpp
+++ b/esp/platform/espcfg.cpp
@@ -261,7 +261,7 @@ CEspConfig::CEspConfig(IProperties* inputs, IPropertyTree* envpt, IPropertyTree*
     // load options
     const char* level = m_cfg->queryProp("@logLevel");
     m_options.logLevel = level ? atoi(level) : LogMin;
-    m_options.logReq = m_cfg->getPropBool("@logRequests", true);
+    m_options.logReq = readLogRequest(m_cfg->queryProp("@logRequests"));
     m_options.logResp = m_cfg->getPropBool("@logResponses", false);
     m_options.txSummaryLevel = m_cfg->getPropInt("@txSummaryLevel", LogMin);
     m_options.txSummaryResourceReq = m_cfg->getPropBool("@txSummaryResourceReq", false);
@@ -517,7 +517,6 @@ CEspConfig::CEspConfig(IProperties* inputs, IPropertyTree* envpt, IPropertyTree*
         }
     }
 }
-
 
 void CEspConfig::sendAlert(int severity, char const * descr, char const * subject) const
 {

--- a/esp/platform/espcfg.ipp
+++ b/esp/platform/espcfg.ipp
@@ -90,14 +90,14 @@ struct builtin
 struct esp_option
 {   
     LogLevel logLevel;
-    bool logReq;
+    LogRequest logReq;
     bool logResp;
     LogLevel txSummaryLevel;
     bool txSummaryResourceReq;
     StringAttr frameTitle;
     unsigned slowProcessingTime; //default 30 seconds
 
-    esp_option() : logReq(false), logResp(false), logLevel(LogMin), txSummaryLevel(LogMin), txSummaryResourceReq(false), slowProcessingTime(30000)
+    esp_option() : logReq(LogRequestsNever), logResp(false), logLevel(LogMin), txSummaryLevel(LogMin), txSummaryResourceReq(false), slowProcessingTime(30000)
     { }
 };
 

--- a/esp/platform/espcontext.cpp
+++ b/esp/platform/espcontext.cpp
@@ -820,6 +820,22 @@ static IEspContainer*& getContainer()
     return gContainer;
 }
 
+LogRequest readLogRequest(char const* req)
+{
+    if (isEmptyString(req))
+        return LogRequestsNever;
+
+    if (strieq(req, "all"))
+        return LogRequestsAlways;
+    if (strieq(req, "never"))
+        return LogRequestsNever;
+    if (strieq(req, "only-ones-with-issues"))
+        return LogRequestsWithIssuesOnly;
+    if (strieq(req, "true"))
+        return LogRequestsAlways;
+    return LogRequestsWithIssuesOnly;
+}
+
 LogLevel getEspLogLevel() { return getEspLogLevel(NULL); }
 
 LogLevel getEspLogLevel(IEspContext* ctx)
@@ -858,11 +874,11 @@ bool getTxSummaryResourceReq()
     return false;
 }
 
-bool getEspLogRequests()
+LogRequest getEspLogRequests()
 {
     if (getContainer())
         return getContainer()->getLogRequests();
-    return false;
+    return LogRequestsNever;
 }
 
 bool getEspLogResponses()

--- a/esp/platform/espcontext.cpp
+++ b/esp/platform/espcontext.cpp
@@ -831,9 +831,9 @@ LogRequest readLogRequest(char const* req)
         return LogRequestsNever;
     if (strieq(req, "only-ones-with-issues"))
         return LogRequestsWithIssuesOnly;
-    if (strieq(req, "true"))
+    if (strToBool(req))
         return LogRequestsAlways;
-    return LogRequestsWithIssuesOnly;
+    return LogRequestsNever;
 }
 
 LogLevel getEspLogLevel() { return getEspLogLevel(NULL); }

--- a/esp/platform/espcontext.hpp
+++ b/esp/platform/espcontext.hpp
@@ -120,9 +120,10 @@ esp_http_decl void getEspUrlParams(IEspContext& ctx, StringBuffer& params, const
 esp_http_decl void addEspNativeArray(StringBuffer& schema, const char* xsdType, const char* arrayType);
 esp_http_decl void checkRequest(IEspContext& ctx);
 
+esp_http_decl LogRequest readLogRequest(char const* req);
 esp_http_decl LogLevel getEspLogLevel(IEspContext* );
 esp_http_decl LogLevel getEspLogLevel();
-esp_http_decl bool getEspLogRequests();
+esp_http_decl LogRequest getEspLogRequests();
 esp_http_decl bool getEspLogResponses();
 esp_http_decl LogLevel getTxSummaryLevel();
 esp_http_decl bool getTxSummaryResourceReq();

--- a/esp/platform/espp.hpp
+++ b/esp/platform/espp.hpp
@@ -54,7 +54,7 @@ private:
     bool m_exiting;
     bool m_useDali;
     LogLevel m_logLevel;
-    bool m_logReq;
+    LogRequest m_logReq;
     bool m_logResp;
     LogLevel txSummaryLevel;
     bool txSummaryResourceReq;
@@ -151,13 +151,13 @@ public:
     }
 
     void setLogLevel(LogLevel level) { m_logLevel = level; }
-    void setLogRequests(bool logReq) { m_logReq = logReq; }
+    void setLogRequests(LogRequest logReq) { m_logReq = logReq; }
     void setLogResponses(bool logResp) { m_logResp = logResp; }
     void setTxSummaryLevel(LogLevel level) { txSummaryLevel = level; }
     void setTxSummaryResourceReq(bool logReq) { txSummaryResourceReq = logReq; }
 
     LogLevel getLogLevel() { return m_logLevel; }
-    bool getLogRequests() { return m_logReq; }
+    LogRequest getLogRequests() { return m_logReq; }
     bool getLogResponses() { return m_logResp; }
     LogLevel getTxSummaryLevel() { return txSummaryLevel; }
     bool getTxSummaryResourceReq() { return txSummaryResourceReq; }

--- a/esp/scm/esp.ecm
+++ b/esp/scm/esp.ecm
@@ -74,6 +74,13 @@ typedef enum AuthError_
     EspAuthErrorNotAuthorized
 } AuthError;
 
+typedef enum LogRequest_
+{
+    LogRequestsNever,
+    LogRequestsWithIssuesOnly,
+    LogRequestsAlways
+} LogRequest;
+
 #define ESPCTX_NO_NAMESPACES    0x00000001
 #define ESPCTX_WSDL             0x00000010
 #define ESPCTX_WSDL_EXT         0x00000100
@@ -220,8 +227,8 @@ interface IEspContainer : extends IInterface
     virtual void exitESP() = 0;
     virtual void setLogLevel(LogLevel level) = 0;
     virtual LogLevel getLogLevel() = 0;
-    virtual bool getLogRequests() = 0;
-    virtual void setLogRequests(bool logReq) = 0;
+    virtual LogRequest getLogRequests() = 0;
+    virtual void setLogRequests(LogRequest logReq) = 0;
     virtual bool getLogResponses() = 0;
     virtual void setLogResponses(bool logResp) = 0;
     virtual void setTxSummaryLevel(LogLevel level) = 0;

--- a/esp/scm/ws_espcontrol.ecm
+++ b/esp/scm/ws_espcontrol.ecm
@@ -20,7 +20,7 @@ EspInclude(common);
 ESPrequest [nil_remove] SetLoggingRequest
 {
     int LoggingLevel;
-    bool LogRequests;
+    string LogRequests;
     bool LogResponses;
 };
 

--- a/esp/services/espcontrol/ws_espcontrolservice.cpp
+++ b/esp/services/espcontrol/ws_espcontrolservice.cpp
@@ -190,8 +190,7 @@ bool CWSESPControlEx::onSetLogging(IEspContext& context, IEspSetLoggingRequest& 
 
         if (!req.getLoggingLevel_isNull())
             m_container->setLogLevel(req.getLoggingLevel());
-        if (!req.getLogRequests_isNull())
-            m_container->setLogRequests(req.getLogRequests());
+        m_container->setLogRequests(readLogRequest(req.getLogRequests()));
         if (!req.getLogResponses_isNull())
             m_container->setLogResponses(req.getLogResponses());
         resp.setStatus(0);

--- a/initfiles/componentfiles/configschema/xsd/esp.xsd
+++ b/initfiles/componentfiles/configschema/xsd/esp.xsd
@@ -349,8 +349,9 @@
                 <xs:attribute name="componentfilesDir" type="xs:string"
                               hpcc:presetValue="${COMPONENTFILES_PATH}" hpcc:displayName="Component Files Dir"
                               hpcc:tooltip="Sets the componentfiles directory"/>
-                <xs:attribute name="logRequests" type="xs:boolean" hpcc:presetValue="true"
-                              hpcc:displayName="Log Requests"/>
+                <xs:attribute name="logRequests" type="xs:string" hpcc:presetValue="never"
+                              hpcc:displayName="Log Requests"
+                              hpcc:tooltip="never|only-ones-with-issues|all"/>
                 <xs:attribute name="logResponses" type="xs:boolean" hpcc:presetValue="false"
                               hpcc:displayName="Log Responses"/>
                 <xs:attribute name="txSummaryLevel" type="xs:nonNegativeInteger" hpcc:presetValue="1"

--- a/initfiles/componentfiles/configxml/esp.xsd.in
+++ b/initfiles/componentfiles/configxml/esp.xsd.in
@@ -983,7 +983,13 @@
                     </xs:appinfo>
                 </xs:annotation>
             </xs:attribute>
-            <xs:attribute name="logRequests" type="xs:boolean" use="optional" default="true"/>
+            <xs:attribute name="logRequests" type="xs:string" use="optional" default="never">
+                <xs:annotation>
+                    <xs:appinfo>
+                        <tooltip>never|only-ones-with-issues|all</tooltip>
+                    </xs:appinfo>
+                </xs:annotation>
+            </xs:attribute>
             <xs:attribute name="logResponses" type="xs:boolean" use="optional" default="false"/>
             <xs:attribute name="txSummaryLevel" type="xs:nonNegativeInteger" use="optional" default="1">
                 <xs:annotation>

--- a/initfiles/etc/DIR_NAME/config2mgr/esp.xml.in
+++ b/initfiles/etc/DIR_NAME/config2mgr/esp.xml.in
@@ -18,7 +18,7 @@
 -->
 <Environment>
   <Software>
-    <EspProcess build="${CPACK_RPM_PACKAGE_VERSION}_${CPACK_RPM_PACKAGE_RELEASE}" description="ESP server" componentfilesDir="${COMPONENTFILES_PATH}" enableSEHMapping="true" enableSNMP="false" formOptionsAccess="false" httpConfigAccess="true" logDir="${LOG_PATH}/config2mgr" logLevel="10" logRequests="true" logResponses="true" txSummaryLevel="1" txSummaryResourceReq="false" maxBacklogQueueSize="200" maxConcurrentThreads="0" name="configmgr" perfReportDelay="60" computer="localhost" directory="${PID_PATH}/config2mgr">
+    <EspProcess build="${CPACK_RPM_PACKAGE_VERSION}_${CPACK_RPM_PACKAGE_RELEASE}" description="ESP server" componentfilesDir="${COMPONENTFILES_PATH}" enableSEHMapping="true" enableSNMP="false" formOptionsAccess="false" httpConfigAccess="true" logDir="${LOG_PATH}/config2mgr" logLevel="10" logRequests="all" logResponses="true" txSummaryLevel="1" txSummaryResourceReq="false" maxBacklogQueueSize="200" maxConcurrentThreads="0" name="configmgr" perfReportDelay="60" computer="localhost" directory="${PID_PATH}/config2mgr">
       <Environment/>
       <EspProtocol name="http" type="http_protocol" plugin="esphttp" maxRequestEntityLength="8000000"/>
       <EspService name="configmgr" type="ws_configmgr" plugin="libws_configmgr.so"/>

--- a/initfiles/etc/DIR_NAME/configmgr/esp.xml.in
+++ b/initfiles/etc/DIR_NAME/configmgr/esp.xml.in
@@ -19,7 +19,7 @@
 
 <Environment>
 <Software>
-<EspProcess build="${CPACK_RPM_PACKAGE_VERSION}_${CPACK_RPM_PACKAGE_RELEASE}" description="ESP server" componentfilesDir="${COMPONENTFILES_PATH}" enableSEHMapping="true" enableSNMP="false" formOptionsAccess="false" httpConfigAccess="true" logDir="${LOG_PATH}/configmgr" logLevel="1" logRequests="true" logResponses="false" txSummaryLevel="1" txSummaryResourceReq="false" maxBacklogQueueSize="200" maxConcurrentThreads="0" name="configmgr" perfReportDelay="60" computer="localhost" directory="${PID_PATH}/configmgr">
+<EspProcess build="${CPACK_RPM_PACKAGE_VERSION}_${CPACK_RPM_PACKAGE_RELEASE}" description="ESP server" componentfilesDir="${COMPONENTFILES_PATH}" enableSEHMapping="true" enableSNMP="false" formOptionsAccess="false" httpConfigAccess="true" logDir="${LOG_PATH}/configmgr" logLevel="1" logRequests="all" logResponses="false" txSummaryLevel="1" txSummaryResourceReq="false" maxBacklogQueueSize="200" maxConcurrentThreads="0" name="configmgr" perfReportDelay="60" computer="localhost" directory="${PID_PATH}/configmgr">
 <Environment/>
 <EspProtocol name="http" type="http_protocol" plugin="esphttp" maxRequestEntityLength="8000000"/>
 <EspService name="WsDeploy_wsdeploy_esp" type="WsDeploy" plugin="WsDeploy">

--- a/initfiles/etc/DIR_NAME/environment.xml.in
+++ b/initfiles/etc/DIR_NAME/environment.xml.in
@@ -258,7 +258,7 @@
               formOptionsAccess="false"
               httpConfigAccess="true"
               logLevel="1"
-              logRequests="false"
+              logRequests="never"
               logResponses="false"
               txSummaryLevel="1"
               txSummaryResourceReq="false"

--- a/testing/regress/environment.xml.in
+++ b/testing/regress/environment.xml.in
@@ -255,7 +255,7 @@
               formOptionsAccess="false"
               httpConfigAccess="true"
               logLevel="1"
-              logRequests="false"
+              logRequests="never"
               logResponses="false"
               txSummaryLevel="1"
               txSummaryResourceReq="false"


### PR DESCRIPTION
When the logLevel is set to 1 and the logRequests is set to
false, ESP will log requests if there is some exception or
the processing time is longer than a pre-defined value. In
this fix, ESP will also log why requests are logged.

Signed-off-by: wangkx <kevin.wang@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
