### PR TITLE
HPCC-24425 DESDL: Allow script to control in process logging agents

### DIFF
--- a/esp/logging/logginglib/loggingagentbase.hpp
+++ b/esp/logging/logginglib/loggingagentbase.hpp
@@ -146,6 +146,7 @@ interface IEspUpdateLogRequestWrap : extends IInterface
     virtual IPropertyTree* getUserContext()=0;
     virtual IPropertyTree* getUserRequest()=0;
     virtual IPropertyTree* getLogRequestTree()=0;
+    virtual IPropertyTree* getScriptValuesTree()=0;
     virtual IInterface* getExtraLog()=0;
     virtual const char* getBackEndRequest()=0;
     virtual const char* getBackEndResponse()=0;
@@ -159,6 +160,7 @@ interface IEspUpdateLogRequestWrap : extends IInterface
     virtual void setUserContext(IPropertyTree* val)=0;
     virtual void setUserRequest(IPropertyTree* val)=0;
     virtual void setLogRequestTree(IPropertyTree* val)=0;
+    virtual void setScriptValuesTree(IPropertyTree* val)=0;
     virtual void setExtraLog(IInterface* val)=0;
     virtual void setBackEndRequest(const char* val)=0;
     virtual void setBackEndResponse(const char* val)=0;
@@ -178,6 +180,7 @@ class CUpdateLogRequestWrap : implements IEspUpdateLogRequestWrap, public CInter
     Owned<IPropertyTree> userContext;
     Owned<IPropertyTree> userRequest;
     Owned<IPropertyTree> logRequestTree;
+    Owned<IPropertyTree> scriptValuesTree;
     Owned<IInterface> extraLog;
     StringAttr  backEndRequest, backEndResponse;
     StringAttr  userResponse;
@@ -218,6 +221,7 @@ public:
         backEndResponse.clear();
         updateLogRequest.clear();
         logRequestTree.clear();
+        scriptValuesTree.clear();
         extraLog.clear();
     };
 
@@ -228,6 +232,7 @@ public:
     IPropertyTree* getUserContext() {return userContext.getLink();};
     IPropertyTree* getUserRequest() {return userRequest.getLink();};
     IPropertyTree* getLogRequestTree() {return logRequestTree.getLink();};
+    IPropertyTree* getScriptValuesTree() override {return scriptValuesTree.getLink();};
     IInterface* getExtraLog() {return extraLog.getLink();};
     const char* getBackEndRequest() {return backEndRequest.get();};
     const char* getBackEndResponse() {return backEndResponse.get();};
@@ -241,6 +246,7 @@ public:
     void setUserContext(IPropertyTree* val) {userContext.setown(val);};
     void setUserRequest(IPropertyTree* val) {userRequest.setown(val);};
     void setLogRequestTree(IPropertyTree* val) {logRequestTree.setown(val);};
+    void setScriptValuesTree(IPropertyTree* val) override {scriptValuesTree.setown(val);};
     void setExtraLog(IInterface* val) {extraLog.setown(val);};
     void setBackEndRequest(const char* val) {backEndRequest.set(val);};
     void setBackEndResponse(const char* val) {backEndResponse.set(val);};

--- a/esp/logging/loggingmanager/loggingmanager.h
+++ b/esp/logging/loggingmanager/loggingmanager.h
@@ -31,6 +31,7 @@ interface IEspLogEntry  : implements IInterface
     virtual void setOwnUserContextTree(IPropertyTree* tree) = 0;
     virtual void setOwnUserRequestTree(IPropertyTree* tree) = 0;
     virtual void setOwnLogInfoTree(IPropertyTree* tree) = 0;
+    virtual void setOwnScriptValuesTree(IPropertyTree* extra) = 0;
     virtual void setOwnExtraLog(IInterface* extra) = 0;
     virtual void setOption(const char* ptr) = 0;
     virtual void setLogContent(const char* ptr) = 0;
@@ -43,6 +44,7 @@ interface IEspLogEntry  : implements IInterface
     virtual IPropertyTree* getUserContextTree() = 0;
     virtual IPropertyTree* getUserRequestTree() = 0;
     virtual IPropertyTree* getLogInfoTree() = 0;
+    virtual IPropertyTree* getScriptValuesTree() = 0;
     virtual IInterface* getExtraLog() = 0;
     virtual const char* getOption() = 0;
     virtual const char* getLogContent() = 0;

