### PR TITLE
HPCC-22921 Return cached disk usage while rebuilding new usage

### DIFF
--- a/esp/scm/ws_machine.ecm
+++ b/esp/scm/ws_machine.ecm
@@ -423,6 +423,7 @@ ESPrequest [nil_remove] GetComponentUsageRequest
 ESPresponse [encode(0), nil_remove, exceptions_inline] GetComponentUsageResponse 
 {
     ESParray<ESPstruct ComponentUsage> ComponentUsages;
+    [min_ver("1.17")] string UsageTime;
 };
 
 ESPrequest [nil_remove] GetTargetClusterUsageRequest
@@ -434,6 +435,7 @@ ESPrequest [nil_remove] GetTargetClusterUsageRequest
 ESPresponse [encode(0), nil_remove, exceptions_inline] GetTargetClusterUsageResponse 
 {
     ESParray<ESPstruct TargetClusterUsage> TargetClusterUsages;
+    [min_ver("1.17")] string UsageTime;
 };
 
 ESPrequest [nil_remove] GetNodeGroupUsageRequest
@@ -445,10 +447,11 @@ ESPrequest [nil_remove] GetNodeGroupUsageRequest
 ESPresponse [encode(0), nil_remove, exceptions_inline] GetNodeGroupUsageResponse 
 {
     ESParray<ESPstruct NodeGroupUsage> NodeGroupUsages;
+    [min_ver("1.17")] string UsageTime;
 };
 
 //-------- service ---------
-ESPservice [auth_feature("DEFERRED"), version("1.16")] ws_machine
+ESPservice [auth_feature("DEFERRED"), version("1.17")] ws_machine
 {
     ESPmethod [resp_xsl_default("./smc_xslt/clusterprocesses.xslt"), exceptions_inline("./smc_xslt/exceptions.xslt")]
        GetTargetClusterInfo(GetTargetClusterInfoRequest, GetTargetClusterInfoResponse);

--- a/esp/services/ws_machine/CMakeLists.txt
+++ b/esp/services/ws_machine/CMakeLists.txt
@@ -74,6 +74,7 @@ target_link_libraries ( ws_machine
          dalibase 
          environment 
          workunit
+         SMCLib
     )
 
 IF (USE_OPENSSL)

--- a/esp/services/ws_machine/ws_machineService.cpp
+++ b/esp/services/ws_machine/ws_machineService.cpp
@@ -112,6 +112,26 @@ public:
     }
 };
 
