### PR TITLE
HPCC-25521 Change log request check in ESP Transaction log

### DIFF
--- a/esp/logging/logginglib/logthread.cpp
+++ b/esp/logging/logginglib/logthread.cpp
@@ -323,8 +323,13 @@ void CLogThread::sendLog()
 //IEspUpdateLogRequestWrap which contains original log Request.
 IEspUpdateLogRequestWrap* CLogThread::checkAndReadLogRequestFromSharedTankFile(IEspUpdateLogRequestWrap* logRequest)
 {
+    StringBuffer logRequestInFile;
+    appendXMLOpenTag(logRequestInFile, LOGCONTENTINFILE);
+    logRequestInFile.append(logRequest->getUpdateLogRequest());
+    appendXMLCloseTag(logRequestInFile, LOGCONTENTINFILE);
+
     //Read LogRequestInFile info if exists.
-    Owned<IPropertyTree> logInFle = createPTreeFromXMLString(logRequest->getUpdateLogRequest());
+    Owned<IPropertyTree> logInFle = createPTreeFromXMLString(logRequestInFile);
     if (!logInFle)
         return nullptr;
 

--- a/esp/logging/loggingmanager/loggingmanager.cpp
+++ b/esp/logging/loggingmanager/loggingmanager.cpp
@@ -276,20 +276,19 @@ bool CLoggingManager::updateLog(IEspContext* espContext, IEspUpdateLogRequestWra
             if (!saveToTankFile(req, reqInFile))
                 throw MakeStringException(-1, "LoggingManager: failed in saveToTankFile().");
 
-            //Build new log request for logging agents
-            StringBuffer logContent, v;
-            appendXMLOpenTag(logContent, LOGCONTENTINFILE);
-            appendXMLTag(logContent, LOGCONTENTINFILE_FILENAME, reqInFile->getFileName());
-            appendXMLTag(logContent, LOGCONTENTINFILE_FILEPOS, v.append(reqInFile->getPos()));
-            appendXMLTag(logContent, LOGCONTENTINFILE_FILESIZE, v.clear().append(reqInFile->getSize()));
-            appendXMLTag(logContent, LOGREQUEST_GUID, reqInFile->getGUID());
-            appendXMLCloseTag(logContent, LOGCONTENTINFILE);
-
-            Owned<IEspUpdateLogRequest> logRequest = new CUpdateLogRequest("", "");
-            logRequest->setOption(reqInFile->getOption());
-            logRequest->setLogContent(logContent);
             if (!decoupledLogging)
             {
+                //Build new log request for logging agents
+                StringBuffer logContent, v;
+                appendXMLTag(logContent, LOGCONTENTINFILE_FILENAME, reqInFile->getFileName());
+                appendXMLTag(logContent, LOGCONTENTINFILE_FILEPOS, v.append(reqInFile->getPos()));
+                appendXMLTag(logContent, LOGCONTENTINFILE_FILESIZE, v.clear().append(reqInFile->getSize()));
+                appendXMLTag(logContent, LOGREQUEST_GUID, reqInFile->getGUID());
+
+                Owned<IEspUpdateLogRequest> logRequest = new CUpdateLogRequest("", "");
+                logRequest->setOption(reqInFile->getOption());
+                logRequest->setLogContent(logContent);
+
                 for (unsigned int x = 0; x < loggingAgentThreads.size(); x++)
                 {
                     IUpdateLogThread* loggingThread = loggingAgentThreads[x];


### PR DESCRIPTION
The LogContentInFile request is used to let a logging agent know where
the original log request is in a tank file. For non-decouple logging,
ESP logging code has a function to check whether a log request is a
LogContentInFile request or original log request. The existing function
expects that both LogContentInFile request and original log requests
have the top xml tag which is incorrect for some original log requests.

Signed-off-by: wangkx <kevin.wang@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
