### PR TITLE
HPCC-22724 Remove redundant no_createrow expressions

### DIFF
--- a/ecl/hql/hqlexpr.cpp
+++ b/ecl/hql/hqlexpr.cpp
@@ -2105,6 +2105,7 @@ bool checkConstant(node_operator op)
     case no_xmlencode:
     case no_sortpartition:
     case no_clustersize:
+    case no_toxml:
         return false;
     }
     return true;

--- a/ecl/hql/hqlopt.cpp
+++ b/ecl/hql/hqlopt.cpp
@@ -911,7 +911,12 @@ static bool branchesMatch(unsigned options, IHqlExpression * left, IHqlExpressio
     return true;
 }
 
-static IHqlExpression * queryReduntantTransformSource(IHqlExpression * expr, IHqlExpression * record)
+
+/*
+ * Check if the expr is a transform that effectively says SELF := row, where row has the same format as
+ * the target dataset.  If so return row, else return nullptr
+ */
+static IHqlExpression * queryRedundantTransformSource(IHqlExpression * expr, IHqlExpression * record)
 {
     IHqlExpression * result = nullptr;
     ForEachChild(i, expr)
@@ -923,7 +928,7 @@ static IHqlExpression * queryReduntantTransformSource(IHqlExpression * expr, IHq
         case no_skip:
             throwUnexpected();
         case no_assignall:
-            match = queryReduntantTransformSource(cur, record);
+            match = queryRedundantTransformSource(cur, record);
             break;
         case no_assign:
             {
@@ -961,7 +966,7 @@ IHqlExpression * CTreeOptimizer::optimizeCreateRow(IHqlExpression * expr)
     IHqlExpression * transform = expr->queryChild(0);
     if (transformContainsSkip(transform))
         return nullptr;
-    return queryReduntantTransformSource(transform, expr->queryRecord());
+    return queryRedundantTransformSource(transform, expr->queryRecord());
 }
 
 IHqlExpression * CTreeOptimizer::optimizeIf(IHqlExpression * expr)

--- a/ecl/hql/hqlopt.cpp
+++ b/ecl/hql/hqlopt.cpp
@@ -911,6 +911,59 @@ static bool branchesMatch(unsigned options, IHqlExpression * left, IHqlExpressio
     return true;
 }
 
+static IHqlExpression * queryReduntantTransformSource(IHqlExpression * expr, IHqlExpression * record)
+{
+    IHqlExpression * result = nullptr;
+    ForEachChild(i, expr)
+    {
+        IHqlExpression * cur = expr->queryChild(i);
+        IHqlExpression * match = nullptr;
+        switch (cur->getOperator())
+        {
+        case no_skip:
+            throwUnexpected();
+        case no_assignall:
+            match = queryReduntantTransformSource(cur, record);
+            break;
+        case no_assign:
+            {
+                IHqlExpression * lhs = cur->queryChild(0);
+                IHqlExpression * rhs = cur->queryChild(1);
+                if (rhs->getOperator() != no_select)
+                    return nullptr;
+                if (lhs->queryChild(1) != rhs->queryChild(1))
+                    return nullptr;
+                match = rhs->queryChild(0);
+                break;
+            }
+        }
+
+        if (!match)
+            return nullptr;
+        if (result)
+        {
+            if (match != result)
+                return nullptr;
+        }
+        else
+        {
+            if (match->queryRecord() != record)
+                return nullptr;
+            result = match;
+        }
+    }
+    return result;
+}
+
+IHqlExpression * CTreeOptimizer::optimizeCreateRow(IHqlExpression * expr)
+{
+    //Check for createrow(transform(record, SELF.x := <row>.x; SELF.y := <row>.y) -> <row>
+    IHqlExpression * transform = expr->queryChild(0);
+    if (transformContainsSkip(transform))
+        return nullptr;
+    return queryReduntantTransformSource(transform, expr->queryRecord());
+}
+
 IHqlExpression * CTreeOptimizer::optimizeIf(IHqlExpression * expr)
 {
     IHqlExpression * trueExpr = expr->queryChild(1);
@@ -2344,6 +2397,18 @@ IHqlExpression * CTreeOptimizer::doCreateTransformed(IHqlExpression * transforme
     //Removing child nodes could be included, but it may create more spillers/splitters - which may be significant in thor.
     switch (op)
     {
+        case no_createrow:
+        {
+            IHqlExpression * ret = optimizeCreateRow(transformed);
+            if (ret)
+            {
+                DBGLOG("Optimizer: Remove Redundant %s", queryNode0Text(transformed));
+                if (ret->isDataset())
+                    return ensureActiveRow(ret);
+                return LINK(ret);
+            }
+            break;
+        }
     case no_if:
         {
             OwnedHqlExpr ret = optimizeIf(transformed);

--- a/ecl/hql/hqlopt.ipp
+++ b/ecl/hql/hqlopt.ipp
@@ -112,6 +112,7 @@ protected:
 
     IHqlExpression * optimizeAggregateCompound(IHqlExpression * transformed);
     IHqlExpression * optimizeAggregateUnsharedDataset(IHqlExpression * expr, bool isSimpleCount, bool isLocal);
+    IHqlExpression * optimizeCreateRow(IHqlExpression * expr);
     IHqlExpression * optimizeJoinCondition(IHqlExpression * expr);
     IHqlExpression * optimizeDistributeDedup(IHqlExpression * expr);
     IHqlExpression * optimizeIf(IHqlExpression * expr);

--- a/ecl/hql/hqlpmap.cpp
+++ b/ecl/hql/hqlpmap.cpp
@@ -584,6 +584,9 @@ IHqlExpression * NewProjectMapper2::doExpandFields(IHqlExpression * expr, IHqlEx
 
     if (expandCallback && (expr == oldDataset))
     {
+        /*
+         * If the mapping comes from a constant transform, then return ROW(transform) as the expanded value
+         */
         if (mapping->isConstant() && mapping->isTransform())
             return createRow(no_createrow, LINK(mapping));
 
@@ -620,6 +623,7 @@ IHqlExpression * NewProjectMapper2::doExpandFields(IHqlExpression * expr, IHqlEx
                 ret = doNewExpandSelect(ds, oldDataset, newDataset, oldParent);
             else if (ds == oldDataset)
             {
+                //Check for activerow(dataset) and if so return the no_createrow - with a surrounding activerow
                 OwnedHqlExpr mapped = doExpandFields(ds, oldDataset, newDataset, oldParent);
                 if (mapped)
                     return mapped.getClear();

--- a/ecl/hql/hqlpmap.cpp
+++ b/ecl/hql/hqlpmap.cpp
@@ -584,6 +584,9 @@ IHqlExpression * NewProjectMapper2::doExpandFields(IHqlExpression * expr, IHqlEx
 
     if (expandCallback && (expr == oldDataset))
     {
+        if (mapping->isConstant() && mapping->isTransform())
+            return createRow(no_createrow, LINK(mapping));
+
         OwnedHqlExpr mapped = expandCallback->onExpandSelector();
         if (mapped)
             return mapped.getClear();
@@ -615,6 +618,12 @@ IHqlExpression * NewProjectMapper2::doExpandFields(IHqlExpression * expr, IHqlEx
             IHqlExpression * ds = expr->queryChild(0);
             if (ds->getOperator() == no_select)
                 ret = doNewExpandSelect(ds, oldDataset, newDataset, oldParent);
+            else if (ds == oldDataset)
+            {
+                OwnedHqlExpr mapped = doExpandFields(ds, oldDataset, newDataset, oldParent);
+                if (mapped)
+                    return mapped.getClear();
+            }
             break;
         }
     case no_projectrow:


### PR DESCRIPTION
Signed-off-by: Gavin Halliday <gavin.halliday@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [x] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