--- a/esp/logging/loggingmanager/loggingmanager.hpp
+++ b/esp/logging/loggingmanager/loggingmanager.hpp
@@ -39,6 +39,7 @@ class CEspLogEntry : implements IEspLogEntry, public CInterface
     Owned<IPropertyTree> userContextTree;
     Owned<IPropertyTree> userRequestTree;
     Owned<IPropertyTree> logInfoTree;
+    Owned<IPropertyTree> scriptValuesTree;
     Owned<IInterface> extraLog;
 
 public:
@@ -50,6 +51,7 @@ public:
     void setOwnUserContextTree(IPropertyTree* tree) { userContextTree.setown(tree); };
     void setOwnUserRequestTree(IPropertyTree* tree) { userRequestTree.setown(tree); };
     void setOwnLogInfoTree(IPropertyTree* tree) { logInfoTree.setown(tree); };
+    void setOwnScriptValuesTree(IPropertyTree* tree) override { scriptValuesTree.setown(tree); };
     void setOwnExtraLog(IInterface* extra) { extraLog.setown(extra); };
     void setOption(const char* ptr) { option.set(ptr); };
     void setLogContent(const char* ptr) { logContent.set(ptr); };
@@ -62,6 +64,7 @@ public:
     IPropertyTree* getUserContextTree() { return userContextTree; };
     IPropertyTree* getUserRequestTree() { return userRequestTree; };
     IPropertyTree* getLogInfoTree() { return logInfoTree; };
+    IPropertyTree* getScriptValuesTree() override { return scriptValuesTree; };
     IInterface* getExtraLog() { return extraLog; };
     const char* getOption() { return option.get(); };
     const char* getLogContent() { return logContent.get(); };
@@ -86,7 +89,7 @@ class CLoggingManager : implements ILoggingManager, public CInterface
     unsigned serializeLogRequestContent(IEspUpdateLogRequestWrap* request, const char* GUID, StringBuffer& logData);
 
     bool updateLog(IEspContext* espContext, IEspUpdateLogRequestWrap& req, IEspUpdateLogResponse& resp, StringBuffer& status);
-    bool updateLog(IEspContext* espContext, const char* option, IPropertyTree* userContext, IPropertyTree* userRequest,
+    bool updateLog(IEspContext* espContext, const char* option, IPropertyTree* userContext, IPropertyTree* userRequest, IPropertyTree *scriptValues,
         const char* backEndReq, const char* backEndResp, const char* userResp, const char* logDatasets, StringBuffer& status);
     bool updateLog(IEspContext* espContext, const char* option, const char* logContent, StringBuffer& status);
     bool updateLog(IEspContext* espContext, const char* option, IPropertyTree* logInfo, IInterface* extraLog, StringBuffer& status);

--- a/esp/services/esdl_svc_engine/esdl_binding.cpp
+++ b/esp/services/esdl_svc_engine/esdl_binding.cpp
@@ -650,6 +650,26 @@ static inline bool isPublishedQuery(EsdlMethodImplType implType)
     return (implType==EsdlMethodImplRoxie || implType==EsdlMethodImplWsEcl);
 }
 
