### PR TITLE
HPCC-23160 Add back DFUFileParts code to WsDFU.DFUInfo

### DIFF
--- a/esp/services/ws_dfu/ws_dfuService.cpp
+++ b/esp/services/ws_dfu/ws_dfuService.cpp
@@ -1911,6 +1911,83 @@ bool CWsDfuEx::getUserFilePermission(IEspContext &context, IUserDescriptor* udes
     return true;
 }
 
+void CWsDfuEx::getFilePartsOnClusters(IEspContext &context, const char *clusterReq, StringArray &clusters,
+    IDistributedFile *df, IEspDFUFileDetail &fileDetails)
+{
+    double version = context.getClientVersion();
+    IArrayOf<IConstDFUFilePartsOnCluster>& partsOnClusters = fileDetails.getDFUFilePartsOnClusters();
+    ForEachItemIn(i, clusters)
+    {
+        const char* clusterName = clusters.item(i);
+        if (isEmptyString(clusterName) || (!isEmptyString(clusterReq) && !strieq(clusterReq, clusterName)))
+            continue;
+
+        Owned<IEspDFUFilePartsOnCluster> partsOnCluster = createDFUFilePartsOnCluster();
+        partsOnCluster->setCluster(clusterName);
+
+        IArrayOf<IConstDFUPart> &filePartList = partsOnCluster->getDFUFileParts();
+
+        Owned<IFileDescriptor> fdesc = df->getFileDescriptor(clusterName);
+        Owned<IPartDescriptorIterator> pi = fdesc->getIterator();
+        ForEach(*pi)
+        {
+            IPartDescriptor &part = pi->query();
+            unsigned partIndex = part.queryPartIndex();
+
+            __int64 size = -1;
+            StringBuffer partSizeStr;
+            IPropertyTree *partPropertyTree = &part.queryProperties();
+            if (!partPropertyTree)
+                partSizeStr.set("<N/A>");
+            else
+            {
+                size = partPropertyTree->getPropInt64("@size", -1);
+                comma c4(size);
+                partSizeStr<<c4;
+            }
+
+            for (unsigned i=0; i<part.numCopies(); i++)
+            {
+                StringBuffer url;
+                part.queryNode(i)->endpoint().getUrlStr(url);
+
+                Owned<IEspDFUPart> FilePart = createDFUPart();
+                FilePart->setId(partIndex+1);
+                FilePart->setPartsize(partSizeStr.str());
+                if (version >= 1.38)
+                    FilePart->setPartSizeInt64(size);
+                FilePart->setIp(url.str());
+                FilePart->setCopy(i+1);
+
+                filePartList.append(*FilePart.getClear());
+            }
+        }
+
+        if (version >= 1.31)
+        {
+            IClusterInfo *clusterInfo = fdesc->queryCluster(clusterName);
+            if (clusterInfo) //Should be valid. But, check it just in case.
+            {
+                partsOnCluster->setReplicate(clusterInfo->queryPartDiskMapping().isReplicated());
+                Owned<CThorNodeGroup> nodeGroup = thorNodeGroupCache->lookup(clusterName, nodeGroupCacheTimeout);
+                if (nodeGroup)
+                    partsOnCluster->setCanReplicate(nodeGroup->queryCanReplicate());
+                const char *defaultDir = fdesc->queryDefaultDir();
+                if (!isEmptyString(defaultDir))
+                {
+                    DFD_OS os = SepCharBaseOs(getPathSepChar(defaultDir));
+                    StringBuffer baseDir, repDir;
+                    clusterInfo->getBaseDir(baseDir, os);
+                    clusterInfo->getReplicateDir(repDir, os);
+                    partsOnCluster->setBaseDir(baseDir.str());
+                    partsOnCluster->setReplicateDir(baseDir.str());
+                }
+            }
+        }
+        partsOnClusters.append(*partsOnCluster.getClear());
+    }
+}
+
 void CWsDfuEx::parseFieldMask(unsigned __int64 fieldMask, unsigned &fieldCount, IntArray &fieldIndexArray)
 {
     while (fieldMask > 0)
@@ -2272,6 +2349,56 @@ void CWsDfuEx::doGetFileDetails(IEspContext &context, IUserDescriptor *udesc, co
                 }
             }
             FileDetails.setFromRoxieCluster(fromRoxieCluster);
+        }
+    }
+
+    if (version >= 1.25)
+        getFilePartsOnClusters(context, cluster, clusters, df, FileDetails);
+    else
+    {
+        FileDetails.setCluster(clusters.item(0));
+        IArrayOf<IConstDFUPart>& PartList = FileDetails.getDFUFileParts();
+
+        Owned<IDistributedFilePartIterator> pi = df->getIterator();
+        ForEach(*pi)
+        {
+            Owned<IDistributedFilePart> part = &pi->get();
+            for (unsigned int i=0; i<part->numCopies(); i++)
+            {
+                Owned<IEspDFUPart> FilePart = createDFUPart();
+
+                StringBuffer url;
+                part->queryNode(i)->endpoint().getUrlStr(url);
+
+                FilePart->setId(part->getPartIndex()+1);
+                FilePart->setCopy(i+1);
+                FilePart->setIp(url.str());
+                FilePart->setPartsize("<N/A>");
+
+                try
+                {
+                    offset_t size = queryDistributedFileSystem().getSize(part);
+                    if (version >= 1.38)
+                        FilePart->setPartSizeInt64(size);
+
+                    comma c4(size);
+                    tmpstr.clear();
+                    tmpstr<<c4;
+                    FilePart->setPartsize(tmpstr.str());
+                }
+                catch(IException *e)
+                {
+                    StringBuffer msg;
+                    IERRLOG("Exception %d:%s in WS_DFU queryDistributedFileSystem().getSize()", e->errorCode(), e->errorMessage(msg).str());
+                    e->Release();
+                }
+                catch(...)
+                {
+                    IERRLOG("Unknown exception in WS_DFU queryDistributedFileSystem().getSize()");
+                }
+
+                PartList.append(*FilePart.getClear());
+            }
         }
     }
 

--- a/esp/services/ws_dfu/ws_dfuService.hpp
+++ b/esp/services/ws_dfu/ws_dfuService.hpp
@@ -238,6 +238,8 @@ private:
     void parseStringArray(const char *input, StringArray& strarray);
     int superfileAction(IEspContext &context, const char* action, const char* superfile, StringArray& subfiles,
         const char* beforeSubFile, bool existingSuperfile, bool autocreatesuper, bool deleteFile, bool removeSuperfile =  true);
+    void getFilePartsOnClusters(IEspContext &context, const char *clusterReq, StringArray &clusters, IDistributedFile *df,
+        IEspDFUFileDetail &fileDetails);
     bool getQueryFile(const char *logicalName, const char *querySet, const char *queryID, IEspDFUFileDetail &fileDetails);
     void queryFieldNames(IEspContext &context, const char *fileName, const char *cluster,
         unsigned __int64 fieldMask, StringArray &fieldNames);


### PR DESCRIPTION
The code was removed by:
https://github.com/hpcc-systems/HPCC-Platform/pull/12856.
The code is needed for ECLWatch to retrieve file parts
information.

Signed-off-by: wangkx <kevin.wang@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
