### PR TITLE
HPCC-24046 Fix redissynctest subscribe/publish error on Roxie.

### DIFF
--- a/testing/regress/ecl/redissynctest.ecl
+++ b/testing/regress/ecl/redissynctest.ecl
@@ -170,7 +170,7 @@ INTEGER N2 := 1000;
 subDS := DATASET(N2, TRANSFORM({ integer a }, SELF.a := (INTEGER)myRedis.Subscribe('PubSubTest' + (STRING)COUNTER, database)));
 
 INTEGER pub(STRING channel) := FUNCTION
-        sl := Std.System.Debug.Sleep(10);
+        sl := Std.System.Debug.Sleep(50);
         value :=  myRedis.Publish(channel, '1', database);
      RETURN WHEN(value, sl, BEFORE);
 END;
@@ -178,7 +178,7 @@ pubDS := DATASET(N2, TRANSFORM({ integer a }, SELF.a := pub('PubSubTest' + (STRI
 
 INTEGER pub2(STRING channel) := FUNCTION
         sl := ORDERED(
-            Std.System.Debug.Sleep(10),
+            Std.System.Debug.Sleep(50),
             myRedis.Publish(channel, '3', database)//This pub is the one read by the sub.
             );
         value :=  myRedis.Publish(channel, '10000', database);//This pub isn't read by the sub, however the returned subscription count is present in the sum


### PR DESCRIPTION
Increase publish (thread) delay from 10 msec to 50 to ensure it is matching to the corresponding subscribe.

Signed-off-by: Attila Vamos <attila.vamos@gmail.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [x] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [x] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [x] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->
Tested manually and in OBT environment.
<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
