### PR TITLE
HPCC-22441 Add packagemap validation options to ignore certain information

### DIFF
--- a/common/workunit/package.h
+++ b/common/workunit/package.h
@@ -52,7 +52,7 @@ interface IHpccPackageMap : extends IInterface
     virtual const IHpccPackage *matchPackage(const char *name) const = 0;
     virtual const char *queryPackageId() const = 0;
     virtual bool isActive() const = 0;
-    virtual bool validate(StringArray &queriesToVerify, StringArray &warn, StringArray &err, StringArray &unmatchedQueries, StringArray &unusedPackages, StringArray &unmatchedFiles) const = 0;
+    virtual bool validate(const StringArray &queriesToVerify, const StringArray &queriesToIgnore, StringArray &warn, StringArray &err, StringArray &unmatchedQueries, StringArray &unusedPackages, StringArray &unmatchedFiles, bool ignoreOptionalFiles) const = 0;
     virtual void gatherFileMappingForQuery(const char *queryname, IPropertyTree *fileInfo) const = 0;
     virtual const StringArray &getPartIds() const = 0;
 };

--- a/ecl/ecl-package/ecl-package.cpp
+++ b/ecl/ecl-package/ecl-package.cpp
@@ -843,10 +843,19 @@ public:
                 continue;
             if (iter.matchFlag(optGlobalScope, ECLOPT_GLOBAL_SCOPE))
                 continue;
+            if (iter.matchFlag(optIgnoreWarnings, ECLOPT_IGNORE_WARNINGS))
+                continue;
+            if (iter.matchFlag(optIgnoreOptionalFiles, ECLOPT_IGNORE_OPTIONAL))
+                continue;
             StringAttr queryIds;
             if (iter.matchOption(queryIds, ECLOPT_QUERYID))
             {
                 optQueryIds.appendList(queryIds.get(), ",");
+                continue;
+            }
+            if (iter.matchOption(queryIds, ECLOPT_IGNORE_QUERIES))
+            {
+                optIgnoreQueries.appendList(queryIds.get(), ",");
                 continue;
             }
             eclCmdOptionMatchIndicator ind = EclCmdCommon::matchCommandLineOption(iter, true);
@@ -928,8 +937,11 @@ public:
         request->setPMID(optPMID);
         request->setTarget(optTarget);
         request->setQueriesToVerify(optQueryIds);
+        request->setQueriesToIgnore(optIgnoreQueries);
         request->setCheckDFS(optCheckDFS);
         request->setGlobalScope(optGlobalScope);
+        request->setIgnoreWarnings(optIgnoreWarnings);
+        request->setIgnoreOptionalFiles(optIgnoreOptionalFiles);
 
         bool validateMessages = false;
         Owned<IClientValidatePackageResponse> resp = packageProcessClient->ValidatePackage(request);
@@ -1025,6 +1037,11 @@ public:
                     "   --queryid                   Query to verify against packagemap, multiple queries can be\n"
                     "                               specified using a comma separated list, or by using --queryid\n"
                     "                               more than once. Default is all queries in the target queryset\n"
+                    "   --ignore-queries            Queries to exclude from verification, multiple queries can be\n"
+                    "                               specified using wildcards, a comma separated list, or by using\n"
+                    "                               --ignore-queries more than once.\n"
+                    "   --ignore-optional           Doesn't warn when optional files are not defined in packagemap.\n"
+                    "   --ignore-warnings           Doesn't output general packagemap warnings.\n"
                     "   --global-scope              The specified packagemap can be shared across multiple targets\n",
                     stdout);
 
@@ -1032,12 +1049,15 @@ public:
     }
 private:
     StringArray optQueryIds;
+    StringArray optIgnoreQueries;
     StringAttr optFileName;
     StringAttr optTarget;
     StringAttr optPMID;
     bool optValidateActive;
     bool optCheckDFS;
     bool optGlobalScope;
+    bool optIgnoreWarnings = false;
+    bool optIgnoreOptionalFiles = false;
 };
 
 class EclCmdPackageQueryFiles : public EclCmdCommon

