### PR TITLE
HPCC-22458 Improve ESDL definition auth_feature handling

### DIFF
--- a/esp/esdllib/CMakeLists.txt
+++ b/esp/esdllib/CMakeLists.txt
@@ -29,6 +29,7 @@ include_directories (
     ${HPCC_SOURCE_DIR}/rtl/eclrtl
     ${HPCC_SOURCE_DIR}/rtl/include #IXMLWriter
     ${HPCC_SOURCE_DIR}/common/thorhelper #JSONWRITER
+    ${HPCC_SOURCE_DIR}/tools/hidl #TAccessMapGenerator
 )
 
 ADD_DEFINITIONS ( -D_USRDLL -DESDLLIB_EXPORTS )

--- a/esp/esdllib/EsdlAccessMapGenerator.hpp
+++ b/esp/esdllib/EsdlAccessMapGenerator.hpp
@@ -1,0 +1,153 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2019 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef _EsdlAccessMapGenerator_HPP_
+#define _EsdlAccessMapGenerator_HPP_
+
+#include "AccessMapGenerator.hpp"
+#include "esdl_def.hpp"
+#include "espcontext.hpp"
+#include "jlog.hpp"
+#include "jscm.hpp"
+#include "seclib.hpp"
+
+using EsdlAccessMapGenerator = TAccessMapGenerator<SecAccessFlags>;
+using EsdlAccessMapScopeMapper = EsdlAccessMapGenerator::ScopeMapper;
+
+struct EsdlAccessMapLevelMapper : public EsdlAccessMapGenerator::LevelMapper
+{
+    SecAccessFlags levelUnavailable() const override { return SecAccess_Unavailable; }
+    SecAccessFlags levelNone() const override { return SecAccess_None; }
+    SecAccessFlags levelDeferred() const override { return SecAccess_None; }
+    SecAccessFlags levelAccess() const override { return SecAccess_Access; }
+    SecAccessFlags levelRead() const override { return SecAccess_Read; }
+    SecAccessFlags levelWrite() const override { return SecAccess_Write; }
+    SecAccessFlags levelFull() const override { return SecAccess_Full; }
+    SecAccessFlags levelUnknown() const override { return SecAccess_Unknown; }
+
+    bool isEqual(SecAccessFlags lhs, SecAccessFlags rhs) const override
+    {
+        return lhs == rhs;
+    }
+
+    const char* toString(SecAccessFlags level) const override
+    {
+#define SECACCESSFLAGS_CASE(flag) case flag: return #flag
+    switch (level)
+    {
+    SECACCESSFLAGS_CASE(SecAccess_Unavailable);
+    SECACCESSFLAGS_CASE(SecAccess_None);
+    SECACCESSFLAGS_CASE(SecAccess_Access);
+    SECACCESSFLAGS_CASE(SecAccess_Read);
+    SECACCESSFLAGS_CASE(SecAccess_Write);
+    SECACCESSFLAGS_CASE(SecAccess_Full);
+    default:
+    SECACCESSFLAGS_CASE(SecAccess_Unknown);
+    }
+#undef SECACCESSFLAGS_CASE
+    }
+};
+
+struct EsdlAccessMapReporter : public EsdlAccessMapGenerator::Reporter
+{
+    MapStringTo<SecAccessFlags>& m_accessMap;
+    Owned<IEsdlDefReporter>      m_reporter;
+
+    EsdlAccessMapReporter(MapStringTo<SecAccessFlags>& accessMap, IEsdlDefReporter* reporter)
+        : m_accessMap(accessMap)
+    {
+        setEsdlReporter(reporter);
+    }
+
+    void setEsdlReporter(IEsdlDefReporter* reporter)
+    {
+        m_reporter.setown(reporter);
+    }
+
+    bool errorsAreFatal() const override
+    {
+        return true;
+    }
+
+    bool reportError() const override
+    {
+        return reportType(IEsdlDefReporter::ReportUError);
+    }
+
+    bool reportWarning() const override
+    {
+        return reportType(IEsdlDefReporter::ReportUWarning);
+    }
+
+    bool reportInfo() const override
+    {
+        return reportType(IEsdlDefReporter::ReportUInfo);
+    }
+
+    bool reportDebug() const override
+    {
+        return reportType(IEsdlDefReporter::ReportDInfo);
+    }
+
+    void entry(const char* name, SecAccessFlags level) const override
+    {
+        m_accessMap.setValue(name, level);
+    }
+
+protected:
+#define REPORT_FLAGS(f) (f | IEsdlDefReporter::ReportMethod)
+    void reportError(const char* fmt, va_list& args) const override
+    {
+        StringBuffer msg;
+        msg.valist_appendf(fmt, args);
+
+        // The exception is thrown first due to a crash in the esdl application when the
+        // exception occurs while fprintf is processing the message.
+        if (errorsAreFatal())
+            throw MakeStringException(0, "%s", msg.str());
+        if (m_reporter.get() != nullptr)
+            m_reporter->report(REPORT_FLAGS(IEsdlDefReporter::ReportUError), fmt, args);
+    }
+
+    void reportWarning(const char* fmt, va_list& args) const override
+    {
+        if (m_reporter.get() != nullptr)
+            m_reporter->report(REPORT_FLAGS(IEsdlDefReporter::ReportUWarning), fmt, args);
+    }
+
+    void reportInfo(const char* fmt, va_list& args) const override
+    {
+        if (m_reporter.get() != nullptr)
+            m_reporter->report(REPORT_FLAGS(IEsdlDefReporter::ReportUInfo), fmt, args);
+    }
+
+    void reportDebug(const char* fmt, va_list& args) const override
+    {
+        if (m_reporter.get() != nullptr)
+            m_reporter->report(REPORT_FLAGS(IEsdlDefReporter::ReportDInfo), fmt, args);
+    }
+
+    bool reportType(IEsdlDefReporter::Flags flag) const
+    {
+        if (m_reporter.get() != nullptr)
+            return m_reporter->testFlags(REPORT_FLAGS(flag));
+        return false;
+    }
+#undef REPORT_FLAGS
+};
+
+#endif // _EsdlAccessMapGenerator_HPP_

