### PR TITLE
HPCC-23203 - Fix: empty Internal ESPstructs are understood as not empty

### DIFF
--- a/esp/bindings/SOAP/Platform/soapparam.cpp
+++ b/esp/bindings/SOAP/Platform/soapparam.cpp
@@ -68,8 +68,9 @@ bool BaseEspParam::unmarshall(IRpcMessage &rpc_call, const char *tagname, const 
         if (optGroup && rpc_call.queryContext())
             rpc_call.queryContext()->addOptGroup(optGroup);
         isNil = false;
+        return true;
     }
-    return isNil;
+    return false;
 }
 
 bool BaseEspParam::unmarshall(IEspContext* ctx, CSoapValue &soapval, const char *tagname, const char* optGroup)
@@ -79,8 +80,9 @@ bool BaseEspParam::unmarshall(IEspContext* ctx, CSoapValue &soapval, const char 
         if (ctx && optGroup)
             ctx->addOptGroup(optGroup);
         isNil = false;
+        return true;
     }
-    return isNil;
+    return false;
 }
 
 bool BaseEspParam::unmarshall(IEspContext* ctx, IProperties &params, MapStrToBuf *attachments, const char *tagname, const char *basepath, const char* optGroup, const char *xsdtype, const char *prefix)
@@ -92,11 +94,12 @@ bool BaseEspParam::unmarshall(IEspContext* ctx, IProperties &params, MapStrToBuf
 
     if (updateValue(params.queryProp(path.str())))
     {
-        isNil = false;
         if (ctx && optGroup)
             ctx->addOptGroup(optGroup);
+        isNil = false;
+        return true;
     }
-    return isNil;
+    return false;
 }
 
 void SoapStringParam::toXMLValue(StringBuffer &s, bool encode)


### PR DESCRIPTION
Signed-off-by: Lucas Mauro de Souza <lucas.souza@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [X] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [X] My code follows the code style of this project.
  - [X] My code does not create any new warnings from compiler, build system, or lint.
- [X] The commit message is properly formatted and free of typos.
  - [X] The commit message title makes sense in a changelog, by itself.
  - [X] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [X] I have read the CONTRIBUTORS document.
- [X] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [X] All new and existing tests passed.
  - [X] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [X] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [X] Existing deployed queries will not be broken
  - [X] This change fixes the problem, not just the symptom
  - [X] The target branch of this pull request is appropriate for such a change.
- [X] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [X] Send notifications about my Pull Request position in Smoketest queue.
- [X] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
