### PR TITLE
HPCC-22911 Fix translate issue with uncompressed fixed width files

### DIFF
--- a/ecl/hthor/hthor.cpp
+++ b/ecl/hthor/hthor.cpp
@@ -8248,9 +8248,6 @@ void CHThorDiskReadBaseActivity::gatherInfo(IFileDescriptor * fileDesc)
         compressed = fileDesc->isCompressed(&blockcompressed); //try new decompression, fall back to old unless marked as block
         if (fixedDiskRecordSize)
         {
-            size32_t dfsSize = fileDesc->queryProperties().getPropInt("@recordSize");
-            if (!((dfsSize == 0) || (dfsSize == fixedDiskRecordSize) || (grouped && (dfsSize+1 == fixedDiskRecordSize)))) //third option for backwards compatibility, as hthor used to publish @recordSize not including the grouping byte
-                throw MakeStringException(0, "Published record size %d for file %s does not match coded record size %d", dfsSize, mangledHelperFileName.str(), fixedDiskRecordSize);
             if (!compressed && (((helper.getFlags() & TDXcompress) != 0) && (fixedDiskRecordSize >= MIN_ROWCOMPRESS_RECSIZE)))
             {
                 StringBuffer msg;

--- a/testing/regress/ecl/key/translatefixed.xml
+++ b/testing/regress/ecl/key/translatefixed.xml
@@ -1,0 +1,12 @@
+<Dataset name='Result 1'>
+</Dataset>
+<Dataset name='Result 2'>
+ <Row><fname>john       </fname></Row>
+ <Row><fname>peter      </fname></Row>
+ <Row><fname>greg       </fname></Row>
+ <Row><fname>paul       </fname></Row>
+ <Row><fname>christian  </fname></Row>
+</Dataset>
+<Dataset name='Result 3'>
+ <Row><Result_3>5</Result_3></Row>
+</Dataset>

--- a/testing/regress/ecl/translatefixed.ecl
+++ b/testing/regress/ecl/translatefixed.ecl
@@ -1,0 +1,33 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2019 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+import $.Setup;
+import Std;
+
+prefix := Setup.Files(false, false).QueryFilePrefix;
+
+ds := DATASET([{'john'}, {'peter'}, {'greg'}, {'paul'}, {'christian'}], { string10 fname; });
+
+tmpFName := prefix+'tmp';
+extDs := DATASET(tmpFName, { string11 fname; }, FLAT);
+
+SEQUENTIAL(
+ OUTPUT(ds, , tmpFName);
+ OUTPUT(extDs);
+ COUNT(extDs);
+ Std.File.DeleteLogicalFile(tmpFName);
+);

--- a/thorlcr/activities/diskread/thdiskreadslave.cpp
+++ b/thorlcr/activities/diskread/thdiskreadslave.cpp
@@ -392,20 +392,6 @@ void CDiskRecordPartHandler::open()
         if (!partStream)
             throw MakeActivityException(&activity, 0, "Failed to open file '%s'", filename.get());
         ActPrintLog(&activity, "%s[part=%d]: %s (%s)", kindStr, which, activity.isFixedDiskWidth ? "fixed" : "variable", filename.get());
-        if (activity.isFixedDiskWidth)
-        {
-            if (!compressed || blockCompressed)
-            {
-                unsigned fixedSize = activity.diskRowMinSz;
-                if (partDesc->queryProperties().hasProp("@size"))
-                {
-                    offset_t lsize = partDesc->queryProperties().getPropInt64("@size");
-                    if (0 != lsize % fixedSize)
-                        throw MakeActivityException(&activity, TE_BadFileLength, "Fixed length file %s [DFS size=%" I64F "d] is not a multiple of fixed record size : %d", filename.get(), lsize, fixedSize);
-                }
-            }
-        }
-
         partStream->setFilters(activity.fieldFilters);
     }
 


### PR DESCRIPTION
When reading a file with a record definition that has a fixed
record format that is also uncompressed, there were some checks
that validated that the physical file size was a multiple of the
fixed record size, and fired an error if not.
These checks are no longer valid, since dynamic record translation,
can translate between the two formats.

Signed-off-by: Jake Smith <jake.smith@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
