### PR TITLE
HPCC-25444 Redirect new ECLWatch homepage to login page

### DIFF
--- a/esp/bindings/http/platform/httpbinding.hpp
+++ b/esp/bindings/http/platform/httpbinding.hpp
@@ -372,18 +372,26 @@ public:
     int getCheckSessionTimeoutSeconds() const { return checkSessionTimeoutSeconds; }
     bool isDomainAuthResources(const char* resource)
     {
+        //Check DomainAuthResources specified in domainAuthResources.
         bool* found = domainAuthResources.getValue(resource);
         if (found && *found)
-            return true;
+            return true; //resource used by domain authentication
 
-        if (strieq(resource, "/esp/files/stub.htm"))
-            return false;
-
+        //Check DomainAuthResources specified in domainAuthResourcesWildMatch.
+        //Both ECLWATCH_STUB_REQ and ECLWATCH_INDEX_REQ are stored inside the /esp/files folder.
+        //Most of the files inside the folder are resources which do not need to be authenticated
+        //and the login page may need those resources to show the page. So, the folder may be in
+        //the domainAuthResourcesWildMatch. But, both ECLWATCH_STUB_REQ and ECLWATCH_INDEX_REQ
+        //are not used by the login page and should be authenticated.
+        if (strieq(resource, ECLWATCH_STUB_REQ))
+            return false; //Not used by domain authentication. Should be authenticated.
+        if (strieq(resource, ECLWATCH_INDEX_REQ))
+            return false; //Not used by domain authentication. Should be authenticated.
         ForEachItemIn(i, domainAuthResourcesWildMatch)
         {
             const char* wildResourcePath = domainAuthResourcesWildMatch.item(i);
             if (WildMatch(resource, wildResourcePath, true))
-                return true;
+                return true; //resource used by domain authentication
         }
         return false;
     }

--- a/esp/platform/espcontext.hpp
+++ b/esp/platform/espcontext.hpp
@@ -48,6 +48,7 @@ static const char* const DEFAULT_LOGIN_URL = "/esp/files/Login.html";
 static const char* const DEFAULT_LOGIN_LOGO_URL = "/esp/files/eclwatch/img/Loginlogo.png";
 static const char* const DEFAULT_GET_USER_NAME_URL = "/esp/files/GetUserName.html";
 static const char* const ECLWATCH_STUB_REQ = "/esp/files/stub.htm";
+static const char* const ECLWATCH_INDEX_REQ = "/esp/files/index.html";
 static const char* const DEFAULT_UNRESTRICTED_RESOURCES = "/favicon.ico,/esp/files/*,/esp/xslt/*";
 static const char* const AUTH_STATUS_NA = "NA";
 static const char* const AUTH_STATUS_FAIL = "Fail";


### PR DESCRIPTION
The existing code does not redirect new ECLWatch homepage to
the login page because the homepage /esp/files/index.html is
inside the /esp/files folder and most of the files inside the
folder are resources which do not need to be authenticated.
In this PR, the code is added to handle the new homepage
similar to old ECLWatch homepage /esp/files/stub.htm.

Signed-off-by: wangkx <kevin.wang@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
