### PR TITLE
HPCC-22196 Ensure text of failure is available to FAILMESSAGE

### DIFF
--- a/ecl/eclagent/eclagent.cpp
+++ b/ecl/eclagent/eclagent.cpp
@@ -1484,7 +1484,7 @@ void EclAgent::addWuAssertFailure(unsigned code, const char * text, const char *
 {
     addException(SeverityError, "user", code, text, filename, lineno, column, false, false);
     if (isAbort)
-        rtlFailOnAssert();      // minimal implementation
+        throw makeStringException(MSGAUD_user, code, text);
 }
 
 IUserDescriptor *EclAgent::queryUserDescriptor()

--- a/roxie/ccd/ccdcontext.cpp
+++ b/roxie/ccd/ccdcontext.cpp
@@ -3716,7 +3716,7 @@ public:
             addExceptionToWorkunit(wu, SeverityError, "user", code, text, filename, lineno, column, 0);
         }
         if (isAbort)
-            rtlFailOnAssert();      // minimal implementation
+            throw makeStringException(MSGAUD_user, code, text);
     }
     IUserDescriptor *queryUserDescriptor()
     {

--- a/testing/regress/ecl/issue22196.ecl
+++ b/testing/regress/ecl/issue22196.ecl
@@ -1,0 +1,11 @@
+import Std.System.Workunit as Wu;
+
+f(STRING i) := FUNCTION
+    chk := ASSERT(i != 'A','Letter \'A\' not allowed',FAIL);
+    RETURN WHEN(OUTPUT(i),chk);
+END : FAILURE(OUTPUT(FAILMESSAGE));
+
+isFirstRun := NOT EXISTS(Wu.WorkunitMessages(WORKUNIT));
+arg := IF(isFirstRun, 'A', 'B');
+
+f(arg) : recovery(output('Recover'));

--- a/testing/regress/ecl/key/issue22196.xml
+++ b/testing/regress/ecl/key/issue22196.xml
@@ -1,0 +1,10 @@
+<Exception><Code>100000</Code><Filename>issue22196.ecl</Filename><Line>4</Line><Source>user</Source><Message>Letter 'A' not allowed</Message></Exception>
+<Dataset name='Result 1'>
+ <Row><Result_1>B</Result_1></Row>
+</Dataset>
+<Dataset name='Result 2'>
+ <Row><Result_2>Letter &apos;A&apos; not allowed (in item 1)</Result_2></Row>
+</Dataset>
+<Dataset name='Result 3'>
+ <Row><Result_3>Recover</Result_3></Row>
+</Dataset>

--- a/testing/regress/ecl/thor/issue22196.xml
+++ b/testing/regress/ecl/thor/issue22196.xml
@@ -1,0 +1,10 @@
+<Exception><Code>100000</Code><Filename>issue22196.ecl</Filename><Line>4</Line><Source>user</Source><Message>Letter 'A' not allowed</Message></Exception>
+<Dataset name='Result 1'>
+ <Row><Result_1>B</Result_1></Row>
+</Dataset>
+<Dataset name='Result 2'>
+ <Row><Result_2>Graph graph1[1], simpleaction[2]: Letter &apos;A&apos; not allowed, Master exception - caused by (100000, Letter &apos;A&apos; not allowed) (in item 1)</Result_2></Row>
+</Dataset>
+<Dataset name='Result 3'>
+ <Row><Result_3>Recover</Result_3></Row>
+</Dataset>

--- a/thorlcr/graph/thgraphmaster.cpp
+++ b/thorlcr/graph/thgraphmaster.cpp
@@ -1186,7 +1186,7 @@ public:
             IERRLOG("Unable to record exception in workunit: unknown exception");
         }
         if (isAbort)
-            rtlFailOnAssert();      // minimal implementation
+            throw makeStringException(MSGAUD_user, code, text);
     }
     virtual unsigned __int64 getFileOffset(const char *logicalName) override { assertex(false); return 0; }
     virtual unsigned getNodes() override { return jobChannel.queryJob().querySlaves(); }


### PR DESCRIPTION
Signed-off-by: Gavin Halliday <gavin.halliday@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [x] I have added tests to cover my changes.
  - [x] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
