### PR TITLE
HPCC-20950 Add ability to set or clear expire via fileservices

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -3215,6 +3215,20 @@ public:
     virtual bool getAccessedTime(CDateTime &dt) = 0;                            // get date and time last accessed (returns false if not set)
     virtual void setAccessedTime(const CDateTime &dt) = 0;                      // set date and time last accessed
     virtual bool isExternal() const { return external; }
+
+    virtual int getExpire()
+    {
+        return queryAttributes().getPropInt("@expireDays", -1);
+    }
+
+    virtual void setExpire(int expireDays)
+    {
+        DistributedFilePropertyLock lock(this);
+        if (expireDays == -1)
+            queryAttributes().removeProp("@expireDays"); // Never expire
+        else
+            queryAttributes().setPropInt("@expireDays", expireDays);
+    }
 };
 
 class CDistributedFile: public CDistributedFileBase<IDistributedFile>

--- a/dali/base/dadfs.hpp
+++ b/dali/base/dadfs.hpp
@@ -413,6 +413,8 @@ interface IDistributedFile: extends IInterface
     virtual void resetHistory() = 0;
     virtual bool isExternal() const = 0;
     virtual bool getSkewInfo(unsigned &maxSkew, unsigned &minSkew, unsigned &maxSkewPart, unsigned &minSkewPart, bool calculateIfMissing) = 0;
+    virtual int  getExpire() = 0;
+    virtual void setExpire(int expireDays) = 0;
 };
 
 

--- a/ecllibrary/std/File.ecl
+++ b/ecllibrary/std/File.ecl
@@ -1040,4 +1040,38 @@ EXPORT varstring GetDefaultDropZone() :=
 EXPORT dataset(FsDropZoneRecord) GetDropZones() :=
     lib_fileservices.FileServices.GetDropZones();
 
+/**
+ * Return the expire days property of the specified logical filename.
+ *
+ * @param lfn           The name of the logical file.
+ * @return              Value of @expiredays properties of the file or -1 if that property not exists (never expire)
+ *                      0 return value means using system expire value.
+ *
+ */
+
+EXPORT integer4 GetExpireDays(varstring lfn) := 
+	lib_fileservices.Fileservices.GetExpireDays(lfn);
+	
+
+/**
+ * Set the expire days property of the specified logical filename.
+ *
+ * @param lfn           The name of the logical file.
+ * @param expireDays    Number of days before file expired. 0 means using system expire value.
+ *                      
+ */
+
+EXPORT SetExpireDays(varstring lfn, integer4 expireDays) := 
+	lib_fileservices.Fileservices.SetExpireDays(lfn, expireDays);
+
+/**
+ * Clear the expire days property of the specified logical filename.
+ *
+ * @param lfn           The name of the logical file.
+ *
+ */
+
+EXPORT ClearExpireDays(varstring lfn) := 
+	lib_fileservices.Fileservices.ClearExpireDays(lfn);
+
 END;

--- a/plugins/fileservices/fileservices.hpp
+++ b/plugins/fileservices/fileservices.hpp
@@ -170,6 +170,9 @@ FILESERVICES_API void FILESERVICES_CALL fsDfuPlusExec(ICodeContext * ctx,const c
 FILESERVICES_API char * FILESERVICES_CALL fsGetEspURL(const char *username, const char *userPW);
 FILESERVICES_API char * FILESERVICES_CALL fsGetDefaultDropZone();
 FILESERVICES_API void FILESERVICES_CALL fsGetDropZones(ICodeContext *ctx,size32_t & __lenResult,void * & __result);
+FILESERVICES_API int FILESERVICES_CALL fsGetExpireDays(ICodeContext * ctx, const char *lfn);
+FILESERVICES_API void FILESERVICES_CALL fsSetExpireDays(ICodeContext * ctx, const char *lfn, int expireDays);
+FILESERVICES_API void FILESERVICES_CALL fsClearExpireDays(ICodeContext * ctx, const char *lfn);
 
 }
 

--- a/testing/regress/ecl/key/spray_expire_test.xml
+++ b/testing/regress/ecl/key/spray_expire_test.xml
@@ -38,3 +38,12 @@
 <Dataset name='RemotePull'>
  <Row><RemotePull>Pass</RemotePull></Row>
 </Dataset>
