### PR TITLE
HPCC-22670 Do not force super copy for super index with <=1 subfile

### DIFF
--- a/dali/dfu/dfurun.cpp
+++ b/dali/dfu/dfurun.cpp
@@ -1230,7 +1230,7 @@ public:
                     srcName.set(tmp);
                     srcFdesc.setown(srcFile->getFileDescriptor());
                     iskey = isFileKey(srcFile);
-                    if ((cmd==DFUcmd_copy) && (srcFile->querySuperFile() != nullptr) && iskey)
+                    if ((cmd==DFUcmd_copy) && (srcFile->querySuperFile() != nullptr) && (srcFile->querySuperFile()->numSubFiles() > 1) && iskey)
                         throwError1(DFTERR_InvalidSuperindexCopy, srcName.str());
 
                     oldRoxiePrefix.set(srcFile->queryAttributes().queryProp("@roxiePrefix"));

--- a/esp/scm/ws_dfu.ecm
+++ b/esp/scm/ws_dfu.ecm
@@ -114,6 +114,7 @@ ESPStruct DFULogicalFile
     [min_ver("1.30")] bool Persistent(false);
     [min_ver("1.34")] bool IsProtected(false);
     [min_ver("1.41")] string KeyType;
+    [min_ver("1.52")] int NumOfSubfiles;
 };
 
 ESPStruct DFUPart
@@ -973,8 +974,8 @@ ESPresponse [exceptions_inline, nil_remove] DFUFilePublishResponse
 //  ===========================================================================
 ESPservice [
     auth_feature("DEFERRED"),
-    version("1.51"),
-    default_client_version("1.51"),
+    version("1.52"),
+    default_client_version("1.52"),
     noforms,
     exceptions_inline("./smc_xslt/exceptions.xslt")] WsDfu
 {

--- a/esp/services/ws_dfu/ws_dfuService.cpp
+++ b/esp/services/ws_dfu/ws_dfuService.cpp
@@ -3595,7 +3595,14 @@ bool CWsDfuEx::addToLogicalFileList(IPropertyTree& file, const char* nodeGroup, 
 
         int numSubFiles = file.hasProp(getDFUQResultFieldName(DFUQRFnumsubfiles));
         if(numSubFiles)
+        {
             lFile->setIsSuperfile(true);
+            if (version >= 1.52)
+            {
+                numSubFiles = file.getPropInt(getDFUQResultFieldName(DFUQRFnumsubfiles));
+                lFile->setNumOfSubfiles(numSubFiles);
+            }
+        }
         else
         {
             lFile->setIsSuperfile(false);

--- a/esp/services/ws_fs/ws_fsService.cpp
+++ b/esp/services/ws_fs/ws_fsService.cpp
@@ -2523,7 +2523,7 @@ bool CFileSprayEx::onCopy(IEspContext &context, IEspCopy &req, IEspCopyResponse 
             if (!file->querySuperFile())
                 supercopy = false;
         }
-        else if (file->querySuperFile() && isFileKey(file))
+        else if (file->querySuperFile() && (file->querySuperFile()->numSubFiles() > 1) && isFileKey(file))
             supercopy = true;
 
         Owned<IDFUWorkUnitFactory> factory = getDFUWorkUnitFactory();


### PR DESCRIPTION
Also return the number of subfiles in DFUQuery. ECLWatch may use the
number to enable/disable the 'Retain Superfile Structure' checkbox.

Signed-off-by: wangkx <kevin.wang@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
