### PR TITLE
HPCC-25219 add Kubernetes Scheduler configuration support

### DIFF
--- a/helm/hpcc/templates/_helpers.tpl
+++ b/helm/hpcc/templates/_helpers.tpl
@@ -615,3 +615,41 @@ resources:
     memory: "100M"
 {{- end -}}
 
+
+{{/*
+Create placement related settings
+*/}}
+{{- define "hpcc.doPlacement" -}}
+{{- if .placement.nodeSelector }}
+nodeSelector:
+{{ toYaml .placement.nodeSelector | indent 2  }}
+{{- end -}}
+{{- if .placement.tolerations }}
+tolerations:
+{{ toYaml .placement.tolerations }}
+{{- end -}}
+{{- if .placement.affinity }}
+affinity:
+{{ toYaml .placement.affinity }}
+{{- end -}}
+{{- if .placement.schedulerNames -}}
+{{- range $profileName := .placement.schedulerNames }}
+schedulerName: {{ $profileName }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Check if there is any placement configuration
+*/}}
+{{- define "hpcc.placementMatchName" -}}
+{{- if .root.Values.placement }}
+{{- $pod := .pod -}}
+{{- $group := .group -}}
+{{- range $placement := .root.Values.placement -}}
+{{- if or (has $pod $placement.pods) (has $group $placement.pods) -}}
+{{ include "hpcc.doPlacement" (dict "placement" $placement) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/helm/hpcc/templates/_helpers.tpl
+++ b/helm/hpcc/templates/_helpers.tpl
@@ -621,22 +621,29 @@ Create placement related settings
 Pass in dict with placement
 */}}
 {{- define "hpcc.doPlacement" -}}
-{{- if .this.placement }}
-{{ toYaml .this.placement }}
+{{- if .me.placement }}
+{{ toYaml .me.placement }}
 {{- end -}}
 {{- end -}}
 
 {{/*
 Check if there is any placement configuration
-Pass in dict with root, pod and type
+Pass in dict with root, job, target and type
 */}}
-{{- define "hpcc.placementsByPodType" -}}
+{{- define "hpcc.placementsByJobTargetType" -}}
 {{- if .root.Values.placements }}
-{{- $pod := .pod -}}
+{{- $job := .job -}}
+{{- $target := (printf "target:%s" .target | default "") -}}
 {{- $type := printf "type:%s" .type -}}
 {{- range $placement := .root.Values.placements -}}
