### PR TITLE
HPCC-22312 Failing Std.Date unit tests on macOS

### DIFF
--- a/ecl/hql/hqllex.l
+++ b/ecl/hql/hqllex.l
@@ -1044,6 +1044,8 @@ __OS__              {
                             return lookupIdentifierToken(returnToken, lexer, lookup, activeState, CUR_TOKEN_TEXT);
 #ifdef _WIN32
                         returnToken.setExpr(createConstant("windows"));
+#elif defined(__APPLE__)
+                        returnToken.setExpr(createConstant("macos"));
 #else
                         returnToken.setExpr(createConstant("linux"));
 #endif

--- a/ecllibrary/teststd/Date/TestFormat.ecl
+++ b/ecllibrary/teststd/Date/TestFormat.ecl
@@ -77,6 +77,11 @@ EXPORT TestFormat := MODULE
     ASSERT(Date.DateToString(19700101, '%d/%m/%y') = '01/01/70');
     ASSERT(Date.DateToString(20110302, '%d %b %Y') = '02 Mar 2011');
     ASSERT(Date.DateToString(20111202, '%d %B %Y') = '02 December 2011');
+#IF(__OS__ = 'macos')
+    ASSERT(Date.DateToString(110131, '%Y-%m-%d') = '0011-01-31');
+#ELSE
+    ASSERT(Date.DateToString(110131, '%Y-%m-%d') = '11-01-31');
+#END
 
     ASSERT(Date.MatchTimeString('123456',TimeFormats) = 123456);
     ASSERT(Date.MatchTimeString('12:34:56',TimeFormats) = 123456);
@@ -96,7 +101,11 @@ EXPORT TestFormat := MODULE
 
     ASSERT(Date.ConvertDateFormatMultiple('1/31/2011',DateFormats,'%Y-%m-%d') = '2011-01-31');
     ASSERT(Date.ConvertDateFormatMultiple('1/31/11',DateFormats2Y,'%Y-%m-%d') = '2011-01-31');
+#IF(__OS__ = 'macos')
+    ASSERT(Date.ConvertDateFormatMultiple('1/31/11',DateFormats,'%Y-%m-%d') = '0011-01-31');
+#ELSE
     ASSERT(Date.ConvertDateFormatMultiple('1/31/11',DateFormats,'%Y-%m-%d') = '11-01-31');
+#END
     ASSERT(Date.ConvertDateFormatMultiple('1/31/11',DateFormats2Y,'%Y-%m-%d') = '2011-01-31');
     ASSERT(Date.ConvertDateFormatMultiple('',DateFormats,'%Y-%m-%d') = ''); // HPCC-16780; Invalid input date
     ASSERT(Date.ConvertDateFormatMultiple('',DateFormats2Y,'%Y-%m-%d') = ''); // HPCC-16780; Invalid input date


### PR DESCRIPTION
This change specifically involves the %Y formatting directive for year output (not parsing).

Complete list of Date functions that were affected:

DateToString
SecondsToString
TimestampToString
ConvertDateFormat
ConvertDateFormatMultiple

Also included with this change is a new __OS__ ECL constant value:  'linux-macos'.

Signed-off-by: Dan S. Camper <dan.camper@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [x] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [ ] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [x] I have added tests to cover my changes.
  - [x] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

Manual testing plus exercising (new and modified) tests in TestStd.Date.TestFormat.

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
