### PR TITLE
HPCC-22584 Support new log format in WsTopology

### DIFF
--- a/esp/services/ws_topology/ws_topologyService.hpp
+++ b/esp/services/ws_topology/ws_topologyService.hpp
@@ -54,6 +54,9 @@ struct ReadLog
     unsigned prevPage;
     unsigned nextPage;
     unsigned TotalPages;
+    unsigned logfields;
+    unsigned columnNumDate;
+    unsigned columnNumTime;
 };
 
 class CWsTopologySoapBindingEx : public CWsTopologySoapBinding
@@ -101,8 +104,8 @@ private:
     bool findTimestampAndLT(const char * logname, IFile* pFile, ReadLog& readLogReq, CDateTime& latestLogTime);
     unsigned findLineTerminator(const char* dataPtr, const size32_t dataSize);
     bool isLineTerminator(const char* dataPtr, const size32_t dataSize, unsigned ltLength);
-    char* readALogLine(char* dataPtr, size32_t& dataSize, unsigned ltLength, StringBuffer& logLine, bool& hasLineTerminator);
-    void addALogLine(offset_t& readFrom, unsigned& locationFlag, const char *dataRow, ReadLog& readLogReq, StringArray& returnbuff);
+    char* readALogLine(char* dataPtr, size32_t& dataSize, ReadLog& readLogReq, StringBuffer& logLine, bool& hasLineTerminator);
+    void addALogLine(offset_t& readFrom, unsigned& locationFlag, const char *dataRow, ReadLog& readLogReq, StringBuffer& logTimeString, StringArray& returnbuff);
     void readTpLogFileRequest(IEspContext &context, const char* fileName, IFile* rFile, IEspTpLogFileRequest  &req, ReadLog& readLogReq);
     void setTpLogFileResponse(IEspContext &context, ReadLog& readLogReq, const char* fileName,
                                          const char* fileType, StringBuffer& returnbuf, IEspTpLogFileResponse &resp);
@@ -112,6 +115,16 @@ private:
                                     bool& bThresholdIsPercentage);
 
     StringBuffer& getAcceptLanguage(IEspContext& context, StringBuffer& acceptLanguage);
+    void readLogMessageFields(char* logStart, size32_t bytesRemaining, ReadLog& readLogReq);
+    const char* readLastLogDateTimeFromContentBuffer(StringBuffer& content, ReadLog& readLogReq, CDateTime& latestLogTime);
+    bool readLastLogDateTime(const char* logName, IFileIO* rIO, size32_t fileSize, size32_t readSize,
+        ReadLog& readLogReq, CDateTime& latestLogTime);
+    void readLogField(const char* lineStart, const unsigned lineLength, const unsigned columnNum,
+        const unsigned columnLength, StringBuffer& logField);
+    bool readLogDateTimeFromLogLine(const char* lineStart, const unsigned lineLength, ReadLog& readLogReq,
+        CDateTime& dt, StringBuffer& logFieldTime);
+    void readLastNRowsToArray(const char* logName, OwnedIFileIO rIO, ReadLog& readLogReq, StringArray& returnBuf);
+
 public:
     IMPLEMENT_IINTERFACE;
     virtual ~CWsTopologyEx(){};


### PR DESCRIPTION
1. Add readLogMessageFields() to read the information about the
log fields in new log format;
2. Rewrite the functions of reading last log time to support new
log format;
3. Move the code for GLOLastNRows into new readLastNRowsToArray()
and clean the code;
4. Refactor readLogFileToArray() to use IStreamLineReader for
GLOFirstNRows, GLOLastNHours and GLOTimeRange;
5. Clean addALogLine().

Signed-off-by: wangkx <kevin.wang@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