+const char* findComponentTypeFromProcessType(const char* ProcessType)
+{
+    if (strieq(ProcessType, eqDali))
+        return "dali";
+    if (strieq(ProcessType, eqEclAgent))
+        return "eclAgent";
+    if (strieq(ProcessType, eqDfu))
+        return "dfuserver";
+    if (strieq(ProcessType, eqEsp))
+        return "esp";
+    if (strieq(ProcessType, eqEclCCServer) || strieq(ProcessType, eqEclServer))
+        return "eclserver";
+    if (strieq(ProcessType, eqEclScheduler))
+        return "eclscheduler";
+    if (strieq(ProcessType, eqSashaServer))
+        return "sasha";
+
+    return nullptr;
+}
+
 void Cws_machineEx::init(IPropertyTree *cfg, const char *process, const char *service)
 {
     //Read settings from esp.xml
@@ -165,9 +185,6 @@ void Cws_machineEx::init(IPropertyTree *cfg, const char *process, const char *se
         pEnvSettings->getProp("user", environmentConfData.m_user.clear());
     }
 
-    machineUsageCache.setown(new MachineUsageCache(MACHINE_USAGE_MAX_CACHE_SIZE));
-    machineUsageCacheMinutes = pServiceNode->getPropInt("MachineUsageCacheMinutes", MACHINE_USAGE_CACHE_MINUTES);
-
     m_threadPoolSize = pServiceNode->getPropInt("ThreadPoolSize", THREAD_POOL_SIZE);
     m_threadPoolStackSize = pServiceNode->getPropInt("ThreadPoolStackSize", THREAD_POOL_STACK_SIZE);
 
@@ -180,6 +197,10 @@ void Cws_machineEx::init(IPropertyTree *cfg, const char *process, const char *se
 
     Owned<IComponentStatusFactory> factory = getComponentStatusFactory();
     factory->init(pServiceNode);
+
+    unsigned machineUsageCacheForceRebuildMinutes = pServiceNode->getPropInt("MachineUsageCacheMinutes", machineUsageCacheMinutes);
+    unsigned machineUsageCacheAutoRebuildMinutes = pServiceNode->getPropInt("MachineUsageCacheAutoRebuildMinutes", defaultMachineUsageCacheAutoBuildMinutes);
+    usageCacheReader.setown(new CUsageCacheReader(this, "Usage Reader", machineUsageCacheAutoRebuildMinutes*60, machineUsageCacheForceRebuildMinutes*60));
 }
 
 StringBuffer& Cws_machineEx::getAcceptLanguage(IEspContext& context, StringBuffer& acceptLanguage)
@@ -2487,7 +2508,8 @@ void Cws_machineEx::readOtherComponentUsageReq(const char* name, const char* typ
     if (isEmptyString(name))
         throw MakeStringException(ECLWATCH_INVALID_INPUT, "Empty Component name");
 
-    if (!strieq(type, eqDali) && !strieq(type, eqEclAgent) && !strieq(type, eqSashaServer))
+    const char* componentType = findComponentTypeFromProcessType(type);
+    if (!componentType)
         throw MakeStringException(ECLWATCH_CANNOT_GET_ENV_INFO, "Component usage function is not supported for %s", type);
 
     Owned<IPropertyTree> componentReq = createPTree("Component");
@@ -2603,16 +2625,22 @@ IArrayOf<IConstComponent>& Cws_machineEx::listComponentsForCheckingUsage(IConstE
     listComponentsByType(envRoot, eqEclAgent, componentList);
     listComponentsByType(envRoot, eqSashaServer, componentList);
     listComponentsByType(envRoot, eqDropZone, componentList);
+    listComponentsByType(envRoot, eqDfu, componentList);
+    listComponentsByType(envRoot, eqEclCCServer, componentList);
+    listComponentsByType(envRoot, eqEclServer, componentList);
+    listComponentsByType(envRoot, eqEclScheduler, componentList);
+    listComponentsByType(envRoot, eqEsp, componentList);
 
     return componentList;
 }
 
-void Cws_machineEx::readComponentUsageReq(IEspGetComponentUsageRequest& req, IConstEnvironment* constEnv, IPropertyTree* usageReq, IPropertyTree* uniqueUsages)
+IPropertyTree* Cws_machineEx::getComponentUsageReq(IEspGetComponentUsageRequest& req, IConstEnvironment* constEnv)
 {
     IArrayOf<IConstComponent>& componentList = req.getComponents();
     if (!componentList.length())
         listComponentsForCheckingUsage(constEnv, componentList);
 
+    Owned<IPropertyTree> usageReq = createPTree("Req");
     ForEachItemIn(i, componentList)
     {
         IConstComponent& component = componentList.item(i);
@@ -2629,9 +2657,7 @@ void Cws_machineEx::readComponentUsageReq(IEspGetComponentUsageRequest& req, ICo
         else
             readOtherComponentUsageReq(component.getName(), type, constEnv, usageReq);
     }
-
-    //Add unique machines from the usageReq to uniqueUsages.
-    setUniqueMachineUsageReq(usageReq, uniqueUsages);
+    return usageReq.getClear();
 }
 
 void Cws_machineEx::getMachineUsages(IEspContext& context, IPropertyTree* uniqueUsages)
@@ -2730,7 +2756,7 @@ void Cws_machineEx::getMachineUsage(IEspContext& context, CGetMachineUsageThread
 }
 
 void Cws_machineEx::readComponentUsageResult(IEspContext& context, IPropertyTree* usageReq,
-    IPropertyTree* uniqueUsages, IArrayOf<IEspComponentUsage>& componentUsages)
+    const IPropertyTree* uniqueUsages, IArrayOf<IEspComponentUsage>& componentUsages)
 {
     Owned<IPropertyTreeIterator> components= usageReq->getElements("Component");
     ForEach(*components)
@@ -2811,6 +2837,19 @@ void Cws_machineEx::readComponentUsageResult(IEspContext& context, IPropertyTree
     }
 }
 
+StringBuffer& Cws_machineEx::setUsageTimeStr(CUsageCache* usageCache, StringBuffer& timeStr)
+{
+    if (usageCache)
+        usageCache->queryTimeCached(timeStr);
+    else
+    {
+        CDateTime timeNow;
+        timeNow.setNow();
+        timeNow.getString(timeStr, true);
+    }
+    return timeStr;
+}
+
 bool Cws_machineEx::onGetComponentUsage(IEspContext& context, IEspGetComponentUsageRequest& req,
     IEspGetComponentUsageResponse& resp)
 {
@@ -2818,24 +2857,38 @@ bool Cws_machineEx::onGetComponentUsage(IEspContext& context, IEspGetComponentUs
     {
         context.ensureFeatureAccess(FEATURE_URL, SecAccess_Read, ECLWATCH_MACHINE_INFO_ACCESS_DENIED, "Failed to Get Machine Information. Permission denied.");
 
-        StringBuffer cacheID;
-        buildComponentUsageCacheID(cacheID, req.getComponents());
+        double version = context.getClientVersion();
 
-        if (!req.getBypassCachedResult() && readComponentUsageCache(context, cacheID, resp))
-            return true;
-
+        StringBuffer timeStr;
+        IArrayOf<IEspComponentUsage> componentUsages;
         Owned<IEnvironmentFactory> envFactory = getEnvironmentFactory(true);
         Owned<IConstEnvironment> constEnv = envFactory->openEnvironment();
+        Owned<IPropertyTree> usageReq = getComponentUsageReq(req, constEnv);
 
-        Owned<IPropertyTree> usageReq = createPTree("Req");
-        Owned<IPropertyTree> uniqueUsages = createPTree("Usage");
-        readComponentUsageReq(req, constEnv, usageReq, uniqueUsages);
+        Owned<CUsageCache> usage;
+        Owned<const IPropertyTree> uniqueUsages;
+        if (req.getBypassCachedResult())
+        {
+            Owned<IPropertyTree> tmpUniqueUsages = createPTree("Usage");
+            //Add unique machines from the usageReq to uniqueUsages.
+            setUniqueMachineUsageReq(usageReq, tmpUniqueUsages);
+            getMachineUsages(context, tmpUniqueUsages);
+            uniqueUsages.setown(tmpUniqueUsages.getClear());
+        }
+        else
+        {
+            usage.setown((CUsageCache*) usageCacheReader->getCachedInfo());
+            if (!usage)
+                throw MakeStringException(ECLWATCH_INTERNAL_ERROR, "Failed to get usage. Please try later.");
 
-        getMachineUsages(context, uniqueUsages);
+            ESPLOG(LogMax, "GetComponentUsage: found UsageCache.");
+            uniqueUsages.set(usage->queryUsages());
+        }
 
-        IArrayOf<IEspComponentUsage> componentUsages;
         readComponentUsageResult(context, usageReq, uniqueUsages, componentUsages);
-        machineUsageCache->add(cacheID, componentUsages);
+        if (version >= 1.17)
+            resp.setUsageTime(setUsageTimeStr(usage, timeStr));
+
         resp.setComponentUsages(componentUsages);
     }
     catch(IException* e)
@@ -2857,13 +2910,13 @@ StringArray& Cws_machineEx::listTargetClusterNames(IConstEnvironment* constEnv, 
     return targetClusters;
 }
 
-void Cws_machineEx::readTargetClusterUsageReq(IEspGetTargetClusterUsageRequest& req, IConstEnvironment* constEnv,
-    IPropertyTree* usageReq, IPropertyTree* uniqueUsages)
+IPropertyTree* Cws_machineEx::getTargetClusterUsageReq(IEspGetTargetClusterUsageRequest& req, IConstEnvironment* constEnv)
 {
     StringArray& targetClusters = req.getTargetClusters();
     if (targetClusters.empty())
         listTargetClusterNames(constEnv, targetClusters);
 
+    Owned<IPropertyTree> usageReq = createPTree("Req");
     Owned<IPropertyTree> envRoot = &constEnv->getPTree();
     ForEachItemIn(i, targetClusters)
     {
@@ -2898,17 +2951,11 @@ void Cws_machineEx::readTargetClusterUsageReq(IEspGetTargetClusterUsageRequest& 
 
         usageReq->addPropTree(targetClusterTree->queryName(), LINK(targetClusterTree));
     }
-
-    Owned<IPropertyTreeIterator> targetClusterItr= usageReq->getElements("TargetCluster");
-    ForEach(*targetClusterItr)
-    {
-        IPropertyTree& targetCluster = targetClusterItr->query();
-        setUniqueMachineUsageReq(&targetCluster, uniqueUsages);
-    }
+    return usageReq.getClear();
 }
 
 void Cws_machineEx::readTargetClusterUsageResult(IEspContext& context, IPropertyTree* usageReq,
-    IPropertyTree* uniqueUsages, IArrayOf<IEspTargetClusterUsage>& targetClusterUsages)
+    const IPropertyTree* uniqueUsages, IArrayOf<IEspTargetClusterUsage>& targetClusterUsages)
 {
     Owned<IPropertyTreeIterator> targetClusters= usageReq->getElements("TargetCluster");
     ForEach(*targetClusters)
@@ -2933,24 +2980,43 @@ bool Cws_machineEx::onGetTargetClusterUsage(IEspContext& context, IEspGetTargetC
     {
         context.ensureFeatureAccess(FEATURE_URL, SecAccess_Read, ECLWATCH_MACHINE_INFO_ACCESS_DENIED, "Failed to Get Machine Information. Permission denied.");
 
-        StringBuffer cacheID;
-        buildUsageCacheID(cacheID, req.getTargetClusters(), "AllTargetClusters");
+        double version = context.getClientVersion();
 
-        if (!req.getBypassCachedResult() && readTargetClusterUsageCache(context, cacheID, resp))
-            return true;
+        StringBuffer timeStr;
+        IArrayOf<IEspTargetClusterUsage> targetClusterUsages;
 
         Owned<IEnvironmentFactory> envFactory = getEnvironmentFactory(true);
         Owned<IConstEnvironment> constEnv = envFactory->openEnvironment();
+        Owned<IPropertyTree> usageReq = getTargetClusterUsageReq(req, constEnv);
 
-        Owned<IPropertyTree> usageReq = createPTree("Req");
-        Owned<IPropertyTree> uniqueUsages = createPTree("Usage");
-        readTargetClusterUsageReq(req, constEnv, usageReq, uniqueUsages);
+        Owned<CUsageCache> usage;
+        Owned<const IPropertyTree> uniqueUsages;
+        if (req.getBypassCachedResult())
+        {
+            Owned<IPropertyTree> tmpUniqueUsages = createPTree("Usage");
 
-        getMachineUsages(context, uniqueUsages);
+            Owned<IPropertyTreeIterator> targetClusterItr= usageReq->getElements("TargetCluster");
+            ForEach(*targetClusterItr)
+            {
+                IPropertyTree& targetCluster = targetClusterItr->query();
+                setUniqueMachineUsageReq(&targetCluster, tmpUniqueUsages);
+            }
+            getMachineUsages(context, tmpUniqueUsages);
+            uniqueUsages.setown(tmpUniqueUsages.getClear());
+        }
+        else
+        {
+            usage.setown((CUsageCache*) usageCacheReader->getCachedInfo());
+            if (!usage)
+                throw MakeStringException(ECLWATCH_INTERNAL_ERROR, "Failed to get usage. Please try later.");
 
-        IArrayOf<IEspTargetClusterUsage> targetClusterUsages;
+            ESPLOG(LogMax, "GetTargetClusterUsage: found UsageCache.");
+            uniqueUsages.set(usage->queryUsages());
+        }
         readTargetClusterUsageResult(context, usageReq, uniqueUsages, targetClusterUsages);
-        machineUsageCache->add(cacheID, targetClusterUsages);
+        if (version >= 1.17)
+            resp.setUsageTime(setUsageTimeStr(usage, timeStr));
+
         resp.setTargetClusterUsages(targetClusterUsages);
     }
     catch(IException* e)
@@ -3050,8 +3116,7 @@ StringArray& Cws_machineEx::listThorHThorNodeGroups(IConstEnvironment* constEnv,
     return nodeGroups;
 }
 
-void Cws_machineEx::readNodeGroupUsageReq(IEspGetNodeGroupUsageRequest& req, IConstEnvironment* constEnv,
-    IPropertyTree* usageReq, IPropertyTree* uniqueUsages)
+IPropertyTree* Cws_machineEx::getNodeGroupUsageReq(IEspGetNodeGroupUsageRequest& req, IConstEnvironment* constEnv)
 {
     StringArray& nodeGroups = req.getNodeGroups();
     if (nodeGroups.empty())
@@ -3059,6 +3124,7 @@ void Cws_machineEx::readNodeGroupUsageReq(IEspGetNodeGroupUsageRequest& req, ICo
     if (nodeGroups.empty())
         throw MakeStringException(ECLWATCH_INVALID_INPUT, "No node group found.");
 
+    Owned<IPropertyTree> usageReq = createPTree("Req");
     Owned<IPropertyTree> envRoot = &constEnv->getPTree();
     ForEachItemIn(i, nodeGroups)
     {
@@ -3085,17 +3151,11 @@ void Cws_machineEx::readNodeGroupUsageReq(IEspGetNodeGroupUsageRequest& req, ICo
 
         usageReq->addPropTree(nodeGroupTree->queryName(), LINK(nodeGroupTree));
     }
-
-    Owned<IPropertyTreeIterator> nodeGroupItr= usageReq->getElements("NodeGroup");
-    ForEach(*nodeGroupItr)
-    {
-        IPropertyTree& nodeGroup = nodeGroupItr->query();
-        setUniqueMachineUsageReq(&nodeGroup, uniqueUsages);
-    }
+    return usageReq.getClear();
 }
 
 void Cws_machineEx::readNodeGroupUsageResult(IEspContext& context, IPropertyTree* usageReq,
-    IPropertyTree* uniqueUsages, IArrayOf<IEspNodeGroupUsage>& nodeGroupUsages)
+    const IPropertyTree* uniqueUsages, IArrayOf<IEspNodeGroupUsage>& nodeGroupUsages)
 {
     Owned<IPropertyTreeIterator> nodeGroups= usageReq->getElements("NodeGroup");
     ForEach(*nodeGroups)
@@ -3120,24 +3180,43 @@ bool Cws_machineEx::onGetNodeGroupUsage(IEspContext& context, IEspGetNodeGroupUs
     {
         context.ensureFeatureAccess(FEATURE_URL, SecAccess_Read, ECLWATCH_MACHINE_INFO_ACCESS_DENIED, "Failed to Get Machine Information. Permission denied.");
 
-        StringBuffer cacheID;
-        buildUsageCacheID(cacheID, req.getNodeGroups(), "AllNodeGroups");
+        double version = context.getClientVersion();
 
-        if (!req.getBypassCachedResult() && readNodeGroupUsageCache(context, cacheID, resp))
-            return true;
+        StringBuffer timeStr;
+        IArrayOf<IEspNodeGroupUsage> nodeGroupUsages;
 
         Owned<IEnvironmentFactory> envFactory = getEnvironmentFactory(true);
         Owned<IConstEnvironment> constEnv = envFactory->openEnvironment();
+        Owned<IPropertyTree> usageReq = getNodeGroupUsageReq(req, constEnv);
 
-        Owned<IPropertyTree> usageReq = createPTree("Req");
-        Owned<IPropertyTree> uniqueUsages = createPTree("Usage");
-        readNodeGroupUsageReq(req, constEnv, usageReq, uniqueUsages);
+        Owned<CUsageCache> usage;
+        Owned<const IPropertyTree> uniqueUsages;
+        if (req.getBypassCachedResult())
+        {
+            Owned<IPropertyTree> tmpUniqueUsages = createPTree("Usage");
 
-        getMachineUsages(context, uniqueUsages);
+            Owned<IPropertyTreeIterator> nodeGroupItr= usageReq->getElements("NodeGroup");
+            ForEach(*nodeGroupItr)
+            {
+                IPropertyTree& nodeGroup = nodeGroupItr->query();
+                setUniqueMachineUsageReq(&nodeGroup, tmpUniqueUsages);
+            }
+            getMachineUsages(context, tmpUniqueUsages);
+            uniqueUsages.setown(tmpUniqueUsages.getClear());
+        }
+        else
+        {
+            usage.setown((CUsageCache*) usageCacheReader->getCachedInfo());
+            if (!usage)
+                throw MakeStringException(ECLWATCH_INTERNAL_ERROR, "Failed to get usage. Please try later.");
 
-        IArrayOf<IEspNodeGroupUsage> nodeGroupUsages;
+            ESPLOG(LogMax, "GetNodeGroupUsage: found UsageCache.");
+            uniqueUsages.set(usage->queryUsages());
+        }
+
         readNodeGroupUsageResult(context, usageReq, uniqueUsages, nodeGroupUsages);
-        machineUsageCache->add(cacheID, nodeGroupUsages);
+        if (version >= 1.17)
+            resp.setUsageTime(setUsageTimeStr(usage, timeStr));
         resp.setNodeGroupUsages(nodeGroupUsages);
     }
     catch(IException* e)
@@ -3145,84 +3224,6 @@ bool Cws_machineEx::onGetNodeGroupUsage(IEspContext& context, IEspGetNodeGroupUs
         FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
     }
 
-    return true;
-}
-
-void Cws_machineEx::buildComponentUsageCacheID(StringBuffer& id, IArrayOf<IConstComponent>& componentList)
-{
-    if (!componentList.ordinality())
-    {
-        id.set("AllComponents");
-        return;
-    }
-
-    StringArray componentNames;
-    ForEachItemIn(i, componentList)
-    {
-        IConstComponent& component = componentList.item(i);
-        StringBuffer str(component.getType());
-        if (str.isEmpty())
-            throw MakeStringException(ECLWATCH_INVALID_INPUT, "Empty Component Type");
-        str.append(":").append(component.getName());
-        componentNames.append(str);
-    }
-    componentNames.sortAscii();
-    componentNames.getString(id, ",");
-}
-
-void Cws_machineEx::buildUsageCacheID(StringBuffer& id, StringArray& names, const char* defaultID)
-{
-    if (names.ordinality())
-    {
-        names.sortAscii();
-        names.getString(id, ",");
-    }
-    else
-        id.set(defaultID);
-}
-
-bool Cws_machineEx::readComponentUsageCache(IEspContext& context, const char* cacheID,
-    IEspGetComponentUsageResponse& resp)
-{
-    Owned<MachineUsageCacheElement> cachedUsage = machineUsageCache->lookup(context,
-        cacheID, machineUsageCacheMinutes);
-    if (!cachedUsage)
-        return false;
-
-    IArrayOf<IEspComponentUsage> componentUsages;
-    ForEachItemIn(i, cachedUsage->componentUsages)
-        componentUsages.append(*LINK(&cachedUsage->componentUsages.item(i)));
-    resp.setComponentUsages(componentUsages);
-    return true;
-}
-
-bool Cws_machineEx::readTargetClusterUsageCache(IEspContext& context, const char* cacheID,
-    IEspGetTargetClusterUsageResponse& resp)
-{
-    Owned<MachineUsageCacheElement> cachedUsage = machineUsageCache->lookup(context,
-        cacheID, machineUsageCacheMinutes);
-    if (!cachedUsage)
-        return false;
-
-    IArrayOf<IEspTargetClusterUsage> targetClusterUsages;
-    ForEachItemIn(i, cachedUsage->tcUsages)
-        targetClusterUsages.append(*LINK(&cachedUsage->tcUsages.item(i)));
-    resp.setTargetClusterUsages(targetClusterUsages);
-    return true;
-}
-
-bool Cws_machineEx::readNodeGroupUsageCache(IEspContext& context, const char* cacheID,
-    IEspGetNodeGroupUsageResponse& resp)
-{
-    Owned<MachineUsageCacheElement> cachedUsage = machineUsageCache->lookup(context,
-        cacheID, machineUsageCacheMinutes);
-    if (!cachedUsage)
-        return false;
-
-    IArrayOf<IEspNodeGroupUsage> nodeGroupUsages;
-    ForEachItemIn(i, cachedUsage->ngUsages)
-        nodeGroupUsages.append(*LINK(&cachedUsage->ngUsages.item(i)));
-    resp.setNodeGroupUsages(nodeGroupUsages);
     return true;
 }
 
@@ -3289,3 +3290,214 @@ bool Cws_machineEx::onUpdateComponentStatus(IEspContext &context, IEspUpdateComp
     return true;
 }
 
+CInfoCache* CUsageCacheReader::read()
+{
+    Owned<IPropertyTree> uniqueUsages = getUsageReqAllMachines();
+
+    //Send usage command to each machine
+    Owned<IEspContext> espContext =  createEspContext();
+    servicePtr->getMachineUsages(*espContext, uniqueUsages);
+
+    Owned<CUsageCache> usageCache = new CUsageCache();
+    usageCache->setUsages(uniqueUsages.getClear());
+    return usageCache.getClear();
+}
+
+IPropertyTree* CUsageCacheReader::getUsageReqAllMachines()
+{
+    //Collect network addresses and HPCC folders for all HPCC machines.
+    Owned<IEnvironmentFactory> envFactory = getEnvironmentFactory(true);
+    Owned<IConstEnvironment> constEnv = envFactory->openEnvironment();
+
+    IArrayOf<IConstComponent> componentList;
+    servicePtr->listComponentsForCheckingUsage(constEnv, componentList);
+
+    //Create a PTree which will be used to store the usages of all HPCC machines.
+    Owned<IPropertyTree> uniqueUsages = createPTree("Usage");
+
+    //Store the network addresses and HPCC folders into the PTree.
+    //Their usages may be added by calling servicePtr->getMachineUsages().
+    ForEachItemIn(i, componentList)
+    {
+        IConstComponent& component = componentList.item(i);
+        const char* type = component.getType();
+        if (isEmptyString(type))
+            throw MakeStringException(ECLWATCH_INVALID_INPUT, "Empty Component Type");
+
+        if (strieq(type, eqThorCluster))
+            addClusterUsageReq(constEnv, component.getName(), true, uniqueUsages);
+        else if (strieq(type, eqRoxieCluster))
+            addClusterUsageReq(constEnv, component.getName(), false, uniqueUsages);
+        else if (strieq(type, eqDropZone))
+            addDropZoneUsageReq(constEnv, component.getName(), uniqueUsages);
+        else
+            addOtherComponentUsageReq(constEnv, component.getName(), type, uniqueUsages);
+    }
+
+    return uniqueUsages.getClear();
+}
+
+void CUsageCacheReader::addClusterUsageReq(IConstEnvironment* constEnv, const char* name, bool thorCluster, IPropertyTree* usageReq)
+{
+    if (isEmptyString(name))
+        throw MakeStringException(ECLWATCH_INVALID_INPUT, "Empty cluster name");
+
+    Owned<IPropertyTree> envRoot = &constEnv->getPTree();
+    IPropertyTree* envDirectories = envRoot->queryPropTree("Software/Directories");
+    Owned<IPropertyTree> logFolderReq = servicePtr->createDiskUsageReq(envDirectories, "log", thorCluster ? "thor" : "roxie", name);
+    Owned<IPropertyTree> dataFolderReq = servicePtr->createDiskUsageReq(envDirectories, "data", thorCluster ? "thor" : "roxie", name);
+    Owned<IPropertyTree> repFolderReq;
+    if (thorCluster)
+        repFolderReq.setown(servicePtr->createDiskUsageReq(envDirectories, "mirror", "thor", name));
+
+    StringBuffer xpath;
+    if (thorCluster)
+        xpath.setf("Software/ThorCluster[@name='%s']/ThorSlaveProcess", name);
+    else
+        xpath.setf("Software/RoxieCluster[@name='%s']/RoxieServerProcess", name);
+    Owned<IPropertyTreeIterator> processes= envRoot->getElements(xpath);
+    ForEach(*processes)
+    {
+        IPropertyTree& process = processes->query();
+        const char* computer = process.queryProp("@computer");
+        if (isEmptyString(computer))
+            throw MakeStringException(ECLWATCH_CANNOT_GET_ENV_INFO, "Failed to get @computer for %s", xpath.str());
+
+        checkAndAddMachineUsageReq(constEnv, computer, logFolderReq, dataFolderReq, repFolderReq, usageReq);
+    }
+
+    if (!thorCluster)
+        return;
+
+    //Read ThorMasterProcess in case it is on a different machine
+    xpath.setf("Software/ThorCluster[@name='%s']/ThorMasterProcess/@computer", name);
+    const char* computer = envRoot->queryProp(xpath);
+    if (isEmptyString(computer))
+        throw MakeStringException(ECLWATCH_CANNOT_GET_ENV_INFO, "Failed to get %s", xpath.str());
+
+    checkAndAddMachineUsageReq(constEnv, computer, logFolderReq, dataFolderReq, repFolderReq, usageReq);
+}
+
+void CUsageCacheReader::checkAndAddMachineUsageReq(IConstEnvironment* constEnv, const char* computer, IPropertyTree* logFolderReq,
+    IPropertyTree* dataFolderReq,  IPropertyTree* repFolderReq, IPropertyTree* usageReq)
+{
+    Owned<IPropertyTree> machineReq = servicePtr->createMachineUsageReq(constEnv, computer);
+    VStringBuffer xpath("Machine[@netAddress='%s']", machineReq->queryProp("@netAddress"));
+    IPropertyTree* foundMachineReqTree = usageReq->queryPropTree(xpath);
+    if (!foundMachineReqTree)
+    {
+        //Not sure we need those folders here. Add them just in case.
+        if (logFolderReq)
+            machineReq->addPropTree(logFolderReq->queryName(), LINK(logFolderReq));
+        if (dataFolderReq)
+            machineReq->addPropTree(dataFolderReq->queryName(), LINK(dataFolderReq));
+        if (repFolderReq)
+            machineReq->addPropTree(repFolderReq->queryName(), LINK(repFolderReq));
+        usageReq->addPropTree(machineReq->queryName(), LINK(machineReq));
+        return;
+    }
+
+    //Add unique disk folders
+    checkAndAddFolderReq(logFolderReq, foundMachineReqTree);
+    checkAndAddFolderReq(dataFolderReq, foundMachineReqTree);
+    checkAndAddFolderReq(repFolderReq, foundMachineReqTree);
+}
+
+void CUsageCacheReader::checkAndAddFolderReq(IPropertyTree* folderReq, IPropertyTree* machineReqTree)
+{
+    if (!folderReq)
+        return;
+
+    //Add unique disk folders
+    VStringBuffer xpath("Folder[@path='%s']", folderReq->queryProp("@path"));
+    if (!machineReqTree->queryPropTree(xpath))
+        machineReqTree->addPropTree(folderReq->queryName(), LINK(folderReq));
+}
+
+void CUsageCacheReader::addDropZoneUsageReq(IConstEnvironment* constEnv, const char* name, IPropertyTree* usageReq)
+{
+    if (isEmptyString(name))
+        throw MakeStringException(ECLWATCH_INVALID_INPUT, "Empty DropZone name");
+
+    Owned<IConstDropZoneInfo> envDropZone = constEnv->getDropZone(name);
+    if (!envDropZone || !envDropZone->isECLWatchVisible())
+        throw MakeStringException(ECLWATCH_INVALID_INPUT, "Dropzone %s not found", name);
+
+    SCMStringBuffer directory;
+    envDropZone->getDirectory(directory);
+    if (directory.length() == 0)
+        throw MakeStringException(ECLWATCH_CANNOT_GET_ENV_INFO, "Failed to get directory for DropZone %s", name);
+
+    Owned<IPropertyTree> dataFolder = createPTree("Folder");
+    dataFolder->addProp("@name", "data");
+    dataFolder->addProp("@path", directory.str());
+
+    SCMStringBuffer computerName;
+    envDropZone->getComputerName(computerName);
+    if (computerName.length() == 0)
+    {
+        OS_TYPE os = (getPathSepChar(directory.str()) == '/') ? OS_LINUX : OS_WINDOWS;
+
+        Owned<IConstDropZoneServerInfoIterator> servers = envDropZone->getServers();
+        ForEach(*servers)
+        {
+            IConstDropZoneServerInfo& server = servers->query();
+
+            StringBuffer serverNetAddress;
+            server.getServer(serverNetAddress.clear());
+
+            VStringBuffer xpath("Machine[@netAddress='%s']", serverNetAddress.str());
+            IPropertyTree* foundMachineReqTree = usageReq->queryPropTree(xpath);
+            if (foundMachineReqTree)
+            {
+                checkAndAddFolderReq(dataFolder, foundMachineReqTree);
+                continue;
+            }
+
+            Owned<IPropertyTree> machineReq = createPTree("Machine");
+            machineReq->addProp("@name", serverNetAddress.str());
+            machineReq->addProp("@netAddress", serverNetAddress.str());
+            machineReq->addPropInt("@OS", os);
+            machineReq->addPropTree(dataFolder->queryName(), LINK(dataFolder));
+
+            usageReq->addPropTree(machineReq->queryName(), LINK(machineReq));
+        }
+    }
+    else
+    { //legacy dropzone settings
+        checkAndAddMachineUsageReq(constEnv, computerName.str(), nullptr, dataFolder, nullptr, usageReq);
+    }
+}
+
+void CUsageCacheReader::addOtherComponentUsageReq(IConstEnvironment* constEnv, const char* name, const char* type, IPropertyTree* usageReq)
+{
+    if (isEmptyString(name))
+        throw MakeStringException(ECLWATCH_INVALID_INPUT, "Empty Component name");
+
+    const char* componentType = findComponentTypeFromProcessType(type);
+    if (!componentType)
+        throw MakeStringException(ECLWATCH_CANNOT_GET_ENV_INFO, "Component usage function is not supported for %s", type);
+
+    //Find disk folders for log, data, etc.
+    Owned<IPropertyTree> envRoot = &constEnv->getPTree();
+    IPropertyTree* envDirectories = envRoot->queryPropTree("Software/Directories");
+
+    Owned<IPropertyTree> dataFolder = servicePtr->createDiskUsageReq(envDirectories, "data", componentType, name);
+    Owned<IPropertyTree> logFolder = servicePtr->createDiskUsageReq(envDirectories, "log", componentType, name);
+    Owned<IPropertyTree> repFolder;
+    if (strieq(type, eqDali))
+        repFolder.setown(servicePtr->createDiskUsageReq(envDirectories, "mirror", "dali", name));
+
+    VStringBuffer xpath("Software/%s[@name='%s']/Instance", type, name);
+    Owned<IPropertyTreeIterator> it = envRoot->getElements(xpath);
+    ForEach(*it)
+    {
+        IPropertyTree& instance = it->query();
+
+        const char* computer = instance.queryProp("@computer");
+        if (isEmptyString(computer))
+            throw MakeStringException(ECLWATCH_CANNOT_GET_ENV_INFO, "Failed to get @computer for %s", xpath.str());
+
+        checkAndAddMachineUsageReq(constEnv, computer, logFolder, dataFolder, repFolder, usageReq);
+    }
+}

--- a/esp/services/ws_machine/ws_machineService.hpp
+++ b/esp/services/ws_machine/ws_machineService.hpp
@@ -25,12 +25,15 @@
 #include <set>
 #include <map>
 #include <list>
+#include "InfoCacheReader.hpp"
 
 class CMachineInfoThreadParam;
 class CRoxieStateInfoThreadParam;
 class CMetricsThreadParam;
 class CRemoteExecThreadParam;
 class CGetMachineUsageThreadParam;
+class CUsageCache;
+class CUsageCacheReader;
 
 static const char *legacyFilterStrings[] = {"AttrServerProcess:attrserver", "DaliProcess:daserver",
 "DfuServerProcess:dfuserver", "DKCSlaveProcess:dkcslave", "EclServerProcess:eclserver", "EclCCServerProcess:eclccserver",
@@ -726,143 +729,8 @@ public:
     int* getChannels(const char* key) { return channelsMap.getValue(key); };
 };
 
-const unsigned MACHINE_USAGE_MAX_CACHE_SIZE = 8;
-const unsigned MACHINE_USAGE_CACHE_MINUTES = 3;
-
-struct MachineUsageCacheElement: public CInterface, implements IInterface
-{
-    IMPLEMENT_IINTERFACE;
-    MachineUsageCacheElement(const char* _id, IArrayOf<IEspComponentUsage>& _usages) : id(_id)
-    {
-        ForEachItemIn(i, _usages)
-        {
-            Owned<IEspComponentUsage> usage= createComponentUsage("","");
-            IEspComponentUsage& _usage = _usages.item(i);
-            usage->copy(_usage);
-
-            componentUsages.append(*usage.getClear());
-        }
-        timeCached.setNow();
-    }
-    MachineUsageCacheElement(const char* _id, IArrayOf<IEspTargetClusterUsage>& _usages) : id(_id)
-    {
-        ForEachItemIn(i, _usages)
-        {
-            Owned<IEspTargetClusterUsage> usage= createTargetClusterUsage("","");
-            IEspTargetClusterUsage& _usage = _usages.item(i);
-            usage->copy(_usage);
-
-            tcUsages.append(*usage.getClear());
-        }
-        timeCached.setNow();
-    }
-    MachineUsageCacheElement(const char* _id, IArrayOf<IEspNodeGroupUsage>& _usages) : id(_id)
-    {
-        ForEachItemIn(i, _usages)
-        {
-            Owned<IEspNodeGroupUsage> usage= createNodeGroupUsage("","");
-            IEspNodeGroupUsage& _usage = _usages.item(i);
-            usage->copy(_usage);
-
-            ngUsages.append(*usage.getClear());
-        }
-        timeCached.setNow();
-    }
-
-    CDateTime timeCached;
-    std::string id;
-    IArrayOf<IEspComponentUsage> componentUsages;
-    IArrayOf<IEspTargetClusterUsage> tcUsages;
-    IArrayOf<IEspNodeGroupUsage> ngUsages;
-};
-
-struct CompareMachines
-{
-    CompareMachines(const char* _id): id(_id) {}
-    bool operator()(const Linked<MachineUsageCacheElement>& e) const
-    {
-        return streq(e->id.c_str(), id.c_str());
-    }
-    std::string id;
-};
-
-struct MachineUsageCache: public CInterface, implements IInterface
-{
-    IMPLEMENT_IINTERFACE;
-    MachineUsageCache(size32_t _maxCacheSize=0) : maxCacheSize(_maxCacheSize){}
-
-    MachineUsageCacheElement* lookup(IEspContext &context, const char* id, unsigned timeOutMinutes)
-    {
-        CriticalBlock block(crit);
-
-        if (cache.size() == 0)
-            return nullptr;
-
-        //erase data if it should be
-        CDateTime timeNow;
-        timeNow.setNow();
-        timeNow.adjustTimeSecs(-timeOutMinutes*60);
-        while (true)
-        {
-            std::list<Linked<MachineUsageCacheElement> >::iterator list_iter = cache.begin();
-            if (list_iter == cache.end())
-                break;
-
-            MachineUsageCacheElement* cachedElement = list_iter->get();
-            if (!cachedElement || (cachedElement->timeCached > timeNow))
-                break;
-
-            cache.pop_front();
-        }
-
-        if (cache.size() == 0)
-            return nullptr;
-
-        //Check whether we have usage cache for those machines.
-        std::list<Linked<MachineUsageCacheElement> >::iterator it = std::find_if(cache.begin(), cache.end(), CompareMachines(id));
-        if (it!=cache.end())
-        {
-            return it->getLink();
-        }
-
-        return nullptr;
-    }
-
-    void add(const char* id, IArrayOf<IEspComponentUsage>& usages)
-    {
-        CriticalBlock block(crit);
-        addUsageCacheElement(new MachineUsageCacheElement(id, usages));
-    }
-
-    void add(const char* id, IArrayOf<IEspTargetClusterUsage>& usages)
-    {
-        CriticalBlock block(crit);
-        addUsageCacheElement(new MachineUsageCacheElement(id, usages));
-    }
-
-    void add(const char* id, IArrayOf<IEspNodeGroupUsage>& usages)
-    {
-        CriticalBlock block(crit);
-        addUsageCacheElement(new MachineUsageCacheElement(id, usages));
-    }
-
-    std::list<Linked<MachineUsageCacheElement> > cache;
-    CriticalSection crit;
-    size32_t maxCacheSize;
-
-private:
-    void addUsageCacheElement(MachineUsageCacheElement* _e)
-    {
-        Owned<MachineUsageCacheElement> e = _e;
-        if (maxCacheSize == 0)
-            return;
-
-        if (cache.size() >= maxCacheSize)
-            cache.pop_front();
-
-        cache.push_back(e.get());
-    }
-};
+const unsigned machineUsageCacheMinutes = 3; //Force usage cache to rebuild
+const unsigned defaultMachineUsageCacheAutoBuildMinutes = 10;
 
 //---------------------------------------------------------------------------------------------
 
@@ -893,7 +761,22 @@ public:
     void doGetMetrics(CMetricsThreadParam* pParam);
     bool doStartStop(IEspContext &context, StringArray& addresses, char* userName, char* password, bool bStop, IEspStartStopResponse &resp);
     void getMachineUsage(IEspContext& context, CGetMachineUsageThreadParam* param);
+    void getMachineUsages(IEspContext& context, IPropertyTree* uniqueUsageReq);
+    IArrayOf<IConstComponent>& listComponentsForCheckingUsage(IConstEnvironment* constEnv, IArrayOf<IConstComponent>& componentList);
+    IPropertyTree* createDiskUsageReq(IPropertyTree* envDirectories, const char* pathName, const char* componentType, const char* componentName);
+    IPropertyTree* createMachineUsageReq(IConstEnvironment* constEnv, const char* computer);
 
+    virtual bool attachServiceToDali() override
+    {
+        usageCacheReader->setActive(true);
+        return true;
+    }
+
+    virtual bool detachServiceFromDali() override
+    {
+        usageCacheReader->setActive(false);
+        return true;
+    }
     IConstEnvironment* getConstEnvironment();
 
     //Used in StartStop/Rexec
@@ -957,38 +840,26 @@ private:
 
     StringArray& listTargetClusterNames(IConstEnvironment* constEnv, StringArray& targetClusters);
     StringArray& listThorHThorNodeGroups(IConstEnvironment* constEnv, StringArray& nodeGroups);
-    IArrayOf<IConstComponent>& listComponentsForCheckingUsage(IConstEnvironment* constEnv, IArrayOf<IConstComponent>& componentList);
     IArrayOf<IConstComponent>& listComponentsByType(IPropertyTree* envRoot, const char* componentType, IArrayOf<IConstComponent>& componentList);
-    IPropertyTree* createDiskUsageReq(IPropertyTree* envDirectories, const char* pathName,
-        const char* componentType, const char* componentName);
-    IPropertyTree* createMachineUsageReq(IConstEnvironment* constEnv, const char* computer);
-    void readTargetClusterUsageReq(IEspGetTargetClusterUsageRequest& req, IConstEnvironment* constEnv,
-        IPropertyTree* usageReq, IPropertyTree* uniqueUsages);
-    void readNodeGroupUsageReq(IEspGetNodeGroupUsageRequest& req, IConstEnvironment* constEnv,
-        IPropertyTree* usageReq, IPropertyTree* uniqueUsages);
-    void readComponentUsageReq(IEspGetComponentUsageRequest& req, IConstEnvironment* constEnv, IPropertyTree* usageReq,
-        IPropertyTree* uniqueUsages);
+    IPropertyTree* getTargetClusterUsageReq(IEspGetTargetClusterUsageRequest& req, IConstEnvironment* constEnv);
+    IPropertyTree* getNodeGroupUsageReq(IEspGetNodeGroupUsageRequest& req, IConstEnvironment* constEnv);
+    IPropertyTree* getComponentUsageReq(IEspGetComponentUsageRequest& req, IConstEnvironment* constEnv);
     void readThorUsageReq(const char* name, IConstEnvironment* constEnv, IPropertyTree* usageReq);
     void readRoxieUsageReq(const char* name, IConstEnvironment* constEnv, IPropertyTree* usageReq);
     void readDropZoneUsageReq(const char* name, IConstEnvironment* constEnv, IPropertyTree* usageReq);
     void readOtherComponentUsageReq(const char* name, const char* type, IConstEnvironment* constEnv, IPropertyTree* usageReq);
     void setUniqueMachineUsageReq(IPropertyTree* usageReq, IPropertyTree* uniqueUsages);
-    void getMachineUsages(IEspContext& context, IPropertyTree* uniqueUsageReq);
     bool getEclAgentNameFromNodeGroupName(const char* nodeGroupName, StringBuffer& agentName);
     void getThorClusterNamesByGroupName(IPropertyTree* envRoot, const char* group, StringArray& thorClusters);
-    void readTargetClusterUsageResult(IEspContext& context, IPropertyTree* usageReq, IPropertyTree* uniqueUsages,
+    void readTargetClusterUsageResult(IEspContext& context, IPropertyTree* usageReq, const IPropertyTree* uniqueUsages,
         IArrayOf<IEspTargetClusterUsage>& targetClusterUsages);
-    void readNodeGroupUsageResult(IEspContext& context, IPropertyTree* usageReq, IPropertyTree* uniqueUsages,
+    void readNodeGroupUsageResult(IEspContext& context, IPropertyTree* usageReq, const IPropertyTree* uniqueUsages,
         IArrayOf<IEspNodeGroupUsage>& nodeGroupUsages);
-    void readComponentUsageResult(IEspContext& context, IPropertyTree* usageReq, IPropertyTree* uniqueUsages,
+    void readComponentUsageResult(IEspContext& context, IPropertyTree* usageReq, const IPropertyTree* uniqueUsages,
         IArrayOf<IEspComponentUsage>& componentUsages);
     bool readDiskSpaceResponse(const char* buf, __int64& free, __int64& used, int& percentAvail, StringBuffer& pathUsed);
-    void buildUsageCacheID(StringBuffer& id, StringArray& names, const char* defaultID);
-    void buildComponentUsageCacheID(StringBuffer& id, IArrayOf<IConstComponent>& componentList);
-    bool readComponentUsageCache(IEspContext& context, const char* id, IEspGetComponentUsageResponse& resp);
-    bool readTargetClusterUsageCache(IEspContext& context, const char* id, IEspGetTargetClusterUsageResponse& resp);
-    bool readNodeGroupUsageCache(IEspContext& context, const char* id, IEspGetNodeGroupUsageResponse& resp);
     void addChannels(CGetMachineInfoData& machineInfoData, IPropertyTree* envRoot, const char* componentType, const char* componentName);
+    StringBuffer& setUsageTimeStr(CUsageCache* usageCache, StringBuffer& timeStr);
 
     //Still used in StartStop/Rexec, so keep them for now.
     enum OpSysType { OS_Windows, OS_Solaris, OS_Linux };
@@ -1007,8 +878,7 @@ private:
     StringBuffer                m_machineInfoFile;
     BoolHash                    m_legacyFilters;
     Mutex                       mutex_machine_info_table;
-    Owned<MachineUsageCache>    machineUsageCache;
-    unsigned                    machineUsageCacheMinutes;
+    Owned<CInfoCacheReader>     usageCacheReader;
 };
 
 //---------------------------------------------------------------------------------------------
@@ -1024,7 +894,7 @@ public:
     StringBuffer          m_sSecurityString; 
     StringBuffer          m_sUserName; 
     StringBuffer          m_sPassword;
-    Linked<Cws_machineEx> m_pService;
+    Cws_machineEx*        m_pService;
 
     virtual void doWork() = 0;
 
@@ -1097,5 +967,36 @@ public:
     }
 };
 
+
+class CUsageCache : public CInfoCache
+{
+    Owned<IPropertyTree> usages;
+public:
+    CUsageCache() {}
+
+    void setUsages(IPropertyTree *tree) { usages.setown(tree); timeCached.setNow(); }
+    const IPropertyTree *queryUsages() const { return usages; }
+};
+
+class CUsageCacheReader : public CInfoCacheReader
+{
+    Cws_machineEx *servicePtr;
+
+    IPropertyTree *getUsageReqAllMachines();
+    void addClusterUsageReq(IConstEnvironment *constEnv, const char *name, bool thorCluster, IPropertyTree *usageReq);
+    void checkAndAddMachineUsageReq(IConstEnvironment *constEnv, const char *computer, IPropertyTree *logFolder,
+        IPropertyTree *dataFolder,  IPropertyTree *repFolder, IPropertyTree *usageReq);
+    void checkAndAddFolderReq(IPropertyTree *folder, IPropertyTree *machineReqTree);
+    void addDropZoneUsageReq(IConstEnvironment *constEnv, const char* name, IPropertyTree *usageReq);
+    void addOtherComponentUsageReq(IConstEnvironment *constEnv, const char *name, const char *type, IPropertyTree *usageReq);
+
+public:
+    IMPLEMENT_IINTERFACE;
+
+    CUsageCacheReader(Cws_machineEx *_service, const char* _name, unsigned _autoRebuildSeconds, unsigned _forceRebuildSeconds)
+        : servicePtr(_service), CInfoCacheReader(_name, _autoRebuildSeconds, _forceRebuildSeconds) {}
+
+    virtual CInfoCache *read() override;
+};
 #endif //_ESPWIZ_ws_machine_HPP__
 

--- a/esp/services/ws_smc/ws_smcService.cpp
+++ b/esp/services/ws_smc/ws_smcService.cpp
@@ -141,14 +141,14 @@ void CWsSMCEx::init(IPropertyTree *cfg, const char *process, const char *service
         m_PortalURL.append(portalURL);
 
     xpath.setf("Software/EspProcess[@name=\"%s\"]/EspService[@name=\"%s\"]/ActivityInfoCacheSeconds", process, service);
-    unsigned activityInfoCacheSeconds = cfg->getPropInt(xpath.str(), DEFAULTACTIVITYINFOCACHEFORCEBUILDSECOND);
+    unsigned activityInfoCacheSeconds = cfg->getPropInt(xpath.str(), defaultActivityInfoCacheForceBuildSecond);
     xpath.setf("Software/EspProcess[@name=\"%s\"]/EspService[@name=\"%s\"]/LogDaliConnection", process, service);
     if (cfg->getPropBool(xpath.str()))
         querySDS().setConfigOpt("Client/@LogConnection", "true");
 
     xpath.setf("Software/EspProcess[@name=\"%s\"]/EspService[@name=\"%s\"]/ActivityInfoCacheAutoRebuildSeconds", process, service);
-    unsigned activityInfoCacheAutoRebuildSeconds = cfg->getPropInt(xpath.str(), DEFAULTACTIVITYINFOCACHEAUTOREBUILDSECOND);
-    activityInfoReader.setown(new CActivityInfoReader(activityInfoCacheAutoRebuildSeconds, activityInfoCacheSeconds));
+    unsigned activityInfoCacheAutoRebuildSeconds = cfg->getPropInt(xpath.str(), defaultActivityInfoCacheAutoRebuildSecond);
+    activityInfoCacheReader.setown(new CActivityInfoCacheReader("Activity Reader", activityInfoCacheAutoRebuildSeconds, activityInfoCacheSeconds));
 }
 
 struct CActiveWorkunitWrapper: public CActiveWorkunit
@@ -234,13 +234,6 @@ struct CActiveWorkunitWrapper: public CActiveWorkunit
         return;
     }
 };
-
-bool CActivityInfo::isCachedActivityInfoValid(unsigned timeOutSeconds)
-{
-    CDateTime timeNow;
-    timeNow.setNow();
-    return timeNow.getSimple() <= timeCached.getSimple() + timeOutSeconds;;
-}
 
 void CActivityInfo::createActivityInfo(IEspContext& context)
 {
@@ -1197,7 +1190,7 @@ bool CWsSMCEx::onActivity(IEspContext &context, IEspActivityRequest &req, IEspAc
         if (version >= 1.06)
             setBannerAndChatData(version, resp);
 
-        Owned<CActivityInfo> activityInfo = activityInfoReader->getActivityInfo();
+        Owned<CActivityInfo> activityInfo = (CActivityInfo*) activityInfoCacheReader->getCachedInfo();
         if (!activityInfo)
             throw MakeStringException(ECLWATCH_INTERNAL_ERROR, "Failed to get Activity Info. Please try later.");
         setActivityResponse(context, activityInfo, req, resp);
@@ -1265,7 +1258,7 @@ void CWsSMCEx::setActivityResponse(IEspContext &context, CActivityInfo* activity
     {
         StringBuffer s;
         resp.setActivityTime(activityInfo->queryTimeCached(s));
-        resp.setDaliDetached(activityInfoReader->isDaliDetached());
+        resp.setDaliDetached(!activityInfoCacheReader->isActive());
     }
     if (version >= 1.16)
     {
@@ -1407,7 +1400,7 @@ bool CWsSMCEx::onMoveJobDown(IEspContext &context, IEspSMCJobRequest &req, IEspS
             }
         }
         AccessSuccess(context, "Changed job priority %s",req.getWuid());
-        activityInfoReader->rebuild();
+        activityInfoCacheReader->buildCachedInfo();
         resp.setRedirectUrl("/WsSMC/");
     }
     catch(IException* e)
@@ -1436,7 +1429,7 @@ bool CWsSMCEx::onMoveJobUp(IEspContext &context, IEspSMCJobRequest &req, IEspSMC
             }
         }
         AccessSuccess(context, "Changed job priority %s",req.getWuid());
-        activityInfoReader->rebuild();
+        activityInfoCacheReader->buildCachedInfo();
         resp.setRedirectUrl("/WsSMC/");
     }
     catch(IException* e)
@@ -1482,7 +1475,7 @@ bool CWsSMCEx::onMoveJobBack(IEspContext &context, IEspSMCJobRequest &req, IEspS
             }
         }
         AccessSuccess(context, "Changed job priority %s",req.getWuid());
-        activityInfoReader->rebuild();
+        activityInfoCacheReader->buildCachedInfo();
         resp.setRedirectUrl("/WsSMC/");
     }
     catch(IException* e)
@@ -1529,7 +1522,7 @@ bool CWsSMCEx::onMoveJobFront(IEspContext &context, IEspSMCJobRequest &req, IEsp
         }
 
         AccessSuccess(context, "Changed job priority %s",req.getWuid());
-        activityInfoReader->rebuild();
+        activityInfoCacheReader->buildCachedInfo();
         resp.setRedirectUrl("/WsSMC/");
     }
     catch(IException* e)
@@ -1559,7 +1552,7 @@ bool CWsSMCEx::onRemoveJob(IEspContext &context, IEspSMCJobRequest &req, IEspSMC
             }
         }
         AccessSuccess(context, "Removed job %s",req.getWuid());
-        activityInfoReader->rebuild();
+        activityInfoCacheReader->buildCachedInfo();
         resp.setRedirectUrl("/WsSMC/");
     }
     catch(IException* e)
@@ -1581,7 +1574,7 @@ bool CWsSMCEx::onStopQueue(IEspContext &context, IEspSMCQueueRequest &req, IEspS
             queue->stop(createQueueActionInfo(context, "stopped", req, info));
         }
         AccessSuccess(context, "Stopped queue %s", req.getCluster());
-        activityInfoReader->rebuild();
+        activityInfoCacheReader->buildCachedInfo();
         double version = context.getClientVersion();
         if (version >= 1.19)
             getStatusServerInfo(context, req.getServerType(), req.getCluster(), req.getNetworkAddress(), req.getPort(), resp.updateStatusServerInfo());
@@ -1607,7 +1600,7 @@ bool CWsSMCEx::onResumeQueue(IEspContext &context, IEspSMCQueueRequest &req, IEs
             queue->resume(createQueueActionInfo(context, "resumed", req, info));
         }
         AccessSuccess(context, "Resumed queue %s", req.getCluster());
-        activityInfoReader->rebuild();
+        activityInfoCacheReader->buildCachedInfo();
         double version = context.getClientVersion();
         if (version >= 1.19)
             getStatusServerInfo(context, req.getServerType(), req.getCluster(), req.getNetworkAddress(), req.getPort(), resp.updateStatusServerInfo());
@@ -1650,7 +1643,7 @@ bool CWsSMCEx::onPauseQueue(IEspContext &context, IEspSMCQueueRequest &req, IEsp
             queue->pause(createQueueActionInfo(context, "paused", req, info));
         }
         AccessSuccess(context, "Paused queue %s", req.getCluster());
-        activityInfoReader->rebuild();
+        activityInfoCacheReader->buildCachedInfo();
         double version = context.getClientVersion();
         if (version >= 1.19)
             getStatusServerInfo(context, req.getServerType(), req.getCluster(), req.getNetworkAddress(), req.getPort(), resp.updateStatusServerInfo());
@@ -1680,7 +1673,7 @@ bool CWsSMCEx::onClearQueue(IEspContext &context, IEspSMCQueueRequest &req, IEsp
             queue->clear();
         }
         AccessSuccess(context, "Cleared queue %s",req.getCluster());
-        activityInfoReader->rebuild();
+        activityInfoCacheReader->buildCachedInfo();
         double version = context.getClientVersion();
         if (version >= 1.19)
             getStatusServerInfo(context, req.getServerType(), req.getCluster(), req.getNetworkAddress(), req.getPort(), resp.updateStatusServerInfo());
@@ -1749,7 +1742,7 @@ bool CWsSMCEx::onSetJobPriority(IEspContext &context, IEspSMCPriorityRequest &re
             }
         }
 