--- a/ecl/eclcmd/eclcmd_common.hpp
+++ b/ecl/eclcmd/eclcmd_common.hpp
@@ -117,6 +117,9 @@ typedef IEclCommand *(*EclCommandFactory)(const char *cmdname);
 #define ECLOPT_PART_NAME "--part-name"
 #define ECLOPT_PROTECT "--protect"
 #define ECLOPT_USE_EXISTING "--use-existing"
+#define ECLOPT_IGNORE_WARNINGS "--ignore-warnings"
+#define ECLOPT_IGNORE_OPTIONAL "--ignore-optional"
+#define ECLOPT_IGNORE_QUERIES "--ignore-queries"
 
 #define ECLOPT_MAIN "--main"
 #define ECLOPT_MAIN_S "-main"  //eclcc compatible format

--- a/esp/scm/ws_packageprocess.ecm
+++ b/esp/scm/ws_packageprocess.ecm
@@ -189,8 +189,11 @@ ESPrequest ValidatePackageRequest
     string PMID;
     string QueryIdToVerify;
     ESParray<string> QueriesToVerify;
+    ESParray<string> QueriesToIgnore;
     bool CheckDFS;
     bool GlobalScope(0);
+    bool IgnoreWarnings(0);
+    bool IgnoreOptionalFiles(0);
 };
 
 ESPstruct ValidatePackageInfo

--- a/esp/services/ws_packageprocess/ws_packageprocessService.cpp
+++ b/esp/services/ws_packageprocess/ws_packageprocessService.cpp
@@ -1165,10 +1165,18 @@ bool CWsPackageProcessEx::onValidatePackage(IEspContext &context, IEspValidatePa
         if (queryid && *queryid)
             queriesToVerify.appendUniq(queryid);
     }
-    map->validate(queriesToVerify, warnings, errors, unmatchedQueries, unusedPackages, unmatchedFiles);
+    StringArray queriesToIgnore;
+    ForEachItemIn(i2, req.getQueriesToIgnore())
+    {
+        queryid = req.getQueriesToIgnore().item(i2);
+        if (queryid && *queryid)
+            queriesToIgnore.appendUniq(queryid);
+    }
+    map->validate(queriesToVerify, queriesToIgnore, warnings, errors, unmatchedQueries, unusedPackages, unmatchedFiles, req.getIgnoreOptionalFiles());
 
     resp.setPMID(map->queryPackageId());
-    resp.setWarnings(warnings);
+    if (!req.getIgnoreWarnings())
+        resp.setWarnings(warnings);
     resp.setErrors(errors);
     resp.updateQueries().setUnmatched(unmatchedQueries);
     resp.updatePackages().setUnmatched(unusedPackages);

--- a/roxie/ccd/ccdstate.cpp
+++ b/roxie/ccd/ccdstate.cpp
@@ -824,9 +824,9 @@ public:
     {
         return BASE::getPartIds();
     }
-    virtual bool validate(StringArray &queryids, StringArray &wrn, StringArray &err, StringArray &unmatchedQueries, StringArray &unusedPackages, StringArray &unmatchedFiles) const
+    virtual bool validate(const StringArray &queryids, const StringArray &queriesToIgnore, StringArray &wrn, StringArray &err, StringArray &unmatchedQueries, StringArray &unusedPackages, StringArray &unmatchedFiles, bool ignoreOptionalFiles) const
     {
-        return BASE::validate(queryids, wrn, err, unmatchedQueries, unusedPackages, unmatchedFiles);
+        return BASE::validate(queryids, queriesToIgnore, wrn, err, unmatchedQueries, unusedPackages, unmatchedFiles, ignoreOptionalFiles);
     }
     virtual void gatherFileMappingForQuery(const char *queryname, IPropertyTree *fileInfo) const
     {


### PR DESCRIPTION
Add 3 new options to the ecl packagmap validate command.

--ingnore-optional
   Will not report optional files that are not defined in the packagemap.

--ignore-warnings
   Will not report general packagemap warnings.

--ignore-queries='my*query'
   Will not report on the queries which match the expression.
   A set of queries/expressions can be built as either a comma separated
   list, or by using the option once per entry.

Signed-off-by: Anthony Fishbeck <anthony.fishbeck@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [x] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [x] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
