### PR TITLE
HPCC-23265 Add Unprotect All to WsDFU, etc

### DIFF
--- a/esp/platform/espcontext.cpp
+++ b/esp/platform/espcontext.cpp
@@ -26,6 +26,7 @@
 #include "sechandler.hpp"
 #include "espprotocol.hpp"
 #include "espsecurecontext.hpp"
+#include "ldapsecurity.ipp"
 
 class CEspContext : public CInterface, implements IEspContext
 {
@@ -441,6 +442,16 @@ public:
         {
             setAuthStatus(AUTH_STATUS_NOACCESS);
             throw MakeStringException(excCode, "%s", excMsg);
+        }
+    }
+
+    virtual void ensureSuperUser(unsigned excCode, const char* excMsg)
+    {
+        CLdapSecManager* secmgr = dynamic_cast<CLdapSecManager*>(m_secmgr.get());
+        if (secmgr && !secmgr->isSuperUser(m_user.get()))
+        {
+            setAuthStatus(AUTH_STATUS_NOACCESS);
+            throw makeStringException(excCode, excMsg);
         }
     }
 

--- a/esp/scm/esp.ecm
+++ b/esp/scm/esp.ecm
@@ -140,6 +140,7 @@ interface IEspContext : extends IInterface
     virtual bool validateFeaturesAccess(MapStringTo<SecAccessFlags> & pmap, bool throwExcpt) = 0;
     virtual bool validateFeatureAccess(const char * pszFeatureUrl, unsigned required, bool throwExcpt) = 0;
     virtual void ensureFeatureAccess(const char * pszFeatureUrl, unsigned required, unsigned excCode, const char * excMsg) = 0;
+    virtual void ensureSuperUser(unsigned excCode, const char * excMsg) = 0;
     virtual void setServAddress(const char * host, short port) = 0;
     virtual void getServAddress(StringBuffer & host, short & port) = 0;
     virtual void AuditMessage(AuditType type, const char * filterType, const char * title, const char * parms, ...) __attribute__((format(printf, 5, 6))) = 0;

--- a/esp/scm/ws_dfu.ecm
+++ b/esp/scm/ws_dfu.ecm
@@ -22,13 +22,16 @@ ESPenum DFUArrayActions : string
 {
     Delete("Delete"),
     AddToSuperfile("Add To Superfile"),
+    ChangeProtection("Change Protection"),
+    ChangeRestriction("Change Restriction")
 };
 
 ESPenum DFUChangeProtection : int
 {
     NoChange(0, "No Change"),
     Protect(1, "Protect"),
-    Unprotect(2, "Unprotect")
+    Unprotect(2, "Unprotect"),
+    UnprotectAll(3, "UnprotectAll")
 };
 
 
@@ -343,6 +346,8 @@ DFUArrayActionRequest
     ESParray<string> LogicalFiles;
     bool removeFromSuperfiles(false);
     bool removeRecursively(false);
+    [min_ver("1.55")] ESPenum DFUChangeProtection Protect;
+    [min_ver("1.55")] ESPenum DFUChangeRestriction Restrict;
 };
 
 ESPresponse
@@ -986,8 +991,8 @@ ESPresponse [exceptions_inline, nil_remove] DFUFilePublishResponse
 //  ===========================================================================
 ESPservice [
     auth_feature("DEFERRED"),
-    version("1.54"),
-    default_client_version("1.54"),
+    version("1.55"),
+    default_client_version("1.55"),
     noforms,
     exceptions_inline("./smc_xslt/exceptions.xslt")] WsDfu
 {

--- a/esp/services/ws_dfu/ws_dfuService.hpp
+++ b/esp/services/ws_dfu/ws_dfuService.hpp
@@ -144,6 +144,8 @@ class CWsDfuEx : public CWsDfu
     void clearFileProtections(IDistributedFile *df);
     bool changeFileProtections(IEspContext &context, IEspDFUArrayActionRequest &req, IEspDFUArrayActionResponse &resp);
     bool changeFileRestrictions(IEspContext &context, IEspDFUArrayActionRequest &req, IEspDFUArrayActionResponse &resp);
+    void addFileActionResult(const char* fileName, const char* nodeGroup, bool failed, const  char* msg,
+        IArrayOf<IEspDFUActionInfo>& actionResults);
 public:
     IMPLEMENT_IINTERFACE;
     virtual ~CWsDfuEx(){};

--- a/esp/services/ws_dfu/ws_dfuService.hpp
+++ b/esp/services/ws_dfu/ws_dfuService.hpp
@@ -141,6 +141,9 @@ class CWsDfuEx : public CWsDfu
     static const unsigned defaultMaxFileAccessExpirySeconds=86400; // 24 hours
 
     void dFUFileAccessCommon(IEspContext &context, const CDfsLogicalFileName &lfn, SessionId clientSessionId, const char *requestId, unsigned expirySecs, bool returnTextResponse, unsigned lockTimeoutMs, IEspDFUFileAccessResponse &resp);
+    void clearFileProtections(IDistributedFile *df);
+    bool changeFileProtections(IEspContext &context, IEspDFUArrayActionRequest &req, IEspDFUArrayActionResponse &resp);
+    bool changeFileRestrictions(IEspContext &context, IEspDFUArrayActionRequest &req, IEspDFUArrayActionResponse &resp);
 public:
     IMPLEMENT_IINTERFACE;
     virtual ~CWsDfuEx(){};


### PR DESCRIPTION
The Unprotect All allows an Admin user to remove the Protect flags
set by all users.

The WsDFU.DFUArrayAction is upgraded to support File Protection
and File Restriction.

Signed-off-by: wangkx <kevin.wang@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