-{{- if or (has $pod $placement.pods) (has $type $placement.pods) -}}
-{{ include "hpcc.doPlacement" (dict "this" $placement) -}}
+{{- if or (has $target $placement.pods) (has $type $placement.pods) -}}
+{{ include "hpcc.doPlacement" (dict "me" $placement) -}}
+{{- else -}}
+{{- range $jobPattern := $placement.pods -}}
+{{- if mustRegexMatch $jobPattern $job -}}
+{{ include "hpcc.doPlacement" (dict "me" $placement) -}}
+{{- end -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}
@@ -649,11 +656,11 @@ Pass in dict with root, pod, target and type
 {{- define "hpcc.placementsByPodTargetType" -}}
 {{- if .root.Values.placements }}
 {{- $pod := .pod -}}
-{{- $target := printf "target:%s" .target -}}
+{{- $target := (printf "target:%s" .target | default "") -}}
 {{- $type := printf "type:%s" .type -}}
 {{- range $placement := .root.Values.placements -}}
 {{- if or (has $pod $placement.pods) (has $target $placement.pods) (has $type $placement.pods) -}}
-{{ include "hpcc.doPlacement" (dict "this" $placement) -}}
+{{ include "hpcc.doPlacement" (dict "me" $placement) -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/helm/hpcc/templates/_helpers.tpl
+++ b/helm/hpcc/templates/_helpers.tpl
@@ -621,37 +621,39 @@ Create placement related settings
 Pass in dict with placement
 */}}
 {{- define "hpcc.doPlacement" -}}
-{{- if .placement.nodeSelector }}
-nodeSelector:
-{{ toYaml .placement.nodeSelector | indent 2 }}
+{{- if .this.placement }}
+{{ toYaml .this.placement }}
 {{- end -}}
-{{- if .placement.tolerations }}
-tolerations:
-{{ toYaml .placement.tolerations }}
 {{- end -}}
-{{- if .placement.affinity }}
-affinity:
-{{ toYaml .placement.affinity }}
+
+{{/*
+Check if there is any placement configuration
+Pass in dict with root, pod and type
+*/}}
+{{- define "hpcc.placementsByPodType" -}}
+{{- if .root.Values.placements }}
+{{- $pod := .pod -}}
+{{- $type := printf "type:%s" .type -}}
+{{- range $placement := .root.Values.placements -}}
+{{- if or (has $pod $placement.pods) (has $type $placement.pods) -}}
+{{ include "hpcc.doPlacement" (dict "this" $placement) -}}
 {{- end -}}
-{{- if .placement.schedulerNames -}}
-{{- range $profileName := .placement.schedulerNames }}
-schedulerName: {{ $profileName }}
 {{- end -}}
 {{- end -}}
 {{- end -}}
 
 {{/*
 Check if there is any placement configuration
-Pass in dict with root, pod, cluster and type
+Pass in dict with root, pod, target and type
 */}}
-{{- define "hpcc.placementMatchName" -}}
-{{- if .root.Values.placement }}
+{{- define "hpcc.placementsByPodTargetType" -}}
+{{- if .root.Values.placements }}
 {{- $pod := .pod -}}
-{{- $cluster := .cluster -}}
-{{- $type := .type -}}
-{{- range $placement := .root.Values.placement -}}
-{{- if or (has $pod $placement.pods) (has $cluster $placement.pods) (has $type $placement.pods) -}}
-{{ include "hpcc.doPlacement" (dict "placement" $placement) -}}
+{{- $target := printf "target:%s" .target -}}
+{{- $type := printf "type:%s" .type -}}
+{{- range $placement := .root.Values.placements -}}
+{{- if or (has $pod $placement.pods) (has $target $placement.pods) (has $type $placement.pods) -}}
+{{ include "hpcc.doPlacement" (dict "this" $placement) -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/helm/hpcc/templates/_helpers.tpl
+++ b/helm/hpcc/templates/_helpers.tpl
@@ -618,11 +618,12 @@ resources:
 
 {{/*
 Create placement related settings
+Pass in dict with placement
 */}}
 {{- define "hpcc.doPlacement" -}}
 {{- if .placement.nodeSelector }}
 nodeSelector:
-{{ toYaml .placement.nodeSelector | indent 2  }}
+{{ toYaml .placement.nodeSelector | indent 2 }}
 {{- end -}}
 {{- if .placement.tolerations }}
 tolerations:
@@ -641,13 +642,15 @@ schedulerName: {{ $profileName }}
 
 {{/*
 Check if there is any placement configuration
+Pass in dict with root, pod, cluster and type
 */}}
 {{- define "hpcc.placementMatchName" -}}
 {{- if .root.Values.placement }}
 {{- $pod := .pod -}}
-{{- $group := .group -}}
+{{- $cluster := .cluster -}}
+{{- $type := .type -}}
 {{- range $placement := .root.Values.placement -}}
-{{- if or (has $pod $placement.pods) (has $group $placement.pods) -}}
+{{- if or (has $pod $placement.pods) (has $cluster $placement.pods) (has $type $placement.pods) -}}
 {{ include "hpcc.doPlacement" (dict "placement" $placement) -}}
 {{- end -}}
 {{- end -}}

--- a/helm/hpcc/templates/dali.yaml
+++ b/helm/hpcc/templates/dali.yaml
@@ -16,7 +16,7 @@ spec:
         run: {{ .name | quote }}
         app: dali
     spec:
-      {{- include "hpcc.placementMatchName" (dict "root" $ "pod" .name "group" "dali") | indent 6 }}
+      {{- include "hpcc.placementMatchName" (dict "root" $ "pod" .name "cluster" .name "type" "dali") | indent 6 }}
       serviceAccountName: "hpcc-default"
       initContainers: 
         {{- include "hpcc.checkDaliMount" (dict "root" $) | indent 6 }}

--- a/helm/hpcc/templates/dali.yaml
+++ b/helm/hpcc/templates/dali.yaml
@@ -16,7 +16,7 @@ spec:
         run: {{ .name | quote }}
         app: dali
     spec:
-      {{- include "hpcc.placementsByPodType" (dict "root" $ "pod" .name "type" "dali") | indent 6 }}
+      {{- include "hpcc.placementsByPodTargetType" (dict "root" $ "pod" .name "type" "dali") | indent 6 }}
       serviceAccountName: "hpcc-default"
       initContainers: 
         {{- include "hpcc.checkDaliMount" (dict "root" $) | indent 6 }}

--- a/helm/hpcc/templates/dali.yaml
+++ b/helm/hpcc/templates/dali.yaml
@@ -16,6 +16,7 @@ spec:
         run: {{ .name | quote }}
         app: dali
     spec:
+      {{- include "hpcc.placementMatchName" (dict "root" $ "pod" .name "group" "dali") | indent 6 }}
       serviceAccountName: "hpcc-default"
       initContainers: 
         {{- include "hpcc.checkDaliMount" (dict "root" $) | indent 6 }}

--- a/helm/hpcc/templates/dali.yaml
+++ b/helm/hpcc/templates/dali.yaml
@@ -16,7 +16,7 @@ spec:
         run: {{ .name | quote }}
         app: dali
     spec:
-      {{- include "hpcc.placementMatchName" (dict "root" $ "pod" .name "cluster" .name "type" "dali") | indent 6 }}
+      {{- include "hpcc.placementsByPodType" (dict "root" $ "pod" .name "type" "dali") | indent 6 }}
       serviceAccountName: "hpcc-default"
       initContainers: 
         {{- include "hpcc.checkDaliMount" (dict "root" $) | indent 6 }}

--- a/helm/hpcc/templates/eclagent.yaml
+++ b/helm/hpcc/templates/eclagent.yaml
@@ -18,7 +18,7 @@ spec:
         accessDali: "yes"
         accessEsp: {{ .useChildProcesses | default false | ternary "yes" "no" | quote }}
     spec:
-            {{- include "hpcc.placementsByPodTargetType" (dict "root" $ "pod" .name "target" .name "type" "eclagent" ) | indent 6 }}
+      {{- include "hpcc.placementsByPodTargetType" (dict "root" $ "pod" .name "target" .name "type" "eclagent" ) | indent 6 }}
       serviceAccountName: {{ .useChildProcesses | default false | ternary "hpcc-default" "hpcc-agent" }}
       initContainers:
         {{- include "hpcc.checkDataMount" (dict "root" $) | indent 6 }}
@@ -66,12 +66,12 @@ data:
     global:
 {{ include "hpcc.generateGlobalConfigMap" $ | indent 6 }}
 {{- if not .useChildProcesses }} 
-{{- $jobNamePrefix := printf "%s-%s-" .name $apptype }}
+{{- $jobName := printf "%s-%jobname" $apptype }}
   {{ $apptype }}-jobspec.yaml: |
     apiVersion: batch/v1
     kind: Job
     metadata:
-      name: {{ $apptype }}-%jobname
+      name: {{ $jobName }}
     spec:
       ttlSecondsAfterFinished: 100
       template:
@@ -80,10 +80,10 @@ data:
             accessDali: "yes"
             accessEsp: "yes"
         spec:
-          {{- include "hpcc.placementsByPodTargetType" (dict "root" $ "pod" $jobNamePrefix "target" .name "type" "eclagent") | indent 10 }}
+          {{- include "hpcc.placementsByJobTargetType" (dict "root" $ "job" $jobName "target" .name "type" "eclagent") | indent 10 }}
           serviceAccountName: "hpcc-default"
           containers:
-          - name: {{ $apptype }}-%jobname
+          - name: {{ $jobName }}
 {{- include "hpcc.addSecurityContext" (dict "root" $ "me" .) | indent 12 }}
 {{ include "hpcc.addImageAttrs" (dict "root" $ "me" .) | indent 12 }}
 {{- include "hpcc.addResources" (dict "me" .resources) | indent 12 }}

--- a/helm/hpcc/templates/eclagent.yaml
+++ b/helm/hpcc/templates/eclagent.yaml
@@ -18,7 +18,7 @@ spec:
         accessDali: "yes"
         accessEsp: {{ .useChildProcesses | default false | ternary "yes" "no" | quote }}
     spec:
-      {{- include "hpcc.placementMatchName" (dict "root" $ "pod" .name "group" "eclagent" ) | indent 6 }}
+      {{- include "hpcc.placementMatchName" (dict "root" $ "pod" .name "cluster" .name "type" "eclagent" ) | indent 6 }}
       serviceAccountName: {{ .useChildProcesses | default false | ternary "hpcc-default" "hpcc-agent" }}
       initContainers:
         {{- include "hpcc.checkDataMount" (dict "root" $) | indent 6 }}
@@ -79,7 +79,7 @@ data:
             accessDali: "yes"
             accessEsp: "yes"
         spec:
-          {{- include "hpcc.placementMatchName" (dict "root" $ "pod" (printf "%s-" $apptype) "group" "eclagent") | indent 10 }}
+          {{- include "hpcc.placementMatchName" (dict "root" $ "pod" (printf "%s-%s-" $apptype .name) "cluster" .name "type" "eclagent") | indent 10 }}
           serviceAccountName: "hpcc-default"
           containers:
           - name: {{ $apptype }}-%jobname

--- a/helm/hpcc/templates/eclagent.yaml
+++ b/helm/hpcc/templates/eclagent.yaml
@@ -18,6 +18,7 @@ spec:
         accessDali: "yes"
         accessEsp: {{ .useChildProcesses | default false | ternary "yes" "no" | quote }}
     spec:
+      {{- include "hpcc.placementMatchName" (dict "root" $ "pod" .name "group" "eclagent" ) | indent 6 }}
       serviceAccountName: {{ .useChildProcesses | default false | ternary "hpcc-default" "hpcc-agent" }}
       initContainers:
         {{- include "hpcc.checkDataMount" (dict "root" $) | indent 6 }}
@@ -78,6 +79,7 @@ data:
             accessDali: "yes"
             accessEsp: "yes"
         spec:
+          {{- include "hpcc.placementMatchName" (dict "root" $ "pod" (printf "%s-" $apptype) "group" "eclagent") | indent 10 }}
           serviceAccountName: "hpcc-default"
           containers:
           - name: {{ $apptype }}-%jobname

--- a/helm/hpcc/templates/eclagent.yaml
+++ b/helm/hpcc/templates/eclagent.yaml
@@ -18,7 +18,7 @@ spec:
         accessDali: "yes"
         accessEsp: {{ .useChildProcesses | default false | ternary "yes" "no" | quote }}
     spec:
-      {{- include "hpcc.placementMatchName" (dict "root" $ "pod" .name "cluster" .name "type" "eclagent" ) | indent 6 }}
+            {{- include "hpcc.placementsByPodTargetType" (dict "root" $ "pod" .name "target" .name "type" "eclagent" ) | indent 6 }}
       serviceAccountName: {{ .useChildProcesses | default false | ternary "hpcc-default" "hpcc-agent" }}
       initContainers:
         {{- include "hpcc.checkDataMount" (dict "root" $) | indent 6 }}
@@ -66,6 +66,7 @@ data:
     global:
 {{ include "hpcc.generateGlobalConfigMap" $ | indent 6 }}
 {{- if not .useChildProcesses }} 
+{{- $jobNamePrefix := printf "%s-%s-" .name $apptype }}
   {{ $apptype }}-jobspec.yaml: |
     apiVersion: batch/v1
     kind: Job
@@ -79,7 +80,7 @@ data:
             accessDali: "yes"
             accessEsp: "yes"
         spec:
-          {{- include "hpcc.placementMatchName" (dict "root" $ "pod" (printf "%s-%s-" $apptype .name) "cluster" .name "type" "eclagent") | indent 10 }}
+          {{- include "hpcc.placementsByPodTargetType" (dict "root" $ "pod" $jobNamePrefix "target" .name "type" "eclagent") | indent 10 }}
           serviceAccountName: "hpcc-default"
           containers:
           - name: {{ $apptype }}-%jobname

--- a/helm/hpcc/templates/eclagent.yaml
+++ b/helm/hpcc/templates/eclagent.yaml
@@ -66,7 +66,7 @@ data:
     global:
 {{ include "hpcc.generateGlobalConfigMap" $ | indent 6 }}
 {{- if not .useChildProcesses }} 
-{{- $jobName := printf "%s-%jobname" $apptype }}
+{{- $jobName := printf "%s-%%jobname" $apptype }}
   {{ $apptype }}-jobspec.yaml: |
     apiVersion: batch/v1
     kind: Job

--- a/helm/hpcc/templates/eclccserver.yaml
+++ b/helm/hpcc/templates/eclccserver.yaml
@@ -16,7 +16,7 @@ spec:
         accessDali: "yes"
         accessEsp: {{ .useChildProcesses | default false | ternary "yes" "no" | quote }}
     spec:
-      {{- include "hpcc.placementMatchName" (dict "root" $ "pod" .name "group" "eclccserver") | indent 8 }}
+      {{- include "hpcc.placementMatchName" (dict "root" $ "pod" .name "cluster" .name "type" "eclccserver") | indent 8 }}
       serviceAccountName: {{ .useChildProcesses | default false | ternary "hpcc-default" "hpcc-agent" }}
       terminationGracePeriodSeconds: {{ .terminationGracePeriodSeconds | default 600 }}
       initContainers:
@@ -81,7 +81,7 @@ data:
             accessDali: "yes"
             accessEsp: "yes"
         spec:
-          {{- include "hpcc.placementMatchName" (dict "root" $ "pod" "compile-" "group" "eclccserver") | indent 10 }}
+          {{- include "hpcc.placementMatchName" (dict "root" $ "pod" (printf "%s-compile-" .name) "cluster" .name "type" "eclccserver") | indent 10 }}
           serviceAccountName: "hpcc-default"
           containers:
           - name: compile-%jobname

--- a/helm/hpcc/templates/eclccserver.yaml
+++ b/helm/hpcc/templates/eclccserver.yaml
@@ -16,6 +16,7 @@ spec:
         accessDali: "yes"
         accessEsp: {{ .useChildProcesses | default false | ternary "yes" "no" | quote }}
     spec:
+      {{- include "hpcc.placementMatchName" (dict "root" $ "pod" .name "group" "eclccserver") | indent 8 }}
       serviceAccountName: {{ .useChildProcesses | default false | ternary "hpcc-default" "hpcc-agent" }}
       terminationGracePeriodSeconds: {{ .terminationGracePeriodSeconds | default 600 }}
       initContainers:
@@ -80,6 +81,7 @@ data:
             accessDali: "yes"
             accessEsp: "yes"
         spec:
+          {{- include "hpcc.placementMatchName" (dict "root" $ "pod" "compile-" "group" "eclccserver") | indent 10 }}
           serviceAccountName: "hpcc-default"
           containers:
           - name: compile-%jobname

--- a/helm/hpcc/templates/eclccserver.yaml
+++ b/helm/hpcc/templates/eclccserver.yaml
@@ -68,12 +68,12 @@ data:
     global:
 {{ include "hpcc.generateGlobalConfigMap" $ | indent 6 }}
 {{- if not .useChildProcesses }} 
-{{- $jobNamePrefix := printf "%s-compile-" .name }}
+{{- $jobName := printf "compile-%%jobname" }}
   compile-jobspec.yaml: |
     apiVersion: batch/v1
     kind: Job
     metadata:
-      name: compile-%jobname
+      name: {{ $jobName }}
     spec:
       ttlSecondsAfterFinished: 100
       template:
@@ -82,10 +82,10 @@ data:
             accessDali: "yes"
             accessEsp: "yes"
         spec:
-          {{- include "hpcc.placementsByPodTargetType" (dict "root" $ "pod" $jobNamePrefix "target" .name "type" "eclccserver") | indent 10 }}
+          {{- include "hpcc.placementsByJobTargetType" (dict "root" $ "job" $jobName "target" .name "type" "eclccserver") | indent 10 }}
           serviceAccountName: "hpcc-default"
           containers:
-          - name: compile-%jobname
+          - name: {{ $jobName }}
 {{- include "hpcc.addSecurityContext" (dict "root" $ "me" .) | indent 12 }}
 {{- include "hpcc.addResources" (dict "me" .resources) | indent 12 }}
 {{ include "hpcc.addImageAttrs" (dict "root" $ "me" .) | indent 12 }}

--- a/helm/hpcc/templates/eclccserver.yaml
+++ b/helm/hpcc/templates/eclccserver.yaml
@@ -16,7 +16,7 @@ spec:
         accessDali: "yes"
         accessEsp: {{ .useChildProcesses | default false | ternary "yes" "no" | quote }}
     spec:
-      {{- include "hpcc.placementMatchName" (dict "root" $ "pod" .name "cluster" .name "type" "eclccserver") | indent 8 }}
+      {{- include "hpcc.placementsByPodTargetType" (dict "root" $ "pod" .name "target" .name "type" "eclccserver") | indent 6 }}
       serviceAccountName: {{ .useChildProcesses | default false | ternary "hpcc-default" "hpcc-agent" }}
       terminationGracePeriodSeconds: {{ .terminationGracePeriodSeconds | default 600 }}
       initContainers:
@@ -68,6 +68,7 @@ data:
     global:
 {{ include "hpcc.generateGlobalConfigMap" $ | indent 6 }}
 {{- if not .useChildProcesses }} 
+{{- $jobNamePrefix := printf "%s-compile-" .name }}
   compile-jobspec.yaml: |
     apiVersion: batch/v1
     kind: Job
@@ -81,7 +82,7 @@ data:
             accessDali: "yes"
             accessEsp: "yes"
         spec:
-          {{- include "hpcc.placementMatchName" (dict "root" $ "pod" (printf "%s-compile-" .name) "cluster" .name "type" "eclccserver") | indent 10 }}
+          {{- include "hpcc.placementsByPodTargetType" (dict "root" $ "pod" $jobNamePrefix "target" .name "type" "eclccserver") | indent 10 }}
           serviceAccountName: "hpcc-default"
           containers:
           - name: compile-%jobname

--- a/helm/hpcc/templates/esp.yaml
+++ b/helm/hpcc/templates/esp.yaml
@@ -17,7 +17,7 @@ spec:
         accessDali: "yes"
         app: {{ $application }}
     spec:
-      {{- include "hpcc.placementMatchName" (dict "root" $ "pod" .name "group" "esp") | indent 6 }}
+      {{- include "hpcc.placementMatchName" (dict "root" $ "pod" .name "cluster" .name "type" "esp") | indent 6 }}
       serviceAccountName: "hpcc-default"
       containers:
       - name: {{ .name | quote }}

--- a/helm/hpcc/templates/esp.yaml
+++ b/helm/hpcc/templates/esp.yaml
@@ -17,7 +17,7 @@ spec:
         accessDali: "yes"
         app: {{ $application }}
     spec:
-      {{- include "hpcc.placementsByPodType" (dict "root" $ "pod" .name "type" "esp") | indent 6 }}
+      {{- include "hpcc.placementsByPodTargetType" (dict "root" $ "pod" .name "type" "esp") | indent 6 }}
       serviceAccountName: "hpcc-default"
       containers:
       - name: {{ .name | quote }}

--- a/helm/hpcc/templates/esp.yaml
+++ b/helm/hpcc/templates/esp.yaml
@@ -17,7 +17,7 @@ spec:
         accessDali: "yes"
         app: {{ $application }}
     spec:
-      {{- include "hpcc.placementMatchName" (dict "root" $ "pod" .name "cluster" .name "type" "esp") | indent 6 }}
+      {{- include "hpcc.placementsByPodType" (dict "root" $ "pod" .name "type" "esp") | indent 6 }}
       serviceAccountName: "hpcc-default"
       containers:
       - name: {{ .name | quote }}

--- a/helm/hpcc/templates/esp.yaml
+++ b/helm/hpcc/templates/esp.yaml
@@ -17,6 +17,7 @@ spec:
         accessDali: "yes"
         app: {{ $application }}
     spec:
+      {{- include "hpcc.placementMatchName" (dict "root" $ "pod" .name "group" "esp") | indent 6 }}
       serviceAccountName: "hpcc-default"
       containers:
       - name: {{ .name | quote }}

--- a/helm/hpcc/templates/localroxie.yaml
+++ b/helm/hpcc/templates/localroxie.yaml
@@ -22,6 +22,7 @@ spec:
         accessDali: "yes"
         accessEsp: "yes"
     spec:
+      {{- include "hpcc.placementMatchName" (dict "root" $ "pod" $roxie.name "group" "roxie") | indent 6 }}
       serviceAccountName: "hpcc-default"
       initContainers:
         {{- include "hpcc.checkDataMount" (dict "root" $) | indent 6 }}

--- a/helm/hpcc/templates/localroxie.yaml
+++ b/helm/hpcc/templates/localroxie.yaml
@@ -22,7 +22,7 @@ spec:
         accessDali: "yes"
         accessEsp: "yes"
     spec:
-      {{- include "hpcc.placementMatchName" (dict "root" $ "pod" $roxie.name "group" "roxie") | indent 6 }}
+      {{- include "hpcc.placementMatchName" (dict "root" $ "pod" $roxie.name "cluster" $roxie.name "type" "roxie") | indent 6 }}
       serviceAccountName: "hpcc-default"
       initContainers:
         {{- include "hpcc.checkDataMount" (dict "root" $) | indent 6 }}

--- a/helm/hpcc/templates/localroxie.yaml
+++ b/helm/hpcc/templates/localroxie.yaml
@@ -22,7 +22,7 @@ spec:
         accessDali: "yes"
         accessEsp: "yes"
     spec:
-      {{- include "hpcc.placementMatchName" (dict "root" $ "pod" $roxie.name "cluster" $roxie.name "type" "roxie") | indent 6 }}
+      {{- include "hpcc.placementsByPodTargetType" (dict "root" $ "pod" $roxie.name "target" $roxie.name "type" "roxie") | indent 6 }}
       serviceAccountName: "hpcc-default"
       initContainers:
         {{- include "hpcc.checkDataMount" (dict "root" $) | indent 6 }}

--- a/helm/hpcc/templates/roxie.yaml
+++ b/helm/hpcc/templates/roxie.yaml
@@ -23,7 +23,7 @@ spec:
         run: {{ $toponame | quote }}
         roxie-cluster: {{ $roxie.name | quote }}
     spec:
-      {{- include "hpcc.placementMatchName" (dict "root" $ "pod" $toponame "group" "roxie") | indent 6 }}
+      {{- include "hpcc.placementMatchName" (dict "root" $ "pod" $toponame "cluster" $roxie.name "type" "roxie") | indent 6 }}
       serviceAccountName: "hpcc-default"
       containers:
       - name: {{ $toponame | quote }}
@@ -137,7 +137,7 @@ spec:
         accessDali: "yes"
         accessEsp: "yes"
     spec:
-      {{- include "hpcc.placementMatchName" (dict "root" $ "pod" $servername "group" "roxie") | indent 6 }}
+      {{- include "hpcc.placementMatchName" (dict "root" $ "pod" $servername "cluster" $roxie.name "type" "roxie") | indent 6 }}
       serviceAccountName: "hpcc-default"
       initContainers:
         {{- include "hpcc.checkDataMount" (dict "root" $) | indent 6 }}
@@ -202,7 +202,7 @@ spec:
         accessDali: "yes"
         accessEsp: "yes"
     spec:
-      {{- include "hpcc.placementMatchName" (dict "root" $ "pod" $name "group" "roxie") | indent 6 }}
+      {{- include "hpcc.placementMatchName" (dict "root" $ "pod" $name "cluster" $roxie.name "type" "roxie") | indent 6 }}
       serviceAccountName: "hpcc-default"
       initContainers:
         {{- include "hpcc.checkDataMount" (dict "root" $) | indent 6 }}

--- a/helm/hpcc/templates/roxie.yaml
+++ b/helm/hpcc/templates/roxie.yaml
@@ -23,7 +23,7 @@ spec:
         run: {{ $toponame | quote }}
         roxie-cluster: {{ $roxie.name | quote }}
     spec:
-      {{- include "hpcc.placementMatchName" (dict "root" $ "pod" $toponame "cluster" $roxie.name "type" "roxie") | indent 6 }}
+      {{- include "hpcc.placementsByPodTargetType" (dict "root" $ "pod" $toponame "target" $roxie.name "type" "roxie") | indent 6 }}
       serviceAccountName: "hpcc-default"
       containers:
       - name: {{ $toponame | quote }}
@@ -137,7 +137,7 @@ spec:
         accessDali: "yes"
         accessEsp: "yes"
     spec:
-      {{- include "hpcc.placementMatchName" (dict "root" $ "pod" $servername "cluster" $roxie.name "type" "roxie") | indent 6 }}
+      {{- include "hpcc.placementsByPodTargetType" (dict "root" $ "pod" $servername "target" $roxie.name "type" "roxie") | indent 6 }}
       serviceAccountName: "hpcc-default"
       initContainers:
         {{- include "hpcc.checkDataMount" (dict "root" $) | indent 6 }}
@@ -202,7 +202,7 @@ spec:
         accessDali: "yes"
         accessEsp: "yes"
     spec:
-      {{- include "hpcc.placementMatchName" (dict "root" $ "pod" $name "cluster" $roxie.name "type" "roxie") | indent 6 }}
+      {{- include "hpcc.placementsByPodTargetType" (dict "root" $ "pod" $name "target" $roxie.name "type" "roxie") | indent 6 }}
       serviceAccountName: "hpcc-default"
       initContainers:
         {{- include "hpcc.checkDataMount" (dict "root" $) | indent 6 }}

--- a/helm/hpcc/templates/roxie.yaml
+++ b/helm/hpcc/templates/roxie.yaml
@@ -23,6 +23,7 @@ spec:
         run: {{ $toponame | quote }}
         roxie-cluster: {{ $roxie.name | quote }}
     spec:
+      {{- include "hpcc.placementMatchName" (dict "root" $ "pod" $toponame "group" "roxie") | indent 6 }}
       serviceAccountName: "hpcc-default"
       containers:
       - name: {{ $toponame | quote }}
@@ -136,6 +137,7 @@ spec:
         accessDali: "yes"
         accessEsp: "yes"
     spec:
+      {{- include "hpcc.placementMatchName" (dict "root" $ "pod" $servername "group" "roxie") | indent 6 }}
       serviceAccountName: "hpcc-default"
       initContainers:
         {{- include "hpcc.checkDataMount" (dict "root" $) | indent 6 }}
@@ -200,6 +202,7 @@ spec:
         accessDali: "yes"
         accessEsp: "yes"
     spec:
+      {{- include "hpcc.placementMatchName" (dict "root" $ "pod" $name "group" "roxie") | indent 6 }}
       serviceAccountName: "hpcc-default"
       initContainers:
         {{- include "hpcc.checkDataMount" (dict "root" $) | indent 6 }}

--- a/helm/hpcc/templates/thor.yaml
+++ b/helm/hpcc/templates/thor.yaml
@@ -30,7 +30,7 @@ spec:
         accessDali: "yes"
         accessEsp: {{ $eclAgentUseChildProcesses | ternary "yes" "no" | quote }}
     spec:
-      {{- include "hpcc.placementMatchName" (dict "root" $ "pod" $eclAgentName "group" "thor") | indent 6 }}
+      {{- include "hpcc.placementMatchName" (dict "root" $ "pod" $eclAgentName "cluster" .name "type" "thor") | indent 6 }}
       serviceAccountName: {{ $eclAgentUseChildProcesses | ternary "hpcc-default" "hpcc-agent" }}
       containers:
       - name: {{ $eclAgentName | quote }}
@@ -75,7 +75,7 @@ spec:
         accessDali: "yes"
         accessEsp: "no"
     spec:
-      {{- include "hpcc.placementMatchName" (dict "root" $ "pod" $thorAgentName "group" "thor") | indent 6 }}
+      {{- include "hpcc.placementMatchName" (dict "root" $ "pod" $thorAgentName "cluster" .name "type" "thor") | indent 6 }}
       serviceAccountName: "hpcc-thoragent"
       containers:
       - name: {{ $thorAgentName | quote }}
@@ -145,7 +145,7 @@ data:
             accessDali: "yes"
             accessEsp: "yes"
         spec:
-          {{- include "hpcc.placementMatchName" (dict "root" $ "pod" (printf "%s-" $eclAgentType) "group" "thor") | indent 10 }}
+          {{- include "hpcc.placementMatchName" (dict "root" $ "pod" (printf "%s-%s-" .name $eclAgentType) "cluster" .name "type" "thor") | indent 10 }}
           serviceAccountName: "hpcc-agent"
           initContainers: 
             {{- include "hpcc.checkDataMount" (dict "root" $) | indent 10 }}
@@ -190,7 +190,7 @@ data:
             accessEsp: "yes"
             job: %jobname
         spec:
-          {{- include "hpcc.placementMatchName" (dict "root" $ "pod" "thormanager-" "group" "thor") | indent 10 }}
+          {{- include "hpcc.placementMatchName" (dict "root" $ "pod" (printf "%s-thormanager-" .name) "cluster" .name "type" "thor") | indent 10 }}
           serviceAccountName: hpcc-agent
           initContainers:
             {{- include "hpcc.checkDataMount" (dict "root" $) | indent 10 }}
@@ -225,7 +225,7 @@ data:
     metadata:
       name: thorworker-%jobname
     spec:
-      {{- include "hpcc.placementMatchName" (dict "root" $ "pod" "thorworker-" "group" "thor") | indent 6 }}
+      {{- include "hpcc.placementMatchName" (dict "root" $ "pod" (printf "%s-thorworker-" .name) "cluster" .name "type" "thor") | indent 6 }}
       parallelism: %numWorkers
       ttlSecondsAfterFinished: 100
       template:

--- a/helm/hpcc/templates/thor.yaml
+++ b/helm/hpcc/templates/thor.yaml
@@ -132,7 +132,7 @@ data:
 {{ include "hpcc.generateGlobalConfigMap" $ | indent 6 }}
 
 {{- if not $eclAgentUseChildProcesses }}
-{{- $eclAgentJobName := printf "%s-%jobname" $eclAgentType }}
+{{- $eclAgentJobName := printf "%s-%%jobname" $eclAgentType }}
   {{ $eclAgentType }}-jobspec.yaml: |
     apiVersion: batch/v1
     kind: Job
@@ -176,7 +176,7 @@ data:
       backoffLimit: 0
 {{- end }}
 
-  {{- $thorMgrJobName := printf "thormanager-%jobname" }}
+  {{- $thorMgrJobName := printf "thormanager-%%jobname" }}
   thormanager-jobspec.yaml: |
     apiVersion: batch/v1
     kind: Job
@@ -221,7 +221,7 @@ data:
           restartPolicy: Never
       backoffLimit: 0
 
-  {{- $thorWkrJobName := printf "thorworker-%jobname" }}
+  {{- $thorWkrJobName := printf "thorworker-%%jobname" }}
   thorworker-jobspec.yaml: |
     apiVersion: batch/v1
     kind: Job

--- a/helm/hpcc/templates/thor.yaml
+++ b/helm/hpcc/templates/thor.yaml
@@ -30,7 +30,7 @@ spec:
         accessDali: "yes"
         accessEsp: {{ $eclAgentUseChildProcesses | ternary "yes" "no" | quote }}
     spec:
-      {{- include "hpcc.placementMatchName" (dict "root" $ "pod" $eclAgentName "cluster" .name "type" "thor") | indent 6 }}
+      {{- include "hpcc.placementsByPodTargetType" (dict "root" $ "pod" $eclAgentName "target" .name "type" "thor") | indent 6 }}
       serviceAccountName: {{ $eclAgentUseChildProcesses | ternary "hpcc-default" "hpcc-agent" }}
       containers:
       - name: {{ $eclAgentName | quote }}
@@ -75,7 +75,7 @@ spec:
         accessDali: "yes"
         accessEsp: "no"
     spec:
-      {{- include "hpcc.placementMatchName" (dict "root" $ "pod" $thorAgentName "cluster" .name "type" "thor") | indent 6 }}
+      {{- include "hpcc.placementsByPodTargetType" (dict "root" $ "pod" $thorAgentName "target" .name "type" "thor") | indent 6 }}
       serviceAccountName: "hpcc-thoragent"
       containers:
       - name: {{ $thorAgentName | quote }}
@@ -132,6 +132,7 @@ data:
 {{ include "hpcc.generateGlobalConfigMap" $ | indent 6 }}
 
 {{- if not $eclAgentUseChildProcesses }}
+{{- $eclAgentJobNamePrefix := printf "%s-%s-" .name  $eclAgentType }}
   {{ $eclAgentType }}-jobspec.yaml: |
     apiVersion: batch/v1
     kind: Job
@@ -145,7 +146,7 @@ data:
             accessDali: "yes"
             accessEsp: "yes"
         spec:
-          {{- include "hpcc.placementMatchName" (dict "root" $ "pod" (printf "%s-%s-" .name $eclAgentType) "cluster" .name "type" "thor") | indent 10 }}
+          {{- include "hpcc.placementsByPodTargetType" (dict "root" $ "pod" $eclAgentJobNamePrefix "target" .name "type" "thor") | indent 10 }}
           serviceAccountName: "hpcc-agent"
           initContainers: 
             {{- include "hpcc.checkDataMount" (dict "root" $) | indent 10 }}
@@ -175,6 +176,7 @@ data:
       backoffLimit: 0
 {{- end }}
 
+  {{- $thorMgrJobNamePrefix := printf "%s-thormanager-" .name }}
   thormanager-jobspec.yaml: |
     apiVersion: batch/v1
     kind: Job
@@ -190,7 +192,7 @@ data:
             accessEsp: "yes"
             job: %jobname
         spec:
-          {{- include "hpcc.placementMatchName" (dict "root" $ "pod" (printf "%s-thormanager-" .name) "cluster" .name "type" "thor") | indent 10 }}
+          {{- include "hpcc.placementsByPodTargetType" (dict "root" $ "pod" $thorMgrJobNamePrefix "target" .name "type" "thor") | indent 10 }}
           serviceAccountName: hpcc-agent
           initContainers:
             {{- include "hpcc.checkDataMount" (dict "root" $) | indent 10 }}
@@ -219,13 +221,14 @@ data:
           restartPolicy: Never
       backoffLimit: 0
 
+  {{- $thorWkrJobNamePrefix := printf "%s-thorworker-" .name }}
   thorworker-jobspec.yaml: |
     apiVersion: batch/v1
     kind: Job
     metadata:
       name: thorworker-%jobname
     spec:
-      {{- include "hpcc.placementMatchName" (dict "root" $ "pod" (printf "%s-thorworker-" .name) "cluster" .name "type" "thor") | indent 6 }}
+      {{- include "hpcc.placementsByPodTargetType" (dict "root" $ "pod" $thorWkrJobNamePrefix "target" .name "type" "thor") | indent 6 }}
       parallelism: %numWorkers
       ttlSecondsAfterFinished: 100
       template:

--- a/helm/hpcc/templates/thor.yaml
+++ b/helm/hpcc/templates/thor.yaml
@@ -30,6 +30,7 @@ spec:
         accessDali: "yes"
         accessEsp: {{ $eclAgentUseChildProcesses | ternary "yes" "no" | quote }}
     spec:
+      {{- include "hpcc.placementMatchName" (dict "root" $ "pod" $eclAgentName "group" "thor") | indent 6 }}
       serviceAccountName: {{ $eclAgentUseChildProcesses | ternary "hpcc-default" "hpcc-agent" }}
       containers:
       - name: {{ $eclAgentName | quote }}
@@ -74,6 +75,7 @@ spec:
         accessDali: "yes"
         accessEsp: "no"
     spec:
+      {{- include "hpcc.placementMatchName" (dict "root" $ "pod" $thorAgentName "group" "thor") | indent 6 }}
       serviceAccountName: "hpcc-thoragent"
       containers:
       - name: {{ $thorAgentName | quote }}
@@ -143,6 +145,7 @@ data:
             accessDali: "yes"
             accessEsp: "yes"
         spec:
+          {{- include "hpcc.placementMatchName" (dict "root" $ "pod" (printf "%s-" $eclAgentType) "group" "thor") | indent 10 }}
           serviceAccountName: "hpcc-agent"
           initContainers: 
             {{- include "hpcc.checkDataMount" (dict "root" $) | indent 10 }}
@@ -187,6 +190,7 @@ data:
             accessEsp: "yes"
             job: %jobname
         spec:
+          {{- include "hpcc.placementMatchName" (dict "root" $ "pod" "thormanager-" "group" "thor") | indent 10 }}
           serviceAccountName: hpcc-agent
           initContainers:
             {{- include "hpcc.checkDataMount" (dict "root" $) | indent 10 }}
@@ -221,6 +225,7 @@ data:
     metadata:
       name: thorworker-%jobname
     spec:
+      {{- include "hpcc.placementMatchName" (dict "root" $ "pod" "thorworker-" "group" "thor") | indent 6 }}
       parallelism: %numWorkers
       ttlSecondsAfterFinished: 100
       template:

--- a/helm/hpcc/templates/thor.yaml
+++ b/helm/hpcc/templates/thor.yaml
@@ -132,12 +132,12 @@ data:
 {{ include "hpcc.generateGlobalConfigMap" $ | indent 6 }}
 
 {{- if not $eclAgentUseChildProcesses }}
-{{- $eclAgentJobNamePrefix := printf "%s-%s-" .name  $eclAgentType }}
+{{- $eclAgentJobName := printf "%s-%jobname" $eclAgentType }}
   {{ $eclAgentType }}-jobspec.yaml: |
     apiVersion: batch/v1
     kind: Job
     metadata:
-      name: {{ $eclAgentType }}-%jobname
+      name: {{ $eclAgentJobName }}
     spec:
       ttlSecondsAfterFinished: 100
       template:
@@ -146,12 +146,12 @@ data:
             accessDali: "yes"
             accessEsp: "yes"
         spec:
-          {{- include "hpcc.placementsByPodTargetType" (dict "root" $ "pod" $eclAgentJobNamePrefix "target" .name "type" "thor") | indent 10 }}
+          {{- include "hpcc.placementsByJobTargetType" (dict "root" $ "job" $eclAgentJobName "target" .name "type" "thor") | indent 10 }}
           serviceAccountName: "hpcc-agent"
           initContainers: 
             {{- include "hpcc.checkDataMount" (dict "root" $) | indent 10 }}
           containers:
-          - name: {{ $eclAgentType }}-%jobname
+          - name: {{ $eclAgentJobName }}
 {{- include "hpcc.addSecurityContext" (dict "root" $ "me" .) | indent 12 }}
 {{ include "hpcc.addImageAttrs" (dict "root" $ "me" .) | indent 12 }}
 {{- include "hpcc.addResources" (dict "me" .eclAgentResources) | indent 12 }}
@@ -176,12 +176,12 @@ data:
       backoffLimit: 0
 {{- end }}
 
-  {{- $thorMgrJobNamePrefix := printf "%s-thormanager-" .name }}
+  {{- $thorMgrJobName := printf "thormanager-%jobname" }}
   thormanager-jobspec.yaml: |
     apiVersion: batch/v1
     kind: Job
     metadata:
-      name: thormanager-%jobname
+      name: {{ $thorMgrJobName }}
     spec:
       ttlSecondsAfterFinished: 100
       template:
@@ -192,12 +192,12 @@ data:
             accessEsp: "yes"
             job: %jobname
         spec:
-          {{- include "hpcc.placementsByPodTargetType" (dict "root" $ "pod" $thorMgrJobNamePrefix "target" .name "type" "thor") | indent 10 }}
+          {{- include "hpcc.placementsByJobTargetType" (dict "root" $ "job" $thorMgrJobName "target" .name "type" "thor") | indent 10 }}
           serviceAccountName: hpcc-agent
           initContainers:
             {{- include "hpcc.checkDataMount" (dict "root" $) | indent 10 }}
           containers:
-          - name: thormanager-%jobname
+          - name: {{ $thorMgrJobName }}
 {{- include "hpcc.addSecurityContext" (dict "root" $ "me" .) | indent 12 }}
 {{ include "hpcc.addImageAttrs" (dict "root" $ "me" .) | indent 12 }}
 {{- include "hpcc.addResources" (dict "me" .managerResources) | indent 12 }}
@@ -221,14 +221,14 @@ data:
           restartPolicy: Never
       backoffLimit: 0
 
-  {{- $thorWkrJobNamePrefix := printf "%s-thorworker-" .name }}
+  {{- $thorWkrJobName := printf "thorworker-%jobname" }}
   thorworker-jobspec.yaml: |
     apiVersion: batch/v1
     kind: Job
     metadata:
-      name: thorworker-%jobname
+      name: {{ $thorWkrJobName }}
     spec:
-      {{- include "hpcc.placementsByPodTargetType" (dict "root" $ "pod" $thorWkrJobNamePrefix "target" .name "type" "thor") | indent 6 }}
+      {{- include "hpcc.placementsByJobTargetType" (dict "root" $ "job" $thorWkrJobName "target" .name "type" "thor") | indent 6 }}
       parallelism: %numWorkers
       ttlSecondsAfterFinished: 100
       template:
@@ -240,7 +240,7 @@ data:
         spec:
           serviceAccountName: hpcc-default
           containers:
-          - name: thorworker-%jobname
+          - name: {{ $thorWkrJobName }}
 {{- include "hpcc.addSecurityContext" (dict "root" $ "me" .) | indent 12 }}
 {{ include "hpcc.addImageAttrs" (dict "root" $ "me" .) | indent 12 }}
 {{- include "hpcc.addResources" (dict "me" .workerResources) | indent 12 }}
@@ -268,7 +268,7 @@ data:
     apiVersion: networking.k8s.io/v1
     kind: NetworkPolicy
     metadata:
-      name: thormanager-%jobname
+      name: {{ $thorMgrJobName }}
     spec:
       podSelector:
         matchLabels:

--- a/helm/hpcc/values.schema.json
+++ b/helm/hpcc/values.schema.json
@@ -12,24 +12,24 @@
       "type": "array",
       "items": {
         "type": "object",
-         "properties": {
-           "pods": {
-              "type": "array",
-              "items": { "type": "string" }
-	   },
-           "nodeSelector": {
-             "$ref": "#/definitions/nodeSelector"
-	  },
+        "properties": {
+          "pods": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "nodeSelector": {
+            "$ref": "#/definitions/nodeSelector"
+          },
           "tolerations": {
             "$ref": "#/definitions/tolerations"
-	  },
+          },
           "affinity": {
             "type": "object"
-	  },
+          },
           "schedulerNames": {
             "type": "array",
             "items": { "type": "string" }
-	  }
+          }
         }
       }
     },