+<Dataset name='SetExpireDays'>
+ <Row><SetExpireDays>Pass</SetExpireDays></Row>
+</Dataset>
+<Dataset name='ClearExpireDays'>
+ <Row><ClearExpireDays>Pass</ClearExpireDays></Row>
+</Dataset>
+<Dataset name='ExpireDaysDefault'>
+ <Row><ExpireDaysDefault>Pass</ExpireDaysDefault></Row>
+</Dataset>

--- a/testing/regress/ecl/spray_expire_test.ecl
+++ b/testing/regress/ecl/spray_expire_test.ecl
@@ -144,16 +144,36 @@ expireDaysIn8 := FileServices.GetLogicalFileAttribute(DestFile, 'expireDays');
 res8:=if(expireDaysIn8 = '', 'Pass', 'Fail ('+intformat(expireDaysOut8,2,0)+','+expireDaysIn8+')');
 
 
+// File copy test
 
 CopyDestFile := prefix + 'copy_expire.txt';
 expireDaysOut9 := 19;
 expireDaysIn9 := FileServices.GetLogicalFileAttribute(CopyDestFile, 'expireDays');
 res9:=if(expireDaysIn9 = intformat(expireDaysOut9,2,0), 'Pass', 'Fail ('+intformat(expireDaysOut9,2,0)+','+expireDaysIn9+')');
 
+// remotePull test
+
+
 RemotePullDestFile := prefix + 'remote_pull_expire.txt';
 expireDaysOut10 := 23;
 expireDaysIn10 := FileServices.GetLogicalFileAttribute(RemotePullDestFile, 'expireDays');
 res10:=if(expireDaysIn10 = intformat(expireDaysOut10,2,0), 'Pass', 'Fail ('+intformat(expireDaysOut10,2,0)+','+expireDaysIn10+')');
+
+
+// SetExpireDays()/GetExpireDays() tests
+
+expireDaysOut11 := 43;
+expireDaysIn11 := FileServices.GetExpireDays(RemotePullDestFile);
+res11:=if(expireDaysIn11 = expireDaysOut11, 'Pass', 'Fail ('+expireDaysOut11 + ','+expireDaysIn11+')');
+
+expireDaysOut12 := -1; // but omit expireDay parameter
+expireDaysIn12 := FileServices.GetLogicalFileAttribute(RemotePullDestFile, 'expireDays');
+res12:=if(expireDaysIn12 = '', 'Pass', 'Fail ('+intformat(expireDaysOut12,2,0)+','+expireDaysIn12+')');
+
+// The previous test removed @expiredays from RemotePullDestFile, so this should return with never expire (-1) as default
+expireDaysOut13 := -1; // but omit expireDay parameter
+expireDaysIn13 := FileServices.GetExpireDays(RemotePullDestFile);
+res13:=if(expireDaysIn13 = expireDaysOut13, 'Pass', 'Fail ('+expireDaysOut13 + ','+expireDaysIn13+')');
 
 
 sequential (
@@ -272,6 +292,22 @@ sequential (
                              );
      output(res10, NAMED('RemotePull')),
 
+	FileServices.SetExpireDays(
+                             lfn := RemotePullDestFile,
+                             expireDays := expireDaysOut11
+                             );
+
+	output(res11, NAMED('SetExpireDays')),
+	
+	FileServices.ClearExpireDays(
+                             lfn := RemotePullDestFile
+                             );
+
+	output(res12, NAMED('ClearExpireDays')),
+
+	output(res13, NAMED('ExpireDaysDefault')),
+	
+	
     // Clean-up
     FileServices.DeleteExternalFile('.', desprayOutFileName+'_CSV'),
     FileServices.DeleteExternalFile('.', desprayOutFileName+'_XML'),


### PR DESCRIPTION
Implement:
  - integer4 GetExpireDays(lfn)
  - SetExpireDays(lfn, expireDays)
  - ClearExpireDays(lfn)

functions in file services.

Extend spray_expire_test.ecl to test the 2 new functions.

Signed-off-by: Attila Vamos <attila.vamos@gmail.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [x] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [x] I have created a JIRA ticket to update the documentation.
  - [x] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [x] I have added tests to cover my changes.
  - [x] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->
Tested locally.
<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
