### PR TITLE
HPCC-18819 Add drop zone(s) discovery/listing features to fileservices for ECL programmers.

### DIFF
--- a/ecllibrary/std/File.ecl
+++ b/ecllibrary/std/File.ecl
@@ -97,6 +97,10 @@ EXPORT INTEGER4 PREFIX_VARIABLE_RECSIZE := lib_fileservices.PREFIX_VARIABLE_RECS
 
 EXPORT INTEGER4 PREFIX_VARIABLE_BIGENDIAN_RECSIZE := lib_fileservices.PREFIX_VARIABLE_BIGENDIAN_RECSIZE;
 
+EXPORT FsDropZone := lib_fileservices.FsDropZone;
+
+EXPORT FsDropZoneRecord := lib_fileservices.FsDropZoneRecord;
+
 /*------------------------------------- Spray functions -----------------------------------------------------------*/
 
 /**
@@ -958,5 +962,31 @@ EXPORT PromoteSuperFileList(set of varstring superNames, varstring addHead='', b
  */
 EXPORT varstring GetEspURL(const varstring username = '', const varstring userPW = '') :=
     lib_fileservices.FileServices.GetEspURL(username, userPW);
+
+
+ /**
+ * Returns the path to the default Drop Zone
+ *
+ *
+ * @return              A string containing the path to the default Drop Zone.
+ *                      If more than one Drop Zone
+ *                      process is defined then the first found will
+ *                      be returned; will return an empty string if a Drop Zone
+ *                      cannot be found
+ */
+EXPORT varstring GetDefaultDropZone() :=
+    lib_fileservices.FileServices.GetDefaultDropZone();
+
+ /**
+ * Returns a dataset with full paths to all Drop Zones
+ *
+ *
+ * @return              A dataset containing all defined Drop Zone paths.
+ *                      Will return an empty dataset if a Drop Zone
+ *                      cannot be found
+ */
+
+EXPORT dataset(FsDropZoneRecord) GetDropZones() :=
+    lib_fileservices.FileServices.GetDropZones();
 
 END;

--- a/plugins/fileservices/fileservices.hpp
+++ b/plugins/fileservices/fileservices.hpp
@@ -161,6 +161,8 @@ FILESERVICES_API char * FILESERVICES_CALL fsfGetLogicalFileAttribute(ICodeContex
 FILESERVICES_API void FILESERVICES_CALL fsProtectLogicalFile(ICodeContext * ctx,const char *lfn,bool set);
 FILESERVICES_API void FILESERVICES_CALL fsDfuPlusExec(ICodeContext * ctx,const char *_cmd);
 FILESERVICES_API char * FILESERVICES_CALL fsGetEspURL(const char *username, const char *userPW);
+FILESERVICES_API char * FILESERVICES_CALL fsGetDefaultDropZone();
+FILESERVICES_API void FILESERVICES_CALL fsGetDropZones(ICodeContext *ctx,size32_t & __lenResult,void * & __result);
 
 }
 

--- a/testing/regress/ecl/dropzone_query_test.ecl
+++ b/testing/regress/ecl/dropzone_query_test.ecl
@@ -1,0 +1,24 @@
+/*##############################################################################
+
+    Copyright (C) 2019 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+//nokey
+
+import Std.File AS FileServices;
+
+output(NOTHOR(FileServices.GetDefaultDropZone()));
+
+output(NOTHOR(FileServices.GetDropZones()));

--- a/testing/regress/ecl/spray_test.ecl
+++ b/testing/regress/ecl/spray_test.ecl
@@ -34,7 +34,7 @@ prefix := setup.Files(false, false).QueryFilePrefix;
 boolean sprayFixed := #IFDEFINED(root.sprayFixed, true);
 boolean sprayEmpty := #IFDEFINED(root.sprayEmpty, false);
 
-dropzonePath := '/var/lib/HPCCSystems/mydropzone/' : STORED('dropzonePath');
+dropzonePath := FileServices.GetDefaultDropZone() +'/' : STORED('dropzonePath');
 
 unsigned VERBOSE := 0;
 


### PR DESCRIPTION

Implement GetDefaultDropZone() and GetDropZones() functions into Std.File

Update spray_test.ecl to use GetDefaultDropZone() function to eliminate hardwired path usage.

Add dropzone_query_test.ecl to test both new STTD functions

This is a retargeted version of https://github.com/hpcc-systems/HPCC-Platform/pull/12933

Signed-off-by: Attila Vamos <attila.vamos@gmail.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [x] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [x] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [x] I have added tests to cover my changes.
  - [x] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [x] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->
Tested manually.
<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
