### PR TITLE
HPCC-24685 Disable remote index reads for signed integer key fields

### DIFF
--- a/rtl/eclrtl/rtlfield.hpp
+++ b/rtl/eclrtl/rtlfield.hpp
@@ -752,6 +752,8 @@ extern int ECLRTL_API compareFields(const RtlFieldInfo * const * cur, const byte
 extern unsigned ECLRTL_API hashFields(const RtlFieldInfo * const * cur, const byte *self, unsigned inhash, bool excludePayload = false);
 extern bool ECLRTL_API hasTrailingFileposition(const RtlFieldInfo * const * fields);
 extern bool ECLRTL_API hasTrailingFileposition(const RtlTypeInfo * type);
+extern bool ECLRTL_API containsKeyedSignedInt(const RtlTypeInfo * type);
+
 extern size32_t translateScalar(ARowBuilder &builder, size32_t offset, const RtlFieldInfo *field, const RtlTypeInfo &destType, const RtlTypeInfo &sourceType, const byte *source);
 
 #endif

--- a/rtl/eclrtl/rtlnktest.cpp
+++ b/rtl/eclrtl/rtlnktest.cpp
@@ -311,6 +311,10 @@ protected:
     {
         RtlStringTypeInfo str1(type_string, 1);
         RtlIntTypeInfo int2(type_int, 2);
+        RtlIntTypeInfo int8(type_int, 8);
+        RtlSwapIntTypeInfo swapint2(type_int, 2);
+        RtlSwapIntTypeInfo swapint8(type_int, 8);
+        RtlKeyedIntTypeInfo keyedint8(type_keyedint, 8, &swapint8);
         RtlStringTypeInfo strx(type_string|RFTMunknownsize, 0);
         RtlUtf8TypeInfo utf8(type_utf8|RFTMunknownsize, 0, nullptr);
         testSerialize(int2, "[123]");
@@ -322,6 +326,23 @@ protected:
         testSerialize(int2, "(,)");
         testSerialize(int2, "(123,234),(456,567)");
         testSerialize(int2, "(456,567),(123,234)", "(123,234),(456,567)");
+
+        testSerialize(swapint2, "[123]");
+        testSerialize(swapint2, "(123,234]");
+        testSerialize(swapint2, "[123,234)");
+        testSerialize(swapint2, "(123,234)");
+        testSerialize(swapint2, "(,234)");
+        testSerialize(swapint2, "(128,)");
+        testSerialize(swapint2, "(,)");
+        testSerialize(swapint2, "(123,234),(456,567)");
+        testSerialize(swapint2, "(456,567),(123,234)", "(123,234),(456,567)");
+
+        testSerialize(int8, "[9223372036854775807]");
+        testSerialize(int8, "[-9223372036854775808]");
+        testSerialize(swapint8, "[9223372036854775807]");
+        testSerialize(swapint8, "[-9223372036854775808]");
+        testSerialize(keyedint8, "[10]");
+        testSerialize(keyedint8, "[-10]");
 
         testSerialize(str1, "['A']");
         testSerialize(str1, "[',']");

--- a/thorlcr/activities/indexread/thindexreadslave.cpp
+++ b/thorlcr/activities/indexread/thindexreadslave.cpp
@@ -173,7 +173,8 @@ public:
                     Owned<ITranslator> translator = getTranslators(part);
                     IOutputMetaData *actualFormat = translator ? &translator->queryActualFormat() : expectedFormat;
                     bool tryRemoteStream = actualFormat->queryTypeInfo()->canInterpret() && actualFormat->queryTypeInfo()->canSerialize() &&
-                                           projectedFormat->queryTypeInfo()->canInterpret() && projectedFormat->queryTypeInfo()->canSerialize();
+                                           projectedFormat->queryTypeInfo()->canInterpret() && projectedFormat->queryTypeInfo()->canSerialize() &&
+                                           !containsKeyedSignedInt(actualFormat->queryTypeInfo());
 
                     /* If part can potentially be remotely streamed, 1st check if any part is local,
                      * then try to remote stream, and otherwise failover to legacy remote access


### PR DESCRIPTION
Signed-off-by: Gavin Halliday <gavin.halliday@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
