### PR TITLE
HPCC-25346 Add WsTopology.TpStoragePlaneQuery

### DIFF
--- a/esp/scm/ws_topology.ecm
+++ b/esp/scm/ws_topology.ecm
@@ -316,6 +316,14 @@ ESPStruct TpClusterNameType
     bool   IsDefault;
 };
 
+ESPStruct TpStoragePlane
+{
+    string Name;
+    string Hosts;
+    string Prefix;
+    unsigned NumDevices;
+};
+
 ESPrequest TpListTargetClustersRequest
 {
 };
@@ -646,7 +654,17 @@ ESPresponse [nil_remove, exceptions_inline] TpDropZoneQueryResponse
     ESParray<ESPstruct TpDropZone>    TpDropZones;
 };
 
-ESPservice [auth_feature("DEFERRED"), noforms, version("1.31"), cache_group("ESPWsTP"), exceptions_inline("./smc_xslt/exceptions.xslt")] WsTopology
+ESPrequest TpStoragePlaneQueryRequest
+{
+    string Name;
+};
+
+ESPresponse [nil_remove, exceptions_inline] TpStoragePlaneQueryResponse
+{
+    ESParray<ESPstruct TpStoragePlane> TpStoragePlanes;
+};
+
+ESPservice [auth_feature("DEFERRED"), noforms, version("1.32"), cache_group("ESPWsTP"), exceptions_inline("./smc_xslt/exceptions.xslt")] WsTopology
 {
     ESPmethod [cache_seconds(180), cache_global(1), resp_xsl_default("/esp/xslt/targetclusters.xslt")] TpTargetClusterQuery(TpTargetClusterQueryRequest, TpTargetClusterQueryResponse);
     ESPmethod [cache_seconds(180), cache_global(1), resp_xsl_default("/esp/xslt/topology.xslt")] TpClusterQuery(TpClusterQueryRequest, TpClusterQueryResponse);
@@ -669,6 +687,7 @@ ESPservice [auth_feature("DEFERRED"), noforms, version("1.31"), cache_group("ESP
     ESPmethod [cache_seconds(180), cache_global(1), min_ver(1.25)] TpMachineInfo(TpMachineInfoRequest, TpMachineInfoResponse);
 
     ESPmethod SystemLog(SystemLogRequest, SystemLogResponse);
+    ESPmethod [min_ver(1.32)] TpStoragePlaneQuery(TpStoragePlaneQueryRequest, TpStoragePlaneQueryResponse);
 };
 
 SCMexportdef(WSWU);

--- a/esp/services/ws_topology/ws_topologyService.cpp
+++ b/esp/services/ws_topology/ws_topologyService.cpp
@@ -1954,3 +1954,17 @@ bool CWsTopologyEx::onTpDropZoneQuery(IEspContext &context, IEspTpDropZoneQueryR
     }
     return false;
 }
+
+bool CWsTopologyEx::onTpStoragePlaneQuery(IEspContext &context, IEspTpStoragePlaneQueryRequest &req, IEspTpStoragePlaneQueryResponse &resp)
+{
+    try
+    {
+        context.ensureFeatureAccess(FEATURE_URL, SecAccess_Read, ECLWATCH_TOPOLOGY_ACCESS_DENIED, "WsTopology::TpStoragePlaneQuery: Permission denied.");
+        m_TpWrapper.getTpStoragePlanes(context.getClientVersion(), req.getName(), resp.getTpStoragePlanes());
+    }
+    catch(IException *e)
+    {
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
+    }
+    return false;
+}

--- a/esp/services/ws_topology/ws_topologyService.hpp
+++ b/esp/services/ws_topology/ws_topologyService.hpp
@@ -173,6 +173,7 @@ public:
     bool onTpGetComponentFile(IEspContext &context, IEspTpGetComponentFileRequest &req, IEspTpGetComponentFileResponse &resp);
 
     bool onTpThorStatus(IEspContext &context, IEspTpThorStatusRequest &req, IEspTpThorStatusResponse &resp);
+    bool onTpStoragePlaneQuery(IEspContext &context, IEspTpStoragePlaneQueryRequest &req, IEspTpStoragePlaneQueryResponse &resp);
 };
 
 

--- a/esp/smc/SMCLib/TpWrapper.cpp
+++ b/esp/smc/SMCLib/TpWrapper.cpp
@@ -1970,6 +1970,31 @@ void CTpWrapper::getAttPath(const char* Path,StringBuffer& returnStr)
     JBASE64_Decode(Path, returnStr);
 }
 
+void CTpWrapper::getTpStoragePlanes(double version, const char* planeName, IArrayOf<IConstTpStoragePlane>& storagePlanes)
+{
+    IPropertyTree* storage = queryGlobalConfig().queryPropTree("storage");
+    if (!storage)
+        return;
+
+    Owned<IPropertyTreeIterator> planes = storage->getElements("planes");
+    ForEach(*planes)
+    {
+        IPropertyTree& plane = planes->query();
+        const char* name = plane.queryProp("@name");
+        if (isEmptyString(name) || (!isEmptyString(planeName) && !strieq(planeName, name)))
+            continue;
+
+        Owned<IEspTpStoragePlane> storagePlane = createTpStoragePlane();
+        storagePlane->setName(name);
+        storagePlane->setHosts(plane.queryProp("@hosts"));
+        storagePlane->setPrefix(plane.queryProp("@prefix"));
+        storagePlane->setNumDevices(plane.getPropInt("@numDevices", 1));
+        storagePlanes.append(*storagePlane.getLink());
+        if (!isEmptyString(planeName))
+            break;
+    }
+}
+
 extern TPWRAPPER_API ISashaCommand* archiveOrRestoreWorkunits(StringArray& wuids, IProperties* params, bool archive, bool dfu)
 {
     StringBuffer sashaAddress;

--- a/esp/smc/SMCLib/TpWrapper.hpp
+++ b/esp/smc/SMCLib/TpWrapper.hpp
@@ -185,6 +185,7 @@ public:
     void getTpDkcSlaves(IArrayOf<IConstTpDkcSlave>& list);
     void getTpGenesisServers(IArrayOf<IConstTpGenesisServer>& list);
     void getTpSparkThors(double clientVersion, const char* name, IArrayOf<IConstTpSparkThor>& list);
+    void getTpStoragePlanes(double version, const char* planeName, IArrayOf<IConstTpStoragePlane>& list);
 
     void queryTargetClusters(double version, const char* clusterType, const char* clusterName, IArrayOf<IEspTpTargetCluster>& clusterList);
     void getTargetClusterList(IArrayOf<IEspTpLogicalCluster>& clusters, const char* clusterType = NULL, const char* clusterName = NULL);


### PR DESCRIPTION
The ESP method is added to report the information about storage planes
in a cloud environment.

Signed-off-by: wangkx <kevin.wang@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
