### PR TITLE
HPCC-24786 Abort WsWorkunits.WUResult if client disconnected

### DIFF
--- a/common/fileview2/fileview.hpp
+++ b/common/fileview2/fileview.hpp
@@ -160,10 +160,13 @@ extern FILEVIEW_API IResultSetFactory * getSecResultSetFactory(ISecManager *secm
 extern FILEVIEW_API int findResultSetColumn(const INewResultSet * results, const char * columnName);
 
 extern FILEVIEW_API unsigned getResultCursorXml(IStringVal & ret, IResultSetCursor * cursor, const char * name, unsigned start=0, unsigned count=0, const char * schemaName=NULL, const IProperties *xmlns=NULL);
-extern FILEVIEW_API unsigned getResultXml(IStringVal & ret, INewResultSet * cursor,  const char* name, unsigned start=0, unsigned count=0, const char * schemaName=NULL, const IProperties *xmlns=NULL);
-extern FILEVIEW_API unsigned getResultJSON(IStringVal & ret, INewResultSet * cursor,  const char* name, unsigned start=0, unsigned count=0, const char * schemaName=NULL);
+extern FILEVIEW_API unsigned getResultXml(IStringVal & ret, INewResultSet * cursor,  const char * name,
+    unsigned start=0, unsigned count=0, const char * schemaName=nullptr, const IProperties * xmlns=nullptr, IAbortRequestCallback * abortCheck=nullptr);
+extern FILEVIEW_API unsigned getResultJSON(IStringVal & ret, INewResultSet * cursor,  const char* name,
+    unsigned start=0, unsigned count=0, const char * schemaName=nullptr, IAbortRequestCallback * abortCheck=nullptr);
 extern FILEVIEW_API unsigned writeResultCursorXml(IXmlWriter & writer, IResultSetCursor * cursor, const char * name,
-    unsigned start=0, unsigned count=0, const char * schemaName=NULL, const IProperties *xmlns = NULL, bool flushContent = false);
+    unsigned start=0, unsigned count=0, const char * schemaName=nullptr, const IProperties * xmlns=nullptr, bool flushContent=false,
+    IAbortRequestCallback * abortCheck=nullptr);
 extern FILEVIEW_API unsigned writeResultXml(IXmlWriter & writer, INewResultSet * cursor,  const char* name, unsigned start=0, unsigned count=0, const char * schemaName=NULL, const IProperties *xmlns = NULL);
 
 extern FILEVIEW_API unsigned getResultCursorBin(MemoryBuffer & ret, IResultSetCursor * cursor, unsigned start=0, unsigned count=0);

--- a/common/workunit/workunit.hpp
+++ b/common/workunit/workunit.hpp
@@ -35,6 +35,7 @@
 #include "jstats.h"
 #include "jutil.hpp"
 #include "jprop.hpp"
+#include "jmisc.hpp"
 #include "wuattr.hpp"
 #include <vector>
 #include <list>

--- a/esp/platform/espprotocol.hpp
+++ b/esp/platform/espprotocol.hpp
@@ -217,4 +217,13 @@ public:
 
 esp_http_decl bool checkEspConnection(IEspContext& ctx);
 
+class CESPAbortRequestCallback : implements IAbortRequestCallback
+{
+    IEspContext* context = nullptr;
+public:
+    CESPAbortRequestCallback(IEspContext* _context) : context(_context){ };
+
+    virtual bool abortRequested() override { return !checkEspConnection(*context); }
+};
+
 #endif

--- a/esp/services/ws_workunits/ws_wuresult.cpp
+++ b/esp/services/ws_workunits/ws_wuresult.cpp
@@ -416,8 +416,9 @@ unsigned CWsWuResultOutHelper::getResultCSVStreaming(INewResultSet* result, cons
     writer->finishCSVHeaders();
     writer->flushContent(false);
 
+    CESPAbortRequestCallback abortCallback(context);
     Owned<IResultSetCursor> cursor = result->createCursor();
-    return writeResultCursorXml(*writer, cursor, resultName, start, count, nullptr, nullptr, true);
+    return writeResultCursorXml(*writer, cursor, resultName, start, count, nullptr, nullptr, true, &abortCallback);
 }
 
 //Similar to the getResultJSON in fileview2
@@ -427,17 +428,19 @@ unsigned CWsWuResultOutHelper::getResultJSONStreaming(INewResultSet* result, con
     writer->outputBeginRoot();
     writer->flushContent(false);
 
+    CESPAbortRequestCallback abortCallback(context);
     Owned<IResultSetCursor> cursor = result->createCursor();
-    unsigned rc = writeResultCursorXml(*writer, cursor, resultName, start, count, schemaName, nullptr, true);
+    unsigned rc = writeResultCursorXml(*writer, cursor, resultName, start, count, schemaName, nullptr, true, &abortCallback);
     writer->outputEndRoot();
     return rc;
 }
 
 unsigned CWsWuResultOutHelper::getResultXmlStreaming(INewResultSet* result, const char* resultName, const char* schemaName, const IProperties* xmlns, IXmlStreamFlusher* flusher)
 {
+    CESPAbortRequestCallback abortCallback(context);
     Owned<IResultSetCursor> cursor = result->createCursor();
     Owned<CommonXmlWriter> writer = CreateCommonXmlWriter(XWFexpandempty, 0, flusher);
-    return writeResultCursorXml(*writer, cursor, resultName, start, count, schemaName, xmlns, true);
+    return writeResultCursorXml(*writer, cursor, resultName, start, count, schemaName, xmlns, true, &abortCallback);
 }
 
 


### PR DESCRIPTION
In https://github.com/hpcc-systems/HPCC-Platform/pull/14226, the
checkEspConnection() was added to check if an esp connection for
a context is still valid. The checkEspConnection() is used in
this PR to abort the process of retrieving WUResult.

Signed-off-by: wangkx <kevin.wang@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
