### PR TITLE
WIP HPCC-24691 Proposal for ESP logging compliance

### DIFF
--- a/ecl/eclcmd/ecl.cpp
+++ b/ecl/eclcmd/ecl.cpp
@@ -44,6 +44,9 @@ static int doMain(int argc, const char *argv[])
 int main(int argc, const char *argv[])
 {
     InitModuleObjects();
+    //only here to manipulate default log level on stderr stream for smoketest purposes
+    Owned<ILogMsgFilter> filter = getCategoryLogMsgFilter(MSGAUD_all, MSGCLS_all, LogMin, true);
+    queryLogMsgManager()->changeMonitorFilter(queryStderrLogMsgHandler(), filter);
     queryStderrLogMsgHandler()->setMessageFields(0);
     unsigned exitCode = doMain(argc, argv);
     releaseAtoms();

--- a/esp/bindings/http/client/httpclient.cpp
+++ b/esp/bindings/http/client/httpclient.cpp
@@ -420,11 +420,16 @@ HttpClientErrCode CHttpClient::sendRequest(const char* method, const char* conte
         httprequest->addHeader("WWW-Authenticate", authheader.str());
     }
 
-    if (getEspLogLevel()>LogNormal)
+    /*if (getEspLogLevel()>LogNormal)
     {
         DBGLOG("Content type: %s", contenttype);
         DBGLOG("Request content: %s", request.str());
-    }
+    }*/
+    //Audience = user, Class = progress, Level = ProgressMsgThreshold (50)
+    //PROGLOG("Content type: %s\nRequest content: %s", contenttype, request.str());
+    //or
+    //Audience = operator, Class = progress, Level = ProgressMsgThreshold (50)
+    LOG(MCoperatorProgress, unknownJob, "Content type: %s\nRequest content: %s", contenttype, request.str());
 
     httprequest->setContent(request.str());
 
@@ -467,8 +472,10 @@ HttpClientErrCode CHttpClient::sendRequest(const char* method, const char* conte
     m_persistable = httpresponse->getPersistentEligible();
     m_numRequests++;
 
-    if (getEspLogLevel()>LogNormal)
-        DBGLOG("Response content: %s", response.str());
+    //if (getEspLogLevel()>LogNormal)
+    //    DBGLOG("Response content: %s", response.str());
+    //DBGLOG("Response content: %s", response.str()); //aud = programmer, MSGCLS =  progress, DebugMsgThreshold 80 - perhaps too high
+    LOG(MCuserProgress, unknownJob,"Response content: %s", response.str());//aud = user, MSGCLS = progress, InfoMsgThreshold 50
 
     return HttpClientErrCode::OK;
 }
@@ -600,12 +607,14 @@ HttpClientErrCode CHttpClient::proxyRequest(IHttpMessage *request, IHttpMessage 
     httprequest->setContentType(contentType);
     httprequest->setContent(forwardRequest->queryContent());
 
-    if (getEspLogLevel()>LogNormal)
+    StringBuffer s;
+    /*if (getEspLogLevel()>LogNormal)
     {
         StringBuffer s;
         DBGLOG("Content type: %s", forwardRequest->getContentType(s).str());
         DBGLOG("Request content: %s", forwardRequest->queryContent());
-    }
+    }*/
+    LOG(MCuserProgress, unknownJob,"Content type: %s\nRequest content: %s", forwardRequest->getContentType(s).str(), forwardRequest->queryContent());//aud = user, MSGCLS = progress, InfoMsgThreshold 50
 
     copyCookies(*httprequest, *forwardRequest, m_host);
 
@@ -633,8 +642,9 @@ HttpClientErrCode CHttpClient::proxyRequest(IHttpMessage *request, IHttpMessage 
     m_persistable = httpresponse->getPersistentEligible();
     m_numRequests++;
 
-    if (getEspLogLevel()>LogNormal)
-        DBGLOG("Response content: %s", httpresponse->queryContent());
+    //if (getEspLogLevel()>LogNormal)
+    //    DBGLOG("Response content: %s", httpresponse->queryContent());
+    LOG(MCuserProgress, unknownJob,"Response content: %s", httpresponse->queryContent());//aud = user, MSGCLS = progress, InfoMsgThreshold 50
 
     return HttpClientErrCode::OK;
 }
@@ -721,11 +731,12 @@ HttpClientErrCode CHttpClient::sendRequest(IProperties *headers, const char* met
         httprequest->addHeader("WWW-Authenticate", authheader.str());
     }
 
-    if (getEspLogLevel()>LogNormal)
+    /*if (getEspLogLevel()>LogNormal)
     {
         DBGLOG("Content type: %s", contenttype);
         DBGLOG("Request content: %s", content.str());
-    }
+    }*/
+    LOG(MCuserProgress, unknownJob,"Content type: %s\nRequest content: %s", contenttype, content.str());//aud = user, MSGCLS = progress, InfoMsgThreshold 50
 
     httprequest->setContent(content.str());
 
@@ -772,8 +783,9 @@ HttpClientErrCode CHttpClient::sendRequest(IProperties *headers, const char* met
     m_persistable = httpresponse->getPersistentEligible();
     m_numRequests++;
 
-    if (getEspLogLevel()>LogNormal)
-        DBGLOG("Response content: %s", responseContent.str());
+    //if (getEspLogLevel()>LogNormal)
+    //    DBGLOG("Response content: %s", responseContent.str());
+    LOG(MCuserProgress, unknownJob,"Response content: %s", responseContent.str());//aud = user, MSGCLS = progress, InfoMsgThreshold 50
 
     return HttpClientErrCode::OK;
 }
@@ -981,7 +993,11 @@ HttpClientErrCode CHttpClient::postRequest(ISoapMessage &req, ISoapMessage& resp
             response.set_status(SOAP_CLIENT_ERROR);
 
         response.set_err(errmsg.str());
-        DBGLOG("SOAP_CLIENT_ERROR: %s", errmsg.str());
+        //DBGLOG("SOAP_CLIENT_ERROR: %s", errmsg.str()); //audience = programmer, class = progress, detailthreshold = 80
+        //above message would report, only if loglevel = 80 or above
+
+        //operator error log, perhaps not the perfect message class
+        OERRLOG("SOAP_CLIENT_ERROR: %s", errmsg.str()); //audience = operator, class = error, detailthreshold = 10
         return HttpClientErrCode::Error;
     }
     else if(statusClass == '5')
@@ -1031,11 +1047,14 @@ HttpClientErrCode CHttpClient::postRequest(ISoapMessage &req, ISoapMessage& resp
     StringBuffer content;
     httpresponse->getContent(content);
 
-    if (getEspLogLevel()>LogNormal)
+    if(httpresponse->isTextMessage())
+        LOG(MCuserProgress, unknownJob,"http response content = %s", content.str());//aud = user, MSGCLS = progress, InfoMsgThreshold 50
+
+    /*if (getEspLogLevel()>LogNormal)
     {
         if(httpresponse->isTextMessage())
             DBGLOG("http response content = %s", content.str());
-    }
+    }*/
 
     response.set_text(content.str());
             

--- a/esp/bindings/http/platform/httpbinding.cpp
+++ b/esp/bindings/http/platform/httpbinding.cpp
@@ -671,11 +671,12 @@ void EspHttpBinding::populateRequest(CHttpRequest *request)
         ISecResourceList* settinglist = m_setting_authmap->getResourceList("*");
         if(settinglist == NULL)
             return ;
-        if (getEspLogLevel()>=LogMax)
-        {
+
+        //if (getEspLogLevel()>=LogMax)
+        //{
             StringBuffer s;
             DBGLOG("Set security settings: %s", settinglist->toString(s).str());
-        }
+        //}
         ctx->setSecuritySettings(settinglist);
     }
     return ;
@@ -937,9 +938,11 @@ int EspHttpBinding::onGet(CHttpRequest* request, CHttpResponse* response)
 
     // At this time, the request is already received and fully passed, and
     // the user authenticated
-    LogLevel level = getEspLogLevel(&context);
-    if (level >= LogNormal)
-        DBGLOG("EspHttpBinding::onGet");
+
+    //LogLevel level = getEspLogLevel(&context);
+    //if (level >= LogNormal)
+    //    DBGLOG("EspHttpBinding::onGet");
+    NEWESPLOG(&context, "EspHttpBinding::onGet"); //use esp log to interrogate context for debug mode
     
     response->setVersion(HTTP_VERSION);
     response->addHeader("Expires", "0");
@@ -2796,8 +2799,8 @@ void EspHttpBinding::validateResponse(IEspContext& context, CHttpRequest* reques
     getSchema(xsd,context,request,serviceQName,methodQName,true);
             
     // validation
-    if (getEspLogLevel()>LogMax)
-        DBGLOG("[VALIDATE] xml: %s\nxsd: %s\nns: %s",xml.str(), xsd.str(), ns.str());
+    //if (getEspLogLevel()>LogMax)
+    DBGLOG("[VALIDATE] xml: %s\nxsd: %s\nns: %s",xml.str(), xsd.str(), ns.str());
 
     IXmlValidator* v = getXmlLibXmlValidator();
 
@@ -2846,8 +2849,9 @@ void EspHttpBinding::sortResponse(IEspContext& context, CHttpRequest* request, M
 
         xform->setXmlSource(respXML,respXML.length());
         xform->transform(result);
-        if (getEspLogLevel()>LogNormal)
-            DBGLOG("XML sorted: %s", result.str());
+        //if (getEspLogLevel()>LogNormal)
+        DBGLOG("XML sorted: %s", result.str());
+
         unsigned len = result.length();
         content.setBuffer(len, result.detach(), true);      
     } catch (IException* e) {

--- a/esp/platform/espcontext.hpp
+++ b/esp/platform/espcontext.hpp
@@ -132,6 +132,8 @@ esp_http_decl LogLevel getTxSummaryLevel();
 esp_http_decl bool getTxSummaryResourceReq();
 esp_http_decl unsigned getSlowProcessingTime();
 
+esp_http_decl void NEWESPLOG(IEspContext* ctx, const char* fmt, ...) __attribute__((format(printf, 2, 3)));
+esp_http_decl void NEWESPLOG(const char* fmt, ...) __attribute__((format(printf, 1, 2)));
 esp_http_decl void ESPLOG(IEspContext* ctx, LogLevel level, const char* fmt, ...) __attribute__((format(printf, 3, 4)));
 esp_http_decl void ESPLOG(LogLevel level, const char* fmt, ...) __attribute__((format(printf, 2, 3)));
 esp_http_decl void setEspContainer(IEspContainer* container);

--- a/esp/scm/esp.ecm
+++ b/esp/scm/esp.ecm
@@ -239,7 +239,7 @@ interface IEspContainer : extends IInterface
     virtual LogLevel getTxSummaryLevel() = 0;
     virtual bool getTxSummaryResourceReq() = 0;
     virtual void setTxSummaryResourceReq(bool req) = 0;
-    virtual void log(LogLevel level, const char*,...) __attribute__((format(printf, 3, 4))) = 0;
+    //virtual void log(LogLevel level, const char*,...) __attribute__((format(printf, 3, 4))) = 0;
     virtual unsigned getSlowProcessingTime() = 0;
     virtual void setFrameTitle(const char* title) = 0;
     virtual const char* getFrameTitle() = 0;

--- a/system/jlib/jlog.hpp
+++ b/system/jlib/jlog.hpp
@@ -241,6 +241,7 @@ typedef unsigned LogMsgDetail;
  * It represents the lowest logging level (detail) required to output
  * messages of the given category.
  */
+constexpr LogMsgDetail MuteMsgThreshold        = 0;
 constexpr LogMsgDetail CriticalMsgThreshold    = 1;  //Use to declare categories reporting critical events (log level => 1)
 constexpr LogMsgDetail FatalMsgThreshold       = 1;  //Use to declare categories reporting Fatal events (log level => 1)
 constexpr LogMsgDetail ErrMsgThreshold         = 10; //Use to declare categories reporting Err messages (log level => 10)
@@ -250,6 +251,7 @@ constexpr LogMsgDetail ProgressMsgThreshold    = 50; //Use to declare categories
 constexpr LogMsgDetail InfoMsgThreshold        = 60; //Use to declare categories reporting Info messages (log level => 60)
 constexpr LogMsgDetail DebugMsgThreshold       = 80; //Use to declare categories reporting Debug messages (log level => 80)
 constexpr LogMsgDetail ExtraneousMsgThreshold  = 90; //Use to declare categories reporting Extraneous messages (log level => 90)
+constexpr LogMsgDetail MaxMsgThreshold         = 100;
 
 // Typedef for LogMsgSysInfo
 


### PR DESCRIPTION
- Bare metal logging unaffected
-- Continue to support proc/@logLevel
-- Continue to support espcontrol::setloglevel
-- Filter logging output level via jlog constructs
-- Normalize Legacy esp log levels to jlog log detail range
-- Replace ESPLOG() w/ jlog XXXLOG macros
-- ESPLOG(ctx) to provide appropriate log message class
-- Remove dependance on legacy log levels

- Container mode
-- Global, or component logging standards via yaml
-- Remove dependence on esp specific loglevel config
-- espcontrol::setloglevel to update loghandler

Signed-off-by: Rodrigo Pastrana <rodrigo.pastrana@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [ ] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [ ] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [ ] I have read the CONTRIBUTORS document.
- [ ] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
