### PR TITLE
HPCC-25246 Error in '//timeout' ECL file tag handling

### DIFF
--- a/testing/regress/hpcc/regression/regress.py
+++ b/testing/regress/hpcc/regression/regress.py
@@ -233,6 +233,7 @@ class Regression:
                     query.setIgnoreResult(self.args.ignoreResult)
                     query.setJobname(time.strftime("%y%m%d-%H%M%S"))
                     timeout = query.getTimeout()
+                    logger.debug("Query timeout:%d", -1, timeout)
                     oldCnt = cnt
 
                 started = False
@@ -247,11 +248,12 @@ class Regression:
                                 self.timeouts[startThreadId] = timeout
                             else:
                                 self.timeouts[startThreadId] = self.timeout
+                                timeout = self.timeout
 
-                            self.taskParam[startThreadId]['timeoutValue'] = self.timeout
+                            self.taskParam[startThreadId]['timeoutValue'] = timeout
                             query = suiteItems[self.taskParam[startThreadId]['taskId']]
-                            query.setTimeout(self.timeout)
-                            #logger.debug("self.timeout[%d]:%d", startThreadId, self.timeouts[startThreadId])
+                            logger.debug("self.timeout:%d, self.timeouts[thread:%d]:%d", self.timeout, startThreadId, self.timeouts[startThreadId])
+                            query.setTimeout(timeout)
                             self.taskParam[startThreadId]['jobName'] = query.getJobname()
                             self.taskParam[startThreadId]['retryCount'] = int(self.config.maxAttemptCount)
                             self.exitmutexes[startThreadId].acquire()
@@ -374,7 +376,7 @@ class Regression:
                 wuid =  queryWuid(query.getJobname(),  query.getTaskId())
                 self.retryCount -= 1;
                 if self.retryCount> 0:
-                    self.timeouts[threadId] =  self.timeout
+                    self.timeouts[threadId] = query.getTimeout()
                     self.loggermutex.acquire()
                     logger.warn("%3d. %s has not started yet. Reset due to timeout after %d sec (%d retry attempt(s) remain)." % (cnt, query.ecl, self.timeouts[threadId],  self.retryCount),  extra={'taskId':cnt})
                     logger.debug("%3d. Task parameters: thread id: %d, ecl:'%s',state:'%s', retry count:%d." % (cnt, threadId,  query.ecl,   wuid['state'],  self.retryCount),  extra={'taskId':cnt})

--- a/testing/regress/hpcc/util/ecl/file.py
+++ b/testing/regress/hpcc/util/ecl/file.py
@@ -86,7 +86,7 @@ class ECLFile:
         self.isVersions=False
         self.version=''
         self.versionId=0
-        self.timeout = int(args.timeout)
+        self.timeout = self.checkFileTimeout(int(args.timeout))
         self.args = args
         self.eclccWarning = ''
         self.eclccWarningChanges = ''
@@ -463,30 +463,29 @@ class ECLFile:
     def setVersionId(self,  id):
         self.versionId=id
 
-    def getTimeout(self):
-        timeout = 0
-        if  self.timeout == 0:
-            # Standard string has a problem with unicode characters
-            # use byte arrays and binary file open instead
-            tag = '//timeout'
-            logger.debug("%3d. getTimeout (ecl:'%s', tag:'%s')", self.taskId,  self.ecl, tag)
-            eclText = open(self.getEcl(), 'rb')
-            for line in eclText:
-                try:
-                    line = line.decode("utf-8")
-                except UnicodeDecodeError:
-                    line = str(line)
-                if tag in line:
-                    timeoutParts = line.split()
-                    if len(timeoutParts) == 2:
-                        if (timeoutParts[1] == '-1') or isPositiveIntNum(timeoutParts[1]) :
-                            timeout = int(timeoutParts[1])
-                            self.timeout = timeout
-                    break
-        else:
-            timeout = self.timeout
+    def checkFileTimeout(self,  timeout):
+        timeout = timeout
+        # Standard string has a problem with unicode characters
+        # use byte arrays and binary file open instead
+        tag = '//timeout'
+        logger.debug("%3d. checkFileTimeout (ecl:'%s', tag:'%s')", self.taskId,  self.ecl, tag)
+        eclText = open(self.getEcl(), 'rb')
+        for line in eclText:
+            try:
+                line = line.decode("utf-8")
+            except UnicodeDecodeError:
+                line = str(line)
+            if tag in line:
+                timeoutParts = line.split()
+                if len(timeoutParts) == 2:
+                    if (timeoutParts[1] == '-1') or isPositiveIntNum(timeoutParts[1]) :
+                        timeout = int(timeoutParts[1])
+                break
         logger.debug("%3d. Timeout is :%d sec",  self.taskId,  timeout)
         return timeout
+
+    def getTimeout(self):
+        return self.timeout
 
     def setTimeout(self,  timeout):
         self.timeout = timeout

--- a/testing/regress/hpcc/util/util.py
+++ b/testing/regress/hpcc/util/util.py
@@ -215,7 +215,7 @@ def abortWorkunit(wuid, taskId = -1, engine = None):
                 for p in hpccProcesses:
                     createStackTrace(wuid, p, taskId)
             else:
-                logger.debug("%3d. abortWorkunit(wuid:'%s', engine:'%s') related process to generate stack trace not found.", taskId, wuid, str(engine))
+                logger.error("%3d. abortWorkunit(wuid:'%s', engine:'%s') related process to generate stack trace not found.", taskId, wuid, str(engine))
             pass
         else:
             err = Error("7100")


### PR DESCRIPTION
Enable the Regression Test Engine chekcs the '//timeout <value>' tag in the file only once.

Fix timeout handling in parallel query execution mode to force using timeout from the ECL file.

Signed-off-by: Attila Vamos <attila.vamos@gmail.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [x] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [x] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [x] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [x] This change fixes the problem, not just the symptom
  - [x] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [x] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->
Tested manually.
<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
