### PR TITLE
HPCC-22542 Activity Widget sending hundreds of requests to WUInfo

### DIFF
--- a/esp/src/eclwatch/ActivityWidget.js
+++ b/esp/src/eclwatch/ActivityWidget.js
@@ -293,15 +293,6 @@ define([
 
                 this.openButton = registry.byId(this.id + "Open");
                 this.refreshButton = registry.byId(this.id + "Refresh");
-                this.autoRefreshButton = new ToggleButton({
-                    id: this.id + "AutoRefresh",
-                    iconClass: 'iconAutoRefresh',
-                    showLabel: false,
-                    checked: false,
-                    onClick: function (event) {
-                        context._onAutoRefresh(event);
-                    }
-                }).placeAt(this.refreshButton.domNode, "before");
                 var tmpSplitter = new ToolbarSeparator().placeAt(this.refreshButton.domNode, "before");
                 this.clusterPauseButton = new Button({
                     id: this.id + "PauseButton",

--- a/esp/src/eclwatch/templates/ActivityPageWidget.html
+++ b/esp/src/eclwatch/templates/ActivityPageWidget.html
@@ -3,6 +3,7 @@
         <div id="${id}TabContainer" data-dojo-props="region: 'center', tabPosition: 'top'" style="width: 100%; height: 100%" data-dojo-type="dijit.layout.TabContainer">
             <div id="${id}_Grid" style="width: 100%; height: 100%" data-dojo-props='title:"${gridTitle}"' data-dojo-type="dijit.layout.BorderContainer">
                 <div id="${id}Toolbar" class="topPanel" data-dojo-props="region: 'top'" data-dojo-type="dijit.Toolbar">
+                    <div id="${id}AutoRefresh" data-dojo-attach-event="onClick:_onAutoRefresh" data-dojo-props="iconClass:'iconAutoRefresh', showLabel:false, checked: false" data-dojo-type="dijit.form.ToggleButton">${i18n.AutoRefresh}</div>
                     <div id="${id}Refresh" data-dojo-attach-event="onClick:_onRefresh" data-dojo-props="iconClass:'iconRefresh'" data-dojo-type="dijit.form.Button">${i18n.Refresh}</div>
                     <span data-dojo-type="dijit.ToolbarSeparator"></span>
                     <div id="${id}Open" data-dojo-attach-event="onClick:_onOpen" data-dojo-type="dijit.form.Button">${i18n.Open}</div>

--- a/esp/src/src/ESPActivity.ts
+++ b/esp/src/src/ESPActivity.ts
@@ -171,7 +171,8 @@ var Activity = declare([ESPUtil.Singleton, ESPUtil.Monitor], {
                 }
                 var wu = item.Server === "DFUserver" ? ESPDFUWorkunit.Get(item.Wuid) : ESPWorkunit.Get(item.Wuid);
                 wu.updateData(lang.mixin({
-                    __hpcc_id: item.Wuid
+                    __hpcc_id: item.Wuid,
+                    component: "ActivityWidget"
                 }, item));
                 if (!wu.isComplete || !wu.isComplete()) {
                     queue.addChild(wu);

--- a/esp/src/src/ESPWorkunit.ts
+++ b/esp/src/src/ESPWorkunit.ts
@@ -190,7 +190,7 @@ var Workunit = declare([ESPUtil.Singleton], {  // jshint ignore:line
         if (justCompleted) {
             topic.publish("hpcc/ecl_wu_completed", this);
         }
-        if (!this.hasCompleted) {
+        if (!this.hasCompleted && this.component !== "ActivityWidget") {
             this.startMonitor();
         }
     },


### PR DESCRIPTION
During a change to correct the progress graphic that was out of sync in the WUDetailsWidget a hasCompleted event fired in multiple places. This caused monitoring(timer) to start on the Activity widget needlessly. The Activity widget has its own timer that can monitor its un-completed workunits. I have added an indentifier that destinguishes it from the WUDetailsWidget.

Related to: https://github.com/hpcc-systems/HPCC-Platform/commit/febaf310a0440398cdbf90a50f570419dfe0ca1d#diff-b357ce8bbd5b62aea547413e4862f360

Signed-off: Miguel Vazquez <miguel.vazquez@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [ ] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [x] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
