### PR TITLE
HPCC-24689 Add an option to use dafilersv storage in cloud

### DIFF
--- a/thorlcr/master/thmastermain.cpp
+++ b/thorlcr/master/thmastermain.cpp
@@ -967,6 +967,34 @@ int main( int argc, const char *argv[]  )
                 throwStringExceptionV(0, "Failed to connect to all nodes");
             PROGLOG("verified mp connection to rest of cluster");
 
+#ifdef _CONTAINERIZED
+            if (globals->getPropBool("@_dafsStorage"))
+            {
+/* NB: This option is a developer option only.
+
+ * It is intended to be used to bring up a temporary Thor instance that uses local node storage,
+ * as the data plane.
+ * 
+ * It is likely to be deprecated or need reworking, when DFS is refactored to use SP's properly.
+ * 
+ * The mechanism works by:
+ * a) Creating a pseudo StoragePlane (publishes group to Dali).
+ * b) Spins up a dafilesrv thread in each slave container.
+ * c) Changes the default StoragePlane used to publish files, to point to the SP/group created in step (a).
+ * 
+ * In this way, a Thor instance, whilst up, will act similarly to a bare-metal system, using local disks as storage.
+ * This allows quick cloud based allocation/simulation of bare-metal type clusters for testing purposes.
+ * 
+ * NB: This isn't a real StoragePlane, and it will not be accessible by any other component.
+ *
+ */
+                StringBuffer uniqueGrpName;
+                queryNamedGroupStore().addUnique(&queryProcessGroup(), uniqueGrpName);
+                // change default plane
+                queryComponentConfig().setProp("storagePlane", uniqueGrpName);
+                PROGLOG("Persistent Thor group created with group name: %s", uniqueGrpName.str());
+            }
+#endif
             LOG(MCauditInfo, ",Progress,Thor,Startup,%s,%s,%s,%s",nodeGroup.str(),thorname,queueName.str(),logUrl.str());
             auditStartLogged = true;
 

--- a/thorlcr/mfilemanager/thmfilemanager.cpp
+++ b/thorlcr/mfilemanager/thmfilemanager.cpp
@@ -518,9 +518,12 @@ public:
                 ForEachItemIn(gn, groupNames)
                 {
 #ifdef _CONTAINERIZED
-                    Owned<IStoragePlane> plane = getStoragePlane(groupNames.item(gn));
-                    assertex(plane);
-                    curDir.append(plane->queryPrefix());
+                    if (!globals->getPropBool("@_dafsStorage"))
+                    {
+                        Owned<IStoragePlane> plane = getStoragePlane(groupNames.item(gn));
+                        assertex(plane);
+                        curDir.append(plane->queryPrefix());
+                    }
 #else
                     if (!getConfigurationDirectory(globals->queryPropTree("Directories"), "data", "thor", groupNames.item(gn), curDir))
                         makePhysicalPartName(logicalName, 0, 0, curDir, 0, os); // legacy

--- a/thorlcr/slave/CMakeLists.txt
+++ b/thorlcr/slave/CMakeLists.txt
@@ -31,29 +31,30 @@ set (    SRCS
     )
 
 include_directories ( 
-         ./../thorutil 
-         ./../../fs/dafsclient 
-         ./../../system/jhtree 
-         ./../../system/mp 
-         ./../../common/workunit 
-         ./../shared 
-         .
-         ./../../common/environment 
-         ./../../common/deftype 
-         ./../../system/include 
-         ./../../dali/base 
-         ./../../rtl/include 
-         ./../../common/dllserver 
-         ./../msort 
-         ./../../system/jlib 
-         ./../../rtl/eclrtl 
-         ./../master 
-         ./../graph 
-         ./../../common/thorhelper 
-         ./../../roxie/roxiemem
+         ${HPCC_SOURCE_DIR}/common/deftype 
+         ${HPCC_SOURCE_DIR}/common/dllserver 
+         ${HPCC_SOURCE_DIR}/common/environment 
+         ${HPCC_SOURCE_DIR}/common/thorhelper 
+         ${HPCC_SOURCE_DIR}/common/workunit 
+         ${HPCC_SOURCE_DIR}/dali/base 
+         ${HPCC_SOURCE_DIR}/fs/dafsclient 
+         ${HPCC_SOURCE_DIR}/fs/dafsserver
+         ${HPCC_SOURCE_DIR}/rtl/eclrtl 
+         ${HPCC_SOURCE_DIR}/rtl/include 
+         ${HPCC_SOURCE_DIR}/roxie/roxiemem
+         ${HPCC_SOURCE_DIR}/system/include 
+         ${HPCC_SOURCE_DIR}/system/jhtree 
+         ${HPCC_SOURCE_DIR}/system/jlib 
+         ${HPCC_SOURCE_DIR}/system/mp 
+         ${HPCC_SOURCE_DIR}/system/security/shared
+         ${HPCC_SOURCE_DIR}/thorlcr/graph 
+         ${HPCC_SOURCE_DIR}/thorlcr/master 
+         ${HPCC_SOURCE_DIR}/thorlcr/msort 
+         ${HPCC_SOURCE_DIR}/thorlcr/shared 
+         ${HPCC_SOURCE_DIR}/thorlcr/slave 
+         ${HPCC_SOURCE_DIR}/thorlcr/thorutil 
          ${CMAKE_BINARY_DIR}
          ${CMAKE_BINARY_DIR}/oss
-         ./../../system/security/shared
     )
 
 ADD_DEFINITIONS( -D_CONSOLE )
@@ -84,4 +85,8 @@ target_link_libraries (  thorslave_lcr
          activityslaves_lcr 
     )
 
-
+if (CONTAINERIZED) # only used when dev. option _dafsStorage is enabled
+target_link_libraries (  thorslave_lcr 
+         dafsserver
+    )
+endif()


### PR DESCRIPTION
For testing purposes.

Signed-off-by: Jake Smith <jake.smith@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