-        activityInfoReader->rebuild();
+        activityInfoCacheReader->buildCachedInfo();
         resp.setRedirectUrl("/WsSMC/");
     }
     catch(IException* e)
@@ -2243,7 +2236,7 @@ void CWsSMCEx::getStatusServerInfo(IEspContext &context, const char *serverType,
     if (!serverType || !*serverType)
         throw MakeStringException(ECLWATCH_MISSING_PARAMS, "Server type not specified.");
 
-    Owned<CActivityInfo> activityInfo = activityInfoReader->getActivityInfo();
+    Owned<CActivityInfo> activityInfo = (CActivityInfo*) activityInfoCacheReader->getCachedInfo();
     if (!activityInfo)
         throw MakeStringException(ECLWATCH_INTERNAL_ERROR, "Failed to get Activity Info. Please try later.");
 
@@ -2607,57 +2600,4 @@ bool CWsSMCEx::onLockQuery(IEspContext &context, IEspLockQueryRequest &req, IEsp
     }
 
     return true;
-}
-
-void CActivityInfoReader::threadmain()
-{
-#ifndef _CONTAINERIZED
-    PROGLOG("WsSMC CActivityInfoReader Thread started.");
-    unsigned int autoRebuildMillSeconds = 1000*autoRebuildSeconds;
-    while (!stopping)
-    {
-        if (!detached)
-        {
-            try
-            {
-                EspTimeSection timer("createActivityInfo");
-                Owned<IEspContext> espContext =  createEspContext();
-                Owned<CActivityInfo> activityInfo = new CActivityInfo();
-                activityInfo->createActivityInfo(*espContext);
-                PROGLOG("WsSMC CActivityInfoReader: ActivityInfo collected.");
-
-                CriticalBlock b(crit);
-                activityInfoCache.setown(activityInfo.getClear());
-
-                // if 1st and getActivityInfo blocked, release it.
-                if (first)
-                {
-                    first = false;
-                    if (firstBlocked)
-                    {
-                        firstBlocked = false;
-                        firstSem.signal();
-                    }
-                }
-            }
-            catch(IException *e)
-            {
-                StringBuffer msg;
-                IERRLOG("Exception %d:%s in WsSMC CActivityInfoReader::run", e->errorCode(), e->errorMessage(msg).str());
-                e->Release();
-            }
-            catch(...)
-            {
-                IERRLOG("Unknown exception in WsSMC CActivityInfoReader::run");
-            }
-        }
-
-        waiting = true;
-        if (!sem.wait(autoRebuildMillSeconds))
-        {
-            bool expected = true;
-            waiting.compare_exchange_strong(expected, false);
-        }
-    }
-#endif
 }

