### PR TITLE
HPCC-23971 Std.Crypto: Convert some parameters from VARSTRING to STRI…

### DIFF
--- a/ecllibrary/std/Crypto.ecl
+++ b/ecllibrary/std/Crypto.ecl
@@ -58,7 +58,7 @@ END; // Hashing module
  * Encryption module containing all symmetric encryption/decryption functions
  *
  * @param   algorithm      Symmetric algorithm to use, as returned by SupportedSymmetricCipherAlgorithms()
- * @param   passphrase     Passphrase to use for encryption/encryption
+ * @param   passphrase     Passphrase string to use for encryption/encryption
  */
 EXPORT SymmetricEncryption(VARSTRING algorithm, VARSTRING passphrase) := MODULE
     /**
@@ -84,17 +84,43 @@ EXPORT SymmetricEncryption(VARSTRING algorithm, VARSTRING passphrase) := MODULE
     END;
 END; // SymmetricEncryption module
 
-
-
+/**
+ * Encryption module containing symmetric encryption/decryption functions
+ *
+ * @param   algorithm      Symmetric algorithm to use, as returned by SupportedSymmetricCipherAlgorithms()
+ * @param   passphrase     Passphrase buffer to use for encryption/encryption
+ */
+EXPORT SymmEncryption(VARSTRING algorithm, DATA passphraseBuff) := MODULE
+    /**
+     * Encrypt the given data, using the specified passphrase and symmetric cipher
+     * algorithm that was returned by SupportedSymmetricCipherAlgorithms()
+     *
+     * @param   inputData  Contents to encrypt
+     * @return             Encrypted cipher
+     */
+    EXPORT DATA Encrypt(DATA inputData) := FUNCTION
+        RETURN lib_cryptolib.CryptoLib.SymEncrypt( algorithm, passphraseBuff, inputData );
+    END;
+    /**
+     * Decrypt the given cipher, using the specified passphrase and symmetric cipher
+     * algorithm that was returned by SupportedSymmetricCipherAlgorithms()
+     *
+     * @param   encryptedData  Contents to decrypt
+     * @return                 Decrypted data
+     */
+    EXPORT DATA Decrypt(DATA encryptedData) := FUNCTION
+        RETURN lib_cryptolib.CryptoLib.SymDecrypt( algorithm, passphraseBuff, encryptedData );
+    END;
+END; // SymmEncryption module
 
 /**
- * Encryption module containing all asymmetric encryption/decryption/digital
+ * Encryption module containing asymmetric encryption/decryption/digital
  * signing/signature verification functions
  *
  * @param   pkAlgorithm    ASymmetric algorithm to use, as returned by SupportedPublicKeyAlgorithms()
  * @param   publicKeyFile  File specification of PEM formatted public key file
  * @param   privateKeyFile File specification of PEM formatted private key file
- * @param   passphrase     Passphrase to use for encryption/encryption/signing/verifying
+ * @param   passphrase     Passphrase string to use for encryption/encryption/signing/verifying
  */
 EXPORT PublicKeyEncryption(VARSTRING pkAlgorithm, VARSTRING publicKeyFile = '', VARSTRING privateKeyFile = '', VARSTRING passphrase = '') := MODULE
     /**
@@ -143,15 +169,70 @@ EXPORT PublicKeyEncryption(VARSTRING pkAlgorithm, VARSTRING publicKeyFile = '', 
     END;
 END; // PublicKeyEncryption module
 
+/**
+ * Encryption module containing asymmetric encryption/decryption/digital
+ * signing/signature verification functions
+ *
+ * @param   pkAlgorithm    ASymmetric algorithm to use, as returned by SupportedPublicKeyAlgorithms()
+ * @param   publicKeyFile  File specification of PEM formatted public key file
+ * @param   privateKeyFile File specification of PEM formatted private key file
+ * @param   passphrase     Passphrase buffer to use for encryption/encryption/signing/verifying
+ */
+EXPORT PKEncryption(VARSTRING pkAlgorithm, VARSTRING publicKeyFile = '', VARSTRING privateKeyFile = '', DATA passphraseBuff) := MODULE
+    /**
+     * Encrypt the given data, using the specified public key file,
+     * passphrase, and algorithm
+     *
+     * @param   inputData    Contents to Encrypt
+     * @return               Encrypted data
+     */
+    EXPORT DATA Encrypt(DATA inputData) := FUNCTION
+        RETURN lib_cryptolib.CryptoLib.PKEncrypt( pkAlgorithm, publicKeyFile, passphraseBuff, inputData);
+    END;
+
+    /**
+     * Decrypt the given encrypted data, using the specified private key file,
+     * passphrase, and algorithm
+     *
+     * @param   encryptedData    Contents to Decrypt
+     * @return                   Decrypted data
+     */
+    EXPORT DATA Decrypt(DATA encryptedData) := FUNCTION
+        RETURN lib_cryptolib.CryptoLib.PKDecrypt( pkAlgorithm, privateKeyFile, passphraseBuff, encryptedData);
+    END;
+
+    /**
+     * Create a digital signature of the given data, using the
+     * specified private key file, passphrase and algorithm
+     *
+     * @param   inputData    Contents to sign
+     * @return               Computed Digital signature
+     */
+    EXPORT DATA Sign( DATA inputData) := FUNCTION
+        RETURN lib_cryptolib.CryptoLib.PKSign( pkAlgorithm, privateKeyFile, passphraseBuff, inputData);
+    END;
+
+    /**
+     * Verify the given digital signature of the given data, using
+     * the specified public key file, passphrase and algorithm
+     *
+     * @param   signature      Signature to verify
+     * @param   signedData     Data used to create signature
+     * @return                 Boolean TRUE/FALSE
+     */
+    EXPORT BOOLEAN VerifySignature(DATA signature, DATA signedData) := FUNCTION
+        RETURN lib_cryptolib.CryptoLib.PKVerifySignature( pkAlgorithm, publicKeyFile, passphraseBuff, signature, signedData);
+    END;
+END; // PKEncryption module
 
 /**
- * Encryption module containing all asymmetric encryption/decryption/digital
+ * Encryption module containing asymmetric encryption/decryption/digital
  * signing/signature verification functions
  *
  * @param   pkAlgorithm    Asymmetric algorithm to use, as returned by SupportedPublicKeyAlgorithms()
  * @param   publicKeyLFN   LFN specification of PEM formatted public key file
  * @param   privateKeyLFN  LFN specification of PEM formatted private key file
- * @param   passphrase     Optional Passphrase to use for encryption/encryption/signing/verifying
+ * @param   passphrase     Optional Passphrase string to use for encryption/encryption/signing/verifying
  */
 EXPORT PublicKeyEncryptionFromLFN(VARSTRING pkAlgorithm, VARSTRING publicKeyLFN = '', VARSTRING privateKeyLFN = '', VARSTRING passphrase = '') := MODULE
     /**
@@ -202,13 +283,69 @@ END; // PublicKeyEncryptionFromLFN module
 
 
 /**
+ * Encryption module containing asymmetric encryption/decryption/digital
+ * signing/signature verification functions
+ *
+ * @param   pkAlgorithm    Asymmetric algorithm to use, as returned by SupportedPublicKeyAlgorithms()
+ * @param   publicKeyLFN   LFN specification of PEM formatted public key file
+ * @param   privateKeyLFN  LFN specification of PEM formatted private key file
+ * @param   passphrase     Optional Passphrase buffer to use for encryption/encryption/signing/verifying
+ */
+EXPORT PKEncryptionFromLFN(VARSTRING pkAlgorithm, VARSTRING publicKeyLFN = '', VARSTRING privateKeyLFN = '', DATA passphraseBuff) := MODULE
+    /**
+     * Encrypt the given data, using the specified public key LFN,
+     * passphrase, and algorithm
+     *
+     * @param   inputData    Contents to Encrypt
+     * @return               Encrypted data
+     */
+    EXPORT DATA Encrypt(DATA inputData) := FUNCTION
+        RETURN lib_cryptolib.CryptoLib.PKEncryptLFN( pkAlgorithm, publicKeyLFN, passphraseBuff, inputData);
+    END;
+
+    /**
+     * Decrypt the given encrypted data, using the specified private key LFN,
+     * passphrase, and algorithm
+     *
+     * @param   encryptedData    Contents to Decrypt
+     * @return                   Decrypted data
+     */
+    EXPORT DATA Decrypt(DATA encryptedData) := FUNCTION
+        RETURN lib_cryptolib.CryptoLib.PKDecryptLFN( pkAlgorithm, privateKeyLFN, passphraseBuff, encryptedData);
+    END;
+
+    /**
+     * Create a digital signature of the given data, using the
+     * specified private key LFN, passphrase and algorithm
+     *
+     * @param   inputData    Contents to sign
+     * @return               Computed Digital signature
+     */
+    EXPORT DATA Sign( DATA inputData) := FUNCTION
+        RETURN lib_cryptolib.CryptoLib.PKSignLFN( pkAlgorithm, privateKeyLFN, passphraseBuff, inputData);
+    END;
+
+    /**
+     * Verify the given digital signature of the given data, using
+     * the specified public key LFN, passphrase and algorithm
+     *
+     * @param   signature      Signature to verify
+     * @param   signedData     Data used to create signature
+     * @return                 Boolean TRUE/FALSE
+     */
+    EXPORT BOOLEAN VerifySignature(DATA signature, DATA signedData) := FUNCTION
+        RETURN lib_cryptolib.CryptoLib.PKVerifySignatureLFN( pkAlgorithm, publicKeyLFN, passphraseBuff, signature, signedData);
+    END;
+END; // PKEncryptionFromLFN module
+
+/**
   * Encryption module containing all asymmetric encryption/decryption/digital
   * signing/signature verification functions
   *
   * @param   pkAlgorithm    ASymmetric algorithm to use, as returned by SupportedPublicKeyAlgorithms()
   * @param   publicKeyBuff  PEM formatted Public key buffer
   * @param   privateKeyBuff PEM formatted Private key buffer
-  * @param   passphrase     Passphrase to use for encryption/encryption/signing/verifying
+  * @param   passphrase     Passphrase string to use for encryption/encryption/signing/verifying
   */
 EXPORT PublicKeyEncryptionFromBuffer(VARSTRING pkAlgorithm, VARSTRING publicKeyBuff = '', VARSTRING privateKeyBuff = '', VARSTRING passphrase = '') := MODULE
     /**
@@ -256,7 +393,63 @@ EXPORT PublicKeyEncryptionFromBuffer(VARSTRING pkAlgorithm, VARSTRING publicKeyB
         RETURN lib_cryptolib.CryptoLib.VerifySignatureBuff( pkAlgorithm, publicKeyBuff, passphrase, signature, signedData);
     END;
     
-END; // PublicKeyEncryption module
+END; // PublicKeyEncryptionFromBuffer module
 
+/**
+  * Encryption module containing asymmetric encryption/decryption/digital
+  * signing/signature verification functions
+  *
+  * @param   pkAlgorithm    ASymmetric algorithm to use, as returned by SupportedPublicKeyAlgorithms()
+  * @param   publicKeyBuff  PEM formatted Public key buffer
+  * @param   privateKeyBuff PEM formatted Private key buffer
+  * @param   passphrase     Passphrase buffer to use for encryption/encryption/signing/verifying
+  */
+
+EXPORT PKEncryptionFromBuffer(VARSTRING pkAlgorithm, VARSTRING publicKeyBuff = '', VARSTRING privateKeyBuff = '', DATA passphraseBuff) := MODULE
+    /**
+      * Encrypt the given data, using the specified public key, passphrase,
+      * and algorithm
+      *
+      * @param   inputData    Contents to Encrypt
+      * @return               Encrypted data
+      */
+    EXPORT DATA Encrypt(DATA inputData) := FUNCTION
+        RETURN lib_cryptolib.CryptoLib.PKEncryptBuff( pkAlgorithm, publicKeyBuff, passphraseBuff, inputData);
+    END;
+
+    /**
+      * Decrypt the given data, using the specified private key, passphrase,
+      * and algorithm
+      *
+      * @param   encryptedData  Contents to Decrypt
+      * @return                 Decrypted data
+      */
+    EXPORT DATA Decrypt(DATA encryptedData) := FUNCTION
+        RETURN lib_cryptolib.CryptoLib.PKDecryptBuff(pkAlgorithm, privateKeyBuff, passphraseBuff, encryptedData);
+    END;
+
+    /**
+      * Create a digital signature of the given data, using the specified private key,
+      * passphrase, and algorithm
+      *
+      * @param   inputData    Contents to sign
+      * @return               Computed digital signature
+      */
+    EXPORT DATA Sign(DATA inputData) := FUNCTION
+        RETURN lib_cryptolib.CryptoLib.PKSignBuff( pkAlgorithm, privateKeyBuff, passphraseBuff, inputData);
+    END;
+
+    /**
+      * Verify the given digital signature of the given data, using the specified public key,
+      * passphrase, and algorithm
+      *
+      * @param   signature      Signature to verify
+      * @param   signedData     Data used to create signature
+      * @return                 Booolean TRUE if signature is valid, otherwise FALSE
+      */
+    EXPORT BOOLEAN VerifySignature(DATA signature, DATA signedData) := FUNCTION
+        RETURN lib_cryptolib.CryptoLib.PKVerifySignatureBuff( pkAlgorithm, publicKeyBuff, passphraseBuff, signature, signedData);
+    END;
+END; //PKEncryptionFromBuffer module
 
 END; // Crypto module