+IEsdlScriptContext* EsdlServiceImpl::checkCreateEsdlServiceScriptContext(IEspContext &context, IEsdlDefService &srvdef, IEsdlDefMethod &mthdef, IPropertyTree *tgtcfg)
+{
+    IEsdlCustomTransform *methodCrt = m_customRequestTransformMap.getValue(mthdef.queryMethodName());
+    if (!m_serviceLevelRequestTransform && !methodCrt)
+        return nullptr;
+
+    Owned<IEsdlScriptContext> scriptContext = createEsdlScriptContext(&context);
+
+    scriptContext->setAttribute(ESDLScriptCtxSection_ESDLInfo, "service", srvdef.queryName());
+    scriptContext->setAttribute(ESDLScriptCtxSection_ESDLInfo, "method", mthdef.queryMethodName());
+    scriptContext->setAttribute(ESDLScriptCtxSection_ESDLInfo, "request_type", mthdef.queryRequestType());
+    scriptContext->setAttribute(ESDLScriptCtxSection_ESDLInfo, "request", mthdef.queryRequestType());  //this could diverge from request_type in the future
+
+    if (tgtcfg)
+        scriptContext->setContent(ESDLScriptCtxSection_TargetConfig, tgtcfg);
+    if (m_oEspBindingCfg)
+        scriptContext->setContent(ESDLScriptCtxSection_BindingConfig, m_oEspBindingCfg.get());
+    return scriptContext.getClear();
+}
+
 void EsdlServiceImpl::handleServiceRequest(IEspContext &context,
                                            IEsdlDefService &srvdef,
                                            IEsdlDefMethod &mthdef,
@@ -662,14 +682,14 @@ void EsdlServiceImpl::handleServiceRequest(IEspContext &context,
                                            StringBuffer &logdata,
                                            unsigned int flags)
 {
+    Owned<IEsdlScriptContext> scriptContext;
+
     const char *mthName = mthdef.queryName();
     context.addTraceSummaryValue(LogMin, "method", mthName);
     const char* srvName = srvdef.queryName();
 
-    if (m_serviceLevelCrtFail)
+    if (m_serviceLevelCrtFail) //checked further along in shared code, but might as well avoid extra overhead
         throw MakeStringException(-1, "%s::%s disabled due to Custom Transform errors. Review transform template in configuration.", srvdef.queryName(), mthName);
-
-    IEsdlCustomTransform *crt = m_customRequestTransformMap.getValue(mthdef.queryMethodName());
 
     Owned<MethodAccessMap>* authMap = m_methodAccessMaps.getValue(mthdef.queryMethodName());
     if (authMap != nullptr && authMap->get() != nullptr)
@@ -856,6 +876,9 @@ void EsdlServiceImpl::handleServiceRequest(IEspContext &context,
         }
         else
         {
+            //Future: support transforms for all transaction types by moving scripts and script processing up
+            scriptContext.setown(checkCreateEsdlServiceScriptContext(context, srvdef, mthdef, tgtcfg));
+
             Owned<IXmlWriterExt> reqWriter = createIXmlWriterExt(0, 0, NULL, WTStandard);
 
             //Preprocess Request
@@ -871,7 +894,7 @@ void EsdlServiceImpl::handleServiceRequest(IEspContext &context,
             reqcontent.set(reqWriter->str());
             context.addTraceSummaryTimeStamp(LogNormal, "serialized-xmlreq");
 
-            handleFinalRequest(context, m_serviceLevelRequestTransform, crt, tgtcfg, tgtctx, srvdef, mthdef, ns, reqcontent, origResp, isPublishedQuery(implType), implType==EsdlMethodImplProxy, soapmsg);
+            handleFinalRequest(context, scriptContext, tgtcfg, tgtctx, srvdef, mthdef, ns, reqcontent, origResp, isPublishedQuery(implType), implType==EsdlMethodImplProxy, soapmsg);
             context.addTraceSummaryTimeStamp(LogNormal, "end-HFReq");
 
             if (isPublishedQuery(implType))
@@ -891,12 +914,12 @@ void EsdlServiceImpl::handleServiceRequest(IEspContext &context,
     }
 
     context.addTraceSummaryTimeStamp(LogNormal, "srt-resLogging");
-    handleResultLogging(context, tgtctx.get(), req, soapmsg.str(), origResp.str(), out.str(), logdata.str());
+    handleResultLogging(context, scriptContext, tgtctx.get(), req, soapmsg.str(), origResp.str(), out.str(), logdata.str());
     context.addTraceSummaryTimeStamp(LogNormal, "end-resLogging");
     ESPLOG(LogMax,"Customer Response: %s", out.str());
 }
 
-bool EsdlServiceImpl::handleResultLogging(IEspContext &espcontext, IPropertyTree * reqcontext, IPropertyTree * request,const char *rawreq, const char * rawresp, const char * finalresp, const char * logdata)
+bool EsdlServiceImpl::handleResultLogging(IEspContext &espcontext, IEsdlScriptContext *scriptContext, IPropertyTree * reqcontext, IPropertyTree * request,const char *rawreq, const char * rawresp, const char * finalresp, const char * logdata)
 {
     bool success = true;
     if (m_oLoggingManager)
@@ -910,7 +933,8 @@ bool EsdlServiceImpl::handleResultLogging(IEspContext &espcontext, IPropertyTree
         entry->setBackEndReq(rawreq);
         entry->setBackEndResp(rawresp);
         entry->setLogDatasets(logdata);
-
+        if (scriptContext)
+            entry->setOwnScriptValuesTree(scriptContext->createPTreeFromSection(ESDLScriptCtxSection_Logging));
         StringBuffer logresp;
         success = m_oLoggingManager->updateLog(entry, logresp);
         ESPLOG(LogMin,"ESDLService: Attempted to log ESP transaction: %s", logresp.str());
@@ -1036,8 +1060,7 @@ void EsdlServiceImpl::getSoapError( StringBuffer& out,
 }
 
 void EsdlServiceImpl::handleFinalRequest(IEspContext &context,
-                                         IEsdlCustomTransform *serviceCrt,
-                                         IEsdlCustomTransform *methodCrt,
+                                         IEsdlScriptContext *scriptContext,
                                          Owned<IPropertyTree> &tgtcfg,
                                          Owned<IPropertyTree> &tgtctx,
                                          IEsdlDefService &srvdef,
@@ -1052,7 +1075,7 @@ void EsdlServiceImpl::handleFinalRequest(IEspContext &context,
     const char *tgtUrl = tgtcfg->queryProp("@url");
     if (!isEmptyString(tgtUrl))
     {
-        prepareFinalRequest(context, serviceCrt, methodCrt, tgtcfg, tgtctx, srvdef, mthdef, isroxie, ns, req, soapmsg);
+        prepareFinalRequest(context, scriptContext, tgtcfg, tgtctx, srvdef, mthdef, isroxie, ns, req, soapmsg);
         sendTargetSOAP(context, tgtcfg.get(), soapmsg.str(), out, isproxy, NULL);
     }
     else
@@ -1340,8 +1363,7 @@ void EsdlServiceImpl::getTargetResponseFile(IEspContext & context,
  */
 
 void EsdlServiceImpl::prepareFinalRequest(IEspContext &context,
-                                        IEsdlCustomTransform *serviceCrt,
-                                        IEsdlCustomTransform *methodCrt,
+                                        IEsdlScriptContext *scriptContext,
                                         Owned<IPropertyTree> &tgtcfg,
                                         Owned<IPropertyTree> &tgtctx,
                                         IEsdlDefService &srvdef,
@@ -1423,43 +1445,21 @@ void EsdlServiceImpl::prepareFinalRequest(IEspContext &context,
 
     // Process Custom Request Transforms
 
-    // If the CRTs are nullptr, we could have been called from a context without 
-    // access to them, so pull them from ourself. When they are passed in the
-    // error checking has already been completed.
+    if (m_serviceLevelCrtFail)
+        throw MakeStringException(-1, "%s::%s disabled due to service-level Custom Transform errors. Review transform template in configuration.", srvdef.queryName(), mthName);
 
-    if (!serviceCrt)
+    StringAttr *crtErrorMessage = m_methodCRTransformErrors.getValue(mthName);
+    if (crtErrorMessage && !crtErrorMessage->isEmpty())
+        throw MakeStringException(-1, "%s::%s disabled due to method-level Custom Transform errors: %s. Review transform template in configuration.", srvdef.queryName(), mthName, crtErrorMessage->str());
+
+    if (scriptContext)
     {
-        if (m_serviceLevelCrtFail)
-            throw MakeStringException(-1, "%s::%s disabled due to service-level Custom Transform errors. Review transform template in configuration.", srvdef.queryName(), mthName);
+        IEsdlCustomTransform *methodCrt = m_customRequestTransformMap.getValue(mthName);
 
-        serviceCrt = m_serviceLevelRequestTransform;
-    }
-
-    if (!methodCrt)
-    {
-        StringAttr *crtErrorMessage = m_methodCRTransformErrors.getValue(mthName);
-        if (crtErrorMessage && !crtErrorMessage->isEmpty())
-            throw MakeStringException(-1, "%s::%s disabled due to method-level Custom Transform errors: %s. Review transform template in configuration.", srvdef.queryName(), mthName, crtErrorMessage->str());
-
-        methodCrt = m_customRequestTransformMap.getValue(mthName);
-    }
-
-    if (serviceCrt || methodCrt)
-    {
         context.addTraceSummaryTimeStamp(LogNormal, "srt-custreqtrans");
-
-        //as we add more entry points the script context will move to wider scope
-        Owned<IEsdlScriptContext> scriptContext = createEsdlScriptContext(&context);
         scriptContext->setContent(ESDLScriptCtxSection_ESDLRequest, reqProcessed.str());
-        scriptContext->setAttribute(ESDLScriptCtxSection_ESDLInfo, "service", srvdef.queryName());
-        scriptContext->setAttribute(ESDLScriptCtxSection_ESDLInfo, "method", mthdef.queryMethodName());
-        scriptContext->setAttribute(ESDLScriptCtxSection_ESDLInfo, "request_type", mthdef.queryRequestType());
-        scriptContext->setAttribute(ESDLScriptCtxSection_ESDLInfo, "request", mthdef.queryRequestType());  //this could diverge from request_type in the future
-
-        scriptContext->setContent(ESDLScriptCtxSection_TargetConfig, tgtcfg);
-        scriptContext->setContent(ESDLScriptCtxSection_BindingConfig, m_oEspBindingCfg.get());
-
-        processServiceAndMethodTransforms(scriptContext, {serviceCrt, methodCrt}, ESDLScriptCtxSection_ESDLRequest, ESDLScriptCtxSection_FinalRequest);
+        if (m_serviceLevelRequestTransform || methodCrt) //slightly redundant, but less fragile to future changes to check again here
+            processServiceAndMethodTransforms(scriptContext, {m_serviceLevelRequestTransform, methodCrt}, ESDLScriptCtxSection_ESDLRequest, ESDLScriptCtxSection_FinalRequest);
         scriptContext->toXML(reqProcessed.clear(), ESDLScriptCtxSection_FinalRequest);
 
         context.addTraceSummaryTimeStamp(LogNormal, "end-custreqtrans");
@@ -3356,8 +3356,9 @@ int EsdlBindingImpl::onGetRoxieBuilder(CHttpRequest* request, CHttpResponse* res
                     getRequestContent(*context, reqcontent, request, srvname, mthname, ns, ROXIEREQ_FLAGS);
 
                     tgtctx.setown( m_pESDLService->createTargetContext(*context, tgtcfg, *defsrv, *defmth, req_pt));
-                    
-                    m_pESDLService->prepareFinalRequest(*context, nullptr, nullptr, tgtcfg, tgtctx, *defsrv, *defmth, true, ns.str(), reqcontent, roxiemsg);
+
+                    Owned<IEsdlScriptContext> scriptContext = m_pESDLService->checkCreateEsdlServiceScriptContext(*context, *defsrv, *defmth, tgtcfg.get());
+                    m_pESDLService->prepareFinalRequest(*context, scriptContext, tgtcfg, tgtctx, *defsrv, *defmth, true, ns.str(), reqcontent, roxiemsg);
                 }
                 else
                 {

--- a/esp/services/esdl_svc_engine/esdl_binding.hpp
+++ b/esp/services/esdl_svc_engine/esdl_binding.hpp
@@ -168,6 +168,8 @@ public:
     void addServiceLevelRequestTransform(IPropertyTree *customRequestTransform);
     void addMethodLevelRequestTransform(const char *method, IPropertyTree &methodCfg, IPropertyTree *customRequestTransform);
 
+    IEsdlScriptContext* checkCreateEsdlServiceScriptContext(IEspContext &context, IEsdlDefService &srvdef, IEsdlDefMethod &mthdef, IPropertyTree *tgtcfg);
+
     virtual void handleServiceRequest(IEspContext &context, IEsdlDefService &srvdef, IEsdlDefMethod &mthdef, Owned<IPropertyTree> &tgtcfg, Owned<IPropertyTree> &tgtctx, const char *ns, const char *schema_location, IPropertyTree *req, StringBuffer &out, StringBuffer &logdata, unsigned int flags);
     virtual void generateTransactionId(IEspContext & context, StringBuffer & trxid)=0;
     void generateTargetURL(IEspContext & context, IPropertyTree *srvinfo, StringBuffer & url, bool isproxy);
@@ -179,12 +181,12 @@ public:
     virtual void processHeaders(IEspContext &context, IEsdlDefService &srvdef, IEsdlDefMethod &mthdef, const char *ns, StringBuffer &req, StringBuffer &headers){};
     virtual void processRequest(IEspContext &context, IEsdlDefService &srvdef, IEsdlDefMethod &mthdef, const char *ns, StringBuffer &req) {};
     virtual void processResponse(IEspContext &context, IEsdlDefService &srvdef, IEsdlDefMethod &mthdef, const char *ns, StringBuffer &resp) {};
-    void prepareFinalRequest(IEspContext &context, IEsdlCustomTransform *serviceCrt, IEsdlCustomTransform *methodCrt, Owned<IPropertyTree> &tgtcfg, Owned<IPropertyTree> &tgtctx, IEsdlDefService &srvdef, IEsdlDefMethod &mthdef, bool isroxie, const char* ns, StringBuffer &reqcontent, StringBuffer &reqProcessed);
+    void prepareFinalRequest(IEspContext &context, IEsdlScriptContext *scriptContext, Owned<IPropertyTree> &tgtcfg, Owned<IPropertyTree> &tgtctx, IEsdlDefService &srvdef, IEsdlDefMethod &mthdef, bool isroxie, const char* ns, StringBuffer &reqcontent, StringBuffer &reqProcessed);
     virtual void createServersList(IEspContext &context, IEsdlDefService &srvdef, IEsdlDefMethod &mthdef, StringBuffer &servers) {};
-    virtual bool handleResultLogging(IEspContext &espcontext, IPropertyTree * reqcontext, IPropertyTree * request,  const char * rawreq, const char * rawresp, const char * finalresp, const char * logdata);
+    virtual bool handleResultLogging(IEspContext &espcontext, IEsdlScriptContext *scriptContext, IPropertyTree * reqcontext, IPropertyTree * request,  const char * rawreq, const char * rawresp, const char * finalresp, const char * logdata);
     void handleEchoTest(const char *mthName, IPropertyTree *req, StringBuffer &soapResp, ESPSerializationFormat format);
     void handlePingRequest(const char *srvName, StringBuffer &out, unsigned int flags);
-    virtual void handleFinalRequest(IEspContext &context, IEsdlCustomTransform *srvCrt, IEsdlCustomTransform *mthCrt, Owned<IPropertyTree> &tgtcfg, Owned<IPropertyTree> &tgtctx, IEsdlDefService &srvdef, IEsdlDefMethod &mthdef, const char *ns, StringBuffer& req, StringBuffer &out, bool isroxie, bool isproxy, StringBuffer &rawreq);
+    virtual void handleFinalRequest(IEspContext &context, IEsdlScriptContext *scriptContext, Owned<IPropertyTree> &tgtcfg, Owned<IPropertyTree> &tgtctx, IEsdlDefService &srvdef, IEsdlDefMethod &mthdef, const char *ns, StringBuffer& req, StringBuffer &out, bool isroxie, bool isproxy, StringBuffer &rawreq);
     void getSoapBody(StringBuffer& out,StringBuffer& soapresp);
     void getSoapError(StringBuffer& out,StringBuffer& soapresp,const char *,const char *);
 

--- a/system/xmllib/libxml_xpathprocessor.cpp
+++ b/system/xmllib/libxml_xpathprocessor.cpp
@@ -908,8 +908,9 @@ void copyXmlNode(IPropertyTree *tree, xmlNodePtr node)
 {
     for(xmlAttrPtr att=node->properties;att!=nullptr; att=att->next)
     {
+        VStringBuffer name("@%s", (const char *)att->name);
         xmlChar *value = xmlGetProp(node, att->name);
-        tree->setProp((const char *)att->name, (const char *)value);
+        tree->setProp(name, (const char *)value);
         xmlFree(value);
     }
 
@@ -1171,6 +1172,16 @@ private:
         xmlOutputBufferClose(xmlOut);
 
     }
+    virtual IPropertyTree *createPTreeFromSection(const char *section) override
+    {
+        if (isEmptyString(section))
+            return nullptr;
+        xmlNodePtr sect = getSectionNode(section, nullptr);
+        if (!sect)
+            return nullptr;
+        return createPtreeFromXmlNode(sect);
+    }
+
     virtual void toXML(StringBuffer &xml) override
     {
         toXML(xml, nullptr, true);

--- a/system/xmllib/xpathprocessor.hpp
+++ b/system/xmllib/xpathprocessor.hpp
@@ -115,6 +115,7 @@ interface IEsdlScriptContext : extends IInterface
     virtual bool getXPathBool(const char *xpath, bool dft=false) const = 0;
     virtual void toXML(StringBuffer &xml, const char *section, bool includeParentNode=false) = 0;
     virtual void toXML(StringBuffer &xml) = 0;
+    virtual IPropertyTree *createPTreeFromSection(const char *section) = 0;
 };
 
 extern "C" XMLLIB_API IEsdlScriptContext *createEsdlScriptContext(void * espContext);


### PR DESCRIPTION
We will be using the scriptContext for multiple new features and need it to exist for the entire transaction.

Including that the scriptContext will exist for transaction logging at the end of the transaction.

Provide a low level mechanism where the script can skip a particular log thread queue entry.
Example:
 <xsdl:set-log-option name="thread-queue-myserv-agent1" select="'skip'"/>

Signed-off-by: Anthony Fishbeck <anthony.fishbeck@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [ ] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [x] Send notifications about my Pull Request position in Smoketest queue.
- [x] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
