### PR TITLE
HPCC-23644 Containerized component logging logic

### DIFF
--- a/dali/sasha/saserver.cpp
+++ b/dali/sasha/saserver.cpp
@@ -311,6 +311,7 @@ int main(int argc, const char* argv[])
         return 1;
     }
 
+#ifndef _CONTAINERIZED
     StringBuffer logname;
     StringBuffer logdir;
     if (!stop)
@@ -322,6 +323,9 @@ int main(int argc, const char* argv[])
         lf->setMaxDetail(TopDetail);
         lf->beginLogging();
     }
+#else
+    setupContainerizedLogMsgHandler();
+#endif
     DBGLOG("Build %s", BUILD_TAG);
 
     bool enableSNMP = false;

--- a/dali/server/daserver.cpp
+++ b/dali/server/daserver.cpp
@@ -355,6 +355,8 @@ dali:
   dataPath: "/var/lib/HPCCSystems/dalistore"
   sds:
     environment: "/etc/HPCCSystems/environment.xml"
+  logging:
+    detail: 100
 )!!";
 
 
@@ -405,6 +407,7 @@ int main(int argc, const char* argv[])
             serverConfig.setown(createPTreeFromXMLFile(DALICONF));
 #endif
 
+#ifndef _CONTAINERIZED
         ILogMsgHandler * fileMsgHandler;
         {
             Owned<IComponentLogFileCreator> lf = createComponentLogFileCreator(serverConfig, "dali");
@@ -412,7 +415,9 @@ int main(int argc, const char* argv[])
             lf->setName("DaServer");//override default filename
             fileMsgHandler = lf->beginLogging();
         }
-
+#else
+        setupContainerizedLogMsgHandler();
+#endif
         PROGLOG("Build %s", BUILD_TAG);
 
         StringBuffer dataPath;
@@ -605,8 +610,11 @@ int main(int argc, const char* argv[])
         Owned<IMPServer> mpServer = getMPServer();
         Owned<IWhiteListHandler> whiteListHandler = createWhiteListHandler(populateWhiteListFromEnvironment, formatDaliRole);
         mpServer->installWhiteListCallback(whiteListHandler);
-
+#ifndef _CONTAINERIZED
         setMsgLevel(fileMsgHandler, serverConfig->getPropInt("SDS/@msgLevel", 100));
+#else
+        setupContainerizedLogMsgHandler();
+#endif
         startLogMsgChildReceiver(); 
         startLogMsgParentReceiver();
 

--- a/ecl/agentexec/agentexec.cpp
+++ b/ecl/agentexec/agentexec.cpp
@@ -51,10 +51,14 @@ private:
 CEclAgentExecutionServer::CEclAgentExecutionServer(IPropertyTree *_config) : config(_config)
 {
     //Build logfile from component properties settings
+#ifndef _CONTAINERIZED
     Owned<IComponentLogFileCreator> lf = createComponentLogFileCreator(config, "eclagent");
     lf->setCreateAliasFile(false);
     lf->beginLogging();
     PROGLOG("Logging to %s",lf->queryLogFileSpec());
+#else
+    setupContainerizedLogMsgHandler();
+#endif
 
     agentName = config->queryProp("@name");
     assertex(agentName);

--- a/ecl/eclagent/eclagent.cpp
+++ b/ecl/eclagent/eclagent.cpp
@@ -3361,12 +3361,15 @@ extern int HTHOR_API eclagent_main(int argc, const char *argv[], StringBuffer * 
     if (!standAloneExe)
     {
         setStatisticsComponentName(SCThthor, agentTopology->queryProp("@name"), true);
-
+#ifndef _CONTAINERIZED
         Owned<IComponentLogFileCreator> lf = createComponentLogFileCreator(agentTopology, "eclagent");
         lf->setCreateAliasFile(false);
         logMsgHandler = lf->beginLogging();
         PROGLOG("Logging to %s", lf->queryLogFileSpec());
         logfilespec.set(lf->queryLogFileSpec());
+#else
+        setupContainerizedLogMsgHandler();
+#endif
     }
     else
     {

--- a/ecl/eclcc/eclcc.cpp
+++ b/ecl/eclcc/eclcc.cpp
@@ -503,6 +503,9 @@ static constexpr const char * defaultYaml = R"!!(
 version: "1.0"
 eclccserver:
     name: eclccserver
+    logging:
+      audiences: "USR+ADT"
+      classes: "ERR"
 )!!";
 
 
@@ -515,9 +518,13 @@ int main(int argc, const char *argv[])
 
     configuration.setown(loadConfiguration(defaultYaml, argv, "eclccserver", "ECLCCSERVER", nullptr, nullptr));
 
+#ifndef _CONTAINERIZED
     // Turn logging down (we turn it back up if -v option seen)
     Owned<ILogMsgFilter> filter = getCategoryLogMsgFilter(MSGAUD_user| MSGAUD_operator, MSGCLS_error);
     queryLogMsgManager()->changeMonitorFilter(queryStderrLogMsgHandler(), filter);
+#else
+    setupContainerizedLogMsgHandler();
+#endif
     unsigned exitCode = doMain(argc, argv);
     stopPerformanceMonitor();
     if (!optReleaseAllMemory)

--- a/esp/platform/espp.cpp
+++ b/esp/platform/espp.cpp
@@ -285,11 +285,14 @@ void openEspLogFile(IPropertyTree* envpt, IPropertyTree* procpt)
             procpt->getProp("@logDir", logdir);
     }
 
-
+#ifndef _CONTAINERIZED
     Owned<IComponentLogFileCreator> lf = createComponentLogFileCreator(logdir.str(), "esp");
     lf->setName("esp_main");//override default filename
     lf->setAliasName("esp");
     lf->beginLogging();
+#else
+    setupContainerizedLogMsgHandler();
+#endif
 
     if (procpt->getPropBool("@enableSysLog", false))
         UseSysLogForOperatorMessages();

--- a/fs/dafilesrv/dafilesrv.cpp
+++ b/fs/dafilesrv/dafilesrv.cpp
@@ -788,12 +788,16 @@ int main(int argc,char **argv)
             return ret;
 #endif
     }
