### PR TITLE
HPCC-24512 Use streaming in writeResultCursorXml()

### DIFF
--- a/common/fileview2/fileview.hpp
+++ b/common/fileview2/fileview.hpp
@@ -162,7 +162,8 @@ extern FILEVIEW_API int findResultSetColumn(const INewResultSet * results, const
 extern FILEVIEW_API unsigned getResultCursorXml(IStringVal & ret, IResultSetCursor * cursor, const char * name, unsigned start=0, unsigned count=0, const char * schemaName=NULL, const IProperties *xmlns=NULL);
 extern FILEVIEW_API unsigned getResultXml(IStringVal & ret, INewResultSet * cursor,  const char* name, unsigned start=0, unsigned count=0, const char * schemaName=NULL, const IProperties *xmlns=NULL);
 extern FILEVIEW_API unsigned getResultJSON(IStringVal & ret, INewResultSet * cursor,  const char* name, unsigned start=0, unsigned count=0, const char * schemaName=NULL);
-extern FILEVIEW_API unsigned writeResultCursorXml(IXmlWriter & writer, IResultSetCursor * cursor, const char * name, unsigned start=0, unsigned count=0, const char * schemaName=NULL, const IProperties *xmlns = NULL);
+extern FILEVIEW_API unsigned writeResultCursorXml(IXmlWriter & writer, IResultSetCursor * cursor, const char * name,
+    unsigned start=0, unsigned count=0, const char * schemaName=NULL, const IProperties *xmlns = NULL, bool flushContent = false);
 extern FILEVIEW_API unsigned writeResultXml(IXmlWriter & writer, INewResultSet * cursor,  const char* name, unsigned start=0, unsigned count=0, const char * schemaName=NULL, const IProperties *xmlns = NULL);
 
 extern FILEVIEW_API unsigned getResultCursorBin(MemoryBuffer & ret, IResultSetCursor * cursor, unsigned start=0, unsigned count=0);

--- a/common/fileview2/fvresultset.cpp
+++ b/common/fileview2/fvresultset.cpp
@@ -2318,7 +2318,8 @@ extern FILEVIEW_API unsigned getResultJSON(IStringVal & ret, INewResultSet * res
     return rc;
 }
 
-extern FILEVIEW_API unsigned writeResultCursorXml(IXmlWriter & writer, IResultSetCursor * cursor, const char * name, unsigned start, unsigned count, const char * schemaName, const IProperties *xmlns)
+extern FILEVIEW_API unsigned writeResultCursorXml(IXmlWriter & writer, IResultSetCursor * cursor, const char * name,
+    unsigned start, unsigned count, const char * schemaName, const IProperties *xmlns, bool flushContent)
 {
     if (schemaName)
     {
@@ -2329,6 +2330,8 @@ extern FILEVIEW_API unsigned writeResultCursorXml(IXmlWriter & writer, IResultSe
         meta.getXmlXPathSchema(xsd, false);
         writer.outputInlineXml(xsd.str());
         writer.outputEndNested("XmlSchema");
+        if (flushContent)
+            writer.flushContent(false);
     }
 
     writer.outputBeginDataset(name, true);
@@ -2348,6 +2351,8 @@ extern FILEVIEW_API unsigned writeResultCursorXml(IXmlWriter & writer, IResultSe
     for(bool ok=cursor->absolute(start);ok;ok=cursor->next())
     {
         cursor->writeXmlRow(writer);
+        if (flushContent)
+            writer.flushContent(false);
 
         c++;
         if(count && c>=count)
@@ -2355,6 +2360,8 @@ extern FILEVIEW_API unsigned writeResultCursorXml(IXmlWriter & writer, IResultSe
     }
     cursor->endWriteXmlRows(writer);
     writer.outputEndDataset(name);
+    if (flushContent)
+        writer.flushContent(false);
     return c;
 }
 

--- a/common/thorhelper/roxiedebug.cpp
+++ b/common/thorhelper/roxiedebug.cpp
@@ -529,6 +529,10 @@ public:
     {
         // nothing for now
     }
+    virtual void flushContent(bool close) override
+    {
+        // nothing for now
+    }
 };
 
 class ContainsFieldSearcher : public SimpleFieldSearcher

--- a/plugins/javaembed/javaembed.cpp
+++ b/plugins/javaembed/javaembed.cpp
@@ -2750,6 +2750,9 @@ public:
     virtual void outputInline(const char* text)
     {
     }
+    virtual void flushContent(bool close)
+    {
+    };
 
 public:
     CheckedJNIEnv *JNIenv;

--- a/rtl/eclrtl/rtlformat.hpp
+++ b/rtl/eclrtl/rtlformat.hpp
@@ -67,6 +67,7 @@ public:
     virtual void cutFrom(IInterface *location, StringBuffer& databuf) override { UNIMPLEMENTED; }
     virtual void outputNumericString(const char *field, const char *fieldname) override { UNIMPLEMENTED; }
     virtual void outputInline(const char* text) override { UNIMPLEMENTED; }
+    virtual void flushContent(bool close) override { UNIMPLEMENTED; }
 
 protected:
     StringBuffer out;
@@ -164,6 +165,7 @@ public:
     {
         outputCString(field, fieldname);
     }
+    virtual void flushContent(bool close) override { flush(close); }
 
 protected:
     bool checkForAttribute(const char * fieldname);
@@ -256,6 +258,7 @@ public:
 
     void outputBeginRoot(){out.append('{');}
     void outputEndRoot(){out.append('}');}
+    virtual void flushContent(bool close) override { flush(close); }
 
 protected:
     inline void flush(bool isClose)
@@ -342,6 +345,8 @@ public:
     virtual void outputEndArray(const char *fieldname) override {};
     virtual void outputSetAll();
     virtual void outputXmlns(const char *name, const char *uri);
+    virtual void flushContent(bool close) override {};
+    
 
 protected:
     bool checkForAttribute(const char * fieldname);
@@ -606,6 +611,7 @@ public:
     void outputCSVHeader(const char* name, const char* type);
     void finishCSVHeaders();
     const char* auditStr() const { return auditOut.str(); }
+    virtual void flushContent(bool close) override { flush(close); }
 
 protected:
     IXmlStreamFlusher* flusher;

--- a/rtl/include/eclhelper.hpp
+++ b/rtl/include/eclhelper.hpp
@@ -169,6 +169,7 @@ interface IRecordSize : public IInterface
 interface IXmlWriter : public IInterface
 {
 public:
+    virtual void flushContent(bool close) = 0;
     virtual void outputQuoted(const char *text) = 0;
     virtual void outputString(unsigned len, const char *field, const char *fieldname) = 0;
     virtual void outputBool(bool field, const char *fieldname) = 0;


### PR DESCRIPTION
The flushContent() is added to IXmlWriter. It can be used
to call the flush() in writeResultCursorXml() (and other
IXmlWriters, such as CSV writer and JSON writer) without
affecting the existing functionalities.

Signed-off-by: wangkx <kevin.wang@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
