### PR TITLE
HPCC-25789 Support dfsfile, dfspart, etc in WsDali

### DIFF
--- a/dali/daliadmin/daadmin.hpp
+++ b/dali/daliadmin/daadmin.hpp
@@ -43,18 +43,18 @@ extern DALIADMIN_API bool add(const char *path, const char *val, StringBuffer &o
 extern DALIADMIN_API void delv(const char *path);
 extern DALIADMIN_API unsigned count(const char *path);
 
-extern DALIADMIN_API void dfsfile(const char *lname, IUserDescriptor *userDesc, UnsignedArray *partslist = nullptr);
-extern DALIADMIN_API void dfspart(const char *lname,IUserDescriptor *userDesc, unsigned partnum);
+extern DALIADMIN_API bool dfsfile(const char *lname, IUserDescriptor *userDesc, StringBuffer &out, UnsignedArray *partslist = nullptr);
+extern DALIADMIN_API bool dfspart(const char *lname,IUserDescriptor *userDesc, unsigned partnum, StringBuffer &out);
 extern DALIADMIN_API void dfsmeta(const char *filename,IUserDescriptor *userDesc, bool includeStorage);
-extern DALIADMIN_API void setdfspartattr(const char *lname, unsigned partNum, const char *attr, const char *value, IUserDescriptor *userDesc);
-extern DALIADMIN_API void dfscsv(const char *dali, IUserDescriptor *udesc);
-extern DALIADMIN_API void dfsCheck();
+extern DALIADMIN_API void setdfspartattr(const char *lname, unsigned partNum, const char *attr, const char *value, IUserDescriptor *userDesc, StringBuffer &out);
+extern DALIADMIN_API void dfscsv(const char *dali, IUserDescriptor *udesc, StringBuffer &out);
+extern DALIADMIN_API bool dfsCheck(StringBuffer &out);
 extern DALIADMIN_API void dfsGroup(const char *name, const char *outputFilename);
 extern DALIADMIN_API int clusterGroup(const char *name, const char *outputFilename);
-extern DALIADMIN_API void dfsLs(const char *name, const char *options, bool safe = false);
-extern DALIADMIN_API void dfsmap(const char *lname, IUserDescriptor *user);
+extern DALIADMIN_API bool dfsLs(const char *name, const char *options, StringBuffer &out);
+extern DALIADMIN_API bool dfsmap(const char *lname, IUserDescriptor *user, StringBuffer &out);
 extern DALIADMIN_API int dfsexists(const char *lname, IUserDescriptor *user);
-extern DALIADMIN_API void dfsparents(const char *lname, IUserDescriptor *user);
+extern DALIADMIN_API void dfsparents(const char *lname, IUserDescriptor *user, StringBuffer &out);
 extern DALIADMIN_API void dfsunlink(const char *lname, IUserDescriptor *user);
 extern DALIADMIN_API int dfsverify(const char *name, CDateTime *cutoff, IUserDescriptor *user);
 extern DALIADMIN_API int dfsperm(const char *obj, IUserDescriptor *user);

--- a/dali/daliadmin/daliadmin.cpp
+++ b/dali/daliadmin/daliadmin.cpp
@@ -314,7 +314,7 @@ int main(int argc, const char* argv[])
                     }
                     else if (strieq(cmd,"dfsfile")) {
                         CHECKPARAMS(1,1);
-                        dfsfile(params.item(1),userDesc);
+                        doLog(dfsfile(params.item(1),userDesc,out),out);
                     }
                     else if (strieq(cmd,"dfsmeta")) {
                         CHECKPARAMS(1,3);
@@ -323,19 +323,21 @@ int main(int argc, const char* argv[])
                     }
                     else if (strieq(cmd,"dfspart")) {
                         CHECKPARAMS(2,2);
-                        dfspart(params.item(1),userDesc,atoi(params.item(2)));
+                        doLog(dfspart(params.item(1),userDesc,atoi(params.item(2)),out),out);                        
                     }
                     else if (strieq(cmd,"setdfspartattr")) {
                         CHECKPARAMS(3,4);
-                        setdfspartattr(params.item(1), atoi(params.item(2)), params.item(3), np>3 ? params.item(4) : nullptr, userDesc);
+                        setdfspartattr(params.item(1),atoi(params.item(2)),params.item(3),np>3?params.item(4):nullptr,userDesc,out);
+                        PROGLOG("%s", out.str());
                     }
                     else if (strieq(cmd,"dfscheck")) {
                         CHECKPARAMS(0,0);
-                        dfsCheck();
+                        doLog(dfsCheck(out),out);
                     }
                     else if (strieq(cmd,"dfscsv")) {
                         CHECKPARAMS(1,1);
-                        dfscsv(params.item(1),userDesc);
+                        dfscsv(params.item(1),userDesc,out);
+                        PROGLOG("%s",out.str());
                     }
                     else if (strieq(cmd,"dfsgroup")) {
                         CHECKPARAMS(1,2);
@@ -347,11 +349,11 @@ int main(int argc, const char* argv[])
                     }
                     else if (strieq(cmd,"dfsls")) {
                         CHECKPARAMS(0,2);
-                        dfsLs((np>0)?params.item(1):NULL,(np>1)?params.item(2):NULL);
+                        doLog(dfsLs((np>0)?params.item(1):nullptr,(np>1)?params.item(2):nullptr,out),out);
                     }
                     else if (strieq(cmd,"dfsmap")) {
                         CHECKPARAMS(1,1);
-                        dfsmap(params.item(1), userDesc);
+                        doLog(dfsmap(params.item(1),userDesc,out),out);
                     }
                     else if (strieq(cmd,"dfsexists") || strieq(cmd,"dfsexist")) {
                         // NB: "dfsexist" typo', kept for backward compatibility only (<7.12)
@@ -360,7 +362,8 @@ int main(int argc, const char* argv[])
                     }
                     else if (strieq(cmd,"dfsparents")) {
                         CHECKPARAMS(1,1);
-                        dfsparents(params.item(1),userDesc);
+                        dfsparents(params.item(1),userDesc,out);
+                        PROGLOG("%s",out.str());
                     }
                     else if (strieq(cmd,"dfsunlink")) {
                         CHECKPARAMS(1,1);

--- a/esp/scm/ws_dali.ecm
+++ b/esp/scm/ws_dali.ecm
@@ -17,6 +17,11 @@
 
 EspInclude(common);
 
+ESPresponse [exceptions_inline, nil_remove] BooleanResponse
+{
+    bool Result;
+};
+
 ESPrequest [nil_remove] SetValueRequest
 {
     string Path;
@@ -61,8 +66,59 @@ ESPresponse [exceptions_inline, nil_remove] CountResponse
     unsigned Result;
 };
 
+ESPrequest [nil_remove] GetLogicalFileRequest
+{
+    string FileName;
+};
+
+ESPrequest [nil_remove] GetLogicalFilePartRequest
+{
+    string FileName;
+    unsigned PartNumber;
+};
+
+ESPrequest [nil_remove] SetLogicalFilePartAttrRequest
+{
+    string FileName;
+    unsigned PartNumber;
+    string Attr;
+    string Value;
+};
+
+ESPrequest [nil_remove]  GetDFSCSVRequest
+{
+    string LogicalNameMask;
+};
+
+ESPrequest [nil_remove]  GetDFSMapRequest
+{
+    string FileName;
+};
+
+ESPrequest [nil_remove]  GetDFSParentsRequest
+{
+    string FileName;
+};
+
+ESPrequest [nil_remove]  DFSCheckRequest
+{
+};
+
+ESPrequest [nil_remove]  DFSLSRequest
+{
+    string Name;
+    bool PathAndNameOnly(true);
+    bool IncludeSubFileInfo(false);
+    bool Recursively(false);
+};
+
+ESPrequest [nil_remove]  DFSExistsRequest
+{
+    string FileName;
+};
+
 ESPservice [auth_feature("NONE"), //This declares that the method logic handles feature level authorization
-    version("1.03"), default_client_version("1.03"), exceptions_inline("./smc_xslt/exceptions.xslt")] WSDali
+    version("1.04"), default_client_version("1.04"), exceptions_inline("./smc_xslt/exceptions.xslt")] WSDali
 {
     ESPmethod [min_ver("1.01")] SetValue(SetValueRequest, ResultResponse);
     ESPmethod [min_ver("1.01")] GetValue(GetValueRequest, ResultResponse);
@@ -70,6 +126,15 @@ ESPservice [auth_feature("NONE"), //This declares that the method logic handles 
     ESPmethod [min_ver("1.02")] Delete(DeleteRequest, ResultResponse);
     ESPmethod [min_ver("1.03")] Add(AddRequest, ResultResponse);
     ESPmethod [min_ver("1.03")] Count(CountRequest, CountResponse);
+    ESPmethod [min_ver("1.04")] GetLogicalFile(GetLogicalFileRequest, ResultResponse);
+    ESPmethod [min_ver("1.04")] GetLogicalFilePart(GetLogicalFilePartRequest, ResultResponse);
+    ESPmethod [min_ver("1.04")] SetLogicalFilePartAttr(SetLogicalFilePartAttrRequest, ResultResponse);
+    ESPmethod [min_ver("1.04")] GetDFSCSV(GetDFSCSVRequest, ResultResponse);
+    ESPmethod [min_ver("1.04")] GetDFSMap(GetDFSMapRequest, ResultResponse);
+    ESPmethod [min_ver("1.04")] GetDFSParents(GetDFSParentsRequest, ResultResponse);
+    ESPmethod [min_ver("1.04")] DFSCheck(DFSCheckRequest, ResultResponse);
+    ESPmethod [min_ver("1.04")] DFSLS(DFSLSRequest, ResultResponse);
+    ESPmethod [min_ver("1.04")] DFSExists(DFSExistsRequest, BooleanResponse);
 };
 
 SCMexportdef(WSDali);

--- a/esp/services/ws_dali/ws_daliservice.hpp
+++ b/esp/services/ws_dali/ws_daliservice.hpp
@@ -20,6 +20,7 @@
 
 #include "ws_dali_esp.ipp"
 #include "exception_util.hpp"
+#include "dasds.hpp"
 
 class CWSDaliEx : public CWSDali
 {
@@ -27,6 +28,7 @@ class CWSDaliEx : public CWSDali
     std::atomic<bool> daliDetached{false};
 
     void checkAccess(IEspContext& context);
+    IUserDescriptor* createUserDesc(IEspContext& context);
 public:
     IMPLEMENT_IINTERFACE;
 
@@ -54,6 +56,15 @@ public:
     virtual bool onDelete(IEspContext& context, IEspDeleteRequest& req, IEspResultResponse& resp) override;
     virtual bool onAdd(IEspContext& context, IEspAddRequest& req, IEspResultResponse& resp) override;
     virtual bool onCount(IEspContext& context, IEspCountRequest& req, IEspCountResponse& resp) override;
+    virtual bool onDFSLS(IEspContext& context, IEspDFSLSRequest& req, IEspResultResponse& resp) override;
+    virtual bool onGetDFSCSV(IEspContext& context, IEspGetDFSCSVRequest& req, IEspResultResponse& resp) override;
+    virtual bool onDFSExists(IEspContext& context, IEspDFSExistsRequest& req, IEspBooleanResponse& resp) override;
+    virtual bool onGetLogicalFile(IEspContext& context, IEspGetLogicalFileRequest& req, IEspResultResponse& resp) override;
+    virtual bool onGetLogicalFilePart(IEspContext& context, IEspGetLogicalFilePartRequest& req, IEspResultResponse& resp) override;
+    virtual bool onSetLogicalFilePartAttr(IEspContext& context, IEspSetLogicalFilePartAttrRequest& req, IEspResultResponse& resp) override;
+    virtual bool onGetDFSMap(IEspContext& context, IEspGetDFSMapRequest& req, IEspResultResponse& resp) override;
+    virtual bool onGetDFSParents(IEspContext& context, IEspGetDFSParentsRequest& req, IEspResultResponse& resp) override;
+    virtual bool onDFSCheck(IEspContext& context, IEspDFSCheckRequest& req, IEspResultResponse& resp) override;
 };
 
 class CWSDaliSoapBindingEx : public CWSDaliSoapBinding


### PR DESCRIPTION
Also support the daliadmin functionalities: dfsls,
setdfspartattr, dfsparents, dfsmap, dfscsv,
dfscheck, and dfsexists.

Signed-off-by: wangkx <kevin.wang@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