--- a/tools/esdlcmd/esdl-publish.cpp
+++ b/tools/esdlcmd/esdl-publish.cpp
@@ -122,7 +122,7 @@ public:
         Owned<IClientPublishESDLDefinitionRequest> request = esdlConfigClient->createPublishESDLDefinitionRequest();
 
         StringBuffer esxml;
-        esdlHelper->getServiceESXDL(optSource.get(), optESDLService.get(), esxml, 0, NULL, (DEPFLAG_INCLUDE_TYPES & ~DEPFLAG_INCLUDE_METHOD), optIncludePath.str());
+        esdlHelper->getServiceESXDL(optSource.get(), optESDLService.get(), esxml, 0, NULL, (DEPFLAG_INCLUDE_TYPES & ~DEPFLAG_INCLUDE_METHOD), optIncludePath.str(), optTraceFlags());
         if (esxml.length()==0)
         {
             fprintf(stderr,"\nESDL Definition for service %s could not be loaded from: %s\n", optESDLService.get(), optSource.get());
@@ -1254,7 +1254,7 @@ public:
         Owned<IClientWsESDLConfig> esdlConfigClient = EsdlCmdHelper::getWsESDLConfigSoapService(optWSProcAddress, optWSProcPort, optUser, optPass);
         Owned<IClientGetESDLBindingRequest> getrequest = esdlConfigClient->createGetESDLBindingRequest();
         if (optVerbose)
-            fprintf(stdout,"\nFetching current ESDL binging configuration for (%s)\n", optBindingId.get());
+            fprintf(stdout,"\nFetching current ESDL binding configuration for (%s)\n", optBindingId.get());
         getrequest->setEsdlBindingId(optBindingId.get());
 
         Owned<IClientGetESDLBindingResponse> getresp = esdlConfigClient->GetESDLBinding(getrequest);

--- a/tools/esdlcmd/esdlcmd_core.cpp
+++ b/tools/esdlcmd/esdlcmd_core.cpp
@@ -216,7 +216,7 @@ public:
 
     virtual int processCMD()
     {
-        cmdHelper.loadDefinition(optSource, optService.get(), optInterfaceVersion,"");
+        cmdHelper.loadDefinition(optSource, optService.get(), optInterfaceVersion,"", optTraceFlags());
         createOptionals();
 
         Owned<IEsdlDefObjectIterator> structs = cmdHelper.esdlDef->getDependencies( optService.get(), optMethod.get(), ESDLOPTLIST_DELIMITER, optInterfaceVersion, opts.get(), optFlags );
@@ -503,7 +503,7 @@ public:
 
     virtual int processCMD()
     {
-        cmdHelper.loadDefinition(optSource, optService.get(), optInterfaceVersion, "");
+        cmdHelper.loadDefinition(optSource, optService.get(), optInterfaceVersion, "", optTraceFlags());
         createOptionals();
 
         Owned<IEsdlDefObjectIterator> structs = cmdHelper.esdlDef->getDependencies( optService.get(), optMethod.get(), ESDLOPTLIST_DELIMITER, optInterfaceVersion, opts.get(), optFlags );
@@ -696,7 +696,7 @@ public:
 
     virtual int processCMD()
     {
-        cmdHelper.loadDefinition(optSource, optService, 0, optIncludePath);
+        cmdHelper.loadDefinition(optSource, optService, 0, optIncludePath, optTraceFlags());
         Owned<IEsdlDefObjectIterator> structs = cmdHelper.esdlDef->getDependencies( optService, optMethod, ESDLOPTLIST_DELIMITER, 0, NULL, optFlags );
 
         if(!optPreprocessOutputDir.isEmpty())
@@ -928,7 +928,7 @@ public:
 
     virtual int processCMD()
     {
-        cmdHelper.loadDefinition(optSource, optService, 0, optIncludePath);
+        cmdHelper.loadDefinition(optSource, optService, 0, optIncludePath, optTraceFlags());
         Owned<IEsdlDefObjectIterator> structs = cmdHelper.esdlDef->getDependencies( optService, optMethod, ESDLOPTLIST_DELIMITER, 0, NULL, optFlags );
 
         if(!optPreprocessOutputDir.isEmpty())

--- a/tools/esdlcmd/esdlcmd_monitor.cpp
+++ b/tools/esdlcmd/esdlcmd_monitor.cpp
@@ -294,7 +294,7 @@ public:
 
     virtual void loadServiceDef()
     {
-        cmdHelper.loadDefinition(optSource, optService, 0, optIncludePath);
+        cmdHelper.loadDefinition(optSource, optService, 0, optIncludePath, optTraceFlags());
     }
 
 public:
@@ -984,7 +984,7 @@ public:
 
     virtual int processCMD()
     {
-        cmdHelper.loadDefinition(optSource, optService, 0, optIncludePath);
+        cmdHelper.loadDefinition(optSource, optService, 0, optIncludePath, optTraceFlags());
 
         Owned<IEsdlDefObjectIterator> responseEsdl = cmdHelper.esdlDef->getDependencies(optService, optMethod, 0, nullptr, DEPFLAG_INCLUDE_RESPONSE | DEPFLAG_INCLUDE_METHOD | DEPFLAG_ECL_ONLY);
         Owned<IEsdlDefObjectIterator> requestEsdl = cmdHelper.esdlDef->getDependencies(optService, optMethod, 0, nullptr, DEPFLAG_INCLUDE_REQUEST | DEPFLAG_ECL_ONLY);

--- a/tools/esdlcomp/esdlgram.y
+++ b/tools/esdlcomp/esdlgram.y
@@ -193,12 +193,19 @@ EspServiceStart
         CurService->tags = getClearCurMetaTags();
 
         StringBuffer minPingVer;
+        StringBuffer pingAuthFeature("none");
         for (MetaTagInfo* t = CurService->tags; t!=NULL; t = t->next)
         {
             if (streq("ping_min_ver",t->getName()))
             {
-                minPingVer.set(t->getString());
-                break;
+                if (minPingVer.isEmpty())
+                {
+                    minPingVer.set(t->getString());
+                }
+            }
+            else if (streq("ping_auth_feature", t->getName()))
+            {
+                pingAuthFeature.set(t->getString());
             }
         }
 
@@ -229,12 +236,16 @@ EspServiceStart
 
         EspMethodInfo *method=new EspMethodInfo("Ping", reqname.str(), respname.str());
 
+        CurMetaTags = NULL;
         if(minPingVer.length()!=0)
         {
-            CurMetaTags = NULL;
             AddMetaTag(new MetaTagInfo("min_ver", minPingVer.str()));
-            method->tags = getClearCurMetaTags();
-         }
+        }
+        if(pingAuthFeature.length()!=0)
+        {
+            AddMetaTag(new MetaTagInfo("auth_feature", pingAuthFeature.str()));
+        }
+        method->tags = getClearCurMetaTags();
 
         method->next=CurService->methods;
         CurService->methods=method;

--- a/tools/hidl/hidlgram.y
+++ b/tools/hidl/hidlgram.y
@@ -196,12 +196,19 @@ EspServiceStart
         CurService->tags = getClearCurMetaTags();
 
         StrBuffer minPingVer;
+        StrBuffer pingAuthFeature("none");
         for (MetaTagInfo* t = CurService->tags; t!=NULL; t = t->next)
         {
             if (streq("ping_min_ver",t->getName()))
             {
-                minPingVer.set(t->getString());
-                break;
+                if (minPingVer.length()==0)
+                {
+                    minPingVer.set(t->getString());
+                }
+            }
+            else if (streq("ping_auth_feature", t->getName()))
+            {
+                pingAuthFeature.set(t->getString());
             }
         }
 
@@ -233,12 +240,16 @@ EspServiceStart
 
         EspMethodInfo *method=new EspMethodInfo("Ping", reqname.str(), respname.str());
 
+        CurMetaTags = NULL;
         if(minPingVer.length()!=0)
         {
-            CurMetaTags = NULL;
             AddMetaTag(new MetaTagInfo("min_ver", minPingVer.str()));
-            method->tags = getClearCurMetaTags();
-         }
+        }
+        if (pingAuthFeature.length()!=0)
+        {
+            AddMetaTag(new MetaTagInfo("auth_feature", pingAuthFeature.str()));
+        }
+        method->tags = getClearCurMetaTags();
 
         method->next=CurService->methods;
         CurService->methods=method;


### PR DESCRIPTION
* Remove the hidlcomp requirement that the ESPservice must include a non-empty
  auth_feature metadata value. The metadata 'auth_feature(" ")' satisfied the
  requirement without adding anything meaningful. Also, the same requirement
  was not enforced for dynamic definitions.
* Define an ESPservice-level metadata value, ping_auth_feature, to define the
  security applied to the generated Ping method. If absent, the security for
  Ping is assumed to be "none".
* Support variable substitution in auth_feature content. Given a service S and
  method M, the metadata "${service}Access:read" yields SAccess:SecAccess_Read,
  while the metadata "${method}Access:full" yields MAccess:SecAccess_Full.
* Apply a default security requirement when no security is explicitly declared.
  The default will be "${service}Access:FULL" when the service is known, and
  "${method}Access:FULL" when it is not.
* Expand the auth_feature grammar to support exclusions. If each auth_feature
  value is considered to be a list of tokens, and a level of precedence is
  assigned to each token from each list, exclusion tokens can ignore any or
  all tokens with lower precedence based on either the origin of the token or
  the feature name it references.
* Extend the esdl command line interface to recognize option "-tcat"/
  "--trace-category". The supported category values are derived from jlog, and
  are described in the tool's usage. This change enables a tester to evaluate
  how the security in a dynamic definition is handled when publishing.

This PR is a continuation of PR #12874. A failed rebase caused most of the
changes in that PR to be discarded. This PR includes only the discarded changes.

Signed-off-by: Tim Klemm <tim.klemm@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [x] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [x] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [x] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
