### PR TITLE
HPCC-23737 DFUPlus files should not automatically expire with default expiry days if no expireDays parameter present.

### DIFF
--- a/dali/dfuplus/dfuplus.cpp
+++ b/dali/dfuplus/dfuplus.cpp
@@ -895,6 +895,9 @@ int CDfuPlusHelper::copy()
     else if(globals->hasProp("noRecover"))
         req->setNorecover(globals->getPropBool("noRecover", false));
 
+    if(globals->hasProp("expireDays"))
+        req->setExpireDays(globals->getPropInt("expireDays"));
+
     Owned<IClientCopyResponse> result = sprayclient->Copy(req);
     const char* wuid = result->getResult();
     if(wuid == nullptr || *wuid == '\0')

--- a/dali/ft/filecopy.cpp
+++ b/dali/ft/filecopy.cpp
@@ -3358,11 +3358,9 @@ void FileSprayer::updateTargetProperties()
             curHistory->addPropTree("Origin",newRecord.getClear());
         }
 
-        int expireDays = options->getPropInt("@expireDays");
+        int expireDays = options->getPropInt("@expireDays", -1);
         if (expireDays != -1)
-        {
             curProps.setPropInt("@expireDays", expireDays);
-        }
     }
     if (error)
         throw error.getClear();

--- a/esp/services/ws_fs/ws_fsService.cpp
+++ b/esp/services/ws_fs/ws_fsService.cpp
@@ -2001,7 +2001,8 @@ bool CFileSprayEx::onSprayFixed(IEspContext &context, IEspSprayFixed &req, IEspS
         if (req.getRecordStructurePresent())
             options->setRecordStructurePresent(true);
 
-        options->setExpireDays(req.getExpireDays());
+        if (!req.getExpireDays_isNull())
+            options->setExpireDays(req.getExpireDays());
 
         resp.setWuid(wu->queryId());
         resp.setRedirectUrl(StringBuffer("/FileSpray/GetDFUWorkunit?wuid=").append(wu->queryId()).str());
@@ -2186,7 +2187,8 @@ bool CFileSprayEx::onSprayVariable(IEspContext &context, IEspSprayVariable &req,
         if (req.getRecordStructurePresent())
             options->setRecordStructurePresent(true);
 
-        options->setExpireDays(req.getExpireDays());
+        if (!req.getExpireDays_isNull())
+            options->setExpireDays(req.getExpireDays());
 
         resp.setWuid(wu->queryId());
         resp.setRedirectUrl(StringBuffer("/FileSpray/GetDFUWorkunit?wuid=").append(wu->queryId()).str());

--- a/testing/regress/ecl/key/spray_expire_test.xml
+++ b/testing/regress/ecl/key/spray_expire_test.xml
@@ -23,6 +23,15 @@
 <Dataset name='DFUPlus'>
  <Row><DFUPlus>Pass</DFUPlus></Row>
 </Dataset>
+<Dataset name='DFUPlus2'>
+ <Row><DFUPlus2>Pass</DFUPlus2></Row>
+</Dataset>
+<Dataset name='DFUPlus3'>
+ <Row><DFUPlus3>Pass</DFUPlus3></Row>
+</Dataset>
+<Dataset name='DFUPlus4'>
+ <Row><DFUPlus4>Pass</DFUPlus4></Row>
+</Dataset>
 <Dataset name='Copy'>
  <Row><Copy>Pass</Copy></Row>
 </Dataset>


### PR DESCRIPTION

Change expireDays default value from '0' to '-1'
Improve FileSpray '@expireDays' attribute handling
Extend spray_expire_test.ecl' to execute dfuplus with and without expire days parameter.

Signed-off-by: Attila Vamos <attila.vamos@gmail.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [x] I have added tests to cover my changes.
  - [x] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [x] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->
Tested manually.
<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
