### PR TITLE
HPCC-23313 Disable shebang process in rpm generation.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -395,7 +395,8 @@ if(TOP_LEVEL_PROJECT)
                 "%define _use_internal_dependency_generator 0
                 %define __getdeps()while read file; do /usr/lib/rpm/rpmdeps -%{1} ${file} | %{__grep} -v libantlr3c.so | %{__grep} -v libtbb.so ; done | /bin/sort -u
                 %define __find_provides /bin/sh -c '%{__getdeps P}'
-                %define __find_requires /bin/sh -c '%{__getdeps R}'")
+                %define __find_requires /bin/sh -c '%{__getdeps R}'
+                %undefine __brp_mangle_shebangs")
             message("-- Will build RPM package")
             message("-- Packing BASH installation files")
             if(CLIENTTOOLS_ONLY)

--- a/initfiles/examples/EsdlExample/CppPlugin/runcmake.sh
+++ b/initfiles/examples/EsdlExample/CppPlugin/runcmake.sh
@@ -1,1 +1,2 @@
+#!/bin/bash
 cmake ../source/ -DHPCC_SOURCE_DIR=/home/mayx/git/HPCC-Platform -DHPCC_BUILD_DIR=/home/mayx/git/build -DCMAKE_BUILD_TYPE=Debug -G"Eclipse CDT4 - Unix Makefiles"


### PR DESCRIPTION
Instead of change "#!/usr/bin/python" to "#!/usr/bin/python3 and add shebang to all bash scripts
I use following to skip the checking for rpm build.
Use " %undefine __brp_mangle_shebangs" to skip shebang checking for rpm packaging.
Signed-off-by: Xiaoming Wang xiaoming.wang@lexisnexis.com

@Michael-Gardner please review


## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [ ] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [ ] I have read the CONTRIBUTORS document.
- [ ] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing
<!-- Please describe how this change has been tested.-->
Testing on our build server for Platform, Plugins and LN: http://10.240.32.243/view/CentOS8/
Platform camke options:
     -DUSE_LIBARCHIVE=false  -DUSE_PYTHON2=OFF
Plugins list:
    REMBED MEMCACHED REDIS MYSQLEMBED JAVAEMBED SQLITE3EMBED KAFKA COUCHBASEEMBED SQS
LN cmake options:
   -DCMAKE_CXX_FLAGS=-D_DALIUSER_STACKTRACE        -DUSE_LIBARCHIVE=false -DUSE_OPTIONAL=ON          -DUSE_PYTHON2=OFF
 the time to submit this pull request and to answer all of the above-->
