### PR TITLE
HPCC-25655 Fix getTargetClusterInfo() calls in WsWorkunits and WsDfu

### DIFF
--- a/esp/services/ws_dfu/ws_dfuService.cpp
+++ b/esp/services/ws_dfu/ws_dfuService.cpp
@@ -2638,7 +2638,7 @@ void CWsDfuEx::doGetFileDetails(IEspContext &context, IUserDescriptor *udesc, co
 
 bool CWsDfuEx::getQueryFile(const char *logicalName, const char *querySet, const char *queryID, IEspDFUFileDetail &fileDetails)
 {
-    Owned<IConstWUClusterInfo> info = getTargetClusterInfo(querySet);
+    Owned<IConstWUClusterInfo> info = getWUClusterInfoByName(querySet);
     if (!info || (info->getPlatform()!=RoxieCluster))
         return false;
 

--- a/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
+++ b/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
@@ -288,7 +288,7 @@ void QueryFilesInUse::loadTarget(IPropertyTree *t, const char *target, unsigned 
     if (!target || !*target)
         return;
 
-    Owned<IConstWUClusterInfo> clusterInfo = getTargetClusterInfo(target);
+    Owned<IConstWUClusterInfo> clusterInfo = getWUClusterInfoByName(target);
     if (!clusterInfo || !(clusterInfo->getPlatform() == RoxieCluster))
         return;
 
@@ -476,7 +476,7 @@ bool CWsWorkunitsEx::onWUCopyLogicalFiles(IEspContext &context, IEspWUCopyLogica
         cluster.set(cw->queryClusterName());
     validateTargetName(cluster);
 
-    Owned <IConstWUClusterInfo> clusterInfo = getTargetClusterInfo(cluster.str());
+    Owned<IConstWUClusterInfo> clusterInfo = getWUClusterInfoByName(cluster);
 
     IArrayOf<IConstWUCopyLogicalClusterFileSections> clusterfiles;
     PROGLOG("WUCopyLogicalFiles: %s", wuid.str());
@@ -2363,7 +2363,7 @@ bool CWsWorkunitsEx::getQueryFiles(IEspContext &context, const char* wuid, const
 {
     try
     {
-        Owned<IConstWUClusterInfo> info = getTargetClusterInfo(target);
+        Owned<IConstWUClusterInfo> info = getWUClusterInfoByName(target);
         if (!info || (info->getPlatform()!=RoxieCluster))
             return false;
 
@@ -2946,7 +2946,7 @@ public:
         {
             wufiles->resolveFiles(process, dfsIP, srcPrefix, srcCluster, !(updateFlags & (DALI_UPDATEF_REPLACE_FILE | DALI_UPDATEF_CLONE_FROM)), true, false, true);
             Owned<IDFUhelper> helper = createIDFUhelper();
-            Owned <IConstWUClusterInfo> cl = getTargetClusterInfo(target);
+            Owned <IConstWUClusterInfo> cl = getWUClusterInfoByName(target);
             if (cl)
             {
                 SCMStringBuffer process;
@@ -3009,7 +3009,7 @@ bool CWsWorkunitsEx::onWUCopyQuerySet(IEspContext &context, IEspWUCopyQuerySetRe
     SCMStringBuffer process;
     if (req.getCopyFiles())
     {
-        Owned <IConstWUClusterInfo> clusterInfo = getTargetClusterInfo(target);
+        Owned <IConstWUClusterInfo> clusterInfo = getWUClusterInfoByName(target);
         if (clusterInfo && clusterInfo->getPlatform()==RoxieCluster)
         {
             clusterInfo->getRoxieProcess(process);
@@ -3180,7 +3180,7 @@ bool CWsWorkunitsEx::onWUQuerysetImport(IEspContext &context, IEspWUQuerysetImpo
         if (!target || !*target)
             throw MakeStringException(ECLWATCH_QUERYSET_NOT_FOUND, "Target not specified");
 
-        Owned <IConstWUClusterInfo> clusterInfo = getTargetClusterInfo(target);
+        Owned <IConstWUClusterInfo> clusterInfo = getWUClusterInfoByName(target);
         if (!clusterInfo)
             throw MakeStringException(ECLWATCH_CANNOT_RESOLVE_CLUSTER_NAME, "Target not found");
 

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -4467,7 +4467,7 @@ int CWsWorkunitsSoapBindingEx::onGetForm(IEspContext &context, CHttpRequest* req
                 request->getParameter("Cluster", cluster);
                 request->getParameter("Process",defaultProcess);
                 request->getParameter("Range",range);
-                Owned<IConstWUClusterInfo> clusterInfo = getTargetClusterInfo(cluster);
+                Owned<IConstWUClusterInfo> clusterInfo = getWUClusterInfoByName(cluster);
                 xml.append("<WUJobList>");
 
                 SecAccessFlags accessOwn;


### PR DESCRIPTION
In https://github.com/hpcc-systems/HPCC-Platform/pull/14744, several
methods (getRoxieProcess(), getThorProcesses(),  getRoxieRedundancy(),
etc.) are implemented in the CContainerWUClusterInfo. In the ESP
services which use those methods, the getTargetClusterInfo() calls
should be replaced by getWUClusterInfoByName().

Signed-off-by: wangkx <kevin.wang@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [ ] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
