### PR TITLE
HPCC-24589 Seclib interface corrections

### DIFF
--- a/system/security/LdapSecurity/ldapsecurity.ipp
+++ b/system/security/LdapSecurity/ldapsecurity.ipp
@@ -73,7 +73,7 @@ private:
 
     static Owned<IProperties> sm_emptyParameters;
     static const SecFeatureSet s_safeFeatures = SUF_ALL_FEATURES;
-    static const SecFeatureSet s_implementedFeatures = s_safeFeatures & ~(SUF_GetDataElement | SUF_GetDataElements);
+    static const SecFeatureSet s_implementedFeatures = s_safeFeatures & ~(SUF_GetDataElement | SUF_GetDataElements | SUF_SetData);
 
 public:
     IMPLEMENT_IINTERFACE
@@ -160,6 +160,7 @@ public:
     IPropertyIterator * getPropertyIterator() const override { return sm_emptyParameters->getIterator();}
     IPropertyTree* getDataElement(const char* xpath = ".") const override { return nullptr; }
     IPropertyTreeIterator* getDataElements(const char* xpath = ".") const override { return nullptr; }
+    bool setData(IPropertyTree* data) override { return false; }
 
 //interface ISecCredentials
     bool setPassword(const char * pw);

--- a/system/security/shared/SecureUser.hpp
+++ b/system/security/shared/SecureUser.hpp
@@ -44,7 +44,7 @@ private:
     unsigned        m_sessionToken;
     StringBuffer    m_signature;
     static const SecFeatureSet s_safeFeatures = SUF_ALL_FEATURES;
-    static const SecFeatureSet s_implementedFeatures = (s_safeFeatures & ~(SUF_GetDataElement | SUF_GetDataElements));
+    static const SecFeatureSet s_implementedFeatures = (s_safeFeatures & ~(SUF_GetDataElement | SUF_GetDataElements | SUF_SetData));
 
     CriticalSection crit;
 public:
@@ -322,6 +322,11 @@ public:
     IPropertyTreeIterator* getDataElements(const char* xpath = ".") const override
     {
         return nullptr;
+    }
+
+    bool setData(IPropertyTree* data) override
+    {
+        return false;
     }
 };
 

--- a/system/security/shared/seclib.hpp
+++ b/system/security/shared/seclib.hpp
@@ -267,7 +267,8 @@ static const SecFeatureBit SUF_GetPropertyIterator         = 0x0400000000;
 static const SecFeatureBit SUF_Clone                       = 0x0800000000;
 static const SecFeatureBit SUF_GetDataElement              = 0x1000000000;
 static const SecFeatureBit SUF_GetDataElements             = 0x2000000000;
-static const SecFeatureSet SUF_ALL_FEATURES                = 0x3FFFFFFFFF; // update to include all added feature bits
+static const SecFeatureBit SUF_SetData                     = 0x4000000000;
+static const SecFeatureSet SUF_ALL_FEATURES                = 0x7FFFFFFFFF; // update to include all added feature bits
 
 class CDateTime;
 interface IPropertyIterator;
@@ -312,6 +313,7 @@ interface ISecUser : implements ISecObject
     virtual ISecUser * clone() = 0;
     virtual IPropertyTree* getDataElement(const char* xpath = ".") const = 0;
     virtual IPropertyTreeIterator* getDataElements(const char* xpath = ".") const = 0;
+    virtual bool setData(IPropertyTree* data) = 0;
 };
 
 
@@ -469,8 +471,8 @@ interface ISecManager : extends ISecObject
 {
     virtual ISecUser * createUser(const char * user_name, IEspSecureContext* secureContext = nullptr) = 0;
     virtual ISecResourceList * createResourceList(const char * rlname, IEspSecureContext* secureContext = nullptr) = 0;
-    virtual bool subscribe(ISecAuthenticEvents & events, IEspSecureContext* secureContext) = 0;
-    virtual bool unsubscribe(ISecAuthenticEvents & events, IEspSecureContext* secureContext) = 0;
+    virtual bool subscribe(ISecAuthenticEvents & events, IEspSecureContext* secureContext = nullptr) = 0;
+    virtual bool unsubscribe(ISecAuthenticEvents & events, IEspSecureContext* secureContext = nullptr) = 0;
     virtual bool authorize(ISecUser & user, ISecResourceList * resources, IEspSecureContext* secureContext = nullptr) = 0;
     virtual bool authorizeEx(SecResourceType rtype, ISecUser & user, ISecResourceList * resources, IEspSecureContext* secureContext = nullptr) = 0;
     virtual SecAccessFlags authorizeEx(SecResourceType rtype, ISecUser & user, const char * resourcename, IEspSecureContext* secureContext = nullptr) = 0;


### PR DESCRIPTION
Correct omissions from HPCC-24312, including the addition of ISecUser::setData
and setting the default secureContext values to nullptr for both
ISecManager::subscribe and ISecManager::unsubscribe.

Signed-off-by: Tim Klemm <tim.klemm@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
