### PR TITLE
HPCC-22309 Do not reuse a persistent connection after a write error

### DIFF
--- a/esp/bindings/http/platform/httptransport.cpp
+++ b/esp/bindings/http/platform/httptransport.cpp
@@ -817,6 +817,7 @@ int CHttpMessage::send()
     }
     catch (IException *e) 
     {
+        setPersistentEligible(false);
         StringBuffer estr;
         DBGLOG("In CHttpMessage::send(%d) -- Exception(%d, %s) writing to socket(%d).", __LINE__, e->errorCode(), e->errorMessage(estr).str(), m_socket.OShandle());
         e->Release();
@@ -824,6 +825,7 @@ int CHttpMessage::send()
     }
     catch(...)
     {
+        setPersistentEligible(false);
         ERRLOG("In CHttpMessage::send(%d) -- Unknown exception writing to socket(%d).", __LINE__, m_socket.OShandle());
         return -1;
     }
@@ -850,6 +852,7 @@ int CHttpMessage::send()
                 }
                 catch (IException *e) 
                 {
+                    setPersistentEligible(false);
                     StringBuffer estr;
                     LOG(MCexception(e), "In CHttpMessage::send(%d) -- Exception(%d, %s) writing to socket(%d).", __LINE__, e->errorCode(), e->errorMessage(estr).str(), m_socket.OShandle());
                     e->Release();
@@ -858,6 +861,7 @@ int CHttpMessage::send()
                 }
                 catch(...)
                 {
+                    setPersistentEligible(false);
                     ERRLOG("In CHttpMessage::send(%d) -- Unknown exception writing to socket(%d).", __LINE__, m_socket.OShandle());
                     retcode = -1;
                     break;
@@ -889,14 +893,16 @@ int CHttpMessage::startSend()
     }
     catch (IException *e) 
     {
+        setPersistentEligible(false);
         StringBuffer estr;
-        DBGLOG("In CHttpMessage::send() -- Exception(%d, %s) writing to socket(%d).", e->errorCode(), e->errorMessage(estr).str(), m_socket.OShandle());
+        DBGLOG("In CHttpMessage::startSend() -- Exception(%d, %s) writing to socket(%d).", e->errorCode(), e->errorMessage(estr).str(), m_socket.OShandle());
         e->Release();
         return -1;
     }
     catch(...)
     {
-        ERRLOG("In CHttpMessage::send() -- Unknown exception writing to socket(%d).", m_socket.OShandle());
+        setPersistentEligible(false);
+        ERRLOG("In CHttpMessage::startSend() -- Unknown exception writing to socket(%d).", m_socket.OShandle());
         return -1;
     }
 
@@ -914,14 +920,16 @@ int CHttpMessage::sendChunk(const char *chunk)
     }
     catch (IException *e) 
     {
+        setPersistentEligible(false);
         StringBuffer estr;
-        DBGLOG("In CHttpMessage::send() -- Exception(%d, %s) writing to socket(%d).", e->errorCode(), e->errorMessage(estr).str(), m_socket.OShandle());
+        DBGLOG("In CHttpMessage::sendChunk() -- Exception(%d, %s) writing to socket(%d).", e->errorCode(), e->errorMessage(estr).str(), m_socket.OShandle());
         e->Release();
         return -1;
     }
     catch(...)
     {
-        ERRLOG("In CHttpMessage::send() -- Unknown exception writing to socket(%d).", m_socket.OShandle());
+        setPersistentEligible(false);
+        ERRLOG("In CHttpMessage::sendChunk() -- Unknown exception writing to socket(%d).", m_socket.OShandle());
         return -1;
     }
 
@@ -940,14 +948,16 @@ int CHttpMessage::sendFinalChunk(const char *chunk)
     }
     catch (IException *e) 
     {
+        setPersistentEligible(false);
         StringBuffer estr;
-        DBGLOG("In CHttpMessage::send() -- Exception(%d, %s) writing to socket(%d).", e->errorCode(), e->errorMessage(estr).str(), m_socket.OShandle());
+        DBGLOG("In CHttpMessage::sendFinalChunk() -- Exception(%d, %s) writing to socket(%d).", e->errorCode(), e->errorMessage(estr).str(), m_socket.OShandle());
         e->Release();
         return -1;
     }
     catch(...)
     {
-        ERRLOG("In CHttpMessage::send() -- Unknown exception writing to socket(%d).", m_socket.OShandle());
+        setPersistentEligible(false);
+        ERRLOG("In CHttpMessage::sendFinalChunk() -- Unknown exception writing to socket(%d).", m_socket.OShandle());
         return -1;
     }
 

--- a/esp/platform/persistent.cpp
+++ b/esp/platform/persistent.cpp
@@ -79,7 +79,7 @@ public:
 
     virtual void add(ISocket* sock, SocketEndpoint* ep = nullptr) override
     {
-        if (!sock)
+        if (!sock || sock->OShandle() == INVALID_SOCKET)
             return;
         synchronized block(m_mutex);
         PERSILOG(PersistentLogLevel::PLogNormal, "PERSISTENT: adding socket %d to handler %d", sock->OShandle(), m_id);
@@ -127,6 +127,8 @@ public:
         {
             info->useCount += usesOverOne;
             bool reachedQuota = m_maxReqs > 0 && m_maxReqs <= info->useCount;
+            if(sock->OShandle() == INVALID_SOCKET)
+                keep = false;
             if (keep && !reachedQuota)
             {
                 info->inUse = false;


### PR DESCRIPTION
- Set flag to not re-use the connection when write error happens
- Check if socket is valid before adding the socket to the pool

Signed-off-by: mayx <yanrui.ma@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [x] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [x] Scalability
  - [x] Performance
  - [x] Security
  - [x] Thread-safety
  - [x] Premature optimization
  - [x] Existing deployed queries will not be broken
  - [x] This change fixes the problem, not just the symptom
  - [x] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [x] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