@@ -727,19 +727,19 @@
       "properties": {
         "key": {
           "type": "string"
-	},
+        },
         "operator": {
           "type": "string"
-	},
+        },
         "value": {
           "type": "string"
-	},
+        },
         "effect": {
           "type": "string"
-	},
+        },
         "tolerationSeconds": {
           "type": "integer"
-	}
+        }
       }
     }
   }

--- a/helm/hpcc/values.schema.json
+++ b/helm/hpcc/values.schema.json
@@ -8,7 +8,7 @@
     "hostgroups": {
       "$ref": "#/definitions/hostgroups"
     },
-    "placement": {
+    "placements": {
       "type": "array",
       "items": {
         "type": "object",
@@ -17,18 +17,8 @@
             "type": "array",
             "items": { "type": "string" }
           },
-          "nodeSelector": {
-            "$ref": "#/definitions/nodeSelector"
-          },
-          "tolerations": {
-            "$ref": "#/definitions/tolerations"
-          },
-          "affinity": {
-            "type": "object"
-          },
-          "schedulerNames": {
-            "type": "array",
-            "items": { "type": "string" }
+	  "placement": {
+            "$ref": "#/definitions/placement"
           }
         }
       }
@@ -709,6 +699,23 @@
         },
         "eclAgentResources": {
           "$ref": "#/definitions/resources"
+        }
+      }
+    },
+    "placement": {
+      "type": "object",
+      "properties": {
+        "nodeSelector": {
+          "$ref": "#/definitions/nodeSelector"
+        },
+        "tolerations": {
+          "$ref": "#/definitions/tolerations"
+        },
+        "affinity": {
+          "type": "object"
+        },
+        "schedulerName": {
+          "type": "string"
         }
       }
     },

