### PR TITLE
HPCC-23342 Do not listen/accept for dali clients that do not require it

### DIFF
--- a/dali/base/daclient.cpp
+++ b/dali/base/daclient.cpp
@@ -88,11 +88,11 @@ IDaliClient_Exception *createClientException(DaliClientError err, const char *ms
 
 
 
-bool initClientProcess(IGroup *servergrp, DaliClientRole role, unsigned mpport, const char *clientVersion, const char *minServerVersion, unsigned timeout)
+bool initClientProcess(IGroup *servergrp, DaliClientRole role, unsigned mpport, const char *clientVersion, const char *minServerVersion, unsigned timeout, bool listen)
 {
     assertex(servergrp);
     daliClientIsActive = true;
-    startMPServer(role, mpport);
+    startMPServer(role, mpport, false, listen);
     Owned<ICommunicator> comm(createCommunicator(servergrp,true));
     IGroup * covengrp;
     if (!registerClientProcess(comm.get(),covengrp,timeout,role))

--- a/dali/base/daclient.hpp
+++ b/dali/base/daclient.hpp
@@ -26,7 +26,7 @@
 #include "mpcomm.hpp"
 #include "dasds.hpp"
 
-extern da_decl bool initClientProcess(IGroup *servergrp, DaliClientRole role, unsigned mpport=0, const char *clientVersion=NULL, const char *minServerVersion=NULL, unsigned timeout=MP_WAIT_FOREVER);
+extern da_decl bool initClientProcess(IGroup *servergrp, DaliClientRole role, unsigned mpport=0, const char *clientVersion=NULL, const char *minServerVersion=NULL, unsigned timeout=MP_WAIT_FOREVER, bool listen=false);
 extern da_decl bool reinitClientProcess(IGroup *servergrp, DaliClientRole role, const char *clientVersion=NULL, const char *minServerVersion=NULL, unsigned timeout=MP_WAIT_FOREVER); 
 extern da_decl void closedownClientProcess();
 extern da_decl bool daliClientActive();

--- a/dali/sasha/saserver.cpp
+++ b/dali/sasha/saserver.cpp
@@ -335,7 +335,7 @@ int main(int argc, const char* argv[])
 
         unsigned short port = (stop||coalescer)?0:DEFAULT_SASHA_PORT;
         Owned<IGroup> serverGroup = createIGroupRetry(daliServer.str(),DALI_SERVER_PORT);
-        initClientProcess(serverGroup, DCR_SashaServer, port, NULL, NULL, MP_WAIT_FOREVER);
+        initClientProcess(serverGroup, DCR_SashaServer, port, nullptr, nullptr, MP_WAIT_FOREVER, true);
         if (!stop&!coalescer) {
             startLogMsgParentReceiver();    // for auditing
             connectLogMsgManagerToDali();

--- a/dali/server/daserver.cpp
+++ b/dali/server/daserver.cpp
@@ -612,7 +612,7 @@ int main(int argc, const char* argv[])
         }
 
         unsigned short myport = epa.item(myrank).port;
-        startMPServer(DCR_DaliServer, myport, true);
+        startMPServer(DCR_DaliServer, myport, true, true);
         Owned<IMPServer> mpServer = getMPServer();
         Owned<IWhiteListHandler> whiteListHandler = createWhiteListHandler(populateWhiteListFromEnvironment, formatDaliRole);
         mpServer->installWhiteListCallback(whiteListHandler);
@@ -687,7 +687,7 @@ int main(int argc, const char* argv[])
             throw;
         }
         PROGLOG("DASERVER[%d] starting - listening to port %d",myrank,queryMyNode()->endpoint().port);
-        startMPServer(DCR_DaliServer, myport,false);
+        startMPServer(DCR_DaliServer, myport, false, true);
         bool ok = true;
         ForEachItemIn(i2,servers)
         {

--- a/system/mp/mpcomm.hpp
+++ b/system/mp/mpcomm.hpp
@@ -104,11 +104,11 @@ interface IMPServer : extends IInterface
     virtual IWhiteListHandler *queryWhiteListCallback() const = 0;
 };
 
-extern mp_decl void startMPServer(unsigned port, bool paused=false);
-extern mp_decl void startMPServer(unsigned __int64 role, unsigned port, bool paused=false);
+extern mp_decl void startMPServer(unsigned port, bool paused=false, bool listen=false);
+extern mp_decl void startMPServer(unsigned __int64 role, unsigned port, bool paused=false, bool listen=false);
 extern mp_decl void stopMPServer();
 extern mp_decl IMPServer *getMPServer();
-extern mp_decl IMPServer *startNewMPServer(unsigned port);
+extern mp_decl IMPServer *startNewMPServer(unsigned port, bool listen=false);
 
 interface IConnectionMonitor: extends IInterface
 {

--- a/thorlcr/master/thmastermain.cpp
+++ b/thorlcr/master/thmastermain.cpp
@@ -654,7 +654,7 @@ int main( int argc, const char *argv[]  )
             try
             {
                 LOG(MCdebugProgress, thorJob, "calling initClientProcess %d", thorEp.port);
-                initClientProcess(serverGroup, DCR_ThorMaster, thorEp.port);
+                initClientProcess(serverGroup, DCR_ThorMaster, thorEp.port, nullptr, nullptr, MP_WAIT_FOREVER, true);
                 if (0 == thorEp.port)
                     thorEp.port = queryMyNode()->endpoint().port;
                 // both same

--- a/thorlcr/slave/slavmain.cpp
+++ b/thorlcr/slave/slavmain.cpp
@@ -1665,7 +1665,7 @@ public:
         for (unsigned sc=1; sc<channelsPerSlave; sc++)
         {
             unsigned port = getMachinePortBase() + (sc * localThorPortInc);
-            IMPServer *mpServer = startNewMPServer(port);
+            IMPServer *mpServer = startNewMPServer(port, true);
             if (reconnect)
                 mpServer->setOpt(mpsopt_channelreopen, "true");
             mpServers.append(*mpServer);

--- a/thorlcr/slave/thslavemain.cpp
+++ b/thorlcr/slave/thslavemain.cpp
@@ -394,7 +394,7 @@ int main( int argc, const char *argv[]  )
         if (0 == slfEp.port) // assume default from config if not on command line
             slfEp.port = globals->getPropInt("@slaveport", THOR_BASESLAVE_PORT);
 
-        startMPServer(DCR_ThorSlave, slfEp.port, false);
+        startMPServer(DCR_ThorSlave, slfEp.port, false, true);
         if (0 == slfEp.port)
             slfEp.port = queryMyNode()->endpoint().port;
         setMachinePortBase(slfEp.port);


### PR DESCRIPTION
Signed-off-by: Mark Kelly <mark.kelly@lexisnexisrisk.com>

The mplib design implies peer connection status and automatically opens a port in the MP port range and listens for connections, even when only acting as a Dali client.  Mplib internals also require a valid or unique IP:port for all INodes/IGroups created.  This PR prevents listening for new connections for those Dali clients that do not need to accept future client connections themselves.  It does still, however, need to create a socket and bind to an unused port to ensure a unique IP:port tuple.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [ ] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [x] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [x] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

Regression suite testing.

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