--- a/esp/services/ws_smc/ws_smcService.hpp
+++ b/esp/services/ws_smc/ws_smcService.hpp
@@ -23,9 +23,10 @@
 #include "wujobq.hpp"
 #include "TpWrapper.hpp"
 #include "WUXMLInfo.hpp"
+#include "InfoCacheReader.hpp"
 
-const unsigned DEFAULTACTIVITYINFOCACHEFORCEBUILDSECOND = 10;
-const unsigned DEFAULTACTIVITYINFOCACHEAUTOREBUILDSECOND = 120;
+const unsigned defaultActivityInfoCacheForceBuildSecond = 10;
+const unsigned defaultActivityInfoCacheAutoRebuildSecond = 120;
 
 enum BulletType
 {
@@ -100,9 +101,8 @@ public:
     virtual ~CWsSMCTargetCluster(){};
 };
 
-class CActivityInfo : public CInterface, implements IInterface
+class CActivityInfo : public CInfoCache
 {
-    CDateTime timeCached;
     BoolHash uniqueECLWUIDs;
 
     Owned<IJQSnapshot> jobQueueSnapshot;
@@ -142,12 +142,9 @@ class CActivityInfo : public CInterface, implements IInterface
     void addQueuedServerQueueJob(IEspContext& context, const char* serverName, const char* queueName, const char* instanceName, CIArrayOf<CWsSMCTargetCluster>& targetClusters);
 
 public:
-    IMPLEMENT_IINTERFACE;
-
     CActivityInfo() {};
     virtual ~CActivityInfo() { jobQueueSnapshot.clear(); };
 
-    bool isCachedActivityInfoValid(unsigned timeOutSeconds);
     void createActivityInfo(IEspContext& context);
 
     inline CIArrayOf<CWsSMCTargetCluster>& queryThorTargetClusters() { return thorTargetClusters; };
@@ -157,88 +154,21 @@ public:
     inline IArrayOf<IEspActiveWorkunit>& queryActiveWUs() { return aws; };
     inline IArrayOf<IEspServerJobQueue>& queryServerJobQueues() { return serverJobQueues; };
     inline IArrayOf<IEspDFUJob>& queryDFURecoveryJobs() { return DFURecoveryJobs; };
-    inline StringBuffer& queryTimeCached(StringBuffer& str) { return timeCached.getString(str, true); }
 };
 
