### PR TITLE
HPCC-24858 Allow dynamic logging manager configurations

### DIFF
--- a/esp/logging/loggingmanager/loggingmanager.cpp
+++ b/esp/logging/loggingmanager/loggingmanager.cpp
@@ -78,6 +78,12 @@ bool CLoggingManager::init(IPropertyTree* cfg, const char* service)
         }
         loggingAgent->init(agentName, agentType, &loggingAgentTree, service);
         loggingAgent->initVariants(&loggingAgentTree);
+        if (loggingAgent->hasService(LGSTGetTransactionID))
+            setServiceMaskService(LGSTGetTransactionID);
+        if (loggingAgent->hasService(LGSTGetTransactionSeed))
+            setServiceMaskService(LGSTGetTransactionSeed);
+        if (loggingAgent->hasService(LGSTUpdateLOG))
+            setServiceMaskService(LGSTUpdateLOG);
         IUpdateLogThread* logThread = createUpdateLogThread(&loggingAgentTree, service, agentName, failSafeLogsDir.get(), loggingAgent);
         if(!logThread)
             throw MakeStringException(-1, "Failed to create update log thread for %s", agentName);
@@ -108,6 +114,11 @@ IEspLogAgent* CLoggingManager::loadLoggingAgent(const char* name, const char* dl
 IEspLogEntry* CLoggingManager::createLogEntry()
 {
     return new CEspLogEntry();
+}
+
+bool CLoggingManager::hasService(LOGServiceType service) const
+{
+    return ((serviceMask & (1 << service)) != 0);
 }
 
 bool CLoggingManager::updateLog(IEspLogEntry* entry, StringBuffer& status)

--- a/esp/logging/loggingmanager/loggingmanager.hpp
+++ b/esp/logging/loggingmanager/loggingmanager.hpp
@@ -82,7 +82,9 @@ class CLoggingManager : implements ILoggingManager, public CInterface
     bool oneTankFile = false, decoupledLogging = false, initialized = false;
     Owned<ILogFailSafe> logFailSafe;
     CLogContentFilter logContentFilter;
+    unsigned serviceMask = 0;
 
+    inline void setServiceMaskService(LOGServiceType service) { serviceMask |= (1 << service); }
     IEspLogAgent* loadLoggingAgent(const char* name, const char* dll, const char* type, IPropertyTree* cfg);
     bool updateLogImpl(IEspUpdateLogRequestWrap& req, IEspUpdateLogResponse& resp);
     bool saveToTankFile(IEspUpdateLogRequestWrap& req, CLogRequestInFile* reqInFile);
@@ -103,6 +105,7 @@ public:
     virtual bool init(IPropertyTree* cfg, const char* service);
 
     virtual IEspLogEntry* createLogEntry();
+    bool hasService(LOGServiceType service) const override;
     virtual bool updateLog(IEspContext* espContext, IEspUpdateLogRequestWrap& req, IEspUpdateLogResponse& resp);
     virtual bool updateLog(IEspLogEntry* entry, StringBuffer& status);
     virtual bool getTransactionSeed(StringBuffer& transactionSeed, StringBuffer& status);

--- a/esp/platform/pluginloader.hpp
+++ b/esp/platform/pluginloader.hpp
@@ -1,0 +1,184 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2020 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef _PluginLoader_HPP_
+#define _PluginLoader_HPP_
+
+#include "jlog.hpp"
+#include "jmutex.hpp"
+#include "jptree.hpp"
+#include <map>
+#include <string>
+
+/**
+ * TPluginLoader encapsulates the logic used to obtain an entry-point function pointer from a
+ * shared library. The logic involved is not complex, but it is repetitive.
+ *
+ * The shared library name may be configured dynamically or known in advance. Given a
+ * configuration property tree and an XPath, the name will be extracted from the property tree.
+ * Given only a default name, the default will be used. Given all three, a configured value will
+ * be used if one exists and the default will be used otherwise.
+ *
+ * The entry-point function name may be configured dynamically or known in advance. Given a
+ * configuration property tree and an XPath, the name will be extracted from the property tree.
+ * Given only a default name, the default will be used. Given all three, a configured value will
+ * be used if one exists and the default will be used otherwise.
+ *
+ * The template parameter is an entry point function signature. This suggests a limitation of
+ * one kind of plugin per instance.
+ */
+template <typename entry_point_t>
+class TPluginLoader
+{
+public:
+    template <typename instance_t>
+    using Creator = std::function<instance_t*(entry_point_t entryPoint)>;
+
+    TPluginLoader(const char* libraryDefault, const char* entryPointDefault, const char* libraryXPath, const char* entryPointXPath)
+        : m_libraryXPath(libraryXPath)
+        , m_libraryDefault(libraryDefault)
+        , m_entryPointXPath(entryPointXPath)
+        , m_entryPointDefault(entryPointDefault)
+    {
+        StringBuffer missing;
+        if (m_libraryXPath.isEmpty() && m_libraryDefault.isEmpty())
+        {
+            if (!missing.isEmpty())
+                missing.append(" and ");
+            missing.append("library name");
+        }
+        if (m_entryPointXPath.isEmpty() && m_entryPointDefault.isEmpty())
+        {
+            if (!missing.isEmpty())
+                missing.append(" and ");
+            missing.append("entry-point function name");
+        }
+        if (!missing.isEmpty())
+            ERRLOG("bad plugin loading configuration - missing %s", missing.str());
+    }
+
+    template <typename instance_t>
+    instance_t* create(const IPTree& configuration, Creator<instance_t> creator)
+    {
+        instance_t* instance = nullptr;
+        if (!creator)
+        {
+            ERRLOG("plugin creation failed - invalid creation hook function");
+            return nullptr;
+        }
+        else
+        {
+            try
+            {
+                entry_point_t entryPoint = lookup(configuration);
+                if (entryPoint)
+                    instance = creator(entryPoint);
+            }
+            catch (IException* e)
+            {
+                StringBuffer msg;
+                ERRLOG("plugin creation exception: %s", e->errorMessage(msg).str());
+            }
+            catch (...)
+            {
+                ERRLOG("plugin creation exception");
+            }
+        }
+        return instance;
+    }
+
+    entry_point_t lookup(const IPTree& configuration)
+    {
+        const char* libraryName = nullptr;
+        const char* entryPointName = nullptr;
+        if (!m_libraryXPath.isEmpty())
+            libraryName = configuration.queryProp(m_libraryXPath);
+        if (!m_entryPointXPath.isEmpty())
+            entryPointName = configuration.queryProp(m_entryPointXPath);
+        return lookup(libraryName, entryPointName);
+    }
+
+    entry_point_t lookup(const char* libraryName, const char* entryPointName)
+    {
+        bool canFind = true;
+        if (isEmptyString(libraryName))
+        {
+            if (m_libraryDefault.isEmpty())
+            {
+                ERRLOG("plugin loader name lookup failed - no library name and no default value");
+                canFind = false;
+            }
+            else
+                libraryName = m_libraryDefault;
+        }
+        if (isEmptyString(entryPointName))
+        {
+            if (m_entryPointDefault.isEmpty())
+            {
+                ERRLOG("plugin loader name lookup failed - no entry point name and no default value");
+                canFind = false;
+            }
+            else
+                entryPointName = m_entryPointDefault;
+        }
+        return (canFind ? find(libraryName, entryPointName) : nullptr);
+    }
+
+private:
+    using EntryPointMap = std::map<std::string, entry_point_t>;
+    struct Plugin
+    {
+        HINSTANCE library = nullptr;
+        EntryPointMap entryPoints;
+    };
+    using PluginMap = std::map<std::string, Plugin>;
+    PluginMap       m_plugins;
+    CriticalSection m_lock;
+    StringBuffer    m_libraryXPath;
+    StringBuffer    m_libraryDefault;
+    StringBuffer    m_entryPointXPath;
+    StringBuffer    m_entryPointDefault;
+
+    entry_point_t find(const char* libraryName, const char* entryPointName)
+    {
+        VStringBuffer realName("%s%s%s", SharedObjectPrefix, libraryName, SharedObjectExtension);
+        CriticalBlock block(m_lock);
+        Plugin& plugin = m_plugins[libraryName];
+        if (!plugin.library)
+        {
+            plugin.library = LoadSharedObject(realName, true, false);
+            if (!plugin.library)
+            {
+                ERRLOG("plugin loader lookup failed - cannot load library '%s'", realName.str());
+                return nullptr;
+            }
+        }
+        entry_point_t& entryPoint = plugin.entryPoints[entryPointName];
+        if (!entryPoint)
+        {
+            entryPoint = (entry_point_t)GetSharedProcedure(plugin.library, entryPointName);
+            if (!entryPoint)
+            {
+                ERRLOG("plugin loader lookup failed - library '%s' does not export '%s'", realName.str(), entryPointName);
+                return nullptr;
+            }
+        }
+        return entryPoint;
+    }
+};
+
+#endif // _PluginLoader_HPP_

--- a/esp/services/esdl_svc_engine/esdl_binding.hpp
+++ b/esp/services/esdl_svc_engine/esdl_binding.hpp
@@ -71,13 +71,15 @@ typedef int (*cpp_service_method_t)(const char* CtxXML, const char* ReqXML, Stri
 class EsdlServiceImpl : public CInterface, implements IEspService
 {
 private:
+    inline Owned<ILoggingManager>& loggingManager() { return m_oDynamicLoggingManager ? m_oDynamicLoggingManager : m_oStaticLoggingManager; }
     IEspContainer *container;
     MapStringToMyClass<ISmartSocketFactory> connMap;
     MapStringToMyClass<IEmbedServiceContext> javaServiceMap;
     MapStringToMyClass<IException> javaExceptionMap;
     MapStringToMyClass<IEspPlugin> cppPluginMap;
     MapStringTo<cpp_service_method_t, cpp_service_method_t> cppProcMap;
-    Owned<ILoggingManager> m_oLoggingManager;
+    Owned<ILoggingManager> m_oDynamicLoggingManager;
+    Owned<ILoggingManager> m_oStaticLoggingManager;
     bool m_bGenerateLocalTrxId;
     MapStringToMyClass<IEsdlCustomTransform> m_customRequestTransformMap;
     Owned<IEsdlCustomTransform> m_serviceLevelRequestTransform;
@@ -159,9 +161,10 @@ public:
         m_methodCRTransformErrors.kill();
     }
 
-    virtual bool loadLogggingManager();
+    virtual bool loadLoggingManager(Owned<ILoggingManager>& manager, IPTree* configuration);
     virtual void init(const IPropertyTree *cfg, const char *process, const char *service);
     virtual void configureTargets(IPropertyTree *cfg, const char *service);
+    virtual void configureLogging(IPropertyTree *cfg);
     void configureJavaMethod(const char *method, IPropertyTree &entry, const char *classPath);
     void configureCppMethod(const char *method, IPropertyTree &entry, IEspPlugin*& plugin);
     void configureUrlMethod(const char *method, IPropertyTree &entry);


### PR DESCRIPTION
Update the DESDL service to detect and use a logging manager defined in the
dynamic binding in addition to one defined in the static configuration. The
format of the dynamic configuration matches the format currently expected
from esp.xml.

A dynamically configured manager will always be used. A statically configured
manager will always be used in the absence of a dynamically configured
manager, meaning it persists in the presence of a dynamically configured
manager so it can take effect if the binding is republished without a
configured manager.

Signed-off-by: Tim Klemm <tim.klemm@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [x] I have checked that this change does not introduce memory leaks.
  - [x] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
