### PR TITLE
HPCC-24599 Improve decoupled ESDL transaction logging

### DIFF
--- a/esp/logging/logginglib/LogFailSafe.hpp
+++ b/esp/logging/logginglib/LogFailSafe.hpp
@@ -29,11 +29,12 @@ const unsigned long DEFAULT_SAFE_ROLLOVER_REQ_THRESHOLD = 500000L;
 const char* const PropSafeRolloverThreshold = "SafeRolloverThreshold";
 const char* const PropFailSafeLogsDir = "FailSafeLogsDir";
 const char* const DefaultFailSafeLogsDir = "./FailSafeLogs";
+const char* const PropDecoupledLogging = "DecoupledLogging";
 
 interface ILogFailSafe : IInterface
 {
-    virtual void Add(const char*, const char *strContents, CLogRequestInFile* reqInFile)=0;//
-    virtual void Add(const char*,IInterface& pIn, CLogRequestInFile* reqInFile)=0;
+    virtual void Add(const char*, IPropertyTree* scriptValues, const char *strContents, CLogRequestInFile* reqInFile)=0;//
+    virtual void Add(const char*, IPropertyTree* scriptValues, IInterface& pIn, CLogRequestInFile* reqInFile)=0;
     virtual StringBuffer& GenerateGUID(StringBuffer& GUID,const char* seed="") = 0;
     virtual void AddACK(const char* GUID)=0;
     virtual void RollCurrentLog()=0;
@@ -66,6 +67,7 @@ class CLogFailSafe : implements ILogFailSafe, public CInterface
     GuidMap m_PendingLogs;//
     unsigned long safeRolloverReqThreshold = DEFAULT_SAFE_ROLLOVER_REQ_THRESHOLD;
     unsigned long safeRolloverSizeThreshold = 0;
+    bool decoupledLogging = false;
 
     void readCfg(IPropertyTree* cfg);
     void readSafeRolloverThresholdCfg(StringBuffer& safeRolloverThreshold);
@@ -84,8 +86,8 @@ public:
 
     virtual ~CLogFailSafe();
     StringBuffer& GenerateGUID(StringBuffer& GUID,const char* seed="");
-    virtual void Add(const char*, const char *strContents, CLogRequestInFile* reqInFile);//
-    virtual void Add(const char*,IInterface& pIn, CLogRequestInFile* reqInFile);
+    virtual void Add(const char*, IPropertyTree* scriptValues, const char *strContents, CLogRequestInFile* reqInFile);//
+    virtual void Add(const char*, IPropertyTree* scriptValues, IInterface& pIn, CLogRequestInFile* reqInFile);
     virtual void AddACK(const char* GUID);
     virtual void RollCurrentLog();
     virtual void RollOldLogs();

--- a/esp/logging/logginglib/LogSerializer.cpp
+++ b/esp/logging/logginglib/LogSerializer.cpp
@@ -73,11 +73,21 @@ CLogSerializer::~CLogSerializer()
     Close();
 }
 