--- a/helm/hpcc/values.schema.json
+++ b/helm/hpcc/values.schema.json
@@ -8,6 +8,31 @@
     "hostgroups": {
       "$ref": "#/definitions/hostgroups"
     },
+    "placement": {
+      "type": "array",
+      "items": {
+        "type": "object",
+         "properties": {
+           "pods": {
+              "type": "array",
+              "items": { "type": "string" }
+	   },
+           "nodeSelector": {
+             "$ref": "#/definitions/nodeSelector"
+	  },
+          "tolerations": {
+            "$ref": "#/definitions/tolerations"
+	  },
+          "affinity": {
+            "type": "object"
+	  },
+          "schedulerNames": {
+            "type": "array",
+            "items": { "type": "string" }
+	  }
+        }
+      }
+    },
     "storage": {
       "type": "object",
       "properties": {
@@ -685,6 +710,36 @@
         "eclAgentResources": {
           "$ref": "#/definitions/resources"
         }
+      }
+    },
+    "nodeSelector": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "tolerations": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/toleration" }
+    },
+    "toleration": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string"
+	},
+        "operator": {
+          "type": "string"
+	},
+        "value": {
+          "type": "string"
+	},
+        "effect": {
+          "type": "string"
+	},
+        "tolerationSeconds": {
+          "type": "integer"
+	}
       }
     }
   }

