### PR TITLE
HPCC-23832 DESDL 'Roxie Test' form shows transformed request

### DIFF
--- a/esp/services/esdl_svc_engine/esdl_binding.cpp
+++ b/esp/services/esdl_svc_engine/esdl_binding.cpp
@@ -1049,75 +1049,10 @@ void EsdlServiceImpl::handleFinalRequest(IEspContext &context,
                                          bool isproxy,
                                          StringBuffer& soapmsg)
 {
-    soapmsg.append(
-        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
-        "<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">");
-
-    if(isroxie)
-    {
-        const char *tgtQueryName = tgtcfg->queryProp("@queryname");
-        if (!isEmptyString(tgtQueryName))
-        {
-            soapmsg.append("<soap:Body><").append(tgtQueryName).append(">");
-            soapmsg.appendf("<_TransactionId>%s</_TransactionId>", context.queryTransactionID());
-
-            if (tgtctx)
-                toXML(tgtctx.get(), soapmsg);
-
-            soapmsg.append(req.str());
-            soapmsg.append("</").append(tgtQueryName).append("></soap:Body>");
-
-            auto cfgGateways = tgtcfg->queryBranch("Gateways");
-            if (cfgGateways)
-            {
-                auto baseXpath = cfgGateways->queryProp("@legacyTransformTarget");
-                if (!isEmptyString(baseXpath))
-                {
-                    Owned<IPTree> gws = createPTree("gateways", 0);
-                    Owned<IPTree> soapTree = createPTreeFromXMLString(soapmsg.append("</soap:Envelope>"), ipt_ordered);
-                    StringBuffer xpath(baseXpath);
-                    StringBuffer rowName(cfgGateways->queryProp("@legacyRowName"));
-
-                    if (rowName.isEmpty())
-                        rowName.append("row");
-                    EsdlBindingImpl::transformGatewaysConfig(tgtcfg, gws, rowName);
-                    xpath.replaceString("{$query}", tgtQueryName);
-                    xpath.replaceString("{$method}", mthdef.queryMethodName());
-                    xpath.replaceString("{$service}", srvdef.queryName());
-                    xpath.replaceString("{$request}", mthdef.queryRequestType());
-                    mergePTree(ensurePTree(soapTree, xpath), gws);
-                    toXML(soapTree, soapmsg.clear());
-                    soapmsg.setLength(strstr(soapmsg, "</soap:Envelope>") - soapmsg.str());
-                    soapmsg.trim();
-                }
-            }
-        }
-        else
-            throw makeWsException( ERR_ESDL_BINDING_INTERNERR, WSERR_SERVER, "ESP",
-                        "EsdlServiceImpl::handleFinalRequest() target query name missing");
-    }
-    else
-    {
-        StringBuffer headers;
-        processHeaders(context, srvdef, mthdef, ns, req,headers);
-        if (headers.length() > 0 )
-            soapmsg.append("<soap:Header>").append(headers).append("</soap:Header>");
-
-        processRequest(context, srvdef, mthdef, ns, req);
-        soapmsg.append("<soap:Body>").append(req).append("</soap:Body>");
-    }
-    soapmsg.append("</soap:Envelope>");
-
     const char *tgtUrl = tgtcfg->queryProp("@url");
     if (!isEmptyString(tgtUrl))
     {
-        if (serviceCrt || methodCrt)
-        {
-            context.addTraceSummaryTimeStamp(LogNormal, "srt-custreqtrans");
-            processServiceAndMethodTransforms({serviceCrt, methodCrt}, &context, tgtcfg.get(), tgtctx.get(), srvdef, mthdef, soapmsg, m_oEspBindingCfg.get());
-            context.addTraceSummaryTimeStamp(LogNormal, "end-custreqtrans");
-        }
-
+        prepareFinalRequest(context, serviceCrt, methodCrt, tgtcfg, tgtctx, srvdef, mthdef, isroxie, ns, req, soapmsg);
         sendTargetSOAP(context, tgtcfg.get(), soapmsg.str(), out, isproxy, NULL);
     }
     else
@@ -1397,6 +1332,124 @@ void EsdlServiceImpl::getTargetResponseFile(IEspContext & context,
     ESPLOG(LogMax,"Response file: %s", respfile);
     if (respfile)
         resp.loadFile(respfile);
+}
+
+/*
+    Builds up the request string into the 'reqStr' buffer in a format 
+    suitable for submission to back-end service.
+ */
+
+void EsdlServiceImpl::prepareFinalRequest(IEspContext &context,
+                                        IEsdlCustomTransform *serviceCrt,
+                                        IEsdlCustomTransform *methodCrt,
+                                        Owned<IPropertyTree> &tgtcfg,
+                                        Owned<IPropertyTree> &tgtctx,
+                                        IEsdlDefService &srvdef,
+                                        IEsdlDefMethod &mthdef,
+                                        bool isroxie,
+                                        const char* ns,
+                                        StringBuffer &reqcontent,
+                                        StringBuffer &reqProcessed)
+{
+    const char *mthName = mthdef.queryName();
+    
+    reqProcessed.append(
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+        "<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">");
+
+    if(isroxie)
+    {
+        const char *tgtQueryName =  tgtcfg->queryProp("@queryname");
+        if (!isEmptyString(tgtQueryName))
+        {   
+            reqProcessed.append("<soap:Body><").append(tgtQueryName).append(">");
+            reqProcessed.appendf("<_TransactionId>%s</_TransactionId>", context.queryTransactionID());
+
+            if (tgtctx)
+                toXML(tgtctx.get(), reqProcessed);
+
+            reqProcessed.append(reqcontent.str());
+            reqProcessed.append("</").append(tgtQueryName).append("></soap:Body>");
+
+            // Transform gateways
+            auto cfgGateways = tgtcfg->queryBranch("Gateways");
+            if (cfgGateways)
+            {
+                auto baseXpath = cfgGateways->queryProp("@legacyTransformTarget");
+                if (!isEmptyString(baseXpath))
+                {
+                    Owned<IPTree> gws = createPTree("gateways", 0);
+                    // Temporarily add the closing </soap:Envelope> tag so we have valid
+                    // XML to transform the gateways
+                    Owned<IPTree> soapTree = createPTreeFromXMLString(reqProcessed.append("</soap:Envelope>"), ipt_ordered);
+                    StringBuffer xpath(baseXpath);
+                    StringBuffer rowName(cfgGateways->queryProp("@legacyRowName"));
+
+                    if (rowName.isEmpty())
+                        rowName.append("row");
+                    EsdlBindingImpl::transformGatewaysConfig(tgtcfg, gws, rowName);
+                    xpath.replaceString("{$query}", tgtQueryName);
+                    xpath.replaceString("{$method}", mthName);
+                    xpath.replaceString("{$service}", srvdef.queryName());
+                    xpath.replaceString("{$request}", mthdef.queryRequestType());
+                    mergePTree(ensurePTree(soapTree, xpath), gws);
+                    toXML(soapTree, reqProcessed.clear());
+                    // Remove the </soap:Envelope> tag so it can be unconditionally added
+                    // when the gateways don't require processing
+                    reqProcessed.setLength(strstr(reqProcessed, "</soap:Envelope>") - reqProcessed.str());
+                    reqProcessed.trim();
+                }
+            }
+        } 
+        else
+        {
+            // Use WsException here because both callers throw this type of exception
+            throw makeWsException( ERR_ESDL_BINDING_INTERNERR, WSERR_SERVER, "ESP",
+                        "EsdlServiceImpl::processFinalRequest() target query name missing");
+        }
+    }
+    else
+    {
+        StringBuffer headers;
+        processHeaders(context, srvdef, mthdef, ns, reqcontent, headers);
+        if (headers.length() > 0 )
+            reqProcessed.append("<soap:Header>").append(headers).append("</soap:Header>");
+
+        processRequest(context, srvdef, mthdef, ns, reqcontent);
+        reqProcessed.append("<soap:Body>").append(reqcontent).append("</soap:Body>");
+    }
+
+    reqProcessed.append("</soap:Envelope>");
+
+    // Process Custom Request Transforms
+
+    // If the CRTs are nullptr, we could have been called from a context without 
+    // access to them, so pull them from ourself. When they are passed in the
+    // error checking has already been completed.
+
+    if (!serviceCrt)
+    {
+        if (m_serviceLevelCrtFail)
+            throw MakeStringException(-1, "%s::%s disabled due to service-level Custom Transform errors. Review transform template in configuration.", srvdef.queryName(), mthName);
+
+        serviceCrt = m_serviceLevelRequestTransform;
+    }
+
+    if (!methodCrt)
+    {
+        StringAttr *crtErrorMessage = m_methodCRTransformErrors.getValue(mthName);
+        if (crtErrorMessage && !crtErrorMessage->isEmpty())
+            throw MakeStringException(-1, "%s::%s disabled due to method-level Custom Transform errors: %s. Review transform template in configuration.", srvdef.queryName(), mthName, crtErrorMessage->str());
+
+        methodCrt = m_customRequestTransformMap.getValue(mthName);
+    }
+
+    if (serviceCrt || methodCrt)
+    {
+        context.addTraceSummaryTimeStamp(LogNormal, "srt-custreqtrans");
+        processServiceAndMethodTransforms({serviceCrt, methodCrt}, &context, tgtcfg, tgtctx, srvdef, mthdef, reqProcessed, m_oEspBindingCfg.get());
+        context.addTraceSummaryTimeStamp(LogNormal, "end-custreqtrans");
+    }
 }
 
 EsdlServiceImpl::~EsdlServiceImpl()
@@ -2772,7 +2825,11 @@ int EsdlBindingImpl::onGetXForm(IEspContext &context,
         EspHttpBinding::escapeSingleQuote(tmp,escaped.clear());
         xform->setStringParameter("methodDesc", escaped);
 
-        xform->setParameter("includeRoxieTest", "1");
+        // By default, even if the config property is missing, include the Roxie Test button
+        if (m_esdlBndCfg->getPropBool("@includeRoxieTest", true)==false)
+            xform->setParameter("includeRoxieTest", "0");
+        else
+            xform->setParameter("includeRoxieTest", "1");
         xform->setParameter("includeJsonTest", "1");
         xform->setParameter("includeJsonReqSample", "1");
 
@@ -2961,11 +3018,13 @@ void EsdlBindingImpl::handleJSONPost(CHttpRequest *request, CHttpResponse *respo
     {
         JsonHelpers::appendJSONException(jsonresp.set("{"), iwse);
         jsonresp.append('}');
+        iwse->Release();
     }
     catch (IException *e)
     {
         JsonHelpers::appendJSONException(jsonresp.set("{"), e);
         jsonresp.append("\n}");
+        e->Release();
     }
     catch (...)
     {
@@ -3243,6 +3302,7 @@ int EsdlBindingImpl::onGetRoxieBuilder(CHttpRequest* request, CHttpResponse* res
     context->setTransactionID("ROXIETEST-NOTRXID");
     IEsdlDefService *defsrv = m_esdl->queryService(queryServiceType());
     IEsdlDefMethod *defmth;
+
     if(defsrv)
         defmth = defsrv->queryMethodByName(method);
     else
@@ -3279,16 +3339,8 @@ int EsdlBindingImpl::onGetRoxieBuilder(CHttpRequest* request, CHttpResponse* res
                     getRequestContent(*context, reqcontent, request, srvname, mthname, ns, ROXIEREQ_FLAGS);
 
                     tgtctx.setown( m_pESDLService->createTargetContext(*context, tgtcfg, *defsrv, *defmth, req_pt));
-                    roxiemsg.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">");
-                    roxiemsg.append("<soap:Body><").append(tgtQueryName).append(">");
-
-                    roxiemsg.appendf("<_TransactionId>%s</_TransactionId>", context->queryTransactionID());
-                    if (tgtctx)
-                        toXML(tgtctx.get(), roxiemsg);
-
-                    roxiemsg.append(reqcontent.str());
-                    roxiemsg.append("</").append(tgtQueryName).append("></soap:Body>");
-                    roxiemsg.append("</soap:Envelope>");
+                    
+                    m_pESDLService->prepareFinalRequest(*context, nullptr, nullptr, tgtcfg, tgtctx, *defsrv, *defmth, true, ns.str(), reqcontent, roxiemsg);
                 }
                 else
                 {

--- a/esp/services/esdl_svc_engine/esdl_binding.hpp
+++ b/esp/services/esdl_svc_engine/esdl_binding.hpp
@@ -179,6 +179,7 @@ public:
     virtual void processHeaders(IEspContext &context, IEsdlDefService &srvdef, IEsdlDefMethod &mthdef, const char *ns, StringBuffer &req, StringBuffer &headers){};
     virtual void processRequest(IEspContext &context, IEsdlDefService &srvdef, IEsdlDefMethod &mthdef, const char *ns, StringBuffer &req) {};
     virtual void processResponse(IEspContext &context, IEsdlDefService &srvdef, IEsdlDefMethod &mthdef, const char *ns, StringBuffer &resp) {};
+    void prepareFinalRequest(IEspContext &context, IEsdlCustomTransform *serviceCrt, IEsdlCustomTransform *methodCrt, Owned<IPropertyTree> &tgtcfg, Owned<IPropertyTree> &tgtctx, IEsdlDefService &srvdef, IEsdlDefMethod &mthdef, bool isroxie, const char* ns, StringBuffer &reqcontent, StringBuffer &reqProcessed);
     virtual void createServersList(IEspContext &context, IEsdlDefService &srvdef, IEsdlDefMethod &mthdef, StringBuffer &servers) {};
     virtual bool handleResultLogging(IEspContext &espcontext, IPropertyTree * reqcontext, IPropertyTree * request,  const char * rawreq, const char * rawresp, const char * finalresp, const char * logdata);
     void handleEchoTest(const char *mthName, IPropertyTree *req, StringBuffer &soapResp, ESPSerializationFormat format);


### PR DESCRIPTION
To aid troubleshooting and QA, show the outgoing request to the Roxie after
it has been processed by Custom Request Transforms and legacy gateway
transformation. Previously the request was displayed before these
transformations were made.

The Roxie Test button visibility is controlled by an attribute on the ESDL
binding named 'includeRoxieTest'. To maintain backward compatibility the
button is visible by default.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [x] I have added tests to cover my changes.
  - [x] All new and existing tests passed.
  - [x] I have checked that this change does not introduce memory leaks.
  - [x] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
