### PR TITLE
HPCC-23080 Fix various undefined behaviours caught by sanitize option

### DIFF
--- a/common/deftype/defvalue.cpp
+++ b/common/deftype/defvalue.cpp
@@ -382,7 +382,7 @@ void MemoryValue::toMem(void *target)
 {
     size32_t size = getSize();
     assertThrow(val.length()>=size);
-    memcpy(target, val.get(), size);
+    memcpy_iflen(target, val.get(), size);
 }
 
 unsigned MemoryValue::getHash(unsigned initval)
@@ -460,7 +460,7 @@ StringValue::StringValue(const char *v, ITypeInfo *_type) : MemoryValue(_type)
     unsigned len = _type->getSize();
     assertex(len != UNKNOWN_LENGTH);
     char * temp = (char *)val.allocate(len+1);
-    memcpy(temp, v, len);
+    memcpy_iflen(temp, v, len);
     temp[len] = 0;
 }
 
@@ -603,7 +603,7 @@ IValue *createStringValue(const char *val, ITypeInfo *type, size32_t srcLength, 
     else if (tgtLength > srcLength)
     {
         char * extended = (char *)checked_malloc(tgtLength, DEFVALUE_MALLOC_FAILED);
-        memcpy(extended, val, srcLength);
+        memcpy_iflen(extended, val, srcLength);
         memset(extended+srcLength, type->queryCharset()->queryFillChar(), tgtLength-srcLength);
         IValue * ret = new StringValue(extended, type);
         free(extended);
@@ -720,7 +720,7 @@ void * UnicodeValue::getUCharStringValue(unsigned len, void * out)
     size_t vallen = val.length()/2;
     if(vallen > len)
         vallen = len;
-    memcpy(out, val.get(), vallen*2);
+    memcpy_iflen(out, val.get(), vallen*2);
     if(len > vallen)
         ((UChar *)out)[vallen] = 0x0000;
     return out;
@@ -831,7 +831,7 @@ void UnicodeAttr::set(UChar const * _text, unsigned _len)
 {
     free(text);
     text = (UChar *) checked_malloc((_len+1)*2, DEFVALUE_MALLOC_FAILED);
-    memcpy(text, _text, _len*2);
+    memcpy_iflen(text, _text, _len*2);
     text[_len] = 0x0000;
 }
 
@@ -850,7 +850,7 @@ VarUnicodeValue::VarUnicodeValue(unsigned len, const UChar * v, ITypeInfo * _typ
     else
     {
         UChar * temp = (UChar *)checked_malloc((typeLen+1)*2, DEFVALUE_MALLOC_FAILED);
-        memcpy(temp, v, len*2);
+        memcpy_iflen(temp, v, len*2);
         temp[len] = 0;
         val.set(temp, typeLen);
         free(temp);
@@ -945,7 +945,7 @@ void * VarUnicodeValue::getUCharStringValue(unsigned len, void * out)
     unsigned vallen = val.length();
     if(vallen > len)
         vallen = len;
-    memcpy(out, val.get(), vallen*2);
+    memcpy_iflen(out, val.get(), vallen*2);
     if(len > vallen)
         ((UChar *)out)[vallen] = 0x0000;
     return out;
@@ -1255,7 +1255,7 @@ IValue *DataValue::castTo(ITypeInfo *t)
         else
         {
             char *newstr = (char *) checked_malloc(nsize, DEFVALUE_MALLOC_FAILED);
-            memcpy(newstr, val.get(), osize);
+            memcpy_iflen(newstr, val.get(), osize);
             memset(newstr+osize, 0, nsize-osize);
             IValue * ret = new DataValue(newstr, LINK(t));
             free(newstr);
@@ -1275,7 +1275,7 @@ IValue *DataValue::castTo(ITypeInfo *t)
         else
         {
             char *newstr = (char *) checked_malloc(nsize, DEFVALUE_MALLOC_FAILED);
-            memcpy(newstr, val.get(), osize);
+            memcpy_iflen(newstr, val.get(), osize);
             memset(newstr+osize, t->queryCharset()->queryFillChar(), nsize-osize);
             IValue * ret = new StringValue(newstr, t);
             free(newstr);
@@ -1359,7 +1359,7 @@ QStringValue::QStringValue(const char *v, ITypeInfo *_type) : MemoryValue(_type)
 {
     unsigned newSize = _type->getSize();
     char * temp = (char *)val.allocate(newSize);
-    memcpy(temp, v, newSize);
+    memcpy_iflen(temp, v, newSize);
 }
 
 const char *QStringValue::generateECL(StringBuffer &out)
@@ -1679,7 +1679,7 @@ void IntValue::toMem(void *target)
     if (type->isSwappedEndian())
         _cpyrevn(target, data, size);
     else
-        memcpy(target, data, size);
+        memcpy_iflen(target, data, size);
 }
 
 unsigned IntValue::getHash(unsigned initval)
@@ -2530,7 +2530,7 @@ IValue * addValues(IValue * left, IValue * right)
     case type_int:
     case type_swapint:
     case type_packedint:
-        ret = createTruncIntValue(left->getIntValue() + right->getIntValue(), pnt);
+        ret = createTruncIntValue((__int64)((__uint64)left->getIntValue() + (__uint64)right->getIntValue()), pnt);
         break;
     case type_real:
         ret = createRealValue(left->getRealValue() + right->getRealValue(), pnt);
@@ -2572,7 +2572,7 @@ IValue * subtractValues(IValue * left, IValue * right)
     case type_int:
     case type_swapint:
     case type_packedint:
-        ret = createTruncIntValue(left->getIntValue() - right->getIntValue(), pnt);
+        ret = createTruncIntValue((__int64)((__uint64)left->getIntValue() - (__uint64)right->getIntValue()), pnt);
         break;
     case type_real:
         ret = createRealValue(left->getRealValue() - right->getRealValue(), pnt);
@@ -2782,7 +2782,10 @@ IValue * negateValue(IValue * v)
     case type_int:
     case type_swapint:
     case type_packedint:
-        return createTruncIntValue(-(v->getIntValue()), v->getType());
+        {
+            __uint64 value = - (__uint64)v->getIntValue(); // avoid undefined behaviour if value = int_min
+            return createTruncIntValue((__int64)value, v->getType());
+        }
     case type_real:     
         return createRealValue(-(v->getRealValue()), v->getSize());
     case type_decimal:
@@ -3354,7 +3357,10 @@ IValue * shiftLeftValues(IValue * left, IValue * right)
     case type_int:
     case type_swapint:
     case type_packedint:
-        return createTruncIntValue(left->getIntValue() << right->getIntValue(), retType);
+        {
+            __uint64 value = (__uint64)left->getIntValue() << (__uint64)right->getIntValue();
+            return createTruncIntValue((__int64)value, retType);
+        }
     default:
         UNIMPLEMENTED;
     }

--- a/common/thorhelper/thorrparse.cpp
+++ b/common/thorhelper/thorrparse.cpp
@@ -2537,7 +2537,7 @@ void AsciiDfaBuilder::finished()
     unsigned numAccepts = accepts.ordinality();
     dfa.numAccepts = numAccepts;
     dfa.accepts = (unsigned *)malloc(sizeof(unsigned)*numAccepts);
-    memcpy(dfa.accepts, accepts.getArray(), numAccepts*sizeof(unsigned));
+    memcpy_iflen(dfa.accepts, accepts.getArray(), numAccepts*sizeof(unsigned));
 }
 //---------------------------------------------------------------------------
 

--- a/common/thorhelper/thortalgo.cpp
+++ b/common/thorhelper/thortalgo.cpp
@@ -1130,7 +1130,7 @@ void LRTableBuilder::finished(unsigned rootId)
     table.rootState = rootId;
     table.numExtraActions = extraActions.ordinality();
     table.extraActions = new LRAction[table.numExtraActions];
-    memcpy(table.extraActions, extraActions.getArray(), sizeof(unsigned) * table.numExtraActions);
+    memcpy_iflen(table.extraActions, extraActions.getArray(), sizeof(unsigned) * table.numExtraActions);
 }
 
 

--- a/ecl/hql/hqlfold.cpp
+++ b/ecl/hql/hqlfold.cpp
@@ -4981,8 +4981,11 @@ static IHqlExpression * getLowerCaseConstant(IHqlExpression * expr)
         return LINK(expr);
     }
 
-    const void * data = value->queryValue();
     unsigned size = type->getSize();
+    if (size == 0)
+        return LINK(expr);
+
+    const void * data = value->queryValue();
     unsigned stringLen = type->getStringLen();
 
     MemoryAttr lower(size);

--- a/ecl/hql/hqlstack.cpp
+++ b/ecl/hql/hqlstack.cpp
@@ -140,7 +140,7 @@ int FuncCallStack::push(ITypeInfo* argType, IHqlExpression* curParam)
             unsigned argSize = castParam->getSize();
             const void * text = castParam->queryValue();
             str = (char *)malloc(argSize);
-            memcpy(str, text, argSize);
+            memcpy_iflen(str, text, argSize);
 
             // For STRINGn, len doens't need to be passed in.
             if(argType->getSize() == UNKNOWN_LENGTH)

--- a/plugins/stringlib/stringlib.cpp
+++ b/plugins/stringlib/stringlib.cpp
@@ -421,7 +421,7 @@ STRINGLIB_API void STRINGLIB_CALL slStringSubsOut(unsigned & tgtLen, char * & tg
     }
     else
     {
-        memcpy(tgt, src, srcLen);
+        memcpy_iflen(tgt, src, srcLen);
     }
 
     tgtLen = srcLen;
@@ -452,7 +452,7 @@ STRINGLIB_API void STRINGLIB_CALL slStringSubs(unsigned & tgtLen, char * & tgt, 
     }
     else
     {
-        memcpy(tgt, src, srcLen);
+        memcpy_iflen(tgt, src, srcLen);
     }
 
     tgtLen = srcLen;
@@ -503,7 +503,7 @@ STRINGLIB_API void STRINGLIB_CALL slStringRepad(unsigned & tgtLen, char * & tgt,
         if (!tgt)
             rtlThrowOutOfMemory(0, "In StringLib.StringRepad");
         tgtLen = tLen;
-        memcpy(tgt,base,srcLen);
+        memcpy_iflen(tgt,base,srcLen);
         memset(tgt+srcLen,' ',tLen-srcLen);
     }
     else
@@ -610,7 +610,7 @@ STRINGLIB_API void STRINGLIB_CALL slStringExtract(unsigned & tgtLen, char * & tg
         if ( finger[len] == ',' )
             break;
     tgt = (char *)CTXMALLOC(parentCtx, len);
-    memcpy(tgt,finger,len);
+    memcpy_iflen(tgt,finger,len);
     tgtLen = len;
 }
 
@@ -847,7 +847,7 @@ STRINGLIB_API void STRINGLIB_CALL slStringFindReplace (unsigned & tgtLen, char *
     if ( srcLen < stokLen || stokLen == 0)
     {
         tgt = (char *) CTXMALLOC(parentCtx, srcLen);
-        memcpy(tgt, src, srcLen);
+        memcpy_iflen(tgt, src, srcLen);
         tgtLen = srcLen;
     }
     else
@@ -1129,8 +1129,8 @@ STRINGLIB_API void STRINGLIB_CALL slStringExcludeNthWord(unsigned & tgtLen, char
     if (len)
     {
         tgt = (char *)CTXMALLOC(parentCtx, len);
-        memcpy(tgt,src,startLast);
-        memcpy(tgt+startLast,src+idx,(srcLen - idx));
+        memcpy_iflen(tgt,src,startLast);
+        memcpy_iflen(tgt+startLast,src+idx,(srcLen - idx));
     }
     else
         tgt = NULL;
@@ -1234,7 +1234,7 @@ STRINGLIB_API void STRINGLIB_CALL slSplitWords(bool & __isAllResult, size32_t & 
     if ((lenSeparator == 0) || (lenSrc < lenSeparator))
     {
         *((size32_t *)result) = lenSrc;
-        memcpy(result+sizeof(size32_t), src, lenSrc);
+        memcpy_iflen(result+sizeof(size32_t), src, lenSrc);
         return;
     }
 
@@ -1253,7 +1253,7 @@ STRINGLIB_API void STRINGLIB_CALL slSplitWords(bool & __isAllResult, size32_t & 
             {
                 size32_t len = startWord ? (cur - startWord) : 0;
                 memcpy(target, &len, sizeof(len));
-                memcpy(target+sizeof(size32_t), startWord, len);
+                memcpy_iflen(target+sizeof(size32_t), startWord, len);
                 target += sizeof(size32_t) + len;
                 startWord = NULL;
             }
@@ -1273,7 +1273,7 @@ STRINGLIB_API void STRINGLIB_CALL slSplitWords(bool & __isAllResult, size32_t & 
             startWord = cur;
         size32_t len = (end - startWord);
         memcpy(target, &len, sizeof(len));
-        memcpy(target+sizeof(size32_t), startWord, len);
+        memcpy_iflen(target+sizeof(size32_t), startWord, len);
         target += sizeof(size32_t) + len;
     }
     assert(target == result + sizeRequired);
@@ -1324,7 +1324,7 @@ STRINGLIB_API void STRINGLIB_CALL slCombineWords(size32_t & __lenResult, void * 
         size32_t len;
         memcpy(&len, src+offset, sizeof(len));
         offset += sizeof(len);
-        memcpy(target, src+offset, len);
+        memcpy_iflen(target, src+offset, len);
         target += len;
         offset += len;
     }
@@ -1429,7 +1429,7 @@ STRINGLIB_API void STRINGLIB_CALL slFormatDate(size32_t & __lenResult, char * & 
 #endif
         len = strlen(buf);
         out = static_cast<char *>(CTXMALLOC(parentCtx, len));
-        memcpy(out, buf, len);
+        memcpy_iflen(out, buf, len);
     }
 
     __lenResult = len;
@@ -1454,7 +1454,7 @@ STRINGLIB_API void STRINGLIB_CALL slStringExtract50(char *tgt, unsigned srcLen, 
         memcpy(tgt,resret,50);
     else
     {
-        memcpy(tgt,resret,lenret);
+        memcpy_iflen(tgt,resret,lenret);
         memset(tgt+lenret,' ',50-lenret);
     }
     CTXFREE(parentCtx, resret);
@@ -1505,7 +1505,7 @@ STRINGLIB_API void STRINGLIB_CALL slStringFindReplace80(char * tgt, unsigned src
     {
         if (srcLen > 80)
             srcLen = 80;
-        memcpy(tgt, src, srcLen);
+        memcpy_iflen(tgt, src, srcLen);
         if (srcLen < 80)
             memset(tgt+srcLen, ' ', 80 - srcLen);
     }
@@ -1520,7 +1520,7 @@ STRINGLIB_API void STRINGLIB_CALL slStringFindReplace80(char * tgt, unsigned src
             {
                 if (rtokLen > lim)
                     rtokLen = lim;
-                memcpy(tgt, rtok, rtokLen);
+                memcpy_iflen(tgt, rtok, rtokLen);
                 tgt += rtokLen;
                 i += stokLen;
                 lim -= rtokLen;

--- a/rtl/eclrtl/eclregex.cpp
+++ b/rtl/eclrtl/eclregex.cpp
@@ -106,7 +106,7 @@ public:
         {
             outlen = subs[n].second - subs[n].first;
             out = (char *)rtlMalloc(outlen);
-            memcpy(out, subs[n].first, outlen);
+            memcpy_iflen(out, subs[n].first, outlen);
         }
         else
         {
@@ -200,7 +200,7 @@ public:
         }
         outlen = tgt.length();
         out = (char *)rtlMalloc(outlen);
-        memcpy(out, tgt.data(), outlen);
+        memcpy_iflen(out, tgt.data(), outlen);
     }
 
     IStrRegExprFindInstance * find(const char * str, size32_t from, size32_t len, bool needToKeepSearchString) const

--- a/rtl/eclrtl/rtlint.cpp
+++ b/rtl/eclrtl/rtlint.cpp
@@ -229,7 +229,7 @@ int rtlReadSwapInt2(const void * _data)
 
 int rtlReadSwapInt3(const void * _data)                     
 { 
-    const signed char * scdata = (const signed char *)_data;
+    const unsigned char * scdata = (const unsigned char *)_data;
     int temp = scdata[0] << 16;
     _cpyrev2(&temp, scdata+1);
     return temp;
@@ -244,8 +244,8 @@ int rtlReadSwapInt4(const void * _data)
 
 __int64 rtlReadSwapInt5(const void * _data)                     
 { 
-    const signed char * scdata = (const signed char *)_data;
-    __int64 temp = ((__int64)scdata[0]) << 32;
+    const unsigned char * scdata = (const unsigned char *)_data;
+    __int64 temp = ((__uint64)scdata[0]) << 32;
     _cpyrev4(&temp, scdata+1);
     return temp;
 }
@@ -253,7 +253,7 @@ __int64 rtlReadSwapInt5(const void * _data)
 __int64 rtlReadSwapInt6(const void * _data)                     
 { 
     const signed char * scdata = (const signed char *)_data;
-    __int64 temp = ((__int64)scdata[0]) << 40;
+    __int64 temp = ((__uint64)scdata[0]) << 40;
     _cpyrev5(&temp, scdata+1);
     return temp;
 }
@@ -261,7 +261,7 @@ __int64 rtlReadSwapInt6(const void * _data)
 __int64 rtlReadSwapInt7(const void * _data)                     
 { 
     const signed char * scdata = (const signed char *)_data;
-    __int64 temp = ((__int64)scdata[0]) << 48;
+    __int64 temp = ((__uint64)scdata[0]) << 48;
     _cpyrev6(&temp, scdata+1);
     return temp;
 }

--- a/rtl/eclrtl/rtlqstr.cpp
+++ b/rtl/eclrtl/rtlqstr.cpp
@@ -512,10 +512,12 @@ void rtlQStrToQStr(size32_t outlen, char * out, size32_t inlen, const char * in)
     size32_t inSize = QStrSize(inlen);
     size32_t outSize = QStrSize(outlen);
     if (inSize >= outSize)
-        memcpy(out, in, outSize);
+    {
+        memcpy_iflen(out, in, outSize);
+    }
     else
     {
-        memcpy(out, in, inSize);
+        memcpy_iflen(out, in, inSize);
         memset(out+inSize, 0, outSize-inSize);
     }
 }
@@ -524,7 +526,7 @@ void rtlQStrToQStrX(unsigned & outlen, char * & out, unsigned inlen, const char 
 {
     size32_t inSize = QStrSize(inlen);
     char * data  = (char *)malloc(inSize);
-    memcpy(data, in, inSize);
+    memcpy_iflen(data, in, inSize);
 
     outlen = inlen;
     out = data;
@@ -536,7 +538,7 @@ int rtlCompareQStrQStr(size32_t llen, const void * left, size32_t rlen, const vo
     size32_t rsize = QStrSize(rlen);
     if (lsize < rsize)
     {
-        int ret = memcmp(left, right, lsize);
+        int ret = memcmp_iflen(left, right, lsize);
         if (ret == 0)
         {
             const byte * r = (const byte *)right;
@@ -549,7 +551,7 @@ int rtlCompareQStrQStr(size32_t llen, const void * left, size32_t rlen, const vo
         }
         return ret;
     }
-    int ret = memcmp(left, right, rsize);
+    int ret = memcmp_iflen(left, right, rsize);
     if (ret == 0)
     {
         const byte * l = (const byte *)left;

--- a/system/include/platform.h
+++ b/system/include/platform.h
@@ -540,6 +540,10 @@ typedef unsigned __int64 timestamp_type;
  #define NO_SANITIZE_FUNCTION
 #endif
 
-
+//Versions of memcpy etc which are safe to use with null parameters if the size is 0
+inline void memcpy_iflen(void * dest, const void * src, size_t n)   { if (likely(n)) memcpy(dest, src, n); }
+inline void memmove_iflen(void * dest, const void * src, size_t n)  { if (likely(n)) memmove(dest, src, n); }
+inline void memset_iflen(void * dest, int c, size_t n)              { if (likely(n)) memset(dest, c, n); }
+inline int memcmp_iflen(const void * l, const void * r, size_t n)   { return likely(n) ? memcmp(l, r, n) : 0; }
 
 #endif

--- a/system/jlib/jbuff.cpp
+++ b/system/jlib/jbuff.cpp
@@ -174,7 +174,10 @@ MemoryAttr::MemoryAttr(const MemoryAttr & src)
 
 void MemoryAttr::set(size_t _len, const void * _ptr)
 {
-    memcpy(allocate(_len), _ptr, _len);
+    if (_len)
+        memcpy(allocate(_len), _ptr, _len);
+    else
+        clear();
 }
 
 
@@ -525,10 +528,13 @@ MemoryBuffer & MemoryBuffer::append(const unsigned char * value)
 
 MemoryBuffer & MemoryBuffer::append(unsigned len, const void * value)
 {
-    unsigned newLen = checkMemoryBufferOverflow(curLen, len);
-    _realloc(newLen);
-    memcpy(buffer + curLen, value, len);
-    curLen += len;
+    if (likely(len))
+    {
+        unsigned newLen = checkMemoryBufferOverflow(curLen, len);
+        _realloc(newLen);
+        memcpy(buffer + curLen, value, len);
+        curLen += len;
+    }
     return *this;
 }
 


### PR DESCRIPTION
Never pass nullptr to memset/memcmp/memcpy:
  Note, most of the new gurad conditions check if the length is zero, rather
  than if the pointers are null.  That is because the pointers can only be
  null if th length is zero, and I think the test is more intuitive.

Never shift -ve integers left

Fix potential issues with overflow of signed addition/subtraction

Signed-off-by: Gavin Halliday <gavin.halliday@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [x] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
