### PR TITLE
HPCC-25518 Use '--wait[x]' parameter with ecl tool to avoid Regression Test Engine hangs in containerized environment.

### DIFF
--- a/testing/regress/ecl-test
+++ b/testing/regress/ecl-test
@@ -236,7 +236,7 @@ class RegressMain:
                                 action = 'store_true')
         executionParser.add_argument('--createEclRunArg', help="Generate ECL tool command line.",
                                 action='store_true')
-        executionParser.add_argument('--preAbort', help="Execute an arbitrary command/script before aborting	.",
+        executionParser.add_argument('--preAbort', help="Execute an arbitrary command/script before aborting.",
                                 default=None,  metavar='preAbortscriptName')
 
 
@@ -364,8 +364,14 @@ class RegressMain:
                 exit(err.getErrorCode())
         else:
             self.config.set('generateStackTrace', False)
-    
+
         self.config.set('preAbort', self.args.preAbort)
+
+        if not self.config.has('wuStatusTimeout'):
+            self.config.set('wuStatusTimeout', 30)
+
+        if not self.config.has('wuAbortTimeout'):
+            self.config.set('wuAbortTimeout', 30)
 
         self.config.set('log',  self.log)
         setConfig(self.config)

--- a/testing/regress/ecl-test.json
+++ b/testing/regress/ecl-test.json
@@ -35,6 +35,8 @@
         },
         "timeout":"720",
         "maxAttemptCount":"3",
+        "wuStatusTimeout":"30",
+        "wuAbortTimeout":"30",
         "defaultSetupTargets": [
             "thor",
             "roxie"

--- a/testing/regress/hpcc/common/dict.py
+++ b/testing/regress/hpcc/common/dict.py
@@ -33,3 +33,12 @@ class _dict(object):
             self.__d[attr] = val
         except KeyError:
              raise AttributeError
+
+    def has(self, attr, section=None ):
+        if section:
+            if section in self.__d:
+                return attr in self.__d[section]
+            else:
+                raise AttributeError
+        else:
+            return attr in self.__d

--- a/testing/regress/hpcc/util/ecl/command.py
+++ b/testing/regress/hpcc/util/ecl/command.py
@@ -51,6 +51,9 @@ class ECLcmd(Shell):
         if self.config.useSsl.lower() == 'true':
             args.append('--ssl')
 
+        retryCount = int(kwargs.pop('retryCount',  1))
+        args.append('--wait='+str( ( retryCount * eclfile.getTimeout() + 5 * 60  )* 1000 ))  # + 5 minutes/300 sec to avoid ecl command and RTE timeout clash (ms)
+
         server = kwargs.pop('server', False)
         if server:
             args.append('--server=' + server)

--- a/testing/regress/hpcc/util/util.py
+++ b/testing/regress/hpcc/util/util.py
@@ -127,6 +127,7 @@ def queryWuid(jobname,  taskId):
     args.append('status')
     args.append('-v')
     args.append('-n=' + jobname)
+    args.append('--wait-read='+ gConfig.wuStatusTimeout )  # Timeout while reading from socket (in seconds)
     addCommonEclArgs(args)
 
     res, stderr = shell.command(cmd, *defaults)(*args)
@@ -226,35 +227,36 @@ def abortWorkunit(wuid, taskId = -1, engine = None):
                 logger.error(traceback.format_exc())
                 raise Error(err)
                 pass
-        
+
         if gConfig.preAbort != None:
             try:
                 logger.error("%3d. Execute pre abort script '%s'", taskId, str(gConfig.preAbort))
                 outFile = os.path.expanduser(gConfig.logDir) + '/' + wuid +'-preAbort.log'
-                
+
                 command=gConfig.preAbort + " > " + outFile + " 2>&1"
                 myProc = subprocess.Popen([ command ],  shell=True,  bufsize=8192,  stdout=subprocess.PIPE,  stderr=subprocess.PIPE)
                 result = myProc.stdout.read() + myProc.stderr.read()
-                
+
                 logger.debug("%3d. Pre abort script result '%s'", taskId, wuid, str(result))
                 logger.error("%3d. Pre abort script result stored into '%s'", taskId, outFile)
             except Exception as e:
                 printException("preAbort scrip:" + repr(e),  True)
                 logger.error("%3d. Exception in executing pre abort script: '%s'", taskId, repr(e))
             pass
-            
+
         shell = Shell()
         cmd = 'ecl'
         defaults=[]
         args = []
         args.append('abort')
         args.append('-wu=' + wuid)
+        args.append('--wait-read=' + gConfig.wuAbortTimeout )  # Timeout while reading from socket (in seconds)
         addCommonEclArgs(args)
 
         state=shell.command(cmd, *defaults)(*args)
     else:
         logger.error("%3d. abortWorkunit(wuid:'%s', engine:'%s') invalid WUID.", taskId, wuid, str(engine))
-        
+
     return state
 
 def createZAP(wuid, taskId,  reason=''):


### PR DESCRIPTION

Add 2 new config items:
 - wuStatusTimeout
 - wuAbortTimeout
with 30 seconds value each.

Implemet their checks and use them for workunit status and abort operations.

Add "--wait [timeout_in_msec] " parameter back to "ecl run ..." and
"ecl publish ..." commands with 5 minutes longger timeout than the (RTE)
retryCount * timeout defines to avoid clash and prevent to ECL
command stuck.

Signed-off-by: Attila Vamos <attila.vamos@gmail.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [ ] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [ ] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [ ] I have read the CONTRIBUTORS document.
- [ ] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->
Tested in a local Minikube environment.
<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