--- a/helm/hpcc/values.yaml
+++ b/helm/hpcc/values.yaml
@@ -38,6 +38,64 @@ global:
     moneyLocale: "en_US.UTF-8"
     # perCpu: 0.126
 
+## placement
+## The placement, Kubernetes Scheduler, is responsible for finding the best Node
+## for a Pod. It can be configured through placement to include an array of objects
+## to configure the Kubernetes Scheduler. It must have a "pods" list which tells which
+## pod the settings will be applied to. The list item with suffix "-" means it is Job
+## which tries to distinguish from the same pod name for Development type. If possible
+## tries use unique name to avoid the ambiguity.
+## Here are the HPCC Systems Pods' name or prefixs:
+##   eclwatch, hthor, eclservices, eclqueries, esdl-sandbox, sql2ecl
+##   mydali, roxie-workunit, myeclccserver, roxie-toposerver
+##   thor-eclagent, thor-thoragent
+##   hthor-, compile-, thormanager-, thorworker-, roxie-agent-
+## The settings can be also to one or more group names:
+##    dali, esp, eclagent, eclccserver, roxie, thor
+## Supported placement configuration:
+## 1) nodeSelector
+## 2) taints/tolerations
+## 3) affinity
+##    There is no schema check for the content of affinity. Reference
+##    https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
+## 4) schedulerName: list of scheduler profile names. This requires Kubernetes 1.20.0
+##    beta and later releases
+## Examples:
+#placement:
+#- pods: ["eclwatch", "roxie-workunit", "compile-", "mydali"]
+#  nodeSelector:
+#  name: npone
+#- pods: ["thorworker-", "thor-thoragent", "thormanager-","thor-eclagent","hthor-"]
+#  nodeSelector:
+#    name: nptwo
+#  tolerations:
+#  - key: "name"
+#    operator: "Equal"
+#    value: "nptwo"
+#    effect: "NoSchedule"
+#- pods: ["thorworker-"]
+#  affinity:
+#    nodeAffinity:
+#      requiredDuringSchedulingIgnoredDuringExecution:
+#        nodeSelectorTerms:
+#        - matchExpressions:
+#           - key: kubernetes.io/e2e-az-name
+#             operator: In
+#             values:
+#             - e2e-az1
+#             - e2e-az2
+#- pods: ["sql2ecl"]
+#  schedulerNames: ["my-scheduler"]
+## The settings will be applied to all thor pods
+#- pods: ["thor"]
+#  nodeSelector:
+#    name: nptwo
+#  tolerations:
+#  - key: "name"
+#    operator: "Equal"
+#    value: "nptwo"
+#    effect: "NoSchedule"
+
 ## storage:
 ##
 ## If storage.[type].existingClaim is defined, a Persistent Volume Claim must
