### PR TITLE
HPCC-22791 Std.Date: Supply default day number when parsing a string

### DIFF
--- a/ecllibrary/std/Date.ecl
+++ b/ecllibrary/std/Date.ecl
@@ -621,8 +621,7 @@ EXPORT Seconds_t SecondsFromDateTimeRec(DateTime_rec datetime, BOOLEAN is_local_
 
 
 /**
- * Converts a string to a Date_t using the relevant string format.  The resulting
- * date must be representable within the Gregorian calendar after the year 1600.
+ * Converts a string to a Date_t using the relevant string format.
  *
  * @param date_text     The string to be converted.
  * @param format        The format of the input string.

--- a/ecllibrary/teststd/Date/TestFormat.ecl
+++ b/ecllibrary/teststd/Date/TestFormat.ecl
@@ -23,6 +23,8 @@ EXPORT TestFormat := MODULE
     ASSERT(Date.FromStringToDate('1December1', '%d%b%Y') = 00011201, CONST);
     ASSERT(Date.FromStringToDate('1970-02-01', '%Y-%m-%d') = 19700201, CONST);
     ASSERT(Date.FromStringToDate('', '%Y-%m-%d') = 0, CONST); // HPCC-16780; Invalid input date
+    ASSERT(Date.FromStringToDate('', '') = 19000101, CONST); // HPCC-22791; Supply default day
+    ASSERT(Date.FromStringToDate('201909', '%Y%m') = 20190901, CONST); // HPCC-22791; Supply default day
 
     ASSERT(Date.FromStringToTime('12:34:56', '%H:%M:%S') = 123456, CONST);
 

--- a/plugins/stringlib/stringlib.cpp
+++ b/plugins/stringlib/stringlib.cpp
@@ -1357,6 +1357,7 @@ STRINGLIB_API unsigned STRINGLIB_CALL slStringToDate(size32_t lenS, const char *
 {
     struct tm tm;
     memset(&tm, 0, sizeof(tm));
+    tm.tm_mday = 1;
     if (simple_strptime(lenS, s, fmtin, &tm))
         return makeDate(tm);
     return 0;
@@ -1382,6 +1383,7 @@ STRINGLIB_API unsigned STRINGLIB_CALL slMatchDate(size32_t lenS, const char * s,
         const char * curFormat = formats+off;
         
         memset(&tm, 0, sizeof(tm));
+        tm.tm_mday = 1;
         if (simple_strptime(lenS, s, curFormat, &tm))
             return makeDate(tm);
         off += strlen(curFormat) + 1;


### PR DESCRIPTION
When parsing a string into a Std.Date.Date_t value, there is no requirement to supply a parse format any part of a date (year, month, or day).  When a parse format is missing from one of those parts, a sensible default value needs to be provided.  All other parts of both Std.Date.Date_t and Std.Date.Time_t had default values, but day number within a date did not.

Signed-off-by: Dan S. Camper <dan.camper@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [ ] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [x] I have added tests to cover my changes.
  - [x] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

Manual testing plus modifications to the date unit tests module.

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