--- a/plugins/cryptolib/cryptolib.cpp
+++ b/plugins/cryptolib/cryptolib.cpp
@@ -193,12 +193,12 @@ void verifySymmetricAlgorithm(const char * algorithm, size32_t len)
          throw makeStringExceptionV(-1, "Unsupported symmetric algorithm (%s) specified", algorithm);
 }
 
-CRYPTOLIB_API void CRYPTOLIB_CALL clSymmetricEncrypt(size32_t & __lenResult, void * & __result,
+CRYPTOLIB_API void CRYPTOLIB_CALL clSymmEncrypt(size32_t & __lenResult, void * & __result,
                                                     const char * algorithm,
-                                                    const char * key,
+                                                    size32_t lenKey, const void * key,
                                                     size32_t lenInputdata,const void * inputdata)
 {
-    verifySymmetricAlgorithm(algorithm, strlen(key) );
+    verifySymmetricAlgorithm(algorithm, lenKey );
 
     //Create a unique Initialization Vector
     unsigned char iv[EVP_MAX_IV_LENGTH];
@@ -206,19 +206,19 @@ CRYPTOLIB_API void CRYPTOLIB_CALL clSymmetricEncrypt(size32_t & __lenResult, voi
 
     //temporary buffer for result
     MemoryBuffer out;
-    aesEncrypt(out, lenInputdata, inputdata, strlen(key), key, (const char *)iv);
+    aesEncrypt(out, lenInputdata, inputdata, lenKey, (const char *)key, (const char *)iv);
 
     //build result DATA buffer in the form:
     // (size32_t)EVP_MAX_IV_LENGTH, IV, (size32_t)LenPlainText excluding NULL, (size32_t)LenCipher, Cipher
     symmSerialize(__result, __lenResult, (const char *)iv, sizeof(iv), lenInputdata, out.length(), (const void *)out.bufferBase());
 }
 
-CRYPTOLIB_API void CRYPTOLIB_CALL clSymmetricDecrypt(size32_t & __lenResult,void * & __result,
+CRYPTOLIB_API void CRYPTOLIB_CALL clSymmDecrypt(size32_t & __lenResult,void * & __result,
                                                 const char * algorithm,
-                                                const char * key,
+                                                size32_t lenKey,const void * key,
                                                 size32_t lenEncrypteddata,const void * encrypteddata)
 {
-    verifySymmetricAlgorithm(algorithm, strlen(key));
+    verifySymmetricAlgorithm(algorithm, lenKey);
 
     //Decompose DATA buffer
 
@@ -231,10 +231,25 @@ CRYPTOLIB_API void CRYPTOLIB_CALL clSymmetricDecrypt(size32_t & __lenResult,void
     __lenResult = lenPlainText;
 
     MemoryBuffer decrypted;
-    size32_t len = aesDecrypt(decrypted, sbCipher.length(), sbCipher.str(), strlen(key), key, sbIV.str());
+    size32_t len = aesDecrypt(decrypted, sbCipher.length(), sbCipher.str(), lenKey, (const char *)key, sbIV.str());
     memcpy(__result, decrypted.toByteArray(), __lenResult);
 }
 
+CRYPTOLIB_API void CRYPTOLIB_CALL clSymmetricEncrypt(size32_t & __lenResult, void * & __result,
+                                                    const char * algorithm,
+                                                    const char * key,
+                                                    size32_t lenInputdata,const void * inputdata)
+{
+    return clSymmEncrypt(__lenResult, __result, algorithm, strlen(key), (const void *)key, lenInputdata, inputdata);
+}
+
+CRYPTOLIB_API void CRYPTOLIB_CALL clSymmetricDecrypt(size32_t & __lenResult,void * & __result,
+                                                const char * algorithm,
+                                                const char * key,
+                                                size32_t lenEncrypteddata,const void * encrypteddata)
+{
+    return clSymmDecrypt(__lenResult, __result, algorithm, strlen(key), (const void *)key, lenEncrypteddata, encrypteddata);
+}
 
 
 //-------------------------------------------------------------------------------------------------------------------------------------------
@@ -507,14 +522,14 @@ static CDSMCache g_DSMCache;
 
 //Sign given data using private key
 
-CRYPTOLIB_API void CRYPTOLIB_CALL clPKISign(size32_t & __lenResult,void * & __result,
+CRYPTOLIB_API void CRYPTOLIB_CALL clPKISign2(size32_t & __lenResult,void * & __result,
                                         const char * pkalgorithm,
                                         const char * privatekeyfile,
-                                        const char * passphrase,
+                                        size32_t lenPassPhrase,const void * passphrase,
                                         size32_t lenInputdata,const void * inputdata)
 {
     verifyPKIAlgorithm(pkalgorithm);//TODO extend cryptohelper to support more algorithms
-    Owned<IDigitalSignatureManager> pDSM = g_DSMCache.getInstance(pkalgorithm, nullptr, nullptr, privatekeyfile, nullptr, passphrase, false, nullptr);
+    Owned<IDigitalSignatureManager> pDSM = g_DSMCache.getInstance(pkalgorithm, nullptr, nullptr, privatekeyfile, nullptr, (const char *)passphrase, false, nullptr);
     if (pDSM)
     {
         doPKISign(__lenResult, __result, pDSM, lenInputdata, inputdata);
@@ -523,6 +538,116 @@ CRYPTOLIB_API void CRYPTOLIB_CALL clPKISign(size32_t & __lenResult,void * & __re
     {
         throw makeStringException(-1, "Unable to create Digital Signature Manager");
     }
+}
+
+CRYPTOLIB_API void CRYPTOLIB_CALL clPKISignLFN2(ICodeContext * ctx,
+                                        size32_t & __lenResult,void * & __result,
+                                        const char * pkalgorithm,
+                                        const char * privatekeyLFN,
+                                        size32_t lenPassPhrase,const void * passphrase,
+                                        size32_t lenInputdata,const void * inputdata)
+{
+    verifyPKIAlgorithm(pkalgorithm);
+    IUserDescriptor * udesc = ctx->queryUserDescriptor();
+    Owned<IDigitalSignatureManager> pDSM = g_DSMCache.getInstance(pkalgorithm, nullptr, nullptr, privatekeyLFN, nullptr, (const char *)passphrase, true, udesc);
+    if (pDSM)
+    {
+        doPKISign(__lenResult, __result, pDSM, lenInputdata, inputdata);
+    }
+    else
+    {
+        throw makeStringException(-1, "Unable to create Digital Signature Manager");
+    }
+}
+
+CRYPTOLIB_API void CRYPTOLIB_CALL clPKISignBuff2(size32_t & __lenResult, void * & __result,
+                                            const char * pkalgorithm,
+                                            const char * privatekeybuff,
+                                            size32_t lenPassPhrase,const void * passphrase,
+                                            size32_t lenInputdata, const void * inputdata)
+{
+    verifyPKIAlgorithm(pkalgorithm);
+    Owned<IDigitalSignatureManager> pDSM = g_DSMCache.getInstance(pkalgorithm, nullptr, nullptr, nullptr, privatekeybuff, (const char *)passphrase, false, nullptr);
+    if (pDSM)
+    {
+        doPKISign(__lenResult, __result, pDSM, lenInputdata, inputdata);
+    }
+    else
+    {
+        throw makeStringException(-1, "Unable to create Digital Signature Manager");
+    }
+}
+
+
+CRYPTOLIB_API bool CRYPTOLIB_CALL clPKIVerifySignature2(const char * pkalgorithm,
+                                                    const char * publickeyfile,
+                                                    size32_t lenPassPhrase,const void * passphrase,
+                                                    size32_t lenSignature,const void * signature,
+                                                    size32_t lenSigneddata,const void * signeddata)
+{
+    verifyPKIAlgorithm(pkalgorithm);
+    Owned<IDigitalSignatureManager> pDSM = g_DSMCache.getInstance(pkalgorithm, publickeyfile, nullptr, nullptr, nullptr, (const char *)passphrase, false, nullptr);
+    if (pDSM)
+    {
+        StringBuffer sbSig(lenSignature, (const char *)signature);
+        bool rc = pDSM->digiVerify(sbSig.str(), lenSigneddata, signeddata);
+        return rc;
+    }
+    else
+    {
+        throw makeStringException(-1, "Unable to create Digital Signature Manager");
+    }
+}
+
+CRYPTOLIB_API bool CRYPTOLIB_CALL clPKIVerifySignatureLFN2(ICodeContext * ctx,
+                                                    const char * pkalgorithm,
+                                                    const char * publickeyLFN,
+                                                    size32_t lenPassPhrase,const void * passphrase,
+                                                    size32_t lenSignature,const void * signature,
+                                                    size32_t lenSigneddata,const void * signeddata)
+{
+    verifyPKIAlgorithm(pkalgorithm);
+    IUserDescriptor * udesc = ctx->queryUserDescriptor();
+    Owned<IDigitalSignatureManager> pDSM = g_DSMCache.getInstance(pkalgorithm, publickeyLFN, nullptr, nullptr, nullptr, (const char *)passphrase, true, udesc);
+    if (pDSM)
+    {
+        StringBuffer sbSig(lenSignature, (const char *)signature);
+        bool rc = pDSM->digiVerify(sbSig.str(), lenSigneddata, signeddata);
+        return rc;
+    }
+    else
+    {
+        throw makeStringException(-1, "Unable to create Digital Signature Manager");
+    }
+}
+
+CRYPTOLIB_API bool CRYPTOLIB_CALL clPKIVerifySignatureBuff2(const char * pkalgorithm,
+                                                       const char * publicKeyBuff,
+                                                       size32_t lenPassPhrase,const void * passphrase,
+                                                       size32_t lenSignature, const void * signature,
+                                                       size32_t lenSigneddata, const void * signeddata)
+{
+    verifyPKIAlgorithm(pkalgorithm);
+    Owned<IDigitalSignatureManager> pDSM = g_DSMCache.getInstance(pkalgorithm, nullptr, publicKeyBuff, nullptr, nullptr, (const char *)passphrase, false, nullptr);
+    if (pDSM)
+    {
+        StringBuffer sbSig(lenSignature, (const char *)signature);
+        bool rc = pDSM->digiVerify(sbSig.str(), lenSigneddata, signeddata);
+        return rc;
+    }
+    else
+    {
+        throw makeStringException(-1, "Unable to create Digital Signature Manager");
+    }
+}
+
+CRYPTOLIB_API void CRYPTOLIB_CALL clPKISign(size32_t & __lenResult,void * & __result,
+                                        const char * pkalgorithm,
+                                        const char * privatekeyfile,
+                                        const char * passphrase,
+                                        size32_t lenInputdata,const void * inputdata)
+{
+    return clPKISign2(__lenResult,__result, pkalgorithm, privatekeyfile, strlen(passphrase), (const void *)passphrase, lenInputdata, inputdata);
 }
 
 CRYPTOLIB_API void CRYPTOLIB_CALL clPKISignLFN(ICodeContext * ctx,
@@ -532,17 +657,7 @@ CRYPTOLIB_API void CRYPTOLIB_CALL clPKISignLFN(ICodeContext * ctx,
                                         const char * passphrase,
                                         size32_t lenInputdata,const void * inputdata)
 {
-    verifyPKIAlgorithm(pkalgorithm);
-    IUserDescriptor * udesc = ctx->queryUserDescriptor();
-    Owned<IDigitalSignatureManager> pDSM = g_DSMCache.getInstance(pkalgorithm, nullptr, nullptr, privatekeyLFN, nullptr, passphrase, true, udesc);
-    if (pDSM)
-    {
-        doPKISign(__lenResult, __result, pDSM, lenInputdata, inputdata);
-    }
-    else
-    {
-        throw makeStringException(-1, "Unable to create Digital Signature Manager");
-    }
+    return clPKISignLFN2(ctx, __lenResult,__result, pkalgorithm, privatekeyLFN, strlen(passphrase), (const void *)passphrase, lenInputdata, inputdata);
 }
 
 CRYPTOLIB_API void CRYPTOLIB_CALL clPKISignBuff(size32_t & __lenResult, void * & __result,
@@ -551,16 +666,7 @@ CRYPTOLIB_API void CRYPTOLIB_CALL clPKISignBuff(size32_t & __lenResult, void * &
                                             const char * passphrase,
                                             size32_t lenInputdata, const void * inputdata)
 {
-    verifyPKIAlgorithm(pkalgorithm);
-    Owned<IDigitalSignatureManager> pDSM = g_DSMCache.getInstance(pkalgorithm, nullptr, nullptr, nullptr, privatekeybuff, passphrase, false, nullptr);
-    if (pDSM)
-    {
-        doPKISign(__lenResult, __result, pDSM, lenInputdata, inputdata);
-    }
-    else
-    {
-        throw makeStringException(-1, "Unable to create Digital Signature Manager");
-    }
+    return clPKISignBuff2(__lenResult,__result, pkalgorithm, privatekeybuff, strlen(passphrase), (const void *)passphrase, lenInputdata, inputdata);
 }
 
 
@@ -570,18 +676,7 @@ CRYPTOLIB_API bool CRYPTOLIB_CALL clPKIVerifySignature(const char * pkalgorithm,
                                                     size32_t lenSignature,const void * signature,
                                                     size32_t lenSigneddata,const void * signeddata)
 {
-    verifyPKIAlgorithm(pkalgorithm);
-    Owned<IDigitalSignatureManager> pDSM = g_DSMCache.getInstance(pkalgorithm, publickeyfile, nullptr, nullptr, nullptr, passphrase, false, nullptr);
-    if (pDSM)
-    {
-        StringBuffer sbSig(lenSignature, (const char *)signature);
-        bool rc = pDSM->digiVerify(sbSig.str(), lenSigneddata, signeddata);
-        return rc;
-    }
-    else
-    {
-        throw makeStringException(-1, "Unable to create Digital Signature Manager");
-    }
+    return clPKIVerifySignature2(pkalgorithm, publickeyfile, strlen(passphrase), (const void *)passphrase, lenSignature,signature, lenSigneddata, signeddata);
 }
 
 CRYPTOLIB_API bool CRYPTOLIB_CALL clPKIVerifySignatureLFN(ICodeContext * ctx,
@@ -591,19 +686,7 @@ CRYPTOLIB_API bool CRYPTOLIB_CALL clPKIVerifySignatureLFN(ICodeContext * ctx,
                                                     size32_t lenSignature,const void * signature,
                                                     size32_t lenSigneddata,const void * signeddata)
 {
-    verifyPKIAlgorithm(pkalgorithm);
-    IUserDescriptor * udesc = ctx->queryUserDescriptor();
-    Owned<IDigitalSignatureManager> pDSM = g_DSMCache.getInstance(pkalgorithm, publickeyLFN, nullptr, nullptr, nullptr, passphrase, true, udesc);
-    if (pDSM)
-    {
-        StringBuffer sbSig(lenSignature, (const char *)signature);
-        bool rc = pDSM->digiVerify(sbSig.str(), lenSigneddata, signeddata);
-        return rc;
-    }
-    else
-    {
-        throw makeStringException(-1, "Unable to create Digital Signature Manager");
-    }
+    return clPKIVerifySignatureLFN2(ctx, pkalgorithm, publickeyLFN, strlen(passphrase), (const void *)passphrase, lenSignature,signature, lenSigneddata, signeddata);
 }
 
 CRYPTOLIB_API bool CRYPTOLIB_CALL clPKIVerifySignatureBuff(const char * pkalgorithm,
@@ -612,18 +695,7 @@ CRYPTOLIB_API bool CRYPTOLIB_CALL clPKIVerifySignatureBuff(const char * pkalgori
                                                        size32_t lenSignature, const void * signature,
                                                        size32_t lenSigneddata, const void * signeddata)
 {
-    verifyPKIAlgorithm(pkalgorithm);
-    Owned<IDigitalSignatureManager> pDSM = g_DSMCache.getInstance(pkalgorithm, nullptr, publicKeyBuff, nullptr, nullptr, passphrase, false, nullptr);
-    if (pDSM)
-    {
-        StringBuffer sbSig(lenSignature, (const char *)signature);
-        bool rc = pDSM->digiVerify(sbSig.str(), lenSigneddata, signeddata);
-        return rc;
-    }
-    else
-    {
-        throw makeStringException(-1, "Unable to create Digital Signature Manager");
-    }
+    return clPKIVerifySignatureBuff2(pkalgorithm, publicKeyBuff, strlen(passphrase), (const void *)passphrase, lenSignature,signature, lenSigneddata, signeddata);
 }
 
 
@@ -684,7 +756,7 @@ private:
     bool        m_isPublic = false;
     StringAttr  m_keyFS;
     StringAttr  m_keyBuff;
-    StringAttr  m_passphrase;
+    MemoryBuffer m_passphrase;
     Owned<CLoadedKey> m_loadedKey;
 
     //String compare that treats null ptr and ptr to empty string as matching
@@ -697,13 +769,21 @@ private:
         return strcmp(left, right) == 0;
     }
 
+    //compare buffers
+    inline bool sameBuff(size32_t lenLeft, const void * left, size32_t lenRight, const void * right)
+    {
+        if (lenLeft != lenRight)
+            return false;
+        return memcmp(left, right, lenLeft) == 0;
+    }
+
 public:
 
-    CLoadedKey * getInstance(bool isPublic, const char * keyFS, const char * keyBuff, const char * passphrase, bool isLFN, IUserDescriptor * user)
+    CLoadedKey * getInstance(bool isPublic, const char * keyFS, const char * keyBuff, size32_t lenPassphrase, const void * passphrase, bool isLFN, IUserDescriptor * user)
     {
         if (!m_loadedKey ||
             isPublic != m_isPublic ||
-            !sameString(passphrase, m_passphrase.str())  ||
+            !sameBuff(lenPassphrase, passphrase, m_passphrase.length(), m_passphrase.bufferBase())  ||
             !sameString(keyFS, m_keyFS.str()) ||
             !sameString(keyBuff, m_keyBuff.str()))
         {
@@ -718,12 +798,12 @@ public:
                     if (isPublic)
                         newKey = loadPublicKeyFromMemory(sb.str());
                     else
-                        newKey = loadPrivateKeyFromMemory(sb.str(), passphrase);
+                        newKey = loadPrivateKeyFromMemory(sb.str(), lenPassphrase, passphrase);
                 }
                 else if (isPublic)
                     newKey = loadPublicKeyFromFile(keyFS);
                 else
-                    newKey = loadPrivateKeyFromFile(keyFS, passphrase);
+                    newKey = loadPrivateKeyFromFile(keyFS, lenPassphrase, passphrase);
             }
             else if (!isEmptyString(keyBuff))
             {
@@ -731,7 +811,7 @@ public:
                 if (isPublic)
                     newKey = loadPublicKeyFromMemory(keyBuff);
                 else
-                    newKey = loadPrivateKeyFromMemory(keyBuff, passphrase);
+                    newKey = loadPrivateKeyFromMemory(keyBuff, lenPassphrase, passphrase);
             }
             else
                 throw makeStringException(-1, "Must specify a key filename or provide a key buffer");
@@ -740,7 +820,7 @@ public:
             m_isPublic = isPublic;
             m_keyFS.set(keyFS);
             m_keyBuff.set(keyBuff);
-            m_passphrase.set(passphrase);
+            m_passphrase.clear().append(lenPassphrase, passphrase);
         }
         return LINK(m_loadedKey);
     }
@@ -759,14 +839,14 @@ static bool clearupKeyCache(bool isPooled)
     return false;
 }
 
-static CLoadedKey * getCachedKey(bool isPublic, const char * keyFS, const char * keyBuff, const char * passphrase, bool isLFN, IUserDescriptor * udesc)
+static CLoadedKey * getCachedKey(bool isPublic, const char * keyFS, const char * keyBuff, size32_t lenPassphrase, const void * passphrase, bool isLFN, IUserDescriptor * udesc)
 {
     if (!pKC)
     {
         pKC = new CKeyCache();
         addThreadTermFunc(clearupKeyCache);
     }
-    return pKC->getInstance(isPublic, keyFS, keyBuff, passphrase, isLFN, udesc);
+    return pKC->getInstance(isPublic, keyFS, keyBuff, lenPassphrase, passphrase, isLFN, udesc);
 }
 
 //------------------------------------
@@ -805,15 +885,86 @@ static void doPKIDecrypt(size32_t & __lenResult,void * & __result,
 
 //encryption functions that take filespecs of key files
 
+CRYPTOLIB_API void CRYPTOLIB_CALL clPKIEncrypt2(size32_t & __lenResult,void * & __result,
+                                            const char * pkalgorithm,
+                                            const char * publickeyfile,
+                                            size32_t lenPassPhrase,const void * passphrase,
+                                            size32_t lenInputdata,const void * inputdata)
+{
+    verifyPKIAlgorithm(pkalgorithm);
+    Owned<CLoadedKey> publicKey = getCachedKey(true, publickeyfile, nullptr, lenPassPhrase, passphrase, false, nullptr);
+    doPKIEncrypt(__lenResult, __result, publicKey, lenInputdata, inputdata);
+}
+
+
+CRYPTOLIB_API void CRYPTOLIB_CALL clPKIDecrypt2(size32_t & __lenResult,void * & __result,
+                                            const char * pkalgorithm,
+                                            const char * privatekeyfile,
+                                            size32_t lenPassPhrase,const void * passphrase,
+                                            size32_t lenEncrypteddata,const void * encrypteddata)
+{
+    verifyPKIAlgorithm(pkalgorithm);
+    Owned<CLoadedKey> privateKey = getCachedKey(false, privatekeyfile, nullptr, lenPassPhrase, passphrase, false, nullptr);
+    doPKIDecrypt(__lenResult, __result, privateKey, lenEncrypteddata, encrypteddata);
+}
+
+CRYPTOLIB_API void CRYPTOLIB_CALL clPKIEncryptLFN2(ICodeContext * ctx,
+                                            size32_t & __lenResult,void * & __result,
+                                            const char * pkalgorithm,
+                                            const char * publickeyLFN,
+                                            size32_t lenPassPhrase,const void * passphrase,
+                                            size32_t lenInputdata,const void * inputdata)
+{
+    verifyPKIAlgorithm(pkalgorithm);
+    IUserDescriptor * udesc = ctx->queryUserDescriptor();
+    Owned<CLoadedKey> publicKey = getCachedKey(true, publickeyLFN, nullptr, lenPassPhrase, passphrase, true, udesc);
+    doPKIEncrypt(__lenResult, __result, publicKey, lenInputdata, inputdata);
+}
+
+CRYPTOLIB_API void CRYPTOLIB_CALL clPKIDecryptLFN2(ICodeContext * ctx,
+                                            size32_t & __lenResult,void * & __result,
+                                            const char * pkalgorithm,
+                                            const char * privatekeyLFN,
+                                            size32_t lenPassPhrase,const void * passphrase,
+                                            size32_t lenEncrypteddata,const void * encrypteddata)
+{
+    verifyPKIAlgorithm(pkalgorithm);
+    IUserDescriptor * udesc = ctx->queryUserDescriptor();
+    Owned<CLoadedKey> privateKey = getCachedKey(false, privatekeyLFN, nullptr, lenPassPhrase, passphrase, true, udesc);
+    doPKIDecrypt(__lenResult, __result, privateKey, lenEncrypteddata, encrypteddata);
+}
+
+//encryption functions that take keys in a buffer
+
+CRYPTOLIB_API void CRYPTOLIB_CALL clPKIEncryptBuff2(size32_t & __lenResult,void * & __result,
+                                                const char * pkalgorithm,
+                                                const char * publickeybuff,
+                                                size32_t lenPassPhrase,const void * passphrase,
+                                                size32_t lenInputdata,const void * inputdata)
+{
+    verifyPKIAlgorithm(pkalgorithm);
+    Owned<CLoadedKey> publicKey = getCachedKey(true, nullptr, publickeybuff, lenPassPhrase, passphrase, false, nullptr);
+    doPKIEncrypt(__lenResult, __result, publicKey, lenInputdata, inputdata);
+}
+
+CRYPTOLIB_API void CRYPTOLIB_CALL clPKIDecryptBuff2(size32_t & __lenResult,void * & __result,
+                                                const char * pkalgorithm,
+                                                const char * privatekeybuff,
+                                                size32_t lenPassPhrase,const void * passphrase,
+                                                size32_t lenEncrypteddata,const void * encrypteddata)
+{
+    verifyPKIAlgorithm(pkalgorithm);
+    Owned<CLoadedKey> privateKey = getCachedKey(false, nullptr, privatekeybuff, lenPassPhrase, passphrase, false, nullptr);
+    doPKIDecrypt(__lenResult, __result, privateKey, lenEncrypteddata, encrypteddata);
+}
+
 CRYPTOLIB_API void CRYPTOLIB_CALL clPKIEncrypt(size32_t & __lenResult,void * & __result,
                                             const char * pkalgorithm,
                                             const char * publickeyfile,
                                             const char * passphrase,
                                             size32_t lenInputdata,const void * inputdata)
 {
-    verifyPKIAlgorithm(pkalgorithm);
-    Owned<CLoadedKey> publicKey = getCachedKey(true, publickeyfile, nullptr, passphrase, false, nullptr);
-    doPKIEncrypt(__lenResult, __result, publicKey, lenInputdata, inputdata);
+    return clPKIEncrypt2(__lenResult, __result, pkalgorithm, publickeyfile, strlen(passphrase), (const void *)passphrase, lenInputdata, inputdata);
 }
 
 
@@ -823,9 +974,7 @@ CRYPTOLIB_API void CRYPTOLIB_CALL clPKIDecrypt(size32_t & __lenResult,void * & _
                                             const char * passphrase,
                                             size32_t lenEncrypteddata,const void * encrypteddata)
 {
-    verifyPKIAlgorithm(pkalgorithm);
-    Owned<CLoadedKey> privateKey = getCachedKey(false, privatekeyfile, nullptr, passphrase, false, nullptr);
-    doPKIDecrypt(__lenResult, __result, privateKey, lenEncrypteddata, encrypteddata);
+    return clPKIDecrypt2(__lenResult, __result, pkalgorithm, privatekeyfile, strlen(passphrase), (const void *)passphrase, lenEncrypteddata, encrypteddata);
 }
 
 CRYPTOLIB_API void CRYPTOLIB_CALL clPKIEncryptLFN(ICodeContext * ctx,
@@ -835,10 +984,7 @@ CRYPTOLIB_API void CRYPTOLIB_CALL clPKIEncryptLFN(ICodeContext * ctx,
                                             const char * passphrase,
                                             size32_t lenInputdata,const void * inputdata)
 {
-    verifyPKIAlgorithm(pkalgorithm);
-    IUserDescriptor * udesc = ctx->queryUserDescriptor();
-    Owned<CLoadedKey> publicKey = getCachedKey(true, publickeyLFN, nullptr, passphrase, true, udesc);
-    doPKIEncrypt(__lenResult, __result, publicKey, lenInputdata, inputdata);
+    return clPKIEncryptLFN2(ctx, __lenResult, __result, pkalgorithm, publickeyLFN, strlen(passphrase), (const void *)passphrase, lenInputdata, inputdata);
 }
 
 CRYPTOLIB_API void CRYPTOLIB_CALL clPKIDecryptLFN(ICodeContext * ctx,
@@ -848,10 +994,7 @@ CRYPTOLIB_API void CRYPTOLIB_CALL clPKIDecryptLFN(ICodeContext * ctx,
                                             const char * passphrase,
                                             size32_t lenEncrypteddata,const void * encrypteddata)
 {
-    verifyPKIAlgorithm(pkalgorithm);
-    IUserDescriptor * udesc = ctx->queryUserDescriptor();
-    Owned<CLoadedKey> privateKey = getCachedKey(false, privatekeyLFN, nullptr, passphrase, true, udesc);
-    doPKIDecrypt(__lenResult, __result, privateKey, lenEncrypteddata, encrypteddata);
+    return clPKIDecryptLFN2(ctx, __lenResult, __result, pkalgorithm, privatekeyLFN, strlen(passphrase), (const void *)passphrase, lenEncrypteddata, encrypteddata);
 }
 
 //encryption functions that take keys in a buffer
@@ -862,9 +1005,7 @@ CRYPTOLIB_API void CRYPTOLIB_CALL clPKIEncryptBuff(size32_t & __lenResult,void *
                                                 const char * passphrase,
                                                 size32_t lenInputdata,const void * inputdata)
 {
-    verifyPKIAlgorithm(pkalgorithm);
-    Owned<CLoadedKey> publicKey = getCachedKey(true, nullptr, publickeybuff, passphrase, false, nullptr);
-    doPKIEncrypt(__lenResult, __result, publicKey, lenInputdata, inputdata);
+    return clPKIEncryptBuff2(__lenResult, __result, pkalgorithm, publickeybuff, strlen(passphrase), (const void *)passphrase, lenInputdata, inputdata);
 }
 
 CRYPTOLIB_API void CRYPTOLIB_CALL clPKIDecryptBuff(size32_t & __lenResult,void * & __result,
@@ -873,7 +1014,5 @@ CRYPTOLIB_API void CRYPTOLIB_CALL clPKIDecryptBuff(size32_t & __lenResult,void *
                                                 const char * passphrase,
                                                 size32_t lenEncrypteddata,const void * encrypteddata)
 {
-    verifyPKIAlgorithm(pkalgorithm);
-    Owned<CLoadedKey> privateKey = getCachedKey(false, nullptr, privatekeybuff, passphrase, false, nullptr);
-    doPKIDecrypt(__lenResult, __result, privateKey, lenEncrypteddata, encrypteddata);
+    return clPKIDecryptBuff2(__lenResult, __result, pkalgorithm, privatekeybuff, strlen(passphrase), (const void *)passphrase, lenEncrypteddata, encrypteddata);
 }

--- a/plugins/cryptolib/cryptolib.hpp
+++ b/plugins/cryptolib/cryptolib.hpp
@@ -44,7 +44,7 @@ extern "C"
 
 //Following prototypes can be found in workunit CPP file (/var/lib/HPCCSystems/myeclccserver)
 
-//Hasing encryption/decryption
+//Hashing encryption/decryption
 //CRYPTOLIB_API void CRYPTOLIB_CALL clInstalledHashAlgorithms(bool & __isAllResult, size32_t & __lenResult, void * & __result);
 CRYPTOLIB_API void CRYPTOLIB_CALL clSupportedHashAlgorithms(bool & __isAllResult, size32_t & __lenResult, void * & __result);
 CRYPTOLIB_API void CRYPTOLIB_CALL clHash(size32_t & __lenResult,void * & __result,const char * algorithm,size32_t lenInputdata,const void * inputdata);
@@ -53,19 +53,30 @@ CRYPTOLIB_API void CRYPTOLIB_CALL clHash(size32_t & __lenResult,void * & __resul
 //Cipher symmetric encryption/decryption
 //CRYPTOLIB_API void CRYPTOLIB_CALL clInstalledSymmetricCipherAlgorithms(bool & __isAllResult, size32_t & __lenResult, void * & __result);
 CRYPTOLIB_API void CRYPTOLIB_CALL clSupportedSymmetricCipherAlgorithms(bool & __isAllResult, size32_t & __lenResult, void * & __result);
+
 CRYPTOLIB_API void CRYPTOLIB_CALL clSymmetricEncrypt(size32_t & __lenResult,void * & __result,const char * algorithm,const char * key,size32_t lenInputdata,const void * inputdata);
 CRYPTOLIB_API void CRYPTOLIB_CALL clSymmetricDecrypt(size32_t & __lenResult,void * & __result,const char * algorithm,const char * key,size32_t lenEncrypteddata,const void * encrypteddata);
+
+CRYPTOLIB_API void CRYPTOLIB_CALL clSymmEncrypt(size32_t & __lenResult,void * & __result,const char * algorithm,size32_t lenKey,const void * key,size32_t lenInputdata,const void * inputdata);
+CRYPTOLIB_API void CRYPTOLIB_CALL clSymmDecrypt(size32_t & __lenResult,void * & __result,const char * algorithm,size32_t lenKey,const void * key,size32_t lenEncrypteddata,const void * encrypteddata);
 
 //Public Key encryption/decryption
 
 //CRYPTOLIB_API void CRYPTOLIB_CALL clInstalledPublicKeyAlgorithms(bool & __isAllResult, size32_t & __lenResult, void * & __result);
 //from file system
 CRYPTOLIB_API void CRYPTOLIB_CALL clSupportedPublicKeyAlgorithms(bool & __isAllResult, size32_t & __lenResult, void * & __result);
+
 CRYPTOLIB_API void CRYPTOLIB_CALL clPKIEncrypt(size32_t & __lenResult,void * & __result,const char * pkalgorithm,const char * publickeyfile,const char * passphrase,size32_t lenInputdata,const void * inputdata);
 CRYPTOLIB_API void CRYPTOLIB_CALL clPKIDecrypt(size32_t & __lenResult,void * & __result,const char * pkalgorithm,const char * privatekeyfile,const char * passphrase,size32_t lenEncrypteddata,const void * encrypteddata);
 
 CRYPTOLIB_API void CRYPTOLIB_CALL clPKISign(size32_t & __lenResult,void * & __result,const char * pkalgorithm,const char * privatekeyfile,const char * passphrase,size32_t lenInputdata,const void * inputdata);
 CRYPTOLIB_API bool CRYPTOLIB_CALL clPKIVerifySignature(const char * pkalgorithm,const char * publickeyfile,const char * passphrase,size32_t lenSignature,const void * signature,size32_t lenSigneddata,const void * signeddata);
+
+CRYPTOLIB_API void CRYPTOLIB_CALL clPKIEncrypt2(size32_t & __lenResult,void * & __result,const char * pkalgorithm,const char * publickeyfile,size32_t lenPassPhrase,const void * passphrase,size32_t lenInputdata,const void * inputdata);
+CRYPTOLIB_API void CRYPTOLIB_CALL clPKIDecrypt2(size32_t & __lenResult,void * & __result,const char * pkalgorithm,const char * privatekeyfile,size32_t lenPassPhrase,const void * passphrase,size32_t lenEncrypteddata,const void * encrypteddata);
+
+CRYPTOLIB_API void CRYPTOLIB_CALL clPKISign2(size32_t & __lenResult,void * & __result,const char * pkalgorithm,const char * privatekeyfile,size32_t lenPassPhrase,const void * passphrase,size32_t lenInputdata,const void * inputdata);
+CRYPTOLIB_API bool CRYPTOLIB_CALL clPKIVerifySignature2(const char * pkalgorithm,const char * publickeyfile,size32_t lenPassPhrase,const void * passphrase,size32_t lenSignature,const void * signature,size32_t lenSigneddata,const void * signeddata);
 
 //from LFN
 CRYPTOLIB_API void CRYPTOLIB_CALL clPKIEncryptLFN(ICodeContext * ctx, size32_t & __lenResult,void * & __result,const char * pkalgorithm,const char * publickeyLFN,const char * passphrase,size32_t lenInputdata,const void * inputdata);
@@ -74,11 +85,24 @@ CRYPTOLIB_API void CRYPTOLIB_CALL clPKIDecryptLFN(ICodeContext * ctx, size32_t &
 CRYPTOLIB_API void CRYPTOLIB_CALL clPKISignLFN(ICodeContext * ctx, size32_t & __lenResult,void * & __result,const char * pkalgorithm,const char * privatekeyLFN,const char * passphrase,size32_t lenInputdata,const void * inputdata);
 CRYPTOLIB_API bool CRYPTOLIB_CALL clPKIVerifySignatureLFN(ICodeContext * ctx, const char * pkalgorithm,const char * publickeyLFN,const char * passphrase,size32_t lenSignature,const void * signature,size32_t lenSigneddata,const void * signeddata);
 
+CRYPTOLIB_API void CRYPTOLIB_CALL clPKIEncryptLFN2(ICodeContext * ctx, size32_t & __lenResult,void * & __result,const char * pkalgorithm,const char * publickeyLFN,size32_t lenPassPhrase,const void * passphrase,size32_t lenInputdata,const void * inputdata);
+CRYPTOLIB_API void CRYPTOLIB_CALL clPKIDecryptLFN2(ICodeContext * ctx, size32_t & __lenResult,void * & __result,const char * pkalgorithm,const char * privatekeyLFN,size32_t lenPassPhrase,const void * passphrase,size32_t lenEncrypteddata,const void * encrypteddata);
+
+CRYPTOLIB_API void CRYPTOLIB_CALL clPKISignLFN2(ICodeContext * ctx, size32_t & __lenResult,void * & __result,const char * pkalgorithm,const char * privatekeyLFN,size32_t lenPassPhrase,const void * passphrase,size32_t lenInputdata,const void * inputdata);
+CRYPTOLIB_API bool CRYPTOLIB_CALL clPKIVerifySignatureLFN2(ICodeContext * ctx, const char * pkalgorithm,const char * publickeyLFN,size32_t lenPassPhrase,const void * passphrase,size32_t lenSignature,const void * signature,size32_t lenSigneddata,const void * signeddata);
+
 //from buffer
 CRYPTOLIB_API void CRYPTOLIB_CALL clPKIEncryptBuff(size32_t & __lenResult,void * & __result,const char * pkalgorithm,const char * publickeybuff,const char * passphrase,size32_t lenInputdata,const void * inputdata);
 CRYPTOLIB_API void CRYPTOLIB_CALL clPKIDecryptBuff(size32_t & __lenResult,void * & __result,const char * pkalgorithm,const char * privatekeybuff,const char * passphrase,size32_t lenEncrypteddata,const void * encrypteddata);
 
 CRYPTOLIB_API void CRYPTOLIB_CALL clPKISignBuff(size32_t & __lenResult,void * & __result,const char * pkalgorithm,const char * privatekeybuff,const char * passphrase,size32_t lenInputdata,const void * inputdata);
 CRYPTOLIB_API bool CRYPTOLIB_CALL clPKIVerifySignatureBuff(const char * pkalgorithm,const char * publickeybuff,const char * passphrase,size32_t lenSignature,const void * signature,size32_t lenSigneddata,const void * signeddata);
+
+CRYPTOLIB_API void CRYPTOLIB_CALL clPKIEncryptBuff2(size32_t & __lenResult,void * & __result,const char * pkalgorithm,const char * publickeybuff,size32_t lenPassPhrase,const void * passphrase,size32_t lenInputdata,const void * inputdata);
+CRYPTOLIB_API void CRYPTOLIB_CALL clPKIDecryptBuff2(size32_t & __lenResult,void * & __result,const char * pkalgorithm,const char * privatekeybuff,size32_t lenPassPhrase,const void * passphrase,size32_t lenEncrypteddata,const void * encrypteddata);
+
+CRYPTOLIB_API void CRYPTOLIB_CALL clPKISignBuff2(size32_t & __lenResult,void * & __result,const char * pkalgorithm,const char * privatekeybuff,size32_t lenPassPhrase,const void * passphrase,size32_t lenInputdata,const void * inputdata);
+CRYPTOLIB_API bool CRYPTOLIB_CALL clPKIVerifySignatureBuff2(const char * pkalgorithm,const char * publickeybuff,size32_t lenPassPhrase,const void * passphrase,size32_t lenSignature,const void * signature,size32_t lenSigneddata,const void * signeddata);
+
 }
 #endif

--- a/plugins/proxies/lib_cryptolib.ecllib
+++ b/plugins/proxies/lib_cryptolib.ecllib
@@ -19,36 +19,72 @@
 
 export CryptoLib := SERVICE : plugin('cryptolib')
 
-  //Hashing
-  
+  //----------------------------------
+  // Hashing
+  //----------------------------------
   SET OF STRING SupportedHashAlgorithms() : c, pure, fold, entrypoint='clSupportedHashAlgorithms';
   DATA   Hash(CONST VARSTRING algorithm, CONST DATA inputData) : c, pure, entrypoint='clHash';
 
-  //Symmetric Encryption
-      
+  //----------------------------------
+  // Symmetric Encryption
+  //----------------------------------
   SET OF STRING SupportedSymmetricCipherAlgorithms() : c, pure, fold, entrypoint='clSupportedSymmetricCipherAlgorithms';
-  DATA SymmetricEncrypt(CONST VARSTRING algorithm, CONST VARSTRING passphrase, CONST DATA inputData) : c, pure, entrypoint='clSymmetricEncrypt';
+  
+  //Module SymmetricEncryption
+  DATA SymmetricEncrypt(CONST VARSTRING algorithm, CONST VARSTRING passphrase, CONST DATA inputData)     : c, pure, entrypoint='clSymmetricEncrypt';
   DATA SymmetricDecrypt(CONST VARSTRING algorithm, CONST VARSTRING passphrase, CONST DATA encryptedData) : c, pure, entrypoint='clSymmetricDecrypt';
 
-  //Asymmetric Public Key Encryption
-  
+  //Module SymmEncryption
+  DATA SymEncrypt(CONST VARSTRING algorithm, CONST DATA passphrase, CONST DATA inputData)    : c, pure, entrypoint='clSymmEncrypt';
+  DATA SymDecrypt(CONST VARSTRING algorithm, CONST DATA passphrase, CONST DATA encryptedData): c, pure, entrypoint='clSymmDecrypt';
+
+
+  //----------------------------------
+  // Asymmetric Public Key Encryption
+  //----------------------------------
   SET OF STRING SupportedPublicKeyAlgorithms() : c, pure, fold, entrypoint='clSupportedPublicKeyAlgorithms';
 
   //Accepts key data as file specification
+
+  //Module PublicKeyEncryption
   DATA    Encrypt(CONST VARSTRING pkAlgorithm, CONST VARSTRING publicKeyFile, CONST VARSTRING passphrase, CONST DATA inputData) : c, pure, entrypoint='clPKIEncrypt';
   DATA    Decrypt(CONST VARSTRING pkAlgorithm, CONST VARSTRING privateKeyFile, CONST VARSTRING passphrase, CONST DATA encryptedData) : c, pure, entrypoint='clPKIDecrypt';
   DATA    Sign(CONST VARSTRING pkAlgorithm, CONST VARSTRING privateKeyFile, CONST VARSTRING passphrase, CONST DATA inputData) : c, pure, entrypoint='clPKISign';
   BOOLEAN VerifySignature(CONST VARSTRING pkAlgorithm, CONST VARSTRING publicKeyFile, CONST VARSTRING passphrase, CONST DATA signature, CONST DATA signedData) : c, pure, entrypoint='clPKIVerifySignature';
 
+  //Module PKEncryption
+  DATA    PKEncrypt(CONST VARSTRING pkAlgorithm, CONST VARSTRING publicKeyFile, CONST DATA passphrase, CONST DATA inputData) : c, pure, entrypoint='clPKIEncrypt2';
+  DATA    PKDecrypt(CONST VARSTRING pkAlgorithm, CONST VARSTRING privateKeyFile, CONST DATA passphrase, CONST DATA encryptedData) : c, pure, entrypoint='clPKIDecrypt2';
+  DATA    PKSign(CONST VARSTRING pkAlgorithm, CONST VARSTRING privateKeyFile, CONST DATA passphrase, CONST DATA inputData) : c, pure, entrypoint='clPKISign2';
+  BOOLEAN PKVerifySignature(CONST VARSTRING pkAlgorithm, CONST VARSTRING publicKeyFile, CONST DATA passphrase, CONST DATA signature, CONST DATA signedData) : c, pure, entrypoint='clPKIVerifySignature2';
+
   //Accepts key data as Logical File Name
+
+  //Module PublicKeyEncryptionFromLFN
   DATA    EncryptLFN(CONST VARSTRING pkAlgorithm, CONST VARSTRING publickeyLFN, CONST VARSTRING passphrase, CONST DATA inputData) : c, pure, context, entrypoint='clPKIEncryptLFN';
   DATA    DecryptLFN(CONST VARSTRING pkAlgorithm, CONST VARSTRING privatekeyLFN, CONST VARSTRING passphrase, CONST DATA encryptedData) : c, pure, context, entrypoint='clPKIDecryptLFN';
   DATA    SignLFN(CONST VARSTRING pkAlgorithm, CONST VARSTRING privatekeyLFN, CONST VARSTRING passphrase, CONST DATA inputData) : c, pure, context, entrypoint='clPKISignLFN';
   BOOLEAN VerifySignatureLFN(CONST VARSTRING pkAlgorithm, CONST VARSTRING publickeyLFN, CONST VARSTRING passphrase, CONST DATA signature, CONST DATA signedData) : c, pure, context, entrypoint='clPKIVerifySignatureLFN';
 
-   //Accepts key data as memory buffer
+  //Module PKEncryptionFromLFN
+  DATA    PKEncryptLFN(CONST VARSTRING pkAlgorithm, CONST VARSTRING publickeyLFN, CONST DATA passphrase, CONST DATA inputData) : c, pure, context, entrypoint='clPKIEncryptLFN2';
+  DATA    PKDecryptLFN(CONST VARSTRING pkAlgorithm, CONST VARSTRING privatekeyLFN, CONST DATA passphrase, CONST DATA encryptedData) : c, pure, context, entrypoint='clPKIDecryptLFN2';
+  DATA    PKSignLFN(CONST VARSTRING pkAlgorithm, CONST VARSTRING privatekeyLFN, CONST DATA passphrase, CONST DATA inputData) : c, pure, context, entrypoint='clPKISignLFN2';
+  BOOLEAN PKVerifySignatureLFN(CONST VARSTRING pkAlgorithm, CONST VARSTRING publickeyLFN, CONST DATA passphrase, CONST DATA signature, CONST DATA signedData) : c, pure, context, entrypoint='clPKIVerifySignatureLFN2';
+
+
+  //Accepts key data as memory buffer
+
+  //Module PublicKeyEncryptionFromBuffer
   DATA    EncryptBuff(CONST VARSTRING pkAlgorithm, CONST VARSTRING publicKeyBuff, CONST VARSTRING passphrase, CONST DATA inputData) : c, pure, entrypoint='clPKIEncryptBuff';
   DATA    DecryptBuff(CONST VARSTRING pkAlgorithm, CONST VARSTRING privateKeyBuff, CONST VARSTRING passphrase, CONST DATA encryptedData) : c, pure, entrypoint='clPKIDecryptBuff';
   DATA    SignBuff(CONST VARSTRING pkAlgorithm, CONST VARSTRING privateKeyBuff, CONST VARSTRING passphrase, CONST DATA inputData) : c, pure, entrypoint='clPKISignBuff';
   BOOLEAN VerifySignatureBuff(CONST VARSTRING pkAlgorithm, CONST VARSTRING publicKeyBuff, CONST VARSTRING passphrase, CONST DATA signature, CONST DATA signedData) : c, pure, entrypoint='clPKIVerifySignatureBuff';
+
+  //Module PKEncryptionFromBuffer
+  DATA    PKEncryptBuff(CONST VARSTRING pkAlgorithm, CONST VARSTRING publicKeyBuff, CONST DATA passphrase, CONST DATA inputData) : c, pure, entrypoint='clPKIEncryptBuff2';
+  DATA    PKDecryptBuff(CONST VARSTRING pkAlgorithm, CONST VARSTRING privateKeyBuff, CONST DATA passphrase, CONST DATA encryptedData) : c, pure, entrypoint='clPKIDecryptBuff2';
+  DATA    PKSignBuff(CONST VARSTRING pkAlgorithm, CONST VARSTRING privateKeyBuff, CONST DATA passphrase, CONST DATA inputData) : c, pure, entrypoint='clPKISignBuff2';
+  BOOLEAN PKVerifySignatureBuff(CONST VARSTRING pkAlgorithm, CONST VARSTRING publicKeyBuff, CONST DATA passphrase, CONST DATA signature, CONST DATA signedData) : c, pure, entrypoint='clPKIVerifySignatureBuff2';
+
  END;

--- a/testing/regress/ecl/cryptoplugin_pke.ecl
+++ b/testing/regress/ecl/cryptoplugin_pke.ecl
@@ -16,11 +16,6 @@
 ############################################################################## */
 import Std;
 
-output('PKIEncryption Tests enumerating supported algorithms');
-
-output(Std.Crypto.SupportedPublicKeyAlgorithms());
-
-
 STRING pubKey := '-----BEGIN PUBLIC KEY-----' + '\n' +
 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAr64RncTp5pV0KMnWRAof' + '\n' +
 'od+3AUS/IDngT39j3Iovv9aI2N8g4W5ipqhKftRESmzQ6I/TiUQcmi42soUXmCeE' + '\n' +
@@ -60,11 +55,13 @@ STRING privKey := '-----BEGIN RSA PRIVATE KEY-----' + '\n' +
 'iIhG5ueb6xoj/N0LuXa8loUT5aChKWxRHEYdegqU48f+qxUcJj9R' + '\n' +
 '-----END RSA PRIVATE KEY-----';
 
+output('PKIEncryption Tests enumerating supported algorithms');
+output(Std.Crypto.SupportedPublicKeyAlgorithms());
 
-encModule := Std.Crypto.PublicKeyEncryptionFromBuffer('RSA', pubKey, privKey, '');
+encModule := Std.Crypto.PublicKeyEncryptionFromBuffer('RSA', pubKey, privKey, 'Passphrase');
 
 //Digital Signature tests
-
+output('Testing PKE PublicKeyEncryptionFromBuffer Digital Signatures');
 DATA signature := encModule.Sign((DATA)'The quick brown fox jumps over the lazy dog');
 output( TRUE = encModule.VerifySignature(signature, (DATA)'The quick brown fox jumps over the lazy dog'));
 output(FALSE = encModule.VerifySignature(signature, (DATA)'Your Name Here'));
@@ -72,36 +69,45 @@ output(FALSE = encModule.VerifySignature(signature, (DATA)'Your Name Here'));
 DATA bogus := (DATA)'Not a valid signaturexxx';
 output(FALSE = encModule.VerifySignature(bogus, (DATA)'Not a valid signaturexxx'));
 
-
 DATA sig256Ex := encModule.Sign((DATA)'0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTTUVWXYZ`~!@#$%^&*()_-+=|}]{[":;?/>.<,');
 output(TRUE = encModule.VerifySignature(sig256Ex, (DATA)'0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTTUVWXYZ`~!@#$%^&*()_-+=|}]{[":;?/>.<,'));
 
-//Encrypt/Decrypt tests
 
+//Encrypt/Decrypt tests
+output('Testing PKE PublicKeyEncryptionFromBuffer Encrypt/Decrypt');
 DATA encrypted := encModule.Encrypt((DATA)'The quick brown fox jumps over the lazy dog');
 output( (STRING)encModule.Decrypt(encrypted) );
-output( (STRING)encModule.Decrypt(encrypted) );
-output( (STRING)encModule.Decrypt(encrypted) );
-output( (STRING)encModule.Decrypt(encrypted) );
-output( (STRING)encModule.Decrypt(encrypted) );
+
+DATA sigBuff := encModule.Sign((DATA)'The quick brown fox jumps over the lazy dog');
+output(encModule.VerifySignature(sigBuff, (DATA)'The quick brown fox jumps over the lazy dog'));//TRUE
+
+DATA pkiDat := encModule.Encrypt((DATA)'The quick brown fox jumps over the lazy dog');
+output( (STRING)encModule.Decrypt(pkiDat) );
 
 
-encModuleBuff := Std.Crypto.PublicKeyEncryptionFromBuffer('RSA', pubKey, privKey, '');
 
-DATA sigBuff := encModuleBuff.Sign((DATA)'The quick brown fox jumps over the lazy dog');
-output(encModuleBuff.VerifySignature(sigBuff, (DATA)'The quick brown fox jumps over the lazy dog'));//TRUE
-output(encModuleBuff.VerifySignature(sigBuff, (DATA)'The quick brown fox jumps over the lazy dog'));//TRUE
-output(encModuleBuff.VerifySignature(sigBuff, (DATA)'The quick brown fox jumps over the lazy dog'));//TRUE
-output(encModuleBuff.VerifySignature(sigBuff, (DATA)'The quick brown fox jumps over the lazy dog'));//TRUE
-output(encModuleBuff.VerifySignature(sigBuff, (DATA)'The quick brown fox jumps over the lazy dog'));//TRUE
-output(encModuleBuff.VerifySignature(sigBuff, (DATA)'The quick brown fox jumps over the lazy dog'));//TRUE
+PKEncMod := Std.Crypto.PKEncryptionFromBuffer('RSA', pubKey, privKey, (DATA)'Passphrase');
 
-DATA pkiDat := encModuleBuff.Encrypt((DATA)'The quick brown fox jumps over the lazy dog');
-output( (STRING)encModuleBuff.Decrypt(pkiDat) );
-output( (STRING)encModuleBuff.Decrypt(pkiDat) );
-output( (STRING)encModuleBuff.Decrypt(pkiDat) );
-output( (STRING)encModuleBuff.Decrypt(pkiDat) );
-output( (STRING)encModuleBuff.Decrypt(pkiDat) );
-output( (STRING)encModuleBuff.Decrypt(pkiDat) );
+//Digital Signature tests
+output('Testing PKE PKEncryptionFromBuffer Digital Signatures');
+DATA signature2 := PKEncMod.Sign((DATA)'The quick brown fox jumps over the lazy dog');
+output( TRUE = PKEncMod.VerifySignature(signature2, (DATA)'The quick brown fox jumps over the lazy dog'));
+output(FALSE = PKEncMod.VerifySignature(signature2, (DATA)'Your Name Here'));
+
+DATA bogus2 := (DATA)'Not a valid signaturexxx';
+output(FALSE = PKEncMod.VerifySignature(bogus2, (DATA)'Not a valid signaturexxx'));
+
+DATA sig256Ex2 := PKEncMod.Sign((DATA)'0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTTUVWXYZ`~!@#$%^&*()_-+=|}]{[":;?/>.<,');
+output(TRUE = PKEncMod.VerifySignature(sig256Ex2, (DATA)'0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTTUVWXYZ`~!@#$%^&*()_-+=|}]{[":;?/>.<,'));
 
 
+//Encrypt/Decrypt tests
+output('Testing PKE PKEncryptionFromBuffer Encrypt/Decrypt');
+DATA encrypted2 := PKEncMod.Encrypt((DATA)'The quick brown fox jumps over the lazy dog');
+output( (STRING)PKEncMod.Decrypt(encrypted2) );
+
+DATA sigBuff2 := PKEncMod.Sign((DATA)'The quick brown fox jumps over the lazy dog');
+output(PKEncMod.VerifySignature(sigBuff2, (DATA)'The quick brown fox jumps over the lazy dog'));//TRUE
+
+DATA pkiDat2 := PKEncMod.Encrypt((DATA)'The quick brown fox jumps over the lazy dog');
+output( (STRING)PKEncMod.Decrypt(pkiDat2) );

--- a/testing/regress/ecl/cryptoplugin_pke_lfn.ecl
+++ b/testing/regress/ecl/cryptoplugin_pke_lfn.ecl
@@ -16,11 +16,6 @@
 ############################################################################## */
 import Std;
 
-output('PKIEncryption Tests enumerating supported public key algorithms');
-
-output(Std.Crypto.SupportedPublicKeyAlgorithms());
-
-
 /*###############################
     Create key files for testing
 #################################*/
@@ -84,12 +79,14 @@ OUTPUT(dPrivKey,,'~regress::certificates::privkey.pem', CSV(SEPARATOR(''), TERMI
 /*###############################
     Begin tests
 #################################*/
+output('PKIEncryption Tests enumerating supported public key algorithms');
+output(Std.Crypto.SupportedPublicKeyAlgorithms());
 
 
 encModuleLFN := Std.Crypto.PublicKeyEncryptionFromLFN('RSA', '~regress::certificates::pubkey.pem', '~regress::certificates::privkey.pem', '');
 
 //Digital Signature tests
-output('PKIEncryption Tests for PKI Digital Signatures');
+output('Testing PKI PublicKeyEncryptionFromLFN Digital Signatures');
 
 DATA sig1 := encModuleLFN.Sign((DATA)'The quick brown fox jumps over the lazy dog');
 output(encModuleLFN.VerifySignature(sig1, (DATA)'This should fail'));
@@ -105,7 +102,7 @@ output(encModuleLFN.VerifySignature(sig3, (DATA)'The most beautiful thing in the
 
 
 //Encrypt/Decrypt tests
-output('PKIEncryption Tests for PKI Encrypt/Decrypt');
+output('Testing PKI PublicKeyEncryptionFromLFN Encrypt/Decrypt');
 
 DATA enc1 := encModuleLFN.Encrypt((DATA)'The quick brown fox jumps over the lazy dog');
 output( (STRING)encModuleLFN.Decrypt(enc1) );
@@ -118,4 +115,40 @@ output( (STRING)encModuleLFN.Decrypt(enc3) );//this should use the cached key fi
 output( (STRING)encModuleLFN.Decrypt(enc3) );//this should use the cached key file
 output( (STRING)encModuleLFN.Decrypt(enc2) );//this should use the cached key file
 output( (STRING)encModuleLFN.Decrypt(enc1) );//this should use the cached key file
+
+
+
+
+encModuleLFN2 := Std.Crypto.PKEncryptionFromLFN('RSA', '~regress::certificates::pubkey.pem', '~regress::certificates::privkey.pem', (DATA)'PassPhrase');
+
+//Digital Signature tests
+output('Testing PKI PKEncryptionFromLFN Digital Signatures');
+
+DATA sig12 := encModuleLFN2.Sign((DATA)'The quick brown fox jumps over the lazy dog');
+output(encModuleLFN2.VerifySignature(sig12, (DATA)'This should fail'));
+output(encModuleLFN2.VerifySignature(sig12, (DATA)'The quick brown fox jumps over the lazy dog'));//this should pass
+
+DATA sig22 := encModuleLFN2.Sign((DATA)'0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTTUVWXYZ`~!@#$%^&*()_-+=|}]{[":;?/>.<,');
+DATA sig32 := encModuleLFN2.Sign((DATA)'The most beautiful thing in the world is, of course, the world itself!');
+
+output(encModuleLFN2.VerifySignature(sig12, (DATA)'The quick brown fox jumps over the lazy dog'));//this should pass
+output(encModuleLFN2.VerifySignature(sig22, (DATA)'0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTTUVWXYZ`~!@#$%^&*()_-+=|}]{[":;?/>.<,'));//this should pass
+output(encModuleLFN2.VerifySignature(sig32, (DATA)'The most beautiful thing in the world is, of course, the world itself!'));//this should pass
+
+
+
+//Encrypt/Decrypt tests
+output('Testing PKI PKEncryptionFromLFN Encrypt/Decrypt');
+
+DATA enc12 := encModuleLFN2.Encrypt((DATA)'The quick brown fox jumps over the lazy dog');
+output( (STRING)encModuleLFN2.Decrypt(enc12) );
+
+DATA enc22 := encModuleLFN2.Encrypt((DATA)'0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTTUVWXYZ`~!@#$%^&*()_-+=|}]{[":;?/>.<,');
+DATA enc32 := encModuleLFN2.Encrypt((DATA)'The most beautiful thing in the world is, of course, the world itself!');//this should use the cached key file
+output( (STRING)encModuleLFN2.Decrypt(enc22) );//this should use the cached key file
+output( (STRING)encModuleLFN2.Decrypt(enc32) );//this should use the cached key file
+
+output( (STRING)encModuleLFN2.Decrypt(enc32) );//this should use the cached key file
+output( (STRING)encModuleLFN2.Decrypt(enc22) );//this should use the cached key file
+output( (STRING)encModuleLFN2.Decrypt(enc12) );//this should use the cached key file
 

--- a/testing/regress/ecl/cryptoplugin_pke_pwd.ecl
+++ b/testing/regress/ecl/cryptoplugin_pke_pwd.ecl
@@ -1,0 +1,87 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2020 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the 'License');
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an 'AS IS' BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+import Std;
+
+PKey :=  RECORD
+  STRING  Key;
+END;
+
+/*Private key generated first, using
+   openssl genrsa -aes128 -passout pass:ThisIsMyPassphrase -out priv.pem 1024
+*/
+
+STRING privKey := '-----BEGIN RSA PRIVATE KEY-----' + '\n' +
+'Proc-Type: 4,ENCRYPTED' + '\n' +
+'DEK-Info: AES-128-CBC,27840180591F7545A3BC6AC26017B5E2' + '\n' +
+'' + '\n' +
+'JZ7kSTs0chmd3TmPTWQW3NM9dtfgJN59cecq8UzNeDfNdXQYU5WwhPFebpqX6K4H' + '\n' +
+'hRJ4pKaFCS39+ib68Yalwb5T+vru9t6WHhJkbGcl41bz6U0aXs3FCEEGFUEngVWu' + '\n' +
+'lonE8YjbeC+kiE7UlnGiFweteTJNlzbsFfa0w3U/6/tkfbd6ZDbriEhUvrbp1EPw' + '\n' +
+'JAAZDs9MNCqs2S76VqqWHyWhVI32lgauVRqDNZTZDSnXF9/huUUSuK8fLK4G68Jz' + '\n' +
+'0gSb7AeR9/AaJgg1FVUantmX7Ja60qLQW4O6DzTJgTGtuKEhaX3wNjpH5aKw8Ifn' + '\n' +
+'gVdZrm9hBKGQCxC5JjVjcrKRXKjj7iKf+d0UN57q9BlKcqw+r+ET2Lqf2jnm1XTt' + '\n' +
+'O1i6VkEGCZxSKdy2jb0d1kHNJonXyrW7mukfclO2LKqDwWYr2efu4wv0Dt9ttWeA' + '\n' +
+'jL6taU7O3aGwjTibLW8qcneWKQogIwnmvY2TsDTtL7Pr+zXpIeBOvuu9+IEGV5nm' + '\n' +
+'j4pVrlApKDF7+hhhYyevJSEfnImCwgeji3pZ5CnFEYASBMEGZmGmWtJyZ/sDkrTe' + '\n' +
+'RjyOV22NaHWtu7HISaOgU/inG8NwGsOL91osnmE+hB07vr44Blaz2oHQhtEZb35k' + '\n' +
+'YLeP+sf4MK0iQy/aKnLcZBHig8/m4MIPNKgpHu/MJ03pbiNiUzV34q4IkuvQiEFf' + '\n' +
+'9N/p4HHRx6789Ndf1b8+iW0VtftfTt/HXYnSw2I1InFfB8KmnC20gYIQEorGPUuX' + '\n' +
+'32yYXSjYNdyWZI52PwX57LD/A5YwkuTowib5MyYFoA2Po51B9bHNCTwzN1RTfGbH' + '\n' +
+'-----END RSA PRIVATE KEY-----' + '\n';
+
+/*Public key generated using
+   openssl rsa -in priv.pem -passin pass:ThisIsMyPassphrase -pubout -out pub.pem
+*/
+
+STRING pubKey := '-----BEGIN PUBLIC KEY-----' + '\n' +
+'MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCWnKkGM0l3Y6pKhxMq87hAGBL6' + '\n' +
+'FfEo2HC6XCSQuaAMLkdf7Yjn3FpvFIEO6A1ZYJy70cT8+HOFta+sSUyMn2fDc5cv' + '\n' +
+'VdX8v7XCycYXEBeZ4KsTCHHPCUoO/nxNbxhNz09T8dx/JsIH50LHipR6FTLTSCXR' + '\n' +
+'N9KVLaPXs5DdQx6PjQIDAQAB' + '\n' +
+'-----END PUBLIC KEY-----' + '\n';
+
+//--------------
+//BEGIN TESTING
+//--------------
+
+encModule := Std.Crypto.PKEncryptionFromBuffer('RSA', pubKey, privKey, (DATA)'ThisIsMyPassphrase');
+
+//Digital Signature
+
+//Digital Signature tests
+output('Testing PKE PublicKeyEncryptionFromBuffer Digital Signatures');
+DATA signature := encModule.Sign((DATA)'The quick brown fox jumps over the lazy dog');
+output( TRUE = encModule.VerifySignature(signature, (DATA)'The quick brown fox jumps over the lazy dog'));
+output(FALSE = encModule.VerifySignature(signature, (DATA)'Your Name Here'));
+
+DATA bogus := (DATA)'Not a valid signaturexxx';
+output(FALSE = encModule.VerifySignature(bogus, (DATA)'Not a valid signaturexxx'));
+
+DATA sig256Ex := encModule.Sign((DATA)'0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTTUVWXYZ`~!@#$%^&*()_-+=|}]{[":;?/>.<,');
+output(TRUE = encModule.VerifySignature(sig256Ex, (DATA)'0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTTUVWXYZ`~!@#$%^&*()_-+=|}]{[":;?/>.<,'));
+
+//encrypt/decrypt
+
+DATA enc1 := encModule.Encrypt((DATA)'The quick brown fox jumps over the lazy dog');
+output( (STRING)encModule.Decrypt(enc1) );
+
+DATA enc2 := encModule.Encrypt((DATA)'Hello World!');
+output( (STRING)encModule.Decrypt(enc2) );
+
+DATA enc3 := encModule.Encrypt((DATA)'I like eggs');
+output( (STRING)encModule.Decrypt(enc3) );
+

--- a/testing/regress/ecl/cryptoplugin_ske.ecl
+++ b/testing/regress/ecl/cryptoplugin_ske.ecl
@@ -18,7 +18,7 @@ import Std;
 
 output(Std.Crypto.SupportedSymmetricCipherAlgorithms());
 
-output('aes-256-cbc tests');
+output('Testing SymmetricEncryption aes-256-cbc');
 SymmModule256 := Std.Crypto.SymmetricEncryption( 'aes-256-cbc', '01234567890123456789012345678901' );
 DATA dat256 := SymmModule256.Encrypt( (DATA)'The quick brown fox jumps over the lazy dog');
 output( (STRING)SymmModule256.Decrypt(dat256) );
@@ -26,30 +26,31 @@ output( (STRING)SymmModule256.Decrypt(dat256) );
 DATA dat256Ex := SymmModule256.Encrypt( (DATA)'0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTTUVWXYZ`~!@#$%^&*()_-+=|}]{[":;?/>.<,');
 output( (STRING)SymmModule256.Decrypt(dat256Ex) );
 
-output('aes-192-cbc tests');
+output('Testing SymmetricEncryption aes-192-cbc');
 SymmModule192 := Std.Crypto.SymmetricEncryption( 'aes-192-cbc', '012345678901234567890123' );
 DATA dat192 := SymmModule192.Encrypt( (DATA)'The quick brown fox jumps over the lazy dog');
 output( (STRING)SymmModule192.Decrypt(dat192) );
 
-output('aes-128-cbc tests');
+output('Testing SymmetricEncryption aes-128-cbc');
 SymmModule128 := Std.Crypto.SymmetricEncryption( 'aes-128-cbc', '0123456789012345' );
 DATA dat128 := SymmModule128.Encrypt( (DATA)'The quick brown fox jumps over the lazy dog');
 output( (STRING)SymmModule128.Decrypt(dat128) );
 
-//Try again on previously instantiated modules
 
-output('aes-xxx-cbc combined tests');
-DATA dat256ExEx := SymmModule256.Encrypt( (DATA)'256The quick brown fox jumps over the lazy dog');
-output ( (STRING)SymmModule256.Decrypt(dat256ExEx) );
-output ( (STRING)SymmModule256.Decrypt(dat256ExEx) );
-output ( (STRING)SymmModule256.Decrypt(dat256ExEx) );
+output('Testing SymmEncryption aes-256-cbc');
+SymmModule256p := Std.Crypto.SymmEncryption( 'aes-256-cbc', (DATA)'01234567890123456789012345678901' );
+DATA dat256p := SymmModule256p.Encrypt( (DATA)'The quick brown fox jumps over the lazy dog');
+output( (STRING)SymmModule256p.Decrypt(dat256p) );
 
-DATA dat192Ex := SymmModule192.Encrypt( (DATA)'192The quick brown fox jumps over the lazy dog');
-output ( (STRING)SymmModule192.Decrypt(dat192Ex) );
-output ( (STRING)SymmModule192.Decrypt(dat192Ex) );
-output ( (STRING)SymmModule192.Decrypt(dat192Ex) );
+DATA dat256Exp := SymmModule256p.Encrypt( (DATA)'0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTTUVWXYZ`~!@#$%^&*()_-+=|}]{[":;?/>.<,');
+output( (STRING)SymmModule256p.Decrypt(dat256Exp) );
 
-DATA dat128Ex := SymmModule128.Encrypt( (DATA)'128The quick brown fox jumps over the lazy dog');
-output( (STRING)SymmModule128.Decrypt(dat128Ex) );
-output( (STRING)SymmModule128.Decrypt(dat128Ex) );
-output( (STRING)SymmModule128.Decrypt(dat128Ex) );
+output('Testing SymmEncryption aes-192-cbc');
+SymmModule192p := Std.Crypto.SymmEncryption( 'aes-192-cbc', (DATA)'012345678901234567890123' );
+DATA dat192p := SymmModule192p.Encrypt( (DATA)'The quick brown fox jumps over the lazy dog');
+output( (STRING)SymmModule192p.Decrypt(dat192p) );
+
+output('Testing SymmEncryption aes-128-cbc');
+SymmModule128p := Std.Crypto.SymmEncryption( 'aes-128-cbc', (DATA)'0123456789012345' );
+DATA dat128p := SymmModule128p.Encrypt( (DATA)'The quick brown fox jumps over the lazy dog');
+output( (STRING)SymmModule128p.Decrypt(dat128p) );

--- a/testing/regress/ecl/key/cryptoplugin_pke.xml
+++ b/testing/regress/ecl/key/cryptoplugin_pke.xml
@@ -5,7 +5,7 @@
  <Row><Result_2><Item>RSA</Item></Result_2></Row>
 </Dataset>
 <Dataset name='Result 3'>
- <Row><Result_3>true</Result_3></Row>
+ <Row><Result_3>Testing PKE PublicKeyEncryptionFromBuffer Digital Signatures</Result_3></Row>
 </Dataset>
 <Dataset name='Result 4'>
  <Row><Result_4>true</Result_4></Row>
@@ -17,22 +17,22 @@
  <Row><Result_6>true</Result_6></Row>
 </Dataset>
 <Dataset name='Result 7'>
- <Row><Result_7>The quick brown fox jumps over the lazy dog</Result_7></Row>
+ <Row><Result_7>true</Result_7></Row>
 </Dataset>
 <Dataset name='Result 8'>
- <Row><Result_8>The quick brown fox jumps over the lazy dog</Result_8></Row>
+ <Row><Result_8>Testing PKE PublicKeyEncryptionFromBuffer Encrypt/Decrypt</Result_8></Row>
 </Dataset>
 <Dataset name='Result 9'>
  <Row><Result_9>The quick brown fox jumps over the lazy dog</Result_9></Row>
 </Dataset>
 <Dataset name='Result 10'>
- <Row><Result_10>The quick brown fox jumps over the lazy dog</Result_10></Row>
+ <Row><Result_10>true</Result_10></Row>
 </Dataset>
 <Dataset name='Result 11'>
  <Row><Result_11>The quick brown fox jumps over the lazy dog</Result_11></Row>
 </Dataset>
 <Dataset name='Result 12'>
- <Row><Result_12>true</Result_12></Row>
+ <Row><Result_12>Testing PKE PKEncryptionFromBuffer Digital Signatures</Result_12></Row>
 </Dataset>
 <Dataset name='Result 13'>
  <Row><Result_13>true</Result_13></Row>
@@ -47,23 +47,14 @@
  <Row><Result_16>true</Result_16></Row>
 </Dataset>
 <Dataset name='Result 17'>
- <Row><Result_17>true</Result_17></Row>
+ <Row><Result_17>Testing PKE PKEncryptionFromBuffer Encrypt/Decrypt</Result_17></Row>
 </Dataset>
 <Dataset name='Result 18'>
  <Row><Result_18>The quick brown fox jumps over the lazy dog</Result_18></Row>
 </Dataset>
 <Dataset name='Result 19'>
- <Row><Result_19>The quick brown fox jumps over the lazy dog</Result_19></Row>
+ <Row><Result_19>true</Result_19></Row>
 </Dataset>
 <Dataset name='Result 20'>
  <Row><Result_20>The quick brown fox jumps over the lazy dog</Result_20></Row>
-</Dataset>
-<Dataset name='Result 21'>
- <Row><Result_21>The quick brown fox jumps over the lazy dog</Result_21></Row>
-</Dataset>
-<Dataset name='Result 22'>
- <Row><Result_22>The quick brown fox jumps over the lazy dog</Result_22></Row>
-</Dataset>
-<Dataset name='Result 23'>
- <Row><Result_23>The quick brown fox jumps over the lazy dog</Result_23></Row>
 </Dataset>

--- a/testing/regress/ecl/key/cryptoplugin_pke_lfn.xml
+++ b/testing/regress/ecl/key/cryptoplugin_pke_lfn.xml
@@ -1,15 +1,15 @@
 <Dataset name='Result 1'>
- <Row><Result_1>PKIEncryption Tests enumerating supported public key algorithms</Result_1></Row>
 </Dataset>
 <Dataset name='Result 2'>
- <Row><Result_2><Item>RSA</Item></Result_2></Row>
 </Dataset>
 <Dataset name='Result 3'>
+ <Row><Result_3>PKIEncryption Tests enumerating supported public key algorithms</Result_3></Row>
 </Dataset>
 <Dataset name='Result 4'>
+ <Row><Result_4><Item>RSA</Item></Result_4></Row>
 </Dataset>
 <Dataset name='Result 5'>
- <Row><Result_5>PKIEncryption Tests for PKI Digital Signatures</Result_5></Row>
+ <Row><Result_5>Testing PKI PublicKeyEncryptionFromLFN Digital Signatures</Result_5></Row>
 </Dataset>
 <Dataset name='Result 6'>
  <Row><Result_6>false</Result_6></Row>
@@ -27,7 +27,7 @@
  <Row><Result_10>true</Result_10></Row>
 </Dataset>
 <Dataset name='Result 11'>
- <Row><Result_11>PKIEncryption Tests for PKI Encrypt/Decrypt</Result_11></Row>
+ <Row><Result_11>Testing PKI PublicKeyEncryptionFromLFN Encrypt/Decrypt</Result_11></Row>
 </Dataset>
 <Dataset name='Result 12'>
  <Row><Result_12>The quick brown fox jumps over the lazy dog</Result_12></Row>
@@ -46,4 +46,43 @@
 </Dataset>
 <Dataset name='Result 17'>
  <Row><Result_17>The quick brown fox jumps over the lazy dog</Result_17></Row>
+</Dataset>
+<Dataset name='Result 18'>
+ <Row><Result_18>Testing PKI PKEncryptionFromLFN Digital Signatures</Result_18></Row>
+</Dataset>
+<Dataset name='Result 19'>
+ <Row><Result_19>false</Result_19></Row>
+</Dataset>
+<Dataset name='Result 20'>
+ <Row><Result_20>true</Result_20></Row>
+</Dataset>
+<Dataset name='Result 21'>
+ <Row><Result_21>true</Result_21></Row>
+</Dataset>
+<Dataset name='Result 22'>
+ <Row><Result_22>true</Result_22></Row>
+</Dataset>
+<Dataset name='Result 23'>
+ <Row><Result_23>true</Result_23></Row>
+</Dataset>
+<Dataset name='Result 24'>
+ <Row><Result_24>Testing PKI PKEncryptionFromLFN Encrypt/Decrypt</Result_24></Row>
+</Dataset>
+<Dataset name='Result 25'>
+ <Row><Result_25>The quick brown fox jumps over the lazy dog</Result_25></Row>
+</Dataset>
+<Dataset name='Result 26'>
+ <Row><Result_26>0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTTUVWXYZ`~!@#$%^&amp;*()_-+=|}]{[&quot;:;?/&gt;.&lt;,</Result_26></Row>
+</Dataset>
+<Dataset name='Result 27'>
+ <Row><Result_27>The most beautiful thing in the world is, of course, the world itself!</Result_27></Row>
+</Dataset>
+<Dataset name='Result 28'>
+ <Row><Result_28>The most beautiful thing in the world is, of course, the world itself!</Result_28></Row>
+</Dataset>
+<Dataset name='Result 29'>
+ <Row><Result_29>0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTTUVWXYZ`~!@#$%^&amp;*()_-+=|}]{[&quot;:;?/&gt;.&lt;,</Result_29></Row>
+</Dataset>
+<Dataset name='Result 30'>
+ <Row><Result_30>The quick brown fox jumps over the lazy dog</Result_30></Row>
 </Dataset>

--- a/testing/regress/ecl/key/cryptoplugin_pke_pwd.xml
+++ b/testing/regress/ecl/key/cryptoplugin_pke_pwd.xml
@@ -1,0 +1,24 @@
+<Dataset name='Result 1'>
+ <Row><Result_1>Testing PKE PublicKeyEncryptionFromBuffer Digital Signatures</Result_1></Row>
+</Dataset>
+<Dataset name='Result 2'>
+ <Row><Result_2>true</Result_2></Row>
+</Dataset>
+<Dataset name='Result 3'>
+ <Row><Result_3>true</Result_3></Row>
+</Dataset>
+<Dataset name='Result 4'>
+ <Row><Result_4>true</Result_4></Row>
+</Dataset>
+<Dataset name='Result 5'>
+ <Row><Result_5>true</Result_5></Row>
+</Dataset>
+<Dataset name='Result 6'>
+ <Row><Result_6>The quick brown fox jumps over the lazy dog</Result_6></Row>
+</Dataset>
+<Dataset name='Result 7'>
+ <Row><Result_7>Hello World!</Result_7></Row>
+</Dataset>
+<Dataset name='Result 8'>
+ <Row><Result_8>I like eggs</Result_8></Row>
+</Dataset>

--- a/testing/regress/ecl/key/cryptoplugin_ske.xml
+++ b/testing/regress/ecl/key/cryptoplugin_ske.xml
@@ -2,7 +2,7 @@
  <Row><Result_1><Item>aes-256-cbc</Item><Item>aes-192-cbc</Item><Item>aes-128-cbc</Item></Result_1></Row>
 </Dataset>
 <Dataset name='Result 2'>
- <Row><Result_2>aes-256-cbc tests</Result_2></Row>
+ <Row><Result_2>Testing SymmetricEncryption aes-256-cbc</Result_2></Row>
 </Dataset>
 <Dataset name='Result 3'>
  <Row><Result_3>The quick brown fox jumps over the lazy dog</Result_3></Row>
@@ -11,44 +11,35 @@
  <Row><Result_4>0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTTUVWXYZ`~!@#$%^&amp;*()_-+=|}]{[&quot;:;?/&gt;.&lt;,</Result_4></Row>
 </Dataset>
 <Dataset name='Result 5'>
- <Row><Result_5>aes-192-cbc tests</Result_5></Row>
+ <Row><Result_5>Testing SymmetricEncryption aes-192-cbc</Result_5></Row>
 </Dataset>
 <Dataset name='Result 6'>
  <Row><Result_6>The quick brown fox jumps over the lazy dog</Result_6></Row>
 </Dataset>
 <Dataset name='Result 7'>
- <Row><Result_7>aes-128-cbc tests</Result_7></Row>
+ <Row><Result_7>Testing SymmetricEncryption aes-128-cbc</Result_7></Row>
 </Dataset>
 <Dataset name='Result 8'>
  <Row><Result_8>The quick brown fox jumps over the lazy dog</Result_8></Row>
 </Dataset>
 <Dataset name='Result 9'>
- <Row><Result_9>aes-xxx-cbc combined tests</Result_9></Row>
+ <Row><Result_9>Testing SymmEncryption aes-256-cbc</Result_9></Row>
 </Dataset>
 <Dataset name='Result 10'>
- <Row><Result_10>256The quick brown fox jumps over the lazy dog</Result_10></Row>
+ <Row><Result_10>The quick brown fox jumps over the lazy dog</Result_10></Row>
 </Dataset>
 <Dataset name='Result 11'>
- <Row><Result_11>256The quick brown fox jumps over the lazy dog</Result_11></Row>
+ <Row><Result_11>0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTTUVWXYZ`~!@#$%^&amp;*()_-+=|}]{[&quot;:;?/&gt;.&lt;,</Result_11></Row>
 </Dataset>
 <Dataset name='Result 12'>
- <Row><Result_12>256The quick brown fox jumps over the lazy dog</Result_12></Row>
+ <Row><Result_12>Testing SymmEncryption aes-192-cbc</Result_12></Row>
 </Dataset>
 <Dataset name='Result 13'>
- <Row><Result_13>192The quick brown fox jumps over the lazy dog</Result_13></Row>
+ <Row><Result_13>The quick brown fox jumps over the lazy dog</Result_13></Row>
 </Dataset>
 <Dataset name='Result 14'>
- <Row><Result_14>192The quick brown fox jumps over the lazy dog</Result_14></Row>
+ <Row><Result_14>Testing SymmEncryption aes-128-cbc</Result_14></Row>
 </Dataset>
 <Dataset name='Result 15'>
- <Row><Result_15>192The quick brown fox jumps over the lazy dog</Result_15></Row>
-</Dataset>
-<Dataset name='Result 16'>
- <Row><Result_16>128The quick brown fox jumps over the lazy dog</Result_16></Row>
-</Dataset>
-<Dataset name='Result 17'>
- <Row><Result_17>128The quick brown fox jumps over the lazy dog</Result_17></Row>
-</Dataset>
-<Dataset name='Result 18'>
- <Row><Result_18>128The quick brown fox jumps over the lazy dog</Result_18></Row>
+ <Row><Result_15>The quick brown fox jumps over the lazy dog</Result_15></Row>
 </Dataset>


### PR DESCRIPTION
…NG or DATA

Changed all 'VARSTRING PASSPHRASE' to 'DATA PASSPHRASE.'
Required deprecating ECL Modules
SymmetricEncryption
PublicKeyEncryption
PublicKeyEncryptionFromBuffer
PublicKeyEncryptionFromLFN

and replaced with new modules

SymmEncryption
PKEncryption
PKEncryptionFromBuffer
PKEncryptionFromLFN

Signed-off-by: Russ Whitehead <william.whitehead@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [x] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [x] I have added tests to cover my changes.
  - [x] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [x] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [x] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