@@ -138,6 +196,7 @@ dali:
   #resources:
   #  cpu: "1"
   #  memory: "4G"
+
 
 eclagent:
 - name: hthor

--- a/helm/hpcc/values.yaml
+++ b/helm/hpcc/values.yaml
@@ -38,63 +38,75 @@ global:
     moneyLocale: "en_US.UTF-8"
     # perCpu: 0.126
 
-## placement
+## placements
 ## The placement is responsible for finding the best Node for a Pod. It can be configured
 ## through placement to include an array of objects to configure the Kubernetes Scheduler.
-## It must have a "pods" list which tells which pod the settings will be applied to.
-## The list item with suffix "-" and <cluster name> means it is Job which tries to distinguish
-## from the same pod name for Development type.
-## Here are the HPCC Systems Pods' name or prefixs:
-##   eclwatch, hthor, eclservices, eclqueries, esdl-sandbox, sql2ecl
-##   mydali, roxie-workunit, myeclccserver, roxie-toposerver
-##   <cluster name>-thor-eclagent, <cluster name>-thor-thoragent
-##   <cluster name>-hthor-, <cluster-name>-compile-, <cluster name>-thormanager-,
-##   <cluster name>-thorworker-, <cluster name>-roxie-agent-
-## The settings can also be HPCC Systems component types: dali, esp, eclagent, eclccserver,
-## roxie, thor, or a cluster name which is from the array of items of each type.
-## Supported placement configuration:
+## It must have a "pods" list which tells it which pod the settings will be applied to.
+## The synatx is:
+##   placements:
+##   - pods [list]
+##     placement:
+##       <supported configurations>
+##
+## The list item in "pods" can be one of the following:
+## 1) HPCC Systems component types in format: "type:<type name>". <type name> includes
+##    dali, esp, eclagent, eclccserver, roxie, thor. For example "type:esp"
+## 2) Target, the name of array item of above type in format "target:<target name>"
+##    For example "target:roxie", "target:thor".
+## 3) Pod, "Deployment" metadata name, which usually should be from the name of the array
+##    item of a type. For example, "eclwatch", "mydali", "thor-thoragent"..
+## 4) Job name prefix in format: "<target>-<job id>-". For example "myeclccserver-compile-",
+##    thor-hthor-, thor-thormanager-
+##
+## Supported configurations under each "placement"
 ## 1) nodeSelector
 ## 2) taints/tolerations
 ## 3) affinity
 ##    There is no schema check for the content of affinity. Reference
 ##    https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