+#ifndef _CONTAINERIZED
     {
         Owned<IComponentLogFileCreator> lf = createComponentLogFileCreator(logDir.str(), "DAFILESRV");
         lf->setCreateAliasFile(false);
         lf->setMaxDetail(TopDetail);
         lf->beginLogging();
     }
+#else
+    setupContainerizedLogMsgHandler();
+#endif
 
     write_pidfile(componentName.str());
     PROGLOG("Dafilesrv starting - Build %s", BUILD_TAG);

--- a/roxie/ccd/ccdmain.cpp
+++ b/roxie/ccd/ccdmain.cpp
@@ -543,6 +543,8 @@ roxie:
     - name: workunit
       port: 0
       numThreads: 0
+  logging:
+      detail: 100
 )!!";
 
 int STARTQUERY_API start_query(int argc, const char *argv[])
@@ -764,6 +766,7 @@ int STARTQUERY_API start_query(int argc, const char *argv[])
         directoryTree.clear();
 
         //Logging stuff
+#ifndef _CONTAINERIZED
         if (topology->getPropBool("@stdlog", traceLevel != 0) || topology->getPropBool("@forceStdLog", false))
             queryStderrLogMsgHandler()->setMessageFields(MSGFIELD_time | MSGFIELD_milliTime | MSGFIELD_thread | MSGFIELD_prefix);
         else
@@ -774,6 +777,7 @@ int STARTQUERY_API start_query(int argc, const char *argv[])
             lf->setMaxDetail(TopDetail);
             lf->beginLogging();
             logDirectory.set(lf->queryLogDir());
+
 #ifdef _DEBUG
             unsigned useLogQueue = topology->getPropBool("@useLogQueue", false);
 #else
@@ -789,6 +793,9 @@ int STARTQUERY_API start_query(int argc, const char *argv[])
             if (topology->getPropBool("@enableSysLog",true))
                 UseSysLogForOperatorMessages();
         }
+#else
+        setupContainerizedLogMsgHandler();
+#endif
 
         roxieMetrics.setown(createRoxieMetricsManager());
 

--- a/roxie/topo/toposerver.cpp
+++ b/roxie/topo/toposerver.cpp
@@ -318,6 +318,7 @@ int main(int argc, const char *argv[])
         Owned<IPropertyTree> topology = loadConfiguration(defaultYaml, argv, "roxie", "ROXIE", nullptr, nullptr);
         traceLevel = topology->getPropInt("@traceLevel", 1);
         topoPort = topology->getPropInt("@topoport", TOPO_SERVER_PORT);
+#ifndef _CONTAINERIZED
         if (topology->getPropBool("@stdlog", traceLevel != 0))
             queryStderrLogMsgHandler()->setMessageFields(MSGFIELD_time | MSGFIELD_milliTime | MSGFIELD_thread | MSGFIELD_prefix);
         else
@@ -331,6 +332,9 @@ int main(int argc, const char *argv[])
             queryLogMsgManager()->enterQueueingMode();
             queryLogMsgManager()->setQueueDroppingLimit(512, 32);
         }