-class CWsSMCEx;
-
-class CActivityInfoReader : public CInterface, implements IThreaded
+class CActivityInfoCacheReader : public CInfoCacheReader
 {
-    bool stopping = false;
-    bool detached = false;
-    bool first = true;
-    bool firstBlocked = false;
-    unsigned autoRebuildSeconds = DEFAULTACTIVITYINFOCACHEAUTOREBUILDSECOND;
-    unsigned forceRebuildSeconds = DEFAULTACTIVITYINFOCACHEFORCEBUILDSECOND;
-    Owned<CActivityInfo> activityInfoCache;
-    Semaphore sem;
-    Semaphore firstSem;
-    CriticalSection crit;
-    CThreaded threaded;
-    std::atomic<bool> waiting = {false};
 public:
-    CActivityInfoReader(unsigned _autoRebuildSeconds, unsigned _forceRebuildSeconds)
-        : autoRebuildSeconds(_autoRebuildSeconds), forceRebuildSeconds(_forceRebuildSeconds), threaded("ActivityInfoReader")
+    CActivityInfoCacheReader(const char* _name, unsigned _autoRebuildSeconds, unsigned _forceRebuildSeconds)
+        : CInfoCacheReader(_name, _autoRebuildSeconds, _forceRebuildSeconds) {}
+
+    virtual CInfoCache* read() override
     {
-        threaded.init(this);
+        Owned<IEspContext> espContext =  createEspContext();
+        Owned<CActivityInfo> info = new CActivityInfo();
+        info->createActivityInfo(*espContext);
+        return info.getClear();
     };
-
-    ~CActivityInfoReader()
-    {
-        stopping = true;
-        sem.signal();
-        firstSem.signal(); // in case
-        threaded.join();
-    }
-
-    virtual void threadmain() override;
-    CActivityInfo* getActivityInfo()
-    {
-        CLeavableCriticalBlock b(crit);
-        if (first)
-        {
-            if (detached)
-                return nullptr;
-            firstBlocked = true;
-            b.leave();
-            firstSem.wait();
-            b.enter();
-            if (first)
-                return nullptr;
-        }
-
-        //Now, activityInfoCache should always be available.
-        assertex(activityInfoCache);
-        if (!detached && !activityInfoCache->isCachedActivityInfoValid(forceRebuildSeconds))
-            rebuild();
-        return activityInfoCache.getLink();
-    }
-    void rebuild()
-    {
-        bool expected = true;
-        if (waiting.compare_exchange_strong(expected, false))
-            sem.signal();
-    }
-    void setDetachedState(bool _detached)
-    {
-        CriticalBlock b(crit);
-        if (detached != _detached)
-        {
-            detached = _detached;
-            if (detached)
-            {
-                // NB: first will still be true, signal and getActivityInfo() will return null
-                if (firstBlocked)
-                {
-                    firstBlocked = false;
-                    firstSem.signal(); // NB: first still true
-                }
-            }
-            else
-                rebuild();
-        }
-    }
-    bool isDaliDetached() const { return detached; }
 };
 
 class CWsSMCEx : public CWsSMC
