### PR TITLE
HPCC-21923 Save all custom binding data for a published ESDL binding

### DIFF
--- a/esp/services/ws_esdlconfig/ws_esdlconfigservice.cpp
+++ b/esp/services/ws_esdlconfig/ws_esdlconfigservice.cpp
@@ -32,7 +32,7 @@ enum ESDLConfigInfoType
     ESDLLogTransform = 1,
 };
 
-IPropertyTree * fetchConfigInfo(Owned<IPropertyTree> configTree,
+IPropertyTree * fetchConfigInfo(IPropertyTree* configTree,
                                 StringBuffer & espProcName,
                                 StringBuffer & espBindingName,
                                 StringBuffer & esdlDefId,
@@ -40,7 +40,7 @@ IPropertyTree * fetchConfigInfo(Owned<IPropertyTree> configTree,
 {
     IPropertyTree * methodstree = NULL;
 
-    if (!configTree.get())
+    if (nullptr == configTree)
     {
         throw MakeStringException(-1,"Empty config detected");
     }
@@ -115,7 +115,7 @@ IPropertyTree * fetchConfigInfo(Owned<IPropertyTree> configTree,
         if (!methodstree) //if we didn't already find the methods section of the config, let's look at the root
         {
             if (stricmp(rootname.str(), "Methods") == 0)
-                methodstree = configTree.getLink();
+                methodstree = LINK(configTree);
         }
     }
     return methodstree;

--- a/esp/services/ws_esdlconfig/ws_esdlconfigservice.cpp
+++ b/esp/services/ws_esdlconfig/ws_esdlconfigservice.cpp
@@ -32,7 +32,7 @@ enum ESDLConfigInfoType
     ESDLLogTransform = 1,
 };
 
-IPropertyTree * fetchConfigInfo(const char * config,
+IPropertyTree * fetchConfigInfo(Owned<IPropertyTree> configTree,
                                 StringBuffer & espProcName,
                                 StringBuffer & espBindingName,
                                 StringBuffer & esdlDefId,
@@ -40,7 +40,7 @@ IPropertyTree * fetchConfigInfo(const char * config,
 {
     IPropertyTree * methodstree = NULL;
 
-    if (!config || !*config)
+    if (!configTree.get())
     {
         throw MakeStringException(-1,"Empty config detected");
     }
@@ -50,7 +50,6 @@ IPropertyTree * fetchConfigInfo(const char * config,
         StringBuffer espBindingNameFromConfig;
         StringBuffer esdlDefIdFromConfig;
         StringBuffer esdlServiceNameFromConfig;
-        Owned<IPropertyTree>  configTree = createPTreeFromXMLString(config, ipt_caseInsensitive);
         //Now let's figure out the structure of the configuration passed in...
 
         StringBuffer rootname;
@@ -434,10 +433,14 @@ bool CWsESDLConfigEx::onPublishESDLBinding(IEspContext &context, IEspPublishESDL
 
         StringBuffer config(req.getConfig());
 
+        Owned<IPropertyTree>  configTree;
         Owned<IPropertyTree> methodstree;
 
         if (config.length() != 0)
-            methodstree.setown(fetchConfigInfo(config.str(), espProcName, espBindingName, esdlDefIdSTR, esdlServiceName));
+        {
+            configTree.setown(createPTreeFromXMLString(config, ipt_caseInsensitive));
+            methodstree.setown(fetchConfigInfo(configTree, espProcName, espBindingName, esdlDefIdSTR, esdlServiceName));
+        }
         else
         {
             if (ver >= 1.2)
@@ -505,7 +508,7 @@ bool CWsESDLConfigEx::onPublishESDLBinding(IEspContext &context, IEspPublishESDL
 
             StringBuffer msg;
             resp.updateStatus().setCode(m_esdlStore->bindService(espBindingName.str(),
-                                                           methodstree.get(),
+                                                           (configTree.get() ? configTree.get() : methodstree.get()),
                                                            espProcName.str(),
                                                            espPort.str(),
                                                            esdlDefIdSTR.str(),


### PR DESCRIPTION
The ESDL store accepts a property tree describing either a Binding or a
binding's Definition. In either case, custom root node attributes and all
child elements are added to the new binding, not just the Methods element
previously supported.

The ESDL configuration service passes the entire request configuration to
the ESDL store to be saved, instead of only the contained Methods element.
If no configuration is given, the existing behavior is unchanged.

Signed-off-by: Tim Klemm <Tim.Klemm@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [x] Scalability
  - [x] Performance
  - [x] Security
  - [x] Thread-safety
  - [x] Premature optimization
  - [x] Existing deployed queries will not be broken
  - [x] This change fixes the problem, not just the symptom
  - [x] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [x] Send notifications about my Pull Request position in Smoketest queue.
- [x] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
