### PR TITLE
HPCC-24382 Ftslave error INTERNAL: Command send to wrong computer

### DIFF
--- a/common/remote/rmtspawn.cpp
+++ b/common/remote/rmtspawn.cpp
@@ -447,6 +447,30 @@ void CRemoteSlave::run(int argc, char * argv[])
                         byte action;
                         msg.read(action);
 
+                        // <= 7.6.xx clients also send:
+                        //     num passwords followed by those pwds
+                        // >= 7.8.0 clients until now do not send password data
+
+                        // so next unsigned could be either num passwords or netaddr
+                        // if unsigned value <= 10 assumme it is num passwords
+                        // as IP address will surely have higher bits set and be > 10
+
+                        unsigned numPasswds = 0;
+                        size32_t origPos = msg.getPos();
+                        msg.read(numPasswds);
+                        if (numPasswds <= 10)
+                        {
+                            for (int i=0; i<numPasswds; i++)
+                            {
+                                IpAddress tip;
+                                tip.ipdeserialize(msg);
+                                StringAttr password, username;
+                                msg.read(password).read(username);
+                            }
+                        }
+                        else
+                            msg.reset(origPos);
+
                         ok = processCommand(action, masterSocket, msg, results);
                     }
                     catch (IException * e)

--- a/dali/ft/filecopy.cpp
+++ b/dali/ft/filecopy.cpp
@@ -336,6 +336,11 @@ bool FileTransferThread::performTransfer()
 
         //Send message and wait for response...
         msg.append(action);
+
+        // send 0 for password info that was in <= 7.6 versions
+        unsigned zero = 0;
+        msg.append(zero);
+
         ep.serialize(msg);
         sprayer.srcFormat.serialize(msg);
         sprayer.tgtFormat.serialize(msg);


### PR DESCRIPTION
Signed-off-by: Mark Kelly <mark.kelly@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [ ] I have read the CONTRIBUTORS document.
- [ ] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [x] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [x] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

We need to manually test this specific PR with 7.6.xx and prior 7.8 versions to see if it solves the issue correctly.

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
