### PR TITLE
HPCC-25799 Add check for killall for thorslaves and fix dependency issue for centos8

### DIFF
--- a/cmake_modules/getpackagerevisionarch.sh
+++ b/cmake_modules/getpackagerevisionarch.sh
@@ -83,7 +83,7 @@ elif [ -e /etc/redhat-release ]; then
   if [ -x /bin/rpm ]; then
     OUTPUT="${OUTPUT}\npackage=rpm"
     OS_GROUP=`/bin/rpm -q --qf "%{NAME}" --whatprovides /etc/redhat-release | sed 's/-release.*//' |  tr '[A-Z]' '[a-z]'`
-    REDHAT_VERSION=`/bin/rpm -q --qf "%{VERSION}" --whatprovides /etc/redhat-release`
+    REDHAT_VERSION=`/bin/rpm -q --qf "%{VERSION}" --whatprovides /etc/redhat-release | cut -f1 -d"."`
     case "$OS_GROUP" in
       "centos" | "fedora")
         if [ ${NOARCH} -eq 0 ]; then

--- a/initfiles/bin/init_thorslave.in
+++ b/initfiles/bin/init_thorslave.in
@@ -66,6 +66,19 @@ stop_slaves()
 
 start_slaves()
 {
+    
+    # insuring parent directory structure is setup properly
+    mkdir -p $instancedir
+    mkdir -p $(dirname $logfile)
+
+    cd $instancedir
+
+    log "checking killall dependency"
+    if ! killall -V > /dev/null 2>&1 ; then
+        log "killall dependency not met. Cannot start thorslaves"
+        exit 1
+    fi
+
     killall -0 dafilesrv > /dev/null 2>&1
     if [[ $? -ne 0 ]];then
         # insuring dafilesrv is running on the machine as it is a prerequisite
@@ -78,12 +91,6 @@ start_slaves()
             exit 1
         fi
     fi
-
-    # insuring parent directory structure is setup properly
-    mkdir -p $instancedir
-    mkdir -p $(dirname $logfile)
-
-    cd $instancedir
 
     log "dependency dafilesrv started"
 


### PR DESCRIPTION
CentOS8 has an issue when using getpackagerevisionarch.sh where the old call to `rpm -q --qf "%{VERSION}" --whatprovides` would return a major version, but the behavior has changed to return a major.minor version. This causes an issue in our cmake dependency files where we're expecting to match el8.cmake not el8.1.cmake or el8.2.cmake.  I've fixed this problem, as well as added a check in thorslaves init code to double check for the killall process before we start using it.  Now the dependency file will be included in the package, and the user will get psmisc installed alongside our package, ensuring killall will be present.


<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