-void CLogSerializer::Append(const char* GUID, const char* Data, CLogRequestInFile* reqInFile)
+void CLogSerializer::Append(const char* GUID, IPropertyTree* scriptValues, const char* Data, CLogRequestInFile* reqInFile)
 {
     StringBuffer toWrite,size;
 
-    toWrite.appendf("%s\t%s\r\n",GUID,Data);
+    toWrite.appendf("%s\t", GUID);
+    if (scriptValues)
+    {
+        appendXMLOpenTag(toWrite, logRequestScriptValues);
+        toXML(scriptValues, toWrite);
+        appendXMLCloseTag(toWrite, logRequestScriptValues);
+        toWrite.append("\t");
+    }
+    toWrite.append(Data);
+    toWrite.append("\r\n");
+
     size.appendf("%d",toWrite.length());
     while (size.length() < 8)
         size.insert(0,'0');

--- a/esp/logging/logginglib/LogSerializer.hpp
+++ b/esp/logging/logginglib/LogSerializer.hpp
@@ -31,6 +31,7 @@ typedef std::map<std::string, std::string> GuidMap;
 
 const char* const logFileExt = ".log";
 const char* const rolloverFileExt = ".old";
+const char* const logRequestScriptValues = "ScriptValues";
 
 class CLogRequestInFile : public CSimpleInterface
 {
@@ -81,7 +82,7 @@ public:
     void Close();
     void Remove();
     void Rollover(const char* ClosedPrefix);
-    void Append(const char* GUID, const char* Data, CLogRequestInFile* reqInFile);
+    void Append(const char* GUID, IPropertyTree* scriptValues, const char* Data, CLogRequestInFile* reqInFile);
     void Remove(const char* GUID);
     virtual void SplitRecord(StringBuffer& FullStr, StringBuffer& GUID, StringBuffer& Cache){}
     static void splitLogRecord(MemoryBuffer& rawdata,StringBuffer& GUID, StringBuffer& data);//

--- a/esp/logging/logginglib/loggingagentbase.cpp
+++ b/esp/logging/logginglib/loggingagentbase.cpp
@@ -154,6 +154,7 @@ void CLogContentFilter::filterLogContentTree(StringArray& filters, IPropertyTree
 
 IEspUpdateLogRequestWrap* CLogContentFilter::filterLogContent(IEspUpdateLogRequestWrap* req)
 {
+    Owned<IPropertyTree> scriptValues = req->getScriptValuesTree();
     const char* logContent = req->getUpdateLogRequest();
     Owned<IPropertyTree> logRequestTree = req->getLogRequestTree();
     Owned<IPropertyTree> updateLogRequestTree = createPTree("UpdateLogRequest");
@@ -186,6 +187,10 @@ IEspUpdateLogRequestWrap* CLogContentFilter::filterLogContent(IEspUpdateLogReque
 
             StringBuffer espContextXML, userContextXML, userRequestXML;
             IPropertyTree* logContentTree = ensurePTree(updateLogRequestTree, "LogContent");
+            if (scriptValues)
+            {
+                logContentTree->addPropTree(scriptValues->queryName(), LINK(scriptValues));
+            }
             if (espContext)
             {
                 logContentTree->addPropTree(espContext->queryName(), LINK(espContext));
@@ -328,7 +333,10 @@ IEspUpdateLogRequestWrap* CLogContentFilter::filterLogContent(IEspUpdateLogReque
     toXML(updateLogRequestTree, updateLogRequestXML);
     ESPLOG(LogMax, "filtered content and option: <%s>", updateLogRequestXML.str());
 
-    return new CUpdateLogRequestWrap(req->getGUID(), req->getOption(), updateLogRequestXML.str());
+    Owned<IEspUpdateLogRequestWrap> newReq = new CUpdateLogRequestWrap(req->getGUID(), req->getOption(), updateLogRequestXML.str());
+    if (scriptValues)
+        newReq->setScriptValuesTree(scriptValues);
+    return newReq.getClear();
 }
 
 CLogAgentBase::CVariantIterator::CVariantIterator(const CLogAgentBase& agent)

--- a/esp/logging/logginglib/logthread.hpp
+++ b/esp/logging/logginglib/logthread.hpp
@@ -48,6 +48,7 @@ interface ILogRequestReader : extends IThreaded
     virtual void reportAckedLogFiles(StringArray& ackedLogFiles) = 0;
     virtual void removeUnknownAckedLogFiles(StringArray& ackedLogFiles) = 0;
     virtual void cleanAckedLogFiles(StringArray& fileNames) = 0;
+    virtual void setTankFilePattern(const char* service) = 0;
 };
 
 class CLogRequestReader : public CInterface, implements ILogRequestReader
@@ -55,6 +56,7 @@ class CLogRequestReader : public CInterface, implements ILogRequestReader
     Owned<CLogRequestReaderSettings> settings;
     StringArray newAckedLogFiles;
     StringAttr lastTankFile;
+    StringBuffer tankFilePattern;
     offset_t lastTankFilePos = 0;
     std::set<std::string> ackedLogFileCheckList, ackedLogRequests;
     GuidSet pendingLogGUIDs;
@@ -73,7 +75,8 @@ class CLogRequestReader : public CInterface, implements ILogRequestReader
     StringBuffer& getTankFileTimeString(const char* fileName, StringBuffer& timeString);
     bool readLogRequestsFromTankFile(const char* fileName, StringAttr& tankFileNotFinished, offset_t& tankFileNotFinishedPos);
     offset_t getReadFilePos(const char* fileName);
-    bool parseLogRequest(MemoryBuffer& rawdata, StringBuffer& GUID, StringBuffer& data);
+    bool parseLogRequest(MemoryBuffer& rawdata, StringBuffer& GUID, StringBuffer& data, bool& skipLogRequest);
+    bool checkScriptValues(const char* ptr, const char* end, bool& skipLogRequest);
     void addToAckedLogFileList(const char* fileName, const char* fileNameWithPath);
     void addPendingLogsToQueue();
     void updateAckedFileList();
@@ -97,6 +100,7 @@ public:
     virtual void reportAckedLogFiles(StringArray& ackedLogFiles) override;
     virtual void removeUnknownAckedLogFiles(StringArray& ackedLogFiles) override;
     virtual void cleanAckedLogFiles(StringArray& fileNames) override;
+    virtual void setTankFilePattern(const char* service) override;
 };
 
 interface IUpdateLogThread : extends IInterface
@@ -170,5 +174,5 @@ public:
 };
 
 extern LOGGINGCOMMON_API IUpdateLogThread* createUpdateLogThread(IPropertyTree* _cfg, const char* _service, const char* _agentName, const char* _tankFile, IEspLogAgent* _logAgent);
-
+extern LOGGINGCOMMON_API bool checkSkipThreadQueue(IPropertyTree *scriptValues, IUpdateLogThread &logthread);
 #endif // _LOGTHREAD_HPP__


### PR DESCRIPTION
1. For decoupled logging, skip the loadPendingLogReqsFromExistingLogFiles()
call because CLogRequestReader is used to pickup jobs from tank files;
2. For decoupled logging, skip m_cleared (the file storing acked jobs)
related code because CLogRequestReader has its own logic to skip acked jobs;
3. Store the scriptValues into tank file so that the scriptValues can be
used by CLogRequestReader to skip some predefined jobs. The logging manager
creates a tank file using CLogFailSafe::Add() and CLogSerializer::Append().
Both CLogFailSafe::Add() and CLogSerializer::Append() are enhanced to
handle the scriptValues. The scriptValues input is set to nullptr where the
Append() and the Add() are not called for decoupled logging.
4. When retrieving a logging request from tank file, the CLogRequestReader
checks the scriptValues and skips the predefined jobs as needed.
5. Move the checkSkipThreadQueue() into the logging lib (logthread.cpp) so
that it can be used by both CLogRequestReader and logging manager;
6. Pass FailSafeLogsDir from logging manager to logging agent thread so
that the thread knows where to read tank files.

Signed-off-by: wangkx <kevin.wang@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
