### PR TITLE
HPCC-25341 Add option to regression suite to execute an arbitrary command/script before aborting

### DIFF
--- a/testing/regress/ecl-test
+++ b/testing/regress/ecl-test
@@ -193,8 +193,7 @@ class RegressMain:
         helperParser.add_argument('--config', help="Config file to use. Default: ecl-test.json",
                             nargs='?', default=defaultConfigFile)
         helperParser.add_argument('--loglevel', help="Set the log level. Use debug for more detailed logfile.",
-                            nargs='?', default="info",
-                            choices=['info', 'debug'])
+                            nargs='?', default="info", choices=['info', 'debug'])
 
         commonParser=argparse.ArgumentParser(add_help=False)
         commonParser.add_argument('--suiteDir', '-s', help="SuiteDir to use. Default value is the current directory and it can handle relative path.",
@@ -237,6 +236,8 @@ class RegressMain:
                                 action = 'store_true')
         executionParser.add_argument('--createEclRunArg', help="Generate ECL tool command line.",
                                 action='store_true')
+        executionParser.add_argument('--preAbort', help="Execute an arbitrary command/script before aborting	.",
+                                default=None,  metavar='preAbortscriptName')
 
 
         parser = argparse.ArgumentParser(prog=prog, description=description,  parents=[helperParser, commonParser,  executionParser])
@@ -363,6 +364,8 @@ class RegressMain:
                 exit(err.getErrorCode())
         else:
             self.config.set('generateStackTrace', False)
+    
+        self.config.set('preAbort', self.args.preAbort)
 
         self.config.set('log',  self.log)
         setConfig(self.config)

--- a/testing/regress/hpcc/util/util.py
+++ b/testing/regress/hpcc/util/util.py
@@ -222,11 +222,27 @@ def abortWorkunit(wuid, taskId = -1, engine = None):
                 pass
             else:
                 err = Error("7100")
-                logger.error("%s. clearOSCache error:%s" % (taskId,  err))
+                logger.error("%s. generateStackTrace error:%s" % (taskId,  err))
                 logger.error(traceback.format_exc())
                 raise Error(err)
                 pass
-
+        
+        if gConfig.preAbort != None:
+            try:
+                logger.error("%3d. Execute pre abort script '%s'", taskId, str(gConfig.preAbort))
+                outFile = os.path.expanduser(gConfig.logDir) + '/' + wuid +'-preAbort.log'
+                
+                command=gConfig.preAbort + " > " + outFile + " 2>&1"
+                myProc = subprocess.Popen([ command ],  shell=True,  bufsize=8192,  stdout=subprocess.PIPE,  stderr=subprocess.PIPE)
+                result = myProc.stdout.read() + myProc.stderr.read()
+                
+                logger.debug("%3d. Pre abort script result '%s'", taskId, wuid, str(result))
+                logger.error("%3d. Pre abort script result stored into '%s'", taskId, outFile)
+            except Exception as e:
+                printException("preAbort scrip:" + repr(e),  True)
+                logger.error("%3d. Exception in executing pre abort script: '%s'", taskId, repr(e))
+            pass
+            
         shell = Shell()
         cmd = 'ecl'
         defaults=[]


### PR DESCRIPTION

Add new parameter '--preAbort' with 'None' by default value

Handle when preAbort is not 'None', execute the command and store its stdout
and stderr in same place where the other regression logs are stored under the
'[WUID]-preAbort.log' name.

Signed-off-by: Attila Vamos <attila.vamos@gmail.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [x] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [x] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [x] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->
Tested manually.
<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
