### PR TITLE
HPCC-22908 Return cached Activity while rebuilding new state

### DIFF
--- a/esp/scm/ws_smc.ecm
+++ b/esp/scm/ws_smc.ecm
@@ -157,6 +157,8 @@ ESPresponse [exceptions_inline] ActivityResponse
     [min_ver("1.12")] bool SuperUser(false);
     [min_ver("1.12")] string AccessRight;
     [min_ver("1.14")] ESParray<ESPstruct ServerJobQueue> ServerJobQueues;
+    [min_ver("1.22")] string ActivityTime;
+    [min_ver("1.22")] bool DaliDetached;
 };
 
 ESPrequest SMCIndexRequest
@@ -399,7 +401,7 @@ ESPresponse [exceptions_inline] LockQueryResponse
     int NumLocks;
 };
 
-ESPservice [auth_feature("DEFERRED"), noforms, version("1.21"), exceptions_inline("./smc_xslt/exceptions.xslt"), use_method_name] WsSMC
+ESPservice [auth_feature("DEFERRED"), noforms, version("1.22"), exceptions_inline("./smc_xslt/exceptions.xslt"), use_method_name] WsSMC
 {
     ESPmethod Index(SMCIndexRequest, SMCIndexResponse);
     ESPmethod [resp_xsl_default("/esp/xslt/index.xslt")] Activity(ActivityRequest, ActivityResponse);

--- a/esp/services/ws_smc/ws_smcService.cpp
+++ b/esp/services/ws_smc/ws_smcService.cpp
@@ -55,7 +55,6 @@ static const char* SMC_ACCESS_DENIED = "Access Denied";
 static const char* QUEUE_ACCESS_DENIED = "Failed to access the queue functions. Permission denied.";
 
 const char* PERMISSIONS_FILENAME = "espsmc_permissions.xml";
-const unsigned DEFAULTACTIVITYINFOCACHETIMEOUTSECOND = 10;
 
 void AccessSuccess(IEspContext& context, char const * msg,...) __attribute__((format(printf, 2, 3)));
 void AccessSuccess(IEspContext& context, char const * msg,...)
@@ -142,10 +141,14 @@ void CWsSMCEx::init(IPropertyTree *cfg, const char *process, const char *service
         m_PortalURL.append(portalURL);
 
     xpath.setf("Software/EspProcess[@name=\"%s\"]/EspService[@name=\"%s\"]/ActivityInfoCacheSeconds", process, service);
-    activityInfoCacheSeconds = cfg->getPropInt(xpath.str(), DEFAULTACTIVITYINFOCACHETIMEOUTSECOND);
+    unsigned activityInfoCacheSeconds = cfg->getPropInt(xpath.str(), DEFAULTACTIVITYINFOCACHEFORCEBUILDSECOND);
     xpath.setf("Software/EspProcess[@name=\"%s\"]/EspService[@name=\"%s\"]/LogDaliConnection", process, service);
     if (cfg->getPropBool(xpath.str()))
         querySDS().setConfigOpt("Client/@LogConnection", "true");
+
+    xpath.setf("Software/EspProcess[@name=\"%s\"]/EspService[@name=\"%s\"]/ActivityInfoCacheAutoRebuildSeconds", process, service);
+    unsigned activityInfoCacheAutoRebuildSeconds = cfg->getPropInt(xpath.str(), DEFAULTACTIVITYINFOCACHEAUTOREBUILDSECOND);
+    activityInfoReader.setown(new CActivityInfoReader(activityInfoCacheAutoRebuildSeconds, activityInfoCacheSeconds));
 }
 
 struct CActiveWorkunitWrapper: public CActiveWorkunit
@@ -1194,7 +1197,9 @@ bool CWsSMCEx::onActivity(IEspContext &context, IEspActivityRequest &req, IEspAc
         if (version >= 1.06)
             setBannerAndChatData(version, resp);
 
-        Owned<CActivityInfo> activityInfo = getActivityInfo(context);
+        Owned<CActivityInfo> activityInfo = activityInfoReader->getActivityInfo();
+        if (!activityInfo)
+            throw MakeStringException(ECLWATCH_INTERNAL_ERROR, "Failed to get Activity Info. Please try later.");
         setActivityResponse(context, activityInfo, req, resp);
     }
     catch(IException* e)
@@ -1203,29 +1208,6 @@ bool CWsSMCEx::onActivity(IEspContext &context, IEspActivityRequest &req, IEspAc
     }
 
     return true;
-}
-
-void CWsSMCEx::clearActivityInfoCache()
-{
-    CriticalBlock b(getActivityCrit);
-    activityInfoCache.clear();
-}
-
-CActivityInfo* CWsSMCEx::getActivityInfo(IEspContext &context)
-{
-    CriticalBlock b(getActivityCrit);
-
-    if (activityInfoCache && activityInfoCache->isCachedActivityInfoValid(activityInfoCacheSeconds))
-        return activityInfoCache.getLink();
-
-    DBGLOG("CWsSMCEx::getActivityInfo - rebuild cached information");
-    {
-        EspTimeSection timer("createActivityInfo");
-        activityInfoCache.setown(new CActivityInfo());
-        activityInfoCache->createActivityInfo(context);
-    }
-
-    return activityInfoCache.getLink();
 }
 
 void CWsSMCEx::addWUsToResponse(IEspContext &context, const IArrayOf<IEspActiveWorkunit>& aws, IEspActivityResponse& resp)
