### PR TITLE
HPCC-23686 Don't set LZ timestamp to source if replicating source

### DIFF
--- a/dali/ft/filecopy.cpp
+++ b/dali/ft/filecopy.cpp
@@ -347,7 +347,7 @@ bool FileTransferThread::performTransfer()
         serialize(partition, msg);
         msg.append(sprayer.numParallelSlaves());
         msg.append(slaveUpdateFrequency);
-        msg.append(sprayer.replicate);
+        msg.append(sprayer.replicate); // NB: controls whether FtSlave copies source timestamp
         msg.append(sprayer.mirroring);
         msg.append(sprayer.isSafeMode);
 
@@ -570,6 +570,7 @@ FileSprayer::FileSprayer(IPropertyTree * _options, IPropertyTree * _progress, IR
 {
     totalSize = 0;
     replicate = false;
+    copySource = false;
     unknownSourceFormat = true;
     unknownTargetFormat = true;
     progressTree.set(_progress);
@@ -648,11 +649,10 @@ public:
             }
 
             renameDfuTempToFinal(targetFilename);
-            if (sprayer.replicate)
+            if (sprayer.replicate && !sprayer.mirroring)
             {
                 OwnedIFile file = createIFile(targetFilename);
-                if (!sprayer.mirroring)
-                    file->setTime(NULL, &cur.modifiedTime, NULL);
+                file->setTime(NULL, &cur.modifiedTime, NULL);
             }
             else if (cur.modifiedTime.isNull())
             {
@@ -811,6 +811,8 @@ void FileSprayer::assignPartitionFilenames()
         }
         cur.outputName.set(targets.item(cur.whichOutput).filename);
         setCanAccessDirectly(cur.outputName);
+
+        // NB: partition (cur) is serialized to ftslave and it's this modifiedTime is used if present
         if (replicate)
             cur.modifiedTime.set(targets.item(cur.whichOutput).modifiedTime);
     }
@@ -1304,10 +1306,10 @@ void FileSprayer::checkFormats()
 
         //If format omitted, and number of parts are the same then okay to omit the format
         if (sources.ordinality() == targets.ordinality() && !disallowImplicitReplicate())
-            replicate = true;
+            copySource = true;
 
         bool noSplit = !allowSplit();
-        if (!replicate && !noSplit)
+        if (!replicate && !copySource && !noSplit)
         {
             //copy to a single target => assume same format concatenated.
             if (targets.ordinality() != 1)
@@ -2929,16 +2931,14 @@ void FileSprayer::spray()
     progressTree->setPropBool(ANpull, usePullOperation());
 
     const char * splitPrefix = querySplitPrefix();
-    bool pretendreplicate = false;
     if (!replicate && (sources.ordinality() == targets.ordinality()))
     {
-        if (srcFormat.equals(tgtFormat) && !disallowImplicitReplicate()) {
-            pretendreplicate = true;
-            replicate = true;
-        }
+        if (srcFormat.equals(tgtFormat) && !disallowImplicitReplicate())
+            copySource = true;
     }
 
-    if (compressOutput&&!replicate) {
+    if (compressOutput&&!replicate&&!copySource)
+    {
         PROGLOG("Compress output forcing pull");
         options->setPropBool(ANpull, true);
         allowRecovery = false;
@@ -2946,11 +2946,11 @@ void FileSprayer::spray()
 
 
     gatherFileSizes(true);
-    if (!replicate||pretendreplicate)
-        analyseFileHeaders(!pretendreplicate); // if pretending replicate don't want to remove headers
+    if (!replicate||copySource) // NB: When copySource=true, analyseFileHeaders mainly just sets srcFormat.type
+        analyseFileHeaders(!copySource); // if pretending replicate don't want to remove headers
     afterGatherFileSizes();
 
-    if (compressOutput && !usePullOperation() && !replicate)
+    if (compressOutput && !usePullOperation() && !replicate && !copySource)
         throwError(DFTERR_CannotPushAndCompress);
 
     if (restorePartition())
@@ -2960,7 +2960,7 @@ void FileSprayer::spray()
     else
     {
         LOG(MCdebugProgress, job, "Calculate partition information");
-        if (replicate)
+        if (replicate || copySource)
             calculateOne2OnePartition();
         else if (!allowSplit())
             calculateNoSplitPartition();
@@ -2975,7 +2975,7 @@ void FileSprayer::spray()
         savePartition();
     }
     assignPartitionFilenames();     // assign source filenames - used in insertHeaders..
-    if (!replicate)
+    if (!replicate && !copySource)
     {
         LOG(MCdebugProgress, job, "Insert headers");
         insertHeaders();
@@ -3121,7 +3121,6 @@ void FileSprayer::updateTargetProperties()
                                     failedParts.append("Output CRC failed to match expected: ");
                                 curSource.filename.getPath(failedParts);
                                 failedParts.appendf("(%x,%x)",partCRC.get(),curSource.crc);
-
                             }
                         }
                     }

--- a/dali/ft/filecopy.ipp
+++ b/dali/ft/filecopy.ipp
@@ -306,6 +306,7 @@ protected:
     offset_t                totalSize;
     unsigned __int64        sizeToBeRead;
     bool                    replicate;
+    bool                    copySource;
     bool                    unknownSourceFormat;
     bool                    unknownTargetFormat;
     Owned<IException>       error;

--- a/dali/ft/fttransform.cpp
+++ b/dali/ft/fttransform.cpp
@@ -592,7 +592,7 @@ void TransferServer::deserializeAction(MemoryBuffer & msg, unsigned action)
     deserialize(partition, msg);
     msg.read(numParallelSlaves);
     msg.read(updateFrequency);
-    msg.read(replicate);
+    msg.read(copySourceTimeStamp);
     msg.read(mirror);
     msg.read(isSafeMode);
 
@@ -612,7 +612,7 @@ void TransferServer::deserializeAction(MemoryBuffer & msg, unsigned action)
         LOG(MCdebugProgress, unknownJob, "Process Push Command: %s", localFilename.str());
     }
     LOG(MCdebugProgress, unknownJob, "Num Parallel Slaves=%d Adjust=%d/%d", numParallelSlaves, adjust, updateFrequency);
-    LOG(MCdebugProgress, unknownJob, "replicate(%d) mirror(%d) safe(%d) incrc(%d) outcrc(%d)", replicate, mirror, isSafeMode, calcInputCRC, calcOutputCRC);
+    LOG(MCdebugProgress, unknownJob, "copySourceTimeStamp(%d) mirror(%d) safe(%d) incrc(%d) outcrc(%d)", copySourceTimeStamp, mirror, isSafeMode, calcInputCRC, calcOutputCRC);
 
     displayPartition(partition);
 
@@ -905,7 +905,7 @@ processedProgress:
                     if (fileUmask != -1)
                         output->setFilePermissions(~fileUmask&0666);
 
-                    if (mirror || replicate)
+                    if (mirror || copySourceTimeStamp)
                     {
                         OwnedIFile input = createIFile(curPartition.inputName);
                         CDateTime modifiedTime;

--- a/dali/ft/fttransform.ipp
+++ b/dali/ft/fttransform.ipp
@@ -231,7 +231,7 @@ protected:
     offset_t                totalLengthToRead;
     bool                    calcInputCRC;
     bool                    calcOutputCRC;
-    bool                    replicate;
+    bool                    copySourceTimeStamp;
     bool                    mirror;
     bool                    isSafeMode;
     unsigned                throttleNicSpeed;


### PR DESCRIPTION
Signed-off-by: Jake Smith <jake.smith@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
