### PR TITLE
HPCC-22243 Core when embedded python has syntax error (on Centos 7)

### DIFF
--- a/plugins/py3embed/py3embed.cpp
+++ b/plugins/py3embed/py3embed.cpp
@@ -418,23 +418,25 @@ public:
     {
         // Errors from compiler tend to look like this:
         // "('invalid syntax', ('<embed>', 3, 12, '     sfsf ss fs dfs f sfs\n'))"
-        const char pattern [] = "\\(\\'(.*)\\', \\(\\'.*\\', ([0-9]*), ([0-9]*), (.*)\\)\\)";
+        const char pattern [] = "\\('(.*)', \\('.*', ([0-9]*), ([0-9]*), (.*)\\)\\)";
         // Hopefully there are no embedded quotes in the error message or the filename
-        std::regex regex(pattern);
-        std::cmatch matches;
-        if (std::regex_match(error, matches, regex))
+        rtlCompiledStrRegex r;
+        size32_t outlen;
+        char * out = NULL;
+        r.setPattern(pattern, false);
+        r->replace(outlen, out, strlen(error), error, 2, "$2");
+        if (outlen < strlen(error))
         {
-            assertex(matches.size()==5);  // matches 0 is the whole string
-            std::string err = matches.str(1);
-            unsigned line = atoi(matches.str(2).c_str());
-            unsigned col = atoi(matches.str(3).c_str());
-            std::string extra = matches.str(4);
+            unsigned line = atoi(out);
+            rtlFree(out);
             if (line > leadingLines)
                 line--;
-            return ret.appendf("(%u, %u): %s: %s", line, col, err.c_str(), extra.c_str());
+            r->replace(outlen, out, strlen(error), error, 13, ", $3): $1: $4");
+            ret.appendf("(%d", line);
         }
-        else
-            return ret.append(error);
+        ret.append(outlen, out);
+        rtlFree(out);
+        return ret;
     }
     PyObject *compileScript(const char *text, const char *parameters)
     {


### PR DESCRIPTION
The gcc on Centos 7 is old and the std::regex implementation of it is known
to be buggy. In this instance it is throwing an exception of some sort that
the compiler does not catch.

Recoded to avoid use of std::regex altogether.

Signed-off-by: Richard Chapman <rchapman@hpccsystems.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
Tested manually with some invalid embedded Python3, on both Centos7 and more modern systems.

<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