-## 4) schedulerName: list of scheduler profile names. This requires Kubernetes 1.20.0
-##    beta and later releases
+## 4) schedulerName: profile names. "affinity" defined in scheduler profile  requires
+##    Kubernetes 1.20.0 beta and later releases
+##
 ## Examples:
-#placement:
-#- pods: ["eclwatch", "roxie-workunit", "myeclccserver-compile-", "mydali"]
-#  nodeSelector:
-#    name: npone
-#- pods: ["thor-thorworker-", "thor-thor-thoragent", "thor-thormanager-","thor-thor-eclagent","thor-hthor-"]
-#  nodeSelector:
-#    name: nptwo
-#  tolerations:
-#  - key: "name"
-#    operator: "Equal"
-#    value: "nptwo"
-#    effect: "NoSchedule"
+#placements:
+#- pods: ["eclwatch","roxie-workunit","myeclccserver-compile-","mydali"]
+#  placement:
+#    nodeSelector:
+#      name: npone
+#- pods: ["thor-thorworker-", "thor-thoragent", "thor-thormanager-","thor-eclagent","thor-hthor-"]
+#  placement:
+#    nodeSelector:
+#      name: nptwo
+#    tolerations:
+#    - key: "name"
+#      operator: "Equal"
+#      value: "nptwo"
+#      effect: "NoSchedule"
 #- pods: ["thor-thorworker-"]
-#  affinity:
-#    nodeAffinity:
-#      requiredDuringSchedulingIgnoredDuringExecution:
-#        nodeSelectorTerms:
-#        - matchExpressions:
-#           - key: kubernetes.io/e2e-az-name
-#             operator: In
-#             values:
-#             - e2e-az1
-#             - e2e-az2
-#- pods: ["sql2ecl"]
-#  schedulerNames: ["my-scheduler"]
-## The settings will be applied to all thor pods
-#- pods: ["thor"]
-#  nodeSelector:
-#    name: nptwo
-#  tolerations:
-#  - key: "name"
-#    operator: "Equal"
-#    value: "nptwo"
-#    effect: "NoSchedule"
+#  placement:
+#    affinity:
+#      nodeAffinity:
+#        requiredDuringSchedulingIgnoredDuringExecution:
+#          nodeSelectorTerms:
+#          - matchExpressions:
+#            - key: kubernetes.io/e2e-az-name
+#              operator: In
+#              values:
+#              - e2e-az1
+#              - e2e-az2
+#- pods: ["target:roxie"]
+#  placement:
+#    schedulerName: "my-scheduler"
+## The settings will be applied to all thor pods/jobs and myeclccserver pod and job
+#- pods: ["target:myeclccserver", "type:thor"]
+#  placement:
+#    nodeSelector:
+#      app: "tf-gpu"
+#    tolerations:
+#    - key: "gpu"
+#      operator: "Equal"
+#      value: "true"
+#      effect: "NoSchedule"
 
 ## storage:
 ##
