### PR TITLE
HPCC-22339 Pass 1st warning on remote stream read to workunit

### DIFF
--- a/ecl/eclagent/agentctx.hpp
+++ b/ecl/eclagent/agentctx.hpp
@@ -33,6 +33,7 @@
 #define WRN_UnsupportedAlgorithm            5403
 #define WRN_MismatchGroupInfo               5404
 #define WRN_MismatchCompressInfo            5405
+#define WRN_RemoteReadFailure               5406
 
 struct IHThorGraphResult : extends IInterface
 {

--- a/ecl/hthor/hthor.cpp
+++ b/ecl/hthor/hthor.cpp
@@ -8369,6 +8369,9 @@ bool CHThorDiskReadBaseActivity::openNext()
 #ifdef _DEBUG
                                 EXCLOG(e, nullptr);
 #endif
+                                VStringBuffer msg("Remote streaming failure, failing over to direct read for: '%s'. ", file.str());
+                                e->errorMessage(msg);
+                                agent.addWuException(msg.str(), WRN_RemoteReadFailure, SeverityWarning, "hthor");
                                 e->Release();
                                 continue; // try next copy and ultimately failover to local when no more copies
                             }

--- a/thorlcr/activities/indexread/thindexreadslave.cpp
+++ b/thorlcr/activities/indexread/thindexreadslave.cpp
@@ -196,6 +196,8 @@ public:
                         else
                             remoteCandidates.push_back(copy);
                     }
+                    Owned<IException> remoteReadException;
+                    StringBuffer remoteReadExceptionPath;
                     for (unsigned &copy : remoteCandidates) // only if no local part found above
                     {
                         RemoteFilename rfn;
@@ -243,13 +245,26 @@ public:
 #ifdef _DEBUG
                                 EXCLOG(e, nullptr);
 #endif
-                                e->Release();
+                                if (remoteReadException)
+                                    e->Release(); // only record 1st
+                                else
+                                {
+                                    remoteReadException.setown(e);
+                                    remoteReadExceptionPath.set(path);
+                                }
                                 continue; // try next copy and ultimately failover to local when no more copies
                             }
                             ActPrintLog("[part=%d]: reading remote dafilesrv index '%s' (logical file = %s)", partNum, path.str(), logicalFilename.get());
                             partNum = p;
                             return indexLookup.getClear();
                         }
+                    }
+                    if (remoteReadException)
+                    {
+                        VStringBuffer msg("Remote streaming failure, failing over to direct read for: '%s'. ", remoteReadExceptionPath.str());
+                        remoteReadException->errorMessage(msg);
+                        Owned<IThorException> e2 = MakeActivityWarning(this, TE_RemoteReadFailure, "%s", msg.str());
+                        fireException(e2);
                     }
                 }
 

--- a/thorlcr/graph/thgraphmaster.cpp
+++ b/thorlcr/graph/thgraphmaster.cpp
@@ -496,6 +496,7 @@ bool CMasterActivity::fireException(IException *_e)
         case TE_SpillAdded:
         case TE_ReadPartialFromPipe:
         case TE_LargeAggregateTable:
+        case TE_RemoteReadFailure:
         {
             if (!notedWarnings->testSet(e->errorCode()))
                 CActivityBase::fireException(e);

--- a/thorlcr/shared/thexception.hpp
+++ b/thorlcr/shared/thexception.hpp
@@ -159,7 +159,8 @@
 #define TE_WorkUnitAbortingDumpInfo             TE_Base + 136
 #define TE_RowLeaksDetected                     TE_Base + 137
 #define TE_FileFormatMismatch                   TE_Base + 138
-#define TE_Final                                TE_Base + 139       // keep this last
+#define TE_RemoteReadFailure                    TE_Base + 139
+#define TE_Final                                TE_Base + 140       // keep this last
 #define ISTHOREXCEPTION(n) (n > TE_Base && n < TE_Final)
 
 #endif


### PR DESCRIPTION
Signed-off-by: Jake Smith <jake.smith@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [x] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
