### PR TITLE
HPCC-22686 Update supercopy.ecl to test copy for super index with <=1 and >1 subfile

### DIFF
--- a/dali/ft/filecopy.cpp
+++ b/dali/ft/filecopy.cpp
@@ -3335,9 +3335,12 @@ void FileSprayer::updateTargetProperties()
             if (distributedSource)
             {
                 // add original file name from a single distributed source (like Copy)
-                RemoteFilename remoteFile;
-                distributedSource->queryPart(0).getFilename(remoteFile, 0);
-                splitAndCollectFileInfo(newRecord, remoteFile);
+                if (distributedSource->numParts())
+                {
+                    RemoteFilename remoteFile;
+                    distributedSource->queryPart(0).getFilename(remoteFile, 0);
+                    splitAndCollectFileInfo(newRecord, remoteFile);
+                }
             }
             else if (sources.ordinality())
             {

--- a/testing/regress/ecl/key/supercopy.xml
+++ b/testing/regress/ecl/key/supercopy.xml
@@ -7,14 +7,88 @@
 <Dataset name='Result 4'>
 </Dataset>
 <Dataset name='Result 5'>
- <Row><result>Copy superfile as logical file: Pass</result></Row>
 </Dataset>
 <Dataset name='Result 6'>
- <Row><result>Copy superfile as superfle: Pass</result></Row>
+ <Row><result>Copy superfile with 0 subfile as logical file: Pass</result></Row>
 </Dataset>
-<Dataset name='Result 7'>
- <Row><result>Copy superindex as logical file: Pass</result></Row>
+<Dataset name='CopySuperfileW0SubAsLogicalFileResult'>
+ <Row><filecheck>The file is ok.</filecheck></Row>
 </Dataset>
 <Dataset name='Result 8'>
- <Row><result>Copy superindex as superfle: Pass</result></Row>
+ <Row><result>Copy superfile with 0 subfile as superfile: Pass</result></Row>
+</Dataset>
+<Dataset name='CopySuperfileW0SubAsSuperFileResult'>
+ <Row><filecheck>The file is ok.</filecheck></Row>
+</Dataset>
+<Dataset name='Result 10'>
+ <Row><result>Copy superfile with 1 subfile as logical file: Pass</result></Row>
+</Dataset>
+<Dataset name='CopySuperfileW1SubAsLogicalFileResult'>
+ <Row><filecheck>The file is ok.</filecheck></Row>
+</Dataset>
+<Dataset name='Result 12'>
+ <Row><result>Copy superfile with 1 subfile  as superfile: Pass</result></Row>
+</Dataset>
+<Dataset name='CopySuperfileW1SubAsSuperFileResult'>
+ <Row><filecheck>The file is ok.</filecheck></Row>
+</Dataset>
+<Dataset name='Result 14'>
+ <Row><result>Copy superfile with 2 subfiles as logical file: Pass</result></Row>
+</Dataset>
+<Dataset name='CopySuperfileW2SubsAsLogicalFileResult'>
+ <Row><filecheck>The file is ok.</filecheck></Row>
+</Dataset>
+<Dataset name='Result 16'>
+ <Row><result>Copy superfilewith 2 subfiles as superfile: Pass</result></Row>
+</Dataset>
+<Dataset name='CopySuperfileW2SubsAsSuperFileResult'>
+ <Row><filecheck>The file is ok.</filecheck></Row>
+</Dataset>
+<Dataset name='Result 18'>
+ <Row><result>Copy superindex with 0 subfile as logical file: Pass</result></Row>
+</Dataset>
+<Dataset name='CopySuperIndexW0SubAsLogicalFileResult'>
+ <Row><filecheck>The file is ok.</filecheck></Row>
+</Dataset>
+<Dataset name='Result 20'>
+ <Row><result>Copy superindex with 0 subfile as superfile: Pass</result></Row>
+</Dataset>
+<Dataset name='CopySuperIndexW0SubAsSuperFileResult'>
+ <Row><filecheck>The file is ok.</filecheck></Row>
+</Dataset>
+<Dataset name='Result 22'>
+ <Row><result>Copy superindex with 1 subfile as logical file: Pass</result></Row>
+</Dataset>
+<Dataset name='CopySuperIndexW1SubAsLogicalFileResult'>
+ <Row><filecheck>The file is ok.</filecheck></Row>
+</Dataset>
+<Dataset name='Result 24'>
+ <Row><result>Copy superindex with 1 subfile as superfile: Pass</result></Row>
+</Dataset>
+<Dataset name='CopySuperIndexW1SubAsSuperFileResult'>
+ <Row><filecheck>The file is ok.</filecheck></Row>
+</Dataset>
+<Dataset name='Result 26'>
+ <Row><result>Copy superindex with 2 subfiles as logical file: Pass</result></Row>
+</Dataset>
+<Dataset name='CopySuperIndexW2SubsAsLogicalFileResult'>
+ <Row><filecheck>The file is ok.</filecheck></Row>
+</Dataset>
+<Dataset name='Result 28'>
+ <Row><result>Copy superindex with 2 subfiles as superfile: Pass</result></Row>
+</Dataset>
+<Dataset name='CopySuperIndexW2SubsAsSuperFileResult'>
+ <Row><filecheck>The file is ok.</filecheck></Row>
+</Dataset>
+<Dataset name='Result 30'>
+ <Row><result>Copy superindex with 3 subfiles as logical file: Pass</result></Row>
+</Dataset>
+<Dataset name='CopySuperIndexW3SubsAsLogicalFileResult'>
+ <Row><filecheck>The file is ok.</filecheck></Row>
+</Dataset>
+<Dataset name='Result 32'>
+ <Row><result>Copy superindex with 3 subfiles as superfile: Pass</result></Row>
+</Dataset>
+<Dataset name='CopySuperIndexW3SubsAsSuperFileResult'>
+ <Row><filecheck>The file is ok.</filecheck></Row>
 </Dataset>

--- a/testing/regress/ecl/supercopy.ecl
+++ b/testing/regress/ecl/supercopy.ecl
@@ -20,23 +20,30 @@
 //nothor
 //class=superfile
 
+import std.system.thorlib;
 import Std.File AS FileServices;
 import $.setup;
 prefix := setup.Files(false, false).QueryFilePrefix;
-// Super Fiel and Key Copy regression test
+cluster := thorlib.cluster() + '-' + thorlib.platform();
+
+// Super File and Super Key Copy regression test
 
 unsigned VERBOSE := 0;
+unsigned CLEAN_UP := 1;
+
+boolean SuperFile := TRUE;
+boolean LogicalFile := FALSE;
 
 AlbumRecordDef     := RECORD
-UNSIGNED                        Id;
-STRING80            Title;
-STRING64            Artist;
-UNSIGNED            Tracks;
-UNSIGNED            Mins;
-UNSIGNED            Secs;
-UNSIGNED            Player;
-UNSIGNED            Position;
-                      END;
+    UNSIGNED            Id;
+    STRING80            Title;
+    STRING64            Artist;
+    UNSIGNED            Tracks;
+    UNSIGNED            Mins;
+    UNSIGNED            Secs;
+    UNSIGNED            Player;
+    UNSIGNED            Position;
+END;
 
 ds := DATASET(
 [
@@ -44,23 +51,73 @@ ds := DATASET(
 ], AlbumRecordDef );
 
 
-albumTableName := prefix + 'albums.d00';
-albumTable := DATASET(albumTableName,{AlbumRecordDef,UNSIGNED8 filepos {virtual(fileposition)}},FLAT);
+albumTable1Name := prefix + 'albums.d01';
+albumTable1 := DATASET(albumTable1Name,{AlbumRecordDef,UNSIGNED8 filepos {virtual(fileposition)}},FLAT);
+
+albumTable2Name := prefix + 'albums.d02';
+albumTable2 := DATASET(albumTable2Name,{AlbumRecordDef,UNSIGNED8 filepos {virtual(fileposition)}},FLAT);
 
 albumIndex1Name := prefix + 'albums1.key';
-albumIndex1 := INDEX(albumTable(Tracks<=4),{ Artist, Title, filepos }, albumIndex1Name);
+albumIndex1 := INDEX(albumTable1(Tracks<=4),{ Artist, Title, filepos }, albumIndex1Name);
 
 albumIndex2Name := prefix + 'albums2.key';
-albumIndex2 := INDEX(albumTable((Tracks>4)AND(Tracks<8)),{ Artist, Title, filepos }, albumIndex2Name);
+albumIndex2 := INDEX(albumTable1((Tracks>4)AND(Tracks<8)),{ Artist, Title, filepos }, albumIndex2Name);
 
-albumIndexName := prefix + 'albums.key';
-albumIndex  := INDEX(albumTable,{ Artist, Title, filepos }, albumIndexName);
+albumIndex3Name := prefix + 'albums3.key';
+albumIndex3  := INDEX(albumTable1,{ Artist, Title, filepos }, albumIndex3Name);
 
-superFileName := prefix + 'superalbums';
-superFileCopyName := prefix + 'superalbums_copy';
+superFile0SubName := prefix + 'superalbums0sub';
+superFile0SubLfCopyName := prefix + 'superalbums0sub_lf_copy';
+superFile0SubSfCopyName := prefix + 'superalbums0sub_Sf_copy';
 
-superIndexName := prefix + 'superalbums.key';
-superIndexCopyName := prefix + 'superalbums.key_copy';
+superFile1SubName := prefix + 'superalbums1sub';
+superFile1SubLfCopyName := prefix + 'superalbums1sub_lf_copy';
+superFile1SubSfCopyName := prefix + 'superalbums1sub_Sf_copy';
+
+superFile2SubsName := prefix + 'superalbums2subs';
+superFile2SubsLfCopyName := prefix + 'superalbums2subs_lf_copy';
+superFile2SubsSfCopyName := prefix + 'superalbums2subs_Sf_copy';
+
+
+superIndex0SubName := prefix + 'superalbums0sub.key';
+superIndex0SubLfCopyName := prefix + 'superalbums0sub.key_lf_copy';
+superIndex0SubSfCopyName := prefix + 'superalbums0sub.key_sf_copy';
+
+superIndex1SubName := prefix + 'superalbums1sub.key';
+superIndex1SubLfCopyName := prefix + 'superalbums1sub.key_lf_copy';
+superIndex1SubSfCopyName := prefix + 'superalbums1sub.key_sf_copy';
+
+superIndex2SubName := prefix + 'superalbums2subs.key';
+superIndex2SubsLfCopyName := prefix + 'superalbums2subs.key_lf_copy';
+superIndex2SubsSfCopyName := prefix + 'superalbums2subs.key_sf_copy';
+
+superIndex3SubsName := prefix + 'superalbums3subs.key';
+superIndex3SubsLfCopyName := prefix + 'superalbums3subs.key_lf_copy';
+superIndex3SubsSfCopyName := prefix + 'superalbums3subs.key_sf_copy';
+
+// The rsfile:= FileServices.SuperFileExists('~'+<logical_file_name>); can be used to check target file type, 
+// especially for superindex files with <= 1 subfile
+// See "gatherCounts(string filename, unsigned origRecCount, boolean noSplit, string operation = 'variable') := FUNCTION" 
+// in split_test.ecl (HPCC-21779 PR-12836) 
+
+checkFile(string filename, boolean isSuperfile) := FUNCTION
+
+    isFileExists :=  FileServices.FileExists('~' + filename);
+    isSf := if ( isFileExists = TRUE,
+                 FileServices.SuperFileExists('~' + filename),
+                 FALSE
+               ); 
+               
+    res := if ( isFileExists = FALSE,
+                'File not found.',
+                if (isSuperfile = isSf,
+                    'The file is ok.',
+                    'The ' +  filename + ' is expected as ' + if (isSuperfile = TRUE, 'superfile', 'logical file') + ' but it is a ' + if ( isSf = TRUE, 'superfile', 'logical file') + '.'
+                    )
+              );
+              
+     RETURN DATASET(ROW(TRANSFORM( { STRING fileCheck }, self.fileCheck := res)));
+END;
 
 
 rec := RECORD
@@ -73,131 +130,270 @@ rec := RECORD
 end;
 
 // Copy
-rec supercopy(rec l) := TRANSFORM
-  SELF.msg := FileServices.fCopy(
-                       sourceLogicalName := l.sourceFileName
-                      ,destinationGroup := l.destCluster
-                      ,destinationLogicalName := l.destFileName
-                      ,ASSUPERFILE := l.asSuperfile
-                      ,ALLOWOVERWRITE := True
-                      );
-  SELF.result := l.result + ' Pass';
-  SELF.sourceFileName := l.sourceFileName;
-  SELF.destFileName := l.destFileName;
-  SELF.destCluster := l.destCluster;
-  SELF.asSuperfile := l.asSuperfile;
+supercopy(string sourceFileName, string destCluster, string destFileName, boolean asSuperFile) := FUNCTION
+  RETURN FileServices.fCopy(sourceLogicalName := sourceFileName,
+                            destinationGroup := destCluster,
+                            destinationLogicalName := destFileName,
+                            ASSUPERFILE := asSuperfile,
+                            ALLOWOVERWRITE := True
+                           );
 end;
 
-dst1 := NOFOLD(DATASET([{superFileName, superFileCopyName, 'mythor', False, 'Copy superfile as logical file:', ''}], rec));
-p1 := PROJECT(NOFOLD(dst1), supercopy(LEFT));
-c1 := CATCH(NOFOLD(p1), ONFAIL(TRANSFORM(rec,
-                                 SELF.result := 'Copy superfile as logical file: Fail',
-                                 SELF.msg := FAILMESSAGE,
-                                 SELF.sourceFileName := superFileName,
-                                 SELF.destFileName := superFileCopyName,
-                                 SELF.destCluster := 'mythor',
-                                 SELF.asSuperfile := False
-                                )));
-#if (VERBOSE = 1)
-   supercopyOut := output(c1);
-#else
-   supercopyOut := output(c1, {result});
-#end
+doSuperCopy(string sourceFileName, string destFileName, string destCluster, boolean asSuperFile, string resultMsg) := FUNCTION
+    p1a := PROJECT(DATASET(ROW(TRANSFORM(rec, SELF := []))), TRANSFORM(rec, SELF.msg := supercopy(sourceFileName, destCluster, destFileName, asSuperFile);
+                                                                            SELF.result := resultMsg + ' Pass';
+                                                                            SELF.sourceFileName := sourceFileName;
+                                                                            SELF.destFileName := destFileName;
+                                                                            SELF.destCluster := destCluster;
+                                                                            SELF.asSuperFile := asSuperFile));
+    c1a := CATCH(NOFOLD(p1a), ONFAIL(TRANSFORM(rec, SELF.result := resultMsg + ' Fail',
+                                                    SELF.msg := FAILMESSAGE,
+                                                    SELF.sourceFileName := sourceFileName;
+                                                    SELF.destFileName := destFileName;
+                                                    SELF.destCluster := destCluster;
+                                                    SELF.asSuperFile := asSuperFile;
+                                              )));
+
+    #if (VERBOSE = 1)
+        RETURN output(c1a);
+    #else
+        RETURN output(c1a, {result});
+    #end
+END;
 
 
-dst2 := NOFOLD(DATASET([{superFileName, superFileCopyName, 'mythor', True, 'Copy superfile as superfle:', ''}], rec));
-p2 := PROJECT(NOFOLD(dst2), supercopy(LEFT));
-c2 := CATCH(NOFOLD(p2), ONFAIL(TRANSFORM(rec,
-                                 SELF.result := 'Copy superfile as superfle: Fail',
-                                 SELF.msg := FAILMESSAGE,
-                                 SELF.sourceFileName := superFileName,
-                                 SELF.destFileName := superFileCopyName,
-                                 SELF.destCluster := 'mythor',
-                                 SELF.asSuperfile := True
-                                )));
-#if (VERBOSE = 1)
-   supercopyOut2 := output(c2);
-#else
-   supercopyOut2 := output(c2, {result});
-#end
+// Superfile tests
+// The target should be a logical file (destination cluster is myroxie to avoid  missing info to repartitioning error)
+super0copyOut := doSuperCopy(superFile0SubName, superFile0SubLfCopyName, 'myroxie', LogicalFile, 'Copy superfile with 0 subfile as logical file:');
+super0copyOutCheck := checkFile(superFile0SubLfCopyName, LogicalFile);
+
+// The target should be a super file
+super0copyOut2 := doSuperCopy(superFile0SubName, superFile0SubSfCopyName, 'mythor', SuperFile, 'Copy superfile with 0 subfile as superfile:');
+super0copyOut2Check := checkFile(superFile0SubSfCopyName, SuperFile);
 
 
 
-dst3 := NOFOLD(DATASET([{superIndexName, superIndexCopyName, 'myroxie', False, 'Copy superindex as logical file:', ''}], rec));
-p3 := PROJECT(NOFOLD(dst3), supercopy(LEFT));
-c3 := CATCH(NOFOLD(p3), ONFAIL(TRANSFORM(rec,
-                                 SELF.result := 'Copy superindex as logical file: Fail',
-                                 SELF.msg := FAILMESSAGE,
-                                 SELF.sourceFileName := superIndexName,
-                                 SELF.destFileName := superIndexName + '_copy',
-                                 SELF.destCluster := 'myroxie',
-                                 SELF.asSuperfile := False
-                                )));
-#if (VERBOSE = 1)
-   supercopyOut3 := output(c3);
-#else
-   supercopyOut3 := output(c3, {result});
-#end
+// The target should be a logical file
+super1copyOut := doSuperCopy(superFile1SubName, superFile1SubLfCopyName, 'mythor', LogicalFile, 'Copy superfile with 1 subfile as logical file:');
+super1copyOutCheck := checkFile(superFile1SubLfCopyName, LogicalFile);
+
+// The target should be a super file
+super1copyOut2 := doSuperCopy(superFile1SubName, superFile1SubSfCopyName, 'mythor', SuperFile, 'Copy superfile with 1 subfile  as superfile:');
+super1copyOut2Check := checkFile(superFile1SubSfCopyName, SuperFile);
 
 
-dst4 := NOFOLD(DATASET([{superIndexName, superIndexCopyName, 'mythor', True, 'Copy superindex as superfle:', ''}], rec));
-p4 := PROJECT(NOFOLD(dst4), supercopy(LEFT));
-c4 := CATCH(NOFOLD(p4), ONFAIL(TRANSFORM(rec,
-                                 SELF.result := 'Copy superindex as superfle: Fail',
-                                 SELF.msg := FAILMESSAGE,
-                                 SELF.sourceFileName := superIndexName,
-                                 SELF.destFileName := superIndexCopyName,
-                                 SELF.destCluster := 'mythor',
-                                 SELF.asSuperfile := True
-                                )));
-#if (VERBOSE = 1)
-   supercopyOut4 := output(c4);
-#else
-   supercopyOut4 := output(c4, {result});
-#end
+
+// The target should be a logical file
+super2copyOut := doSuperCopy(superFile2SubsName, superFile2SubsLfCopyName, 'mythor', LogicalFile, 'Copy superfile with 2 subfiles as logical file:');
+super2copyOutCheck := checkFile(superFile2SubsLfCopyName, LogicalFile);
+
+// The target should be a super file
+super2copyOut2 := doSuperCopy(superFile2SubsName, superFile2SubsSfCopyName, 'mythor', SuperFile, 'Copy superfilewith 2 subfiles as superfile:');
+super2copyOut2Check := checkFile(superFile2SubsSfCopyName, SuperFile);
+
+
+
+// Superindex copy tests
+
+// The target should be a logical file (destination cluster is myroxie to avoid missing info to repartitioning error)
+super0copyOut3 := doSuperCopy(superIndex0SubName, superIndex0SubLfCopyName, 'myroxie', LogicalFile, 'Copy superindex with 0 subfile as logical file:');
+super0copyOut3Check := checkFile(superIndex0SubLfCopyName, LogicalFile);
+
+// The target should be a superindex file
+super0copyOut4 := doSuperCopy(superIndex0SubName, superIndex0SubSfCopyName, 'mythor', SuperFile, 'Copy superindex with 0 subfile as superfile:');
+super0copyOut4Check := checkFile(superIndex0SubSfCopyName, SuperFile);
+
+
+
+// Actually this forced to copy as SuperFile. After HPCC-22670 Pr-12891 has been merged, 
+// the target should be a logical file
+super1copyOut3 := doSuperCopy(superIndex1SubName, superIndex1SubLfCopyName, 'mythor', LogicalFile, 'Copy superindex with 1 subfile as logical file:');
+super1copyOut3Check := checkFile(superIndex1SubLfCopyName, LogicalFile);
+
+// The target should be a superindex file
+super1copyOut4 := doSuperCopy(superIndex1SubName, superIndex1SubSfCopyName, 'mythor', SuperFile, 'Copy superindex with 1 subfile as superfile:');
+super1copyOut4Check := checkFile(superIndex1SubSfCopyName, SuperFile);
+
+
+
+// The target should (forced to) be a superindex file
+super2copyOut3 := doSuperCopy(superIndex2SubName, superIndex2SubsLfCopyName, 'mythor', LogicalFile, 'Copy superindex with 2 subfiles as logical file:');
+super2copyOut3Check := checkFile(superIndex2SubsLfCopyName, SuperFile);
+
+// The target should be a superindex file
+super2copyOut4 := doSuperCopy(superIndex2SubName, superIndex2SubsSfCopyName, 'mythor', SuperFile, 'Copy superindex with 2 subfiles as superfile:');
+super2copyOut4Check := checkFile(superIndex2SubsSfCopyName, SuperFile);
+
+
+
+// The target should (forced to) be a superindex file
+super3copyOut3 := doSuperCopy(superIndex3SubsName, superIndex3SubsLfCopyName, 'mythor', LogicalFile, 'Copy superindex with 3 subfiles as logical file:');
+super3copyOut3Check := checkFile(superIndex3SubsLfCopyName, SuperFile);
+
+// The target should be a superindex file
+super3copyOut4 := doSuperCopy(superIndex3SubsName, superIndex3SubsSfCopyName, 'mythor', SuperFile, 'Copy superindex with 3 subfiles as superfile:');
+super3copyOut4Check := checkFile(superIndex3SubsSfCopyName, SuperFile);
+
 
 SEQUENTIAL(
 
     // Create a logical file and add it to a Superfile
-    OUTPUT(ds,,albumTableName,OVERWRITE),
-
-    FileServices.CreateSuperFile(superFileName),
-    FileServices.StartSuperFileTransaction(),
-    FileServices.AddSuperFile(superFileName,albumTableName),
-    FileServices.FinishSuperFileTransaction(),
+    OUTPUT(ds,,albumTable1Name,OVERWRITE),
+    OUTPUT(ds,,albumTable2Name,OVERWRITE),
 
     // Create a some index files and add them to a Superindex
     BUILDINDEX(albumIndex1,OVERWRITE),
     BUILDINDEX(albumIndex2,OVERWRITE),
-    BUILDINDEX(albumIndex,OVERWRITE),
+    BUILDINDEX(albumIndex3,OVERWRITE),
 
-    FileServices.CreateSuperFile(superIndexName),
+
+    // Create superfile without sub-file
+    FileServices.CreateSuperFile(superFile0SubName),
+  
+  
+    // Create superfile and add one subfile to it
+    FileServices.CreateSuperFile(superFile1SubName),
     FileServices.StartSuperFileTransaction(),
-    FileServices.AddSuperFile(prefix + 'superalbums.key', albumIndex1Name),
-    FileServices.AddSuperFile(prefix + 'superalbums.key', albumIndex2Name),
-    FileServices.AddSuperFile(prefix + 'superalbums.key', albumIndexName),
+    FileServices.AddSuperFile(superFile1SubName,albumTable1Name),
+    FileServices.FinishSuperFileTransaction(),
+    
+    // Create superfile and add two subfiles to it
+    FileServices.CreateSuperFile(superFile2SubsName),
+    FileServices.StartSuperFileTransaction(),
+    FileServices.AddSuperFile(superFile2SubsName,albumTable1Name),
+    FileServices.AddSuperFile(superFile2SubsName,albumTable2Name),
     FileServices.FinishSuperFileTransaction(),
 
+
     // Copy Superfile as a logical file - should pass
-    supercopyOut;
+    super0copyOut,
+    output(super0copyOutCheck, NAMED('CopySuperfileW0SubAsLogicalFileResult')),
+    
     // Copy Superfile as a superfile - should pass
-    supercopyOut2;
+    super0copyOut2,
+    output(super0copyOut2Check, NAMED('CopySuperfileW0SubAsSuperFileResult')),
+
+
+    // Copy Superfile as a logical file - should pass
+    super1copyOut,
+    output(super1copyOutCheck, NAMED('CopySuperfileW1SubAsLogicalFileResult')),
+    
+    // Copy Superfile as a superfile - should pass
+    super1copyOut2,
+    output(super1copyOut2Check, NAMED('CopySuperfileW1SubAsSuperFileResult')),
+
+
+    // Copy Superfile as a logical file - should pass
+    super2copyOut,
+    output(super2copyOutCheck, NAMED('CopySuperfileW2SubsAsLogicalFileResult')),
+    
+    // Copy Superfile as a superfile - should pass
+    super2copyOut2,
+    output(super2copyOut2Check, NAMED('CopySuperfileW2SubsAsSuperFileResult')),
+
+    
+    // Create superindex without any sub-index file
+    FileServices.CreateSuperFile(superIndex0SubName),
+
+    
+    // Create superindex with one sub-index file
+    FileServices.CreateSuperFile(superIndex1SubName),
+    FileServices.StartSuperFileTransaction(),
+    FileServices.AddSuperFile(superIndex1SubName, albumIndex1Name),
+    FileServices.FinishSuperFileTransaction(),
+
+
+    // Create superindex with two sub-index files
+    FileServices.CreateSuperFile(superIndex2SubName),
+    FileServices.StartSuperFileTransaction(),
+    FileServices.AddSuperFile(superIndex2SubName, albumIndex1Name),
+    FileServices.AddSuperFile(superIndex2SubName, albumIndex2Name),
+    FileServices.FinishSuperFileTransaction(),
+    
+
+    // Create superindex with three sub-index files
+    FileServices.CreateSuperFile(superIndex3SubsName),
+    FileServices.StartSuperFileTransaction(),
+    FileServices.AddSuperFile(superIndex3SubsName, albumIndex1Name),
+    FileServices.AddSuperFile(superIndex3SubsName, albumIndex2Name),
+    FileServices.AddSuperFile(superIndex3SubsName, albumIndex3Name),
+    FileServices.FinishSuperFileTransaction(),
+
+
 
     //Copy Superindex as a logical file - should fail
-    supercopyOut3;
+    super0copyOut3;
+    output(super0copyOut3Check, NAMED('CopySuperIndexW0SubAsLogicalFileResult')),
 
     // Copy Superindex as a Super file - should pass
-    supercopyOut4;
+    super0copyOut4;
+    output(super0copyOut4Check, NAMED('CopySuperIndexW0SubAsSuperFileResult')),
+    
 
+    //Copy Superindex as a logical file - should fail
+    super1copyOut3;
+    output(super1copyOut3Check, NAMED('CopySuperIndexW1SubAsLogicalFileResult')),
+
+    // Copy Superindex as a Super file - should pass
+    super1copyOut4;
+    output(super1copyOut4Check, NAMED('CopySuperIndexW1SubAsSuperFileResult')),
+
+
+    //Copy Superindex as a logical file - should fail
+    super2copyOut3;
+    output(super2copyOut3Check, NAMED('CopySuperIndexW2SubsAsLogicalFileResult')),
+
+    // Copy Superindex as a Super file - should pass
+    super2copyOut4;
+    output(super2copyOut4Check, NAMED('CopySuperIndexW2SubsAsSuperFileResult')),
+    
+
+    //Copy Superindex as a logical file - should fail
+    super3copyOut3;
+    output(super3copyOut3Check, NAMED('CopySuperIndexW3SubsAsLogicalFileResult')),
+
+    // Copy Superindex as a Super file - should pass
+    super3copyOut4;
+    output(super3copyOut4Check, NAMED('CopySuperIndexW3SubsAsSuperFileResult')),
+
+
+#if (CLEAN_UP = 1)
     // Clean-up
-    FileServices.DeleteSuperFile(superFileName),
-    FileServices.DeleteSuperFile(superFileCopyName),
-    FileServices.DeleteSuperFile(superIndexName),
-    FileServices.DeleteSuperFile(superIndexCopyName),
+    FileServices.DeleteSuperFile(superFile0SubName),
+    FileServices.DeleteLogicalFile(superFile0SubLfCopyName),
+    FileServices.DeleteSuperFile(superFile0SubSfCopyName),
+    
+    FileServices.DeleteSuperFile(superFile1SubName),
+    FileServices.DeleteLogicalFile(superFile1SubLfCopyName),
+    FileServices.DeleteSuperFile(superFile1SubSfCopyName),
+    
+    FileServices.DeleteSuperFile(superFile2SubsName),
+    FileServices.DeleteLogicalFile(superFile2SubsLfCopyName),
+    FileServices.DeleteSuperFile(superFile2SubsSfCopyName),
+    
+    FileServices.DeleteSuperFile(superIndex0SubName),
+    FileServices.DeleteLogicalFile(superIndex0SubLfCopyName),
+    FileServices.DeleteSuperFile(superIndex0SubSfCopyName),
 
+    FileServices.DeleteSuperFile(superIndex1SubName),
+    FileServices.DeleteLogicalFile(superIndex1SubLfCopyName),
+    FileServices.DeleteSuperFile(superIndex1SubSfCopyName),
+    
+    FileServices.DeleteSuperFile(superIndex2SubName),
+    FileServices.DeleteLogicalFile(superIndex2SubsLfCopyName),
+    FileServices.DeleteSuperFile(superIndex2SubsSfCopyName),
+    
+    FileServices.DeleteSuperFile(superIndex3SubsName),
+    FileServices.DeleteLogicalFile(superIndex3SubsLfCopyName),
+    FileServices.DeleteSuperFile(superIndex3SubsSfCopyName),
+   
+   
     FileServices.DeleteLogicalFile(albumIndex1Name),
     FileServices.DeleteLogicalFile(albumIndex2Name),
-    FileServices.DeleteLogicalFile(albumIndexName),
+    FileServices.DeleteLogicalFile(albumIndex3Name),
 
-    FileServices.DeleteLogicalFile(albumTableName),
+    FileServices.DeleteLogicalFile(albumTable1Name),
+    FileServices.DeleteLogicalFile(albumTable2Name)
+#end
+  
 );


### PR DESCRIPTION
Add tests for:

   - Copy superfile with 0, 1, 2 subfiles as logical and as superfile
   - Copy superindex with 0, 1, 2, 3 subfiles as logical and as superfile
   - Check the target file is the same as expected or as it forced to be (for superindex >=1 subfile)

Fix a DFUServer bug related to copy a superfile without subfile.

This PR is an updated and squashed copy of [HPCC-22686-impr-7.4.x.](https://github.com/hpcc-systems/HPCC-Platform/pull/12905)

Signed-off-by: Attila Vamos <attila.vamos@gmail.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [x] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [x] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [x] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [x] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->
Tested manually
<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