+#else
+        setupContainerizedLogMsgHandler();
+#endif
         Owned<ISocket> socket = ISocket::create(topoPort);
         if (traceLevel)
             DBGLOG("Topology server starting");

--- a/system/jlib/jlog.cpp
+++ b/system/jlib/jlog.cpp
@@ -2204,7 +2204,7 @@ ILogMsgHandler * getLogMsgHandlerFromPTree(IPropertyTree * tree)
         if(isdigit(fstr[0]))
             fields = atoi(fstr);
         else
-            fields = LogMsgFieldsFromAbbrevs(fstr);
+            fields = logMsgFieldsFromAbbrevs(fstr);
     }
     if(strcmp(type.str(), "stderr")==0)
         return getHandleLogMsgHandler(stderr, fields, tree->hasProp("@writeXML"));
@@ -2323,6 +2323,75 @@ MODULE_EXIT()
     thePassLocalFilter = NULL;
     thePassAllFilter = NULL;
 }
+
+#ifdef _CONTAINERIZED
+
+static constexpr const char * logFielsdAtt = "@fields";
+static constexpr const char * logMsgDetailAtt = "@detail";
+static constexpr const char * logMsgAudiencesAtt = "@audiences";
+static constexpr const char * logMsgClassesAtt = "@classes";
+static constexpr const char * useLogQueueAtt = "@useLogQueue";
+static constexpr const char * logQueueLenAtt = "@queueLen";
+static constexpr const char * logQueueDropAtt = "@queueDrop";
+static constexpr const char * useSysLogpAtt ="@enableSysLog";
+
+#ifdef _DEBUG
+static constexpr bool useQueueDefault = false;
+#else
+static constexpr bool useQueueDefault = true;
+#endif
+
+static constexpr unsigned queueLenDefault = 512;
+static constexpr unsigned queueDropDefault = 32;
+static constexpr bool useSysLogDefault = false;
+
+void setupContainerizedLogMsgHandler()
+{
+    IPropertyTree * logConfig = queryComponentConfig().queryPropTree("logging");
+    if (logConfig)
+    {
+        if (logConfig->hasProp(logFielsdAtt))
+        {
+            //Supported logging fields: AUD,CLS,DET,MID,TIM,DAT,PID,TID,NOD,JOB,USE,SES,COD,MLT,MCT,NNT,COM,QUO,PFX,ALL,STD
+            const char *logFields = logConfig->queryProp(logFielsdAtt);
+            if (!isEmptyString(logFields))
+                theStderrHandler->setMessageFields(logMsgFieldsFromAbbrevs(logFields));
+        }
+
+        //Only recreate filter if at least one filter attribute configured
+        if (logConfig->hasProp(logMsgDetailAtt) || logConfig->hasProp(logMsgAudiencesAtt) || logConfig->hasProp(logMsgClassesAtt))
+        {
+            LogMsgDetail logDetail = logConfig->getPropInt(logMsgDetailAtt, DefaultDetail);
+
+            unsigned msgClasses = MSGCLS_all;
+            const char *logClasses = logConfig->queryProp(logMsgClassesAtt);
+            if (!isEmptyString(logClasses))
+                msgClasses = logMsgClassesFromAbbrevs(logClasses);
+
+            unsigned msgAudiences = MSGAUD_all;
+            const char *logAudiences = logConfig->queryProp(logMsgAudiencesAtt);
+            if (!isEmptyString(logAudiences))
+                msgAudiences = logMsgAudsFromAbbrevs(logAudiences);
+
+            Owned<ILogMsgFilter> filter = getCategoryLogMsgFilter(msgAudiences, msgClasses, logDetail);
+            theManager->changeMonitorFilter(theStderrHandler, filter);
+        }
+
+        bool useLogQueue = logConfig->getPropBool(useLogQueueAtt, useQueueDefault);
+        if (useLogQueue)
+        {
+            unsigned queueLen = logConfig->getPropInt(logQueueLenAtt, queueLenDefault);
+            unsigned queueDrop = logConfig->getPropInt(logQueueDropAtt, queueDropDefault);
+
+            queryLogMsgManager()->enterQueueingMode();
+            queryLogMsgManager()->setQueueDroppingLimit(queueLen, queueDrop);
+        }
+
+        if (logConfig->getPropBool(useSysLogpAtt, useSysLogDefault))
+            UseSysLogForOperatorMessages();
+    }
+}
+#endif
 
 ILogMsgManager * queryLogMsgManager()
 {
@@ -2800,7 +2869,7 @@ private:
         flushes = true;
         const char *logFields = queryEnvironmentConf().queryProp("logfields");
         if (!isEmptyString(logFields))
-            msgFields = LogMsgFieldsFromAbbrevs(logFields);
+            msgFields = logMsgFieldsFromAbbrevs(logFields);
         else
             msgFields = MSGFIELD_STANDARD;
         msgAudiences = MSGAUD_all;

--- a/system/jlib/jlog.cpp
+++ b/system/jlib/jlog.cpp
@@ -2326,7 +2326,7 @@ MODULE_EXIT()
 
 #ifdef _CONTAINERIZED
 
-static constexpr const char * logFielsdAtt = "@fields";
+static constexpr const char * logFieldsAtt = "@fields";
 static constexpr const char * logMsgDetailAtt = "@detail";
 static constexpr const char * logMsgAudiencesAtt = "@audiences";
 static constexpr const char * logMsgClassesAtt = "@classes";
@@ -2350,10 +2350,10 @@ void setupContainerizedLogMsgHandler()
     IPropertyTree * logConfig = queryComponentConfig().queryPropTree("logging");
     if (logConfig)
     {
-        if (logConfig->hasProp(logFielsdAtt))
+        if (logConfig->hasProp(logFieldsAtt))
         {
             //Supported logging fields: AUD,CLS,DET,MID,TIM,DAT,PID,TID,NOD,JOB,USE,SES,COD,MLT,MCT,NNT,COM,QUO,PFX,ALL,STD
-            const char *logFields = logConfig->queryProp(logFielsdAtt);
+            const char *logFields = logConfig->queryProp(logFieldsAtt);
             if (!isEmptyString(logFields))
                 theStderrHandler->setMessageFields(logMsgFieldsFromAbbrevs(logFields));
         }

--- a/thorlcr/master/thmastermain.cpp
+++ b/thorlcr/master/thmastermain.cpp
@@ -632,16 +632,22 @@ int main( int argc, const char *argv[]  )
     ILogMsgHandler *logHandler;
     try
     {
+#ifndef _CONTAINERIZED
         {
             Owned<IComponentLogFileCreator> lf = createComponentLogFileCreator(globals, "thor");
             lf->setName("thormaster");//override default filename
             lf->setCreateAliasFile(false);
             logHandler = lf->beginLogging();
             createUNCFilename(lf->queryLogFileSpec(), logUrl, false);
+
+            LOG(MCdebugProgress, thorJob, "Opened log file %s", logUrl.str());
         }
-        LOG(MCdebugProgress, thorJob, "Opened log file %s", logUrl.str());
+#else
+        setupContainerizedLogMsgHandler();
+        logHandler = queryStderrLogMsgHandler();
+        logUrl.set("stderr");
+#endif
         LOG(MCdebugProgress, thorJob, "Build %s", BUILD_TAG);
-        globals->setProp("@logURL", logUrl.str());
 
         Owned<IGroup> serverGroup = createIGroupRetry(daliServer.str(), DALI_SERVER_PORT);
 

--- a/thorlcr/slave/thslavemain.cpp
+++ b/thorlcr/slave/thslavemain.cpp
@@ -266,6 +266,7 @@ public:
 
 void startSlaveLog()
 {
+#ifndef _CONTAINERIZED
     StringBuffer fileName("thorslave");
     Owned<IComponentLogFileCreator> lf = createComponentLogFileCreator(globals->queryProp("@logDir"), "thor");
     StringBuffer slaveNumStr;
@@ -274,12 +275,11 @@ void startSlaveLog()
     lf->setName(fileName.str());//override default filename
     lf->beginLogging();
 
-    StringBuffer url;
-    createUNCFilename(lf->queryLogFileSpec(), url);
-
-    LOG(MCdebugProgress, thorJob, "Opened log file %s", url.str());
+    LOG(MCdebugProgress, thorJob, "Opened log file %s", lf->queryLogFileSpec());
+#else
+    setupContainerizedLogMsgHandler();
+#endif
     LOG(MCdebugProgress, thorJob, "Build %s", BUILD_TAG);
-    globals->setProp("@logURL", url.str());
 }
 
 void setSlaveAffinity(unsigned processOnNode)


### PR DESCRIPTION
- Provides simple setupContainerizedLoggingMsgHandler function
- Conditionally removes creation of component log file logic
- Logging to continue on default stderr stream log handler
- Per container customizations are applied to stderr log handler
- Clients and test code continues to log to file
- Provides per component logging configuration support
- Adds log class and log audience string helper methods

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [ ] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