@@ -340,8 +352,3 @@ thor:
   #eclAgentResources:
   #  cpu: "1"
   #  memory: "2G"
-- name: thor2
-  prefix: thor2
-  numWorkers: 3
-  maxJobs: 5
-  maxGraphs: 3

--- a/helm/hpcc/values.yaml
+++ b/helm/hpcc/values.yaml
@@ -39,19 +39,19 @@ global:
     # perCpu: 0.126
 
 ## placement
-## The placement, Kubernetes Scheduler, is responsible for finding the best Node
-## for a Pod. It can be configured through placement to include an array of objects
-## to configure the Kubernetes Scheduler. It must have a "pods" list which tells which
-## pod the settings will be applied to. The list item with suffix "-" means it is Job
-## which tries to distinguish from the same pod name for Development type. If possible
-## tries use unique name to avoid the ambiguity.
+## The placement is responsible for finding the best Node for a Pod. It can be configured
+## through placement to include an array of objects to configure the Kubernetes Scheduler.
+## It must have a "pods" list which tells which pod the settings will be applied to.
+## The list item with suffix "-" and <cluster name> means it is Job which tries to distinguish
+## from the same pod name for Development type.
 ## Here are the HPCC Systems Pods' name or prefixs:
 ##   eclwatch, hthor, eclservices, eclqueries, esdl-sandbox, sql2ecl
 ##   mydali, roxie-workunit, myeclccserver, roxie-toposerver
-##   thor-eclagent, thor-thoragent
-##   hthor-, compile-, thormanager-, thorworker-, roxie-agent-
-## The settings can be also to one or more group names:
-##    dali, esp, eclagent, eclccserver, roxie, thor
+##   <cluster name>-thor-eclagent, <cluster name>-thor-thoragent
+##   <cluster name>-hthor-, <cluster-name>-compile-, <cluster name>-thormanager-,
+##   <cluster name>-thorworker-, <cluster name>-roxie-agent-
+## The settings can also be HPCC Systems component types: dali, esp, eclagent, eclccserver,
+## roxie, thor, or a cluster name which is from the array of items of each type.
 ## Supported placement configuration:
 ## 1) nodeSelector
 ## 2) taints/tolerations
@@ -62,10 +62,10 @@ global:
 ##    beta and later releases
 ## Examples:
 #placement:
-#- pods: ["eclwatch", "roxie-workunit", "compile-", "mydali"]
+#- pods: ["eclwatch", "roxie-workunit", "myeclccserver-compile-", "mydali"]
 #  nodeSelector:
-#  name: npone
-#- pods: ["thorworker-", "thor-thoragent", "thormanager-","thor-eclagent","hthor-"]
+#    name: npone
+#- pods: ["thor-thorworker-", "thor-thor-thoragent", "thor-thormanager-","thor-thor-eclagent","thor-hthor-"]
 #  nodeSelector:
 #    name: nptwo
 #  tolerations:
@@ -73,7 +73,7 @@ global:
 #    operator: "Equal"
 #    value: "nptwo"
 #    effect: "NoSchedule"
-#- pods: ["thorworker-"]
+#- pods: ["thor-thorworker-"]
 #  affinity:
 #    nodeAffinity:
 #      requiredDuringSchedulingIgnoredDuringExecution:
@@ -196,7 +196,6 @@ dali:
   #resources:
   #  cpu: "1"
   #  memory: "4G"
-
 
 eclagent:
 - name: hthor
@@ -341,3 +340,8 @@ thor:
   #eclAgentResources:
   #  cpu: "1"
   #  memory: "2G"
+- name: thor2
+  prefix: thor2
+  numWorkers: 3
+  maxJobs: 5
+  maxGraphs: 3

--- a/helm/hpcc/values.yaml
+++ b/helm/hpcc/values.yaml
@@ -55,8 +55,7 @@ global:
 ##    For example "target:roxie", "target:thor".
 ## 3) Pod, "Deployment" metadata name, which usually should be from the name of the array
 ##    item of a type. For example, "eclwatch", "mydali", "thor-thoragent"..
-## 4) Job name prefix in format: "<target>-<job id>-". For example "myeclccserver-compile-",
-##    thor-hthor-, thor-thormanager-
+## 4) Job name regular express:  For example "compile-" or "compile-.*" or exact match "^compile-.*$"
 ##
 ## Supported configurations under each "placement"
 ## 1) nodeSelector
@@ -69,11 +68,11 @@ global:
 ##
 ## Examples:
 #placements:
-#- pods: ["eclwatch","roxie-workunit","myeclccserver-compile-","mydali"]
+#- pods: ["eclwatch","roxie-workunit","^compile-.*$","mydali"]
 #  placement:
 #    nodeSelector:
 #      name: npone
-#- pods: ["thor-thorworker-", "thor-thoragent", "thor-thormanager-","thor-eclagent","thor-hthor-"]
+#- pods: ["thorworker-", "thor-thoragent", "thormanager-","thor-eclagent","hthor-"]
 #  placement:
 #    nodeSelector:
 #      name: nptwo
@@ -82,7 +81,7 @@ global:
 #      operator: "Equal"
 #      value: "nptwo"
 #      effect: "NoSchedule"
-#- pods: ["thor-thorworker-"]
+#- pods: ["thorworker-.*"]
 #  placement:
 #    affinity:
 #      nodeAffinity:


### PR DESCRIPTION
The configuration includes followings per pod:
nodeSelect, tolerations, affinity and scheudlerName

A "placement" is added to the schema file values.schema.json.
The scheduler is responsible for finding the best Node for a Pod. It can be configured through
placement to include an array of objects to configure the Kubernetes Scheduler
It must have a "pods" list which tells which pod the settings will be applied to.
The list item with suffix "-" means it is Job which try to distinguish from the same pod
name for Development type. If possible tries use unique name to avoid the ambiguity.
Here are the HPCC Systems Pods' name or prefixs:
    eclwatch, hthor, eclservices, eclqueries, esdl-sandbox, sql2ecl 
    mydali, roxie-workunit, myeclccserver, roxie-toposerver
    thor-eclagent, thor-thoragent
    hthor-, compile-, thormanager-, thorworker-, roxie-agent-
Supported Kubernetes Scheduler configuration:
1) nodeSelector
2) taints/tolerations
3) affinity   There is no schema check for the content of affinity. Reference 
   https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
4) schedulerName: list of scheduler profile names. This requires Kubernetes 1.20.0 beta
    and  later releases

Here are some examples in values.yaml:
Examples:
placement:
- pods: ["eclwatch", "roxie-workunit", "compile-"]
   nodeSelector:
      name: npone
- pods: ["thorworker-", "thor-thoragent", "thormanager-","thor-eclagent"]
  nodeSelector:
     name: nptwo
  tolerations:
  - key: "name"
    operator: "Equal"
    value: "nptwo"
    effect: "NoSchedule"
- pods: ["thorworker-"]
  affinity:
      nodeAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
              nodeSelectorTerms:
              - matchExpressions:
                 - key: kubernetes.io/e2e-az-name
                   operator: In
                   values:
                   - e2e-az1
                   - e2e-az2
- pods: ["sql2ecl"]
  schedulerNames: ["my-scheduler"]

 Signed-off-by: Xiaoming Wang <xiaoming.wang@lexisnexis.com>


<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ x] Any new interfaces or exported functions are appropriately commented.
- [ ] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [x] I have added tests to cover my changes.
  - [x] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

1) uncomment "placement" examples in values.yaml. 
    Use "helm template" to generate yaml content to a file. 
    Check the contents
2) Only uncomment "nodeSelector" and "tolerations" in "placement" of the values.yaml. 
    Start AKS by running start.sh in https://github.com/gfortil/HPCC-Tests/tree/main/Azure/Kubernetes/Scheduler-Test/aks-np-1
    Deploy HPCC cluster
    Validate the node assigning according the nodeSelector and tolerations settings
    Delete AKS cluster by running delete-resource-group.sh in https://github.com/gfortil/HPCC-Tests/tree/main/Azure/Kubernetes/Scheduler-Test/aks-np-1

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