@@ -1279,6 +1261,12 @@ void CWsSMCEx::setActivityResponse(IEspContext &context, CActivityInfo* activity
     double version = context.getClientVersion();
     const char* sortBy = req.getSortBy();
     bool descending = req.getDescending();
+    if (version >= 1.22)
+    {
+        StringBuffer s;
+        resp.setActivityTime(activityInfo->queryTimeCached(s));
+        resp.setDaliDetached(activityInfoReader->isDaliDetached());
+    }
     if (version >= 1.16)
     {
         IArrayOf<IEspTargetCluster> thorClusters;
@@ -1419,7 +1407,7 @@ bool CWsSMCEx::onMoveJobDown(IEspContext &context, IEspSMCJobRequest &req, IEspS
             }
         }
         AccessSuccess(context, "Changed job priority %s",req.getWuid());
-        clearActivityInfoCache();
+        activityInfoReader->rebuild();
         resp.setRedirectUrl("/WsSMC/");
     }
     catch(IException* e)
@@ -1448,7 +1436,7 @@ bool CWsSMCEx::onMoveJobUp(IEspContext &context, IEspSMCJobRequest &req, IEspSMC
             }
         }
         AccessSuccess(context, "Changed job priority %s",req.getWuid());
-        clearActivityInfoCache();
+        activityInfoReader->rebuild();
         resp.setRedirectUrl("/WsSMC/");
     }
     catch(IException* e)
@@ -1494,7 +1482,7 @@ bool CWsSMCEx::onMoveJobBack(IEspContext &context, IEspSMCJobRequest &req, IEspS
             }
         }
         AccessSuccess(context, "Changed job priority %s",req.getWuid());
-        clearActivityInfoCache();
+        activityInfoReader->rebuild();
         resp.setRedirectUrl("/WsSMC/");
     }
     catch(IException* e)
@@ -1541,7 +1529,7 @@ bool CWsSMCEx::onMoveJobFront(IEspContext &context, IEspSMCJobRequest &req, IEsp
         }
 
         AccessSuccess(context, "Changed job priority %s",req.getWuid());
-        clearActivityInfoCache();
+        activityInfoReader->rebuild();
         resp.setRedirectUrl("/WsSMC/");
     }
     catch(IException* e)
@@ -1571,7 +1559,7 @@ bool CWsSMCEx::onRemoveJob(IEspContext &context, IEspSMCJobRequest &req, IEspSMC
             }
         }
         AccessSuccess(context, "Removed job %s",req.getWuid());
-        clearActivityInfoCache();
+        activityInfoReader->rebuild();
         resp.setRedirectUrl("/WsSMC/");
     }
     catch(IException* e)
@@ -1593,7 +1581,7 @@ bool CWsSMCEx::onStopQueue(IEspContext &context, IEspSMCQueueRequest &req, IEspS
             queue->stop(createQueueActionInfo(context, "stopped", req, info));
         }
         AccessSuccess(context, "Stopped queue %s", req.getCluster());
-        clearActivityInfoCache();
+        activityInfoReader->rebuild();
         double version = context.getClientVersion();
         if (version >= 1.19)
             getStatusServerInfo(context, req.getServerType(), req.getCluster(), req.getNetworkAddress(), req.getPort(), resp.updateStatusServerInfo());
@@ -1619,7 +1607,7 @@ bool CWsSMCEx::onResumeQueue(IEspContext &context, IEspSMCQueueRequest &req, IEs
             queue->resume(createQueueActionInfo(context, "resumed", req, info));
         }
         AccessSuccess(context, "Resumed queue %s", req.getCluster());
-        clearActivityInfoCache();
+        activityInfoReader->rebuild();
         double version = context.getClientVersion();
         if (version >= 1.19)
             getStatusServerInfo(context, req.getServerType(), req.getCluster(), req.getNetworkAddress(), req.getPort(), resp.updateStatusServerInfo());
@@ -1662,7 +1650,7 @@ bool CWsSMCEx::onPauseQueue(IEspContext &context, IEspSMCQueueRequest &req, IEsp
             queue->pause(createQueueActionInfo(context, "paused", req, info));
         }
         AccessSuccess(context, "Paused queue %s", req.getCluster());
