### PR TITLE
HPCC-25470 Add option to avoid scanning all KJ parts when mapping

### DIFF
--- a/thorlcr/activities/keyedjoin/thkeyedjoin.cpp
+++ b/thorlcr/activities/keyedjoin/thkeyedjoin.cpp
@@ -42,12 +42,15 @@ class CKeyedJoinMaster : public CMasterActivity
     bool local = false;
     bool remoteKeyedLookup = false;
     bool remoteKeyedFetch = false;
+    bool assumePrimary = false;
     unsigned totalIndexParts = 0;
 
     // CMap contains mappings and lists of parts for each slave
     class CMap
     {
+        CKeyedJoinMaster &activity;
     public:
+        CMap(CKeyedJoinMaster &_activity) : activity(_activity) {}
         std::vector<unsigned> allParts;
         std::vector<std::vector<unsigned>> slavePartMap; // vector of slave parts (IPartDescriptor's slavePartMap[<slave>] serialized to each slave)
         std::vector<unsigned> partToSlave; // vector mapping part index to slave (sent to all slaves)
@@ -149,21 +152,37 @@ class CKeyedJoinMaster : public CMasterActivity
                          * Add them to local parts list if found.
                          */
                         unsigned mappedPos = NotFound;
-                        for (unsigned c=0; c<part->numCopies(); c++)
+                        unsigned copies = part->numCopies();
+                        bool filePartExists = false;
+                        if (activity.assumePrimary)
+                        {
+                            /* If the index is big (e.g. large super-index), then it can be expensive
+                             * to walk over all part copies, checking their existence.
+                             * This option provides a workaround in those cases, to avoid that check,
+                             * by assuming the primary copy will exist and be used.
+                             */
+                            copies = 1;
+                            filePartExists = true;
+                        }
+                        for (unsigned c = 0; c < copies; c++)
                         {
                             INode *partNode = part->queryNode(c);
                             unsigned partCopy = p | (c << partBits);
                             unsigned start=nextGroupStartPos;
                             unsigned gn=start;
-                            do
+                            if (!activity.assumePrimary)
                             {
-                                INode &groupNode = dfsGroup.queryNode(gn);
-                                if ((partNode->equals(&groupNode)))
+                                RemoteFilename rfn;
+                                part->getFilename(c, rfn);
+                                Owned<IFile> file = createIFile(rfn);
+                                filePartExists = file->exists(); // skip if copy doesn't exist
+                            }
+                            if (filePartExists)
+                            {
+                                do
                                 {
-                                    RemoteFilename rfn;
-                                    part->getFilename(c, rfn);
-                                    Owned<IFile> file = createIFile(rfn);
-                                    if (file->exists()) // skip if copy doesn't exist
+                                    INode &groupNode = dfsGroup.queryNode(gn);
+                                    if (partNode->equals(&groupNode))
                                     {
                                         /* NB: If there's >1 slave per node (e.g. slavesPerNode>1) then there are multiple matching node's in the dfsGroup
                                         * Which means a copy of a part may already be assigned to a cluster slave map. This check avoid handling it again if it has.
@@ -198,12 +217,12 @@ class CKeyedJoinMaster : public CMasterActivity
                                                 slaveParts.push_back(partCopy);
                                         }
                                     }
+                                    gn++;
+                                    if (gn == groupSize)
+                                        gn = 0;
                                 }
-                                gn++;
-                                if (gn == groupSize)
-                                    gn = 0;
+                                while (gn != start);
                             }
-                            while (gn != start);
                         }
                         if (NotFound == mappedPos)
                         {
@@ -250,7 +269,7 @@ class CKeyedJoinMaster : public CMasterActivity
 
 
 public:
-    CKeyedJoinMaster(CMasterGraphElement *info) : CMasterActivity(info)
+    CKeyedJoinMaster(CMasterGraphElement *info) : CMasterActivity(info), indexMap(*this), dataMap(*this)
     {
         helper = (IHThorKeyedJoinArg *) queryHelper();
         unsigned numStats = helper->diskAccessRequired() ? 8 : 5; // see progressKinds array
@@ -265,6 +284,8 @@ public:
         remoteKeyedFetch = getOptBool(THOROPT_REMOTE_KEYED_FETCH, true);
         if (getOptBool(THOROPT_FORCE_REMOTE_KEYED_FETCH))
             remoteKeyedFetch = true;
+
+        assumePrimary = getOptBool(THOROPT_KJ_ASSUME_PRIMARY);
 
         if (helper->diskAccessRequired())
             numTags += 2;

--- a/thorlcr/thorutil/thormisc.hpp
+++ b/thorlcr/thorutil/thormisc.hpp
@@ -102,6 +102,7 @@
 #define THOROPT_MAXLFN_BLOCKTIME_MINS "maxLfnBlockTimeMins"     // max time permitted to be blocked on a DFS logical file operation.
 #define THOROPT_VALIDATE_FILE_TYPE    "validateFileType"        // validate file type compatibility, e.g. if on fire error if XML reading CSV    (default = true)
 #define THOROPT_MIN_REMOTE_CQ_INDEX_SIZE_MB "minRemoteCQIndexSizeMb" // minimum size of index file to enable server side handling                (default = 0, meaning use heuristic to determin)
+#define THOROPT_KJ_ASSUME_PRIMARY "keyedJoinAssumePrimary"      // assume primary part exists (don't check when mapping, which can be slow)
 
 #define INITIAL_SELFJOIN_MATCH_WARNING_LEVEL 20000  // max of row matches before selfjoin emits warning
 


### PR DESCRIPTION
HINT(keyedJoinAssumePrimary(true))

Will prevent KJ from checking every physical part in an index
involved in a keyed join.
This can be very expensive if it's a large super index.

When this option is used, it will assume the primary parts
exist, and will not utilize any secondary copies.

Signed-off-by: Jake Smith <jake.smith@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