@@ -255,7 +185,7 @@ class CWsSMCEx : public CWsSMC
     int m_BannerAction;
     bool m_EnableChatURL;
     CriticalSection crit;
-    Owned<CActivityInfoReader> activityInfoReader;
+    Owned<CInfoCacheReader> activityInfoCacheReader;
 
 public:
     IMPLEMENT_IINTERFACE;
@@ -281,13 +211,13 @@ public:
 
     virtual bool attachServiceToDali() override
     {
-        activityInfoReader->setDetachedState(false);
+        activityInfoCacheReader->setActive(true);
         return true;
     }
 
     virtual bool detachServiceFromDali() override
     {
-        activityInfoReader->setDetachedState(true);
+        activityInfoCacheReader->setActive(false);
         return true;
     }
 

--- a/esp/smc/SMCLib/CMakeLists.txt
+++ b/esp/smc/SMCLib/CMakeLists.txt
@@ -31,7 +31,8 @@ set (    SRCS
          ${ESPSCM_GENERATED_DIR}/ws_topology_esp.cpp 
          LogicFileWrapper.cpp 
          TpWrapper.cpp 
-         WUXMLInfo.cpp 
+         WUXMLInfo.cpp
+         InfoCacheReader.cpp
     )
 
 include_directories ( 

--- a/esp/smc/SMCLib/InfoCacheReader.cpp
+++ b/esp/smc/SMCLib/InfoCacheReader.cpp
@@ -1,0 +1,77 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2019 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#pragma warning (disable : 4786)
+#include "InfoCacheReader.hpp"
+
+bool CInfoCache::isCachedInfoValid(unsigned timeOutSeconds)
+{
+    CDateTime timeNow;
+    timeNow.setNow();
+    return timeNow.getSimple() <= timeCached.getSimple() + timeOutSeconds;;
+}
+
+void CInfoCacheReaderThread::threadmain()
+{
+#ifndef _CONTAINERIZED
+    PROGLOG("CInfoCacheReaderThread %s started.", name.get());
+    unsigned int autoRebuildMillSeconds = 1000*autoRebuildSeconds;
+    while (!stopping)
+    {
+        if (active)
+        {
+            try
+            {
+                CCycleTimer timer;
+                Owned<CInfoCache> info = infoCacheReader->read();
+                PROGLOG("CInfoCacheReaderThread %s: InfoCache collected (%u seconds).", name.get(), timer.elapsedMs()/1000);
+
+                CriticalBlock b(crit);
+                infoCache.setown(info.getClear());
+
+                // if 1st and getActivityInfo blocked, release it.
+                if (first)
+                {
+                    first = false;
+                    if (firstBlocked)
+                    {
+                        firstBlocked = false;
+                        firstSem.signal();
+                    }
+                }
+            }
+            catch(IException *e)
+            {
+                StringBuffer msg;
+                IERRLOG("Exception %d:%s in CInfoCacheReaderThread(%s)::run", e->errorCode(), e->errorMessage(msg).str(), name.get());
+                e->Release();
+            }
+            catch(...)
+            {
+                IERRLOG("Unknown exception in CInfoCacheReaderThread(%s)::run", name.get());
+            }
+        }
+
+        waiting = true;
+        if (!sem.wait(autoRebuildMillSeconds))
+        {
+            bool expected = true;
+            waiting.compare_exchange_strong(expected, false);
+        }
+    }
+#endif
+}

--- a/esp/smc/SMCLib/InfoCacheReader.hpp
+++ b/esp/smc/SMCLib/InfoCacheReader.hpp
@@ -1,0 +1,152 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2019 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef _ESPWIZ_InfoCacheReader_HPP__
+#define _ESPWIZ_InfoCacheReader_HPP__
+
+#include "jliball.hpp"
+#include "bindutil.hpp"
+#include "TpWrapper.hpp"
+
+const unsigned defaultInfoCacheForceBuildSecond = 10;
+const unsigned defaultInfoCacheAutoRebuildSecond = 120;
+
+class TPWRAPPER_API CInfoCache : public CSimpleInterfaceOf<IInterface>
+{
+protected:
+    CDateTime timeCached;
+public:
+
+    CInfoCache() {};
+
+    bool isCachedInfoValid(unsigned timeOutSeconds);
+    inline StringBuffer& queryTimeCached(StringBuffer& str) { return timeCached.getString(str, true); }
+};
+
+interface IInfoCacheReader : extends IInterface
+{
+    virtual void buildCachedInfo() = 0;
+    virtual CInfoCache *getCachedInfo() const = 0;
+    virtual void setActive(bool active) = 0;
+    virtual bool isActive() const = 0;
+};
+
+class CInfoCacheReader;
+class TPWRAPPER_API CInfoCacheReaderThread : public CSimpleInterfaceOf<IThreaded>
+{
+    StringAttr name;
+    bool stopping = false;
+    bool active = true;
+    bool first = true;
+    bool firstBlocked = false;
+    unsigned autoRebuildSeconds = defaultInfoCacheAutoRebuildSecond;
+    unsigned forceRebuildSeconds = defaultInfoCacheForceBuildSecond;
+    Owned<CInfoCache> infoCache;
+    CInfoCacheReader* infoCacheReader;
+    Semaphore sem;
+    Semaphore firstSem;
+    CriticalSection crit;
+    CThreaded threaded;
+    std::atomic<bool> waiting = {false};
+
+public:
+    CInfoCacheReaderThread(CInfoCacheReader* _reader, const char* _name, unsigned _autoRebuildSeconds, unsigned _forceRebuildSeconds)
+        : infoCacheReader(_reader), name(_name), autoRebuildSeconds(_autoRebuildSeconds), forceRebuildSeconds(_forceRebuildSeconds), threaded(_name)
+    {
+        threaded.init(this);
+    };
+
+    ~CInfoCacheReaderThread()
+    {
+        stopping = true;
+        sem.signal();
+        firstSem.signal(); // in case
+        threaded.join();
+    }
+
+    virtual void threadmain() override;
+    CInfoCache* getCachedInfo()
+    {
+        CLeavableCriticalBlock b(crit);
+        if (first)
+        {
+            if (!active)
+                return nullptr;
+            firstBlocked = true;
+            b.leave();
+            firstSem.wait();
+            b.enter();
+            if (first)
+                return nullptr;
+        }
+
+        //Now, activityInfoCache should always be available.
+        assertex(infoCache);
+        if (active && !infoCache->isCachedInfoValid(forceRebuildSeconds))
+            buildCachedInfo();
+        return infoCache.getLink();
+    }
+    void buildCachedInfo()
+    {
+        bool expected = true;
+        if (waiting.compare_exchange_strong(expected, false))
+            sem.signal();
+    }
+    void setActive(bool _active)
+    {
+        CriticalBlock b(crit);
+        if (active != _active)
+        {
+            active = _active;
+            if (!active)
+            {
+                // NB: first will still be true, signal and getActivityInfo() will return null
+                if (firstBlocked)
+                {
+                    firstBlocked = false;
+                    firstSem.signal(); // NB: first still true
+                }
+            }
+            else
+                buildCachedInfo();
+        }
+    }
+    bool isActive() const { return active; }
+};
+
+class CInfoCacheReader : implements IInfoCacheReader, public CInterface
+{
+public:
+    Owned<CInfoCacheReaderThread> infoCacheReaderThread;
+
+    IMPLEMENT_IINTERFACE;
+
+    CInfoCacheReader(const char* _name, unsigned _autoRebuildSeconds, unsigned _forceRebuildSeconds)
+    {
+        infoCacheReaderThread.setown(new CInfoCacheReaderThread(this, _name, _autoRebuildSeconds, _forceRebuildSeconds));
+    }
+
+    virtual CInfoCache* getCachedInfo() const override { return infoCacheReaderThread->getCachedInfo(); }
+    virtual void buildCachedInfo() override { infoCacheReaderThread->buildCachedInfo(); }
+    virtual void setActive(bool _active) override { infoCacheReaderThread->setActive(_active); }
+    virtual bool isActive() const override { return infoCacheReaderThread->isActive(); }
+
+    virtual CInfoCache* read() = 0;
+};
+
+#endif //_ESPWIZ_InfoCacheReader_HPP__
+

--- a/initfiles/componentfiles/configxml/@temp/esp_service_WsSMC.xsl
+++ b/initfiles/componentfiles/configxml/@temp/esp_service_WsSMC.xsl
@@ -482,6 +482,9 @@ This is required by its binding with ESP service '<xsl:value-of select="$espServ
             <xsl:if test="string(@MachineUsageCacheMinutes) != ''">
                 <MachineUsageCacheMinutes><xsl:value-of select="@MachineUsageCacheMinutes"/></MachineUsageCacheMinutes>
             </xsl:if>
+            <xsl:if test="string(@MachineUsageCacheAutoRebuildMinutes) != ''">
+                <MachineUsageCacheAutoRebuildMinutes><xsl:value-of select="@MachineUsageCacheAutoRebuildMinutes"/></MachineUsageCacheAutoRebuildMinutes>
+            </xsl:if>
         </EspService>
         
         <EspBinding name="{$bindName}" service="{$serviceName}" protocol="{$bindingNode/@protocol}" type="{$bindType}" plugin="{$servicePlugin}" netAddress="0.0.0.0" port="{$bindingNode/@port}">

--- a/initfiles/componentfiles/configxml/espsmcservice.xsd.in
+++ b/initfiles/componentfiles/configxml/espsmcservice.xsd.in
@@ -124,6 +124,13 @@
                     </xs:appinfo>
                 </xs:annotation>
             </xs:attribute>
+            <xs:attribute name="MachineUsageCacheAutoRebuildMinutes" type="xs:nonNegativeInteger" use="optional" default="10">
+                <xs:annotation>
+                    <xs:appinfo>
+                        <tooltip>When idle, ESP automatically rebuilds the cache if this value (in minutes) is exceeded.</tooltip>
+                    </xs:appinfo>
+                </xs:annotation>
+            </xs:attribute>
             <xs:attribute name="serverForArchivedECLWU" type="sashaServerType" use="optional">
                 <xs:annotation>
                     <xs:appinfo>


### PR DESCRIPTION
1. Move the CActivityInfoReader from WsSMC to SMCLib and rename
it to CInfoCacheReaderThread;
2. Upgrade the CInfoCacheReaderThread to support different
Information readers, including the CActivityInfoCacheReader for
WsSMC.Activity and the CUsageCacheReader for WsMachine disk
usage;
3. In Cws_machineEx service code, add new CUsageCacheReader
which replaces the existing code of the usage cache;
4. Add a base class CInfoCache. Both CActivityInfo and new
CUsageCache are inherited from the CInfoCache. The CInfoCache
has the basic cache functions: queryTimeCached() and
isCachedInfoValid().

Signed-off-by: wangkx <kevin.wang@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
