### PR TITLE
HPCC-22014 Add stack capture feature before abort a (time outed) test case

### DIFF
--- a/testing/regress/ecl-test
+++ b/testing/regress/ecl-test
@@ -226,6 +226,8 @@ class RegressMain:
                                 type=checkPqParam,  default = 1,   metavar="runcount")
         executionParser.add_argument('--excludeFile', '--ef', help="Exclude files of suite. Wildcard is enabled. Default value is 'none'",
                                 nargs=1,  default = ['none'],   metavar="filespec[,filespec,...]")
+        executionParser.add_argument('--generateStackTrace', help="Generate stack trace of Thor components before kill a timeouted test case. Trace files are stored into Regression Engine Log directory (see 'LogDir' in ecl-test.json file)",
+                                action = 'store_true')
 
 
         parser = argparse.ArgumentParser(prog=prog, description=description,  parents=[helperParser, commonParser,  executionParser])
@@ -327,6 +329,16 @@ class RegressMain:
         # There is no sense to clear disk cache if same test runnnig parallel by versioning
         if self.args.pq > 1:
             self.args.flushDiskCache = False
+
+        if self.args.generateStackTrace:
+            if isSudoer():
+                self.config.set('generateStackTrace', True)
+            else:
+                err = Error("7100")
+                logging.error("%s. Generate Stack Trace error:%s" % (-1,  err))
+                exit(err.getErrorCode())
+        else:
+            self.config.set('generateStackTrace', False)
 
         self.config.set('log',  self.log)
         setConfig(self.config)

--- a/testing/regress/hpcc/common/error.py
+++ b/testing/regress/hpcc/common/error.py
@@ -38,6 +38,7 @@ ERROR = {
     "6006": "Error in build suite",
     "6007": "Regression Test Engine internal error",
     "7000": "You have not enough privilege to use '--flushDiskCache' parameter. Check sudoer settings or try it with sudo.",
+    "7100": "You have not enough privilege to use '--generateStackTrace' parameter. Check sudoer settings or try it with sudo.",
     "8000": "Did you specified '--username' parameter, but it seems the stdin is not a TTY like device. Check your environment or add your password into ecl-test.json config file."
 }
 

--- a/testing/regress/hpcc/regression/regress.py
+++ b/testing/regress/hpcc/regression/regress.py
@@ -276,7 +276,7 @@ class Regression:
                                 else:
                                     # retry counter exhausted, give up and abort this test case if exists
                                     if 'W' in wuid['wuid']:
-                                        abortWorkunit(wuid['wuid'])
+                                        abortWorkunit(wuid['wuid'], self.taskParam[threadId]['taskId'], engine)
                                         self.loggermutex.acquire()
                                         query = suiteItems[self.taskParam[threadId]['taskId']]
                                         query.setAborReason('Timeout and retry count exhausted!')
@@ -304,7 +304,7 @@ class Regression:
                                 self.loggermutex.release()
                             else:
                                 # Something wrong with this test case, abort it.
-                                abortWorkunit(wuid['wuid'])
+                                abortWorkunit(wuid['wuid'], self.taskParam[threadId]['taskId']+1, engine)
                                 self.loggermutex.acquire()
                                 query = suiteItems[self.taskParam[threadId]['taskId']]
                                 query.setAborReason('Timeout')
@@ -376,7 +376,7 @@ class Regression:
                 else:
                     # retry counter exhausted, give up and abort this test case if exists
                     logging.debug("%3d. Abort %s WUID:'%s'" % (cnt, query.ecl, str(wuid)),  extra={'taskId':cnt})
-                    abortWorkunit(wuid['wuid'])
+                    abortWorkunit(wuid['wuid'],  cnt, self.args.engine)
                     query.setAborReason('Timeout and retry count exhausted!')
                     self.loggermutex.acquire()
                     logging.error("%3d. Timeout occured for %s and no more attempt left. Force to abort... " % (cnt, query.ecl),  extra={'taskId':cnt})


### PR DESCRIPTION
Add a new command line interface parameter called '--generateStackTrace'

Generate stack trace(s) of the executing engine before kill a timeouted test case. Trace files stored into Regression Engine Log directory (see "LogDir" in ecl-test.json file)

(Replacement of https://github.com/hpcc-systems/HPCC-Platform/pull/12496)

Signed-off-by: Attila Vamos <attila.vamos@gmail.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [x] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [x] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [x] Send notifications about my Pull Request position in Smoketest queue.
- [x] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->
Tested manually with long run test case (teststdlibrary.ecl) and short timeout (35 sec).
<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
