### PR TITLE
HPCC-25752 Roxie may crash at startup if parallel-loading R queries

### DIFF
--- a/common/dllserver/thorplugin.cpp
+++ b/common/dllserver/thorplugin.cpp
@@ -846,6 +846,40 @@ void SafePluginMap::loadFromList(const char * pluginsList)
     }
 }
 
+bool SafePluginMap::loadNamed(const char * pluginDirectories, const char * plugin)
+{
+    const char *pluginDir = pluginDirectories;
+    for (;*pluginDir;)
+    {
+        StringBuffer thisFile;
+        while (*pluginDir && *pluginDir != ENVSEPCHAR)
+            thisFile.append(*pluginDir++);
+        if(*pluginDir)
+            pluginDir++;
+
+        if(!thisFile.length())
+            continue;
+        Owned<IFile> dir = createIFile(thisFile);
+        if (dir->isDirectory() == fileBool::foundYes)
+        {
+            Owned<IFile> file = createIFile(addPathSepChar(thisFile).append(plugin));
+            if (file->exists())
+            {
+                if (addPlugin(thisFile, plugin))
+                    return true;
+            }
+        }
+        else if (dir->isFile() == fileBool::foundYes)
+        {
+            StringBuffer tail;
+            splitFilename(thisFile, NULL, NULL, &tail, &tail);
+            if (streq(tail, plugin) && addPlugin(thisFile, plugin))
+                return true;
+        }
+    }
+    return false;
+}
+
 void SafePluginMap::loadFromDirectory(const char * pluginDirectory)
 {
     const char * mask = "*" SharedObjectExtension;

--- a/common/dllserver/thorplugin.hpp
+++ b/common/dllserver/thorplugin.hpp
@@ -91,6 +91,8 @@ public:
     bool addPlugin(const char *path, const char *dllname);
     void loadFromList(const char * pluginsList);
     void loadFromDirectory(const char * pluginDirectory);
+    bool loadNamed(const char * pluginDirectories, const char * plugin);
+
 };
 
 #endif // THORPLUGIN_HPP

--- a/helm/hpcc/values.schema.json
+++ b/helm/hpcc/values.schema.json
@@ -720,6 +720,11 @@
         "logging": {
           "$ref": "#/definitions/logging"
         },
+        "preload": {
+          "description": "Preloaded plugins",
+          "type": "array",
+          "items": { "type": "string" }
+        },
         "services": {
           "description": "Roxie query services",
           "type": "array",

--- a/plugins/Rembed/Rembed.cpp
+++ b/plugins/Rembed/Rembed.cpp
@@ -218,7 +218,11 @@ static RGlobalState *queryGlobalState()
 {
     CriticalBlock b(RCrit);
     if (!globalState)
+    {
+        if (!isMainThread())
+            FAIL("R embed support must be loaded or preloaded on main thread");
         globalState = new RGlobalState;
+    }
     return globalState;
 }
 

--- a/roxie/ccd/ccdstate.cpp
+++ b/roxie/ccd/ccdstate.cpp
@@ -2896,7 +2896,22 @@ extern void loadPlugins()
     if (pluginDirectory.length())
     {
         plugins = new SafePluginMap(&PluginCtx, traceLevel >= 1);
-        plugins->loadFromList(pluginDirectory);
+        if (topology->hasProp("preload"))
+        {
+            Owned<IPropertyTreeIterator> preloads = topology->getElements("preload");
+            ForEach(*preloads)
+            {
+                const char *preload = preloads->query().queryProp(".");
+                if (!streq(preload, "none"))
+                {
+                    VStringBuffer soname(SharedObjectPrefix "%s" SharedObjectExtension, preload);
+                    if (!plugins->loadNamed(pluginDirectory, soname))
+                        DBGLOG("Could not preload plugin %s at any of the following locations: %s", soname.str(), pluginDirectory.str());
+                }
+            }
+        }
+        else
+            plugins->loadFromList(pluginDirectory);
     }
 }
 

--- a/system/jlib/jthread.cpp
+++ b/system/jlib/jthread.cpp
@@ -54,6 +54,11 @@ static struct MainThreadIdHelper
     }
 } mainThreadIdHelper;
 
+extern bool isMainThread()
+{
+    return GetCurrentThreadId() == mainThreadIdHelper.tid;
+}
+
 /*
  * NB: Thread termination hook functions are tracked using a thread local vector (threadTermHooks).
  * However, hook functions installed on the main thread must be tracked separately in a non thread local vector (mainThreadTermHooks).

--- a/system/jlib/jthread.hpp
+++ b/system/jlib/jthread.hpp
@@ -44,7 +44,7 @@ interface jlib_decl IThreadName
 };
 
 
-
+extern jlib_decl bool isMainThread();
 extern jlib_decl void addThreadExceptionHandler(IExceptionHandler *handler);
 extern jlib_decl void removeThreadExceptionHandler(IExceptionHandler *handler);
 extern jlib_decl void enableThreadSEH();


### PR DESCRIPTION
Provide a way to specify which queries are to be preloaded (we may in the
future want to default this list to be empty), and add code to the R plugin to
fail if it is not preloaded.

Signed-off-by: Richard Chapman <rchapman@hpccsystems.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [x] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