-        clearActivityInfoCache();
+        activityInfoReader->rebuild();
         double version = context.getClientVersion();
         if (version >= 1.19)
             getStatusServerInfo(context, req.getServerType(), req.getCluster(), req.getNetworkAddress(), req.getPort(), resp.updateStatusServerInfo());
@@ -1692,7 +1680,7 @@ bool CWsSMCEx::onClearQueue(IEspContext &context, IEspSMCQueueRequest &req, IEsp
             queue->clear();
         }
         AccessSuccess(context, "Cleared queue %s",req.getCluster());
-        clearActivityInfoCache();
+        activityInfoReader->rebuild();
         double version = context.getClientVersion();
         if (version >= 1.19)
             getStatusServerInfo(context, req.getServerType(), req.getCluster(), req.getNetworkAddress(), req.getPort(), resp.updateStatusServerInfo());
@@ -1761,7 +1749,7 @@ bool CWsSMCEx::onSetJobPriority(IEspContext &context, IEspSMCPriorityRequest &re
             }
         }
 
-        clearActivityInfoCache();
+        activityInfoReader->rebuild();
         resp.setRedirectUrl("/WsSMC/");
     }
     catch(IException* e)
@@ -2255,9 +2243,9 @@ void CWsSMCEx::getStatusServerInfo(IEspContext &context, const char *serverType,
     if (!serverType || !*serverType)
         throw MakeStringException(ECLWATCH_MISSING_PARAMS, "Server type not specified.");
 
-    Owned<CActivityInfo> activityInfo = getActivityInfo(context);
+    Owned<CActivityInfo> activityInfo = activityInfoReader->getActivityInfo();
     if (!activityInfo)
-        throw MakeStringException(ECLWATCH_INTERNAL_ERROR, "Failed to get Activity Info cache.");
+        throw MakeStringException(ECLWATCH_INTERNAL_ERROR, "Failed to get Activity Info. Please try later.");
 
     if (strieq(serverType,STATUS_SERVER_THOR))
     {
@@ -2621,3 +2609,53 @@ bool CWsSMCEx::onLockQuery(IEspContext &context, IEspLockQueryRequest &req, IEsp
     return true;
 }
 
+void CActivityInfoReader::threadmain()
+{
+    PROGLOG("WsSMC CActivityInfoReader Thread started.");
+    unsigned int autoRebuildMillSeconds = 1000*autoRebuildSeconds;
+    while (!stopping)
+    {
+        if (!detached)
+        {
+            try
+            {
+                EspTimeSection timer("createActivityInfo");
+                Owned<IEspContext> espContext =  createEspContext();
+                Owned<CActivityInfo> activityInfo = new CActivityInfo();
+                activityInfo->createActivityInfo(*espContext);
+                PROGLOG("WsSMC CActivityInfoReader: ActivityInfo collected.");
+
+                CriticalBlock b(crit);
+                activityInfoCache.setown(activityInfo.getClear());
+
+                // if 1st and getActivityInfo blocked, release it.
+                if (first)
+                {
+                    first = false;
+                    if (firstBlocked)
+                    {
+                        firstBlocked = false;
+                        firstSem.signal();
+                    }
+                }
+            }
+            catch(IException *e)
+            {
+                StringBuffer msg;
+                IERRLOG("Exception %d:%s in WsSMC CActivityInfoReader::run", e->errorCode(), e->errorMessage(msg).str());
+                e->Release();
+            }
+            catch(...)
+            {
+                IERRLOG("Unknown exception in WsSMC CActivityInfoReader::run");
+            }
+        }
+
+        waiting = true;
+        if (!sem.wait(autoRebuildMillSeconds))
+        {
+            bool expected = true;
+            waiting.compare_exchange_strong(expected, false);
+        }
+    }
+}

--- a/initfiles/componentfiles/configxml/@temp/esp_service_WsSMC.xsl
+++ b/initfiles/componentfiles/configxml/@temp/esp_service_WsSMC.xsl
@@ -153,6 +153,9 @@ This is required by its binding with ESP service '<xsl:value-of select="$espServ
             <xsl:if test="string(@ActivityInfoCacheSeconds) != ''">
                 <ActivityInfoCacheSeconds><xsl:value-of select="@ActivityInfoCacheSeconds"/></ActivityInfoCacheSeconds>
             </xsl:if>
+            <xsl:if test="string(@ActivityInfoCacheAutoRebuildSeconds) != ''">
+                <ActivityInfoCacheAutoRebuildSeconds><xsl:value-of select="@ActivityInfoCacheAutoRebuildSeconds"/></ActivityInfoCacheAutoRebuildSeconds>
+            </xsl:if>
             <xsl:if test="string(@enableLogDaliConnection) != ''">
                 <LogDaliConnection><xsl:value-of select="@enableLogDaliConnection"/></LogDaliConnection>
             </xsl:if>

--- a/initfiles/componentfiles/configxml/espsmcservice.xsd.in
+++ b/initfiles/componentfiles/configxml/espsmcservice.xsd.in
@@ -106,7 +106,14 @@
             <xs:attribute name="ActivityInfoCacheSeconds" type="xs:nonNegativeInteger" use="optional" default="10">
                 <xs:annotation>
                     <xs:appinfo>
-                        <tooltip>timeout for activity info cache (in seconds).</tooltip>
+                        <tooltip>If user makes a request and the cache is older than this value (in seconds), ESP returns the cache and starts to rebuild a new cache.</tooltip>
+                    </xs:appinfo>
+                </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="ActivityInfoCacheAutoRebuildSeconds" type="xs:nonNegativeInteger" use="optional" default="120">
+                <xs:annotation>
+                    <xs:appinfo>
+                        <tooltip>When idle, ESP automatically rebuilds the cache if this value (in seconds) exceeded.</tooltip>
                     </xs:appinfo>
                 </xs:annotation>
             </xs:attribute>

--- a/initfiles/etc/DIR_NAME/environment.xml.in
+++ b/initfiles/etc/DIR_NAME/environment.xml.in
@@ -623,6 +623,7 @@
              port="8877"/>
   </SashaServerProcess>
   <EspService ActivityInfoCacheSeconds="10"
+              ActivityInfoCacheAutoRebuildSeconds="120"
               allowNewRoxieOnDemandQuery="false"
               AWUsCacheTimeout="15"
               build="_"

--- a/testing/regress/environment.xml.in
+++ b/testing/regress/environment.xml.in
@@ -536,6 +536,7 @@
              port="8877"/>
   </SashaServerProcess>
   <EspService ActivityInfoCacheSeconds="10"
+              ActivityInfoCacheAutoRebuildSeconds="120"
               allowNewRoxieOnDemandQuery="false"
               AWUsCacheTimeout="15"
               build="_"

--- a/testing/unittests/configmgr/schema/environments/hpcc_port_conflict_test1.xml
+++ b/testing/unittests/configmgr/schema/environments/hpcc_port_conflict_test1.xml
@@ -34,6 +34,7 @@
     </Programs>
     <Software>
         <EspService ActivityInfoCacheSeconds="10"
+                    ActivityInfoCacheAutoRebuildSeconds="120"
                     allowNewRoxieOnDemandQuery="false"
                     AWUsCacheTimeout="15"
                     build="_"

--- a/testing/unittests/configmgr/schema/environments/hpcc_port_conflict_test2.xml
+++ b/testing/unittests/configmgr/schema/environments/hpcc_port_conflict_test2.xml
@@ -34,6 +34,7 @@
     </Programs>
     <Software>
         <EspService ActivityInfoCacheSeconds="10"
+                    ActivityInfoCacheAutoRebuildSeconds="120"
                     allowNewRoxieOnDemandQuery="false"
                     AWUsCacheTimeout="15"
                     build="_"

--- a/testing/unittests/configmgr/schema/environments/hpcc_port_conflict_test3.xml
+++ b/testing/unittests/configmgr/schema/environments/hpcc_port_conflict_test3.xml
@@ -34,6 +34,7 @@
     </Programs>
     <Software>
         <EspService ActivityInfoCacheSeconds="10"
+                    ActivityInfoCacheAutoRebuildSeconds="120"
                     allowNewRoxieOnDemandQuery="false"
                     AWUsCacheTimeout="15"
                     build="_"

--- a/testing/unittests/configmgr/schema/environments/hpcc_port_conflict_test4.xml
+++ b/testing/unittests/configmgr/schema/environments/hpcc_port_conflict_test4.xml
@@ -34,6 +34,7 @@
     </Programs>
     <Software>
         <EspService ActivityInfoCacheSeconds="10"
+                    ActivityInfoCacheAutoRebuildSeconds="120"
                     allowNewRoxieOnDemandQuery="false"
                     AWUsCacheTimeout="15"
                     build="_"


### PR DESCRIPTION
1. ESP begins to build Activity cache when ESP starts and is
attached to dali.
2. User always gets current cached copy back instantly if the
cache is available.
3. If user asks the Activity info before the 1st cache is
available, ESP returns the cache after the cache is available.
4. When idle, ESP automaticaly rebuilds the cache if a pre-
configured timeout exceeds and swaps in new version when ready.
5. If user makes a request and the cache is older than a pre-
configured timeout, ESP returns the cache and informs the cache
builder to refresh the cache.

Signed-off-by: wangkx <kevin.wang@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
