### PR TITLE
HPCC-25489 LDAP credentials should be configurable as secrets

### DIFF
--- a/esp/applications/common/ldap/azure_ldap.yaml
+++ b/esp/applications/common/ldap/azure_ldap.yaml
@@ -6,9 +6,6 @@ ldap:
   localDomain: localdomain
   ldapPort: 389
   ldapSecurePort: 636
-  systemCommonName: hpcc_admin2
-  systemPassword: ""
-  systemUser: hpcc_admin2
   adminGroupName:
   maxConnections: 10
   passwordExpirationWarningDays: 10
@@ -23,3 +20,14 @@ ldap:
   usersBasedn: ou=AADDC Users
   resourcesBasedn: ou=WsEcl,ou=EspServices,ou=ecl
   workunitsBasedn: ou=workunits,ou=ecl
+
+  #LDAP Admin username/password can be specified as a secret, or hard coded here
+
+  #Specify if username/password externalized as a secret
+  ldapAdminSecretKey: ""
+  ldapAdminVaultId: ""
+
+  #Specify if username/password not stored as secret. Password MD5 encoded
+  systemCommonName: "hpcc_admin"
+  systemPassword: ""
+  systemUser: "hpcc_admin"

--- a/esp/applications/common/ldap/ldap.yaml
+++ b/esp/applications/common/ldap/ldap.yaml
@@ -1,14 +1,12 @@
 ldap:
    objname: ldapserver
+   serverType: ActiveDirectory
    description: LDAP server process
    ldapProtocol: ldaps
    localDomain: localdomain
    ldapPort: 389
    ldapSecurePort: 636
-   systemCommonName: hpcc_admin2
-   systemPassword: ""
-   systemUser: hpcc_admin2
-   adminGroupName: HPCCAdmin
+   adminGroupName: HPCCAdmins
    maxConnections: 10
    passwordExpirationWarningDays: 10
    cacheTimeout: 5
@@ -22,3 +20,14 @@ ldap:
    usersBasedn: ou=users,ou=ecl
    resourcesBasedn: ou=WsEcl,ou=EspServices,ou=ecl
    workunitsBasedn: ou=workunits,ou=ecl
+
+   #LDAP Admin username/password can be specified as a secret, or hard coded here
+
+   #Specify if username/password externalized as a secret
+   ldapAdminSecretKey: ""
+   ldapAdminVaultId: ""
+
+   #Specify if username/password not stored as secret. Password MD5 encoded
+   systemCommonName: "hpcc_admin"
+   systemPassword: ""
+   systemUser: "hpcc_admin"

--- a/helm/examples/ldap/README.md
+++ b/helm/examples/ldap/README.md
@@ -1,0 +1,111 @@
+# Containerized HPCC LDAP Support
+
+These examples demonstrate how to enable the HPCC LDAP Security Manager, by adding LDAP administrator account credentials directly to the HPCC helm charts, or by externalizing these credentials using Kubernetes and Hashicorp Vault secrets. Note there are many variations on how to set these values, using yaml, override files and command line settings. To use externalized credentials, you should first run the tutorial on setting up Kubernetes secrets and the Hashicorp Vault, found in the README.md file in the "HPCC-Platform\helm\examples\secrets" folder.
+
+Note that the LDAP Administrator account performs AD directory searches and modifications, and is the only HPCC user that must have LDAP administrator rights.  This account should exist in the configured "systemBasedn" branch of the LDAP AD directory, typically set to cn=Users.
+
+--------------------------------------------------------------------------------------------------------
+
+## Configure LDAP using helm charts and yaml
+
+### Add credentials to ECLWatch ldap.yaml
+   Edit the ECLWatch HPCC-Platform\esp\applications\common\ldap\ldap.yaml (or override file), and fill out the systemCommonName, systemUser, and MD5 encrypted systemPassword entries as follows.
+   Ensure the other settings are correct for your directory, especially the OU settings. Make sure that ldapAdminSecretKey and ldapAdminVaultId are empty.
+
+```bash
+   ldapAdminSecretKey: ""
+   ldapAdminVaultId: ""
+   systemCommonName: "hpcc_admin"
+   systemPassword: "6b3f606902cb9a337904efe2650eb771"
+   systemUser: "hpcc_admin"
+```
+
+### Enable LDAP authentication on the ECLWatch command line
+   Add the following "auth" and "ldapAddress" settings to your ECLWatch command line or override file, ensuring the ldapAddress is the IP of your LDAP server.
+
+```bash
+esp --application=eclwatch --auth=ldap --ldapAddress=10.200.1.2 ...
+```
+
+--------------------------------------------------------------------------------------------------------
+## Configure LDAP to use externalized Kubernetes (k8s) secrets
+
+### Create the k8s secret
+   From the CLI, create the LDAP "secret" similar to the following.
+   Make note of the secret name, "myAdminCreds" in this example.
+   The "username" and "password" key/values are required, additional properties are allowed but ignored.
+
+```bash
+   kubectl create secret generic myAdminCreds --from-literal=username=hpcc_admin --from-literal=password=t0pS3cr3tP@ssw0rd
+   kubectl get secret myAdminCreds
+```
+For more details on how to create secrets, see the "secrets" examples in the "HPCC-Platform\helm\examples\secrets" folder.
+
+### Deploy the secret to the ECLWatch container
+   Modify the HPCC-Platform\helm\hpcc\values.yaml or override file "secrets: / authn:" category as follows.
+   Create a unique key name ("ldapadminsecretkey01" in this example), and set it to the secret value ("myAdminCreds") that you created above.
+
+```bash
+   secrets:
+     authn:
+       ldapadminsecretkey01: "myAdminCreds"
+```
+
+### Reference the k8s secret key
+   In the HPCC-Platform\esp\applications\common\ldap\ldap.yaml or override, set the "ldapAdminSecretKey" to the key name created above. Note that the key name "ldapadminsecretkey" is used by the LDAP security manager to resolve the secret name, and must be spelled exactly as follows.
+
+```bash
+   ldapAdminSecretKey: "ldapadminsecretkey01"
+   ldapAdminVaultId: ""
+   systemCommonName: ""
+   systemPassword: ""
+   systemUser: ""
+```
+
+### Enable LDAP authentication on the ECLWatch command line
+   Add the following "auth" and "ldapAddress" settings to your ECLWatch command line or override file, ensuring the ldapAddress is the IP of your LDAP server.
+
+```bash
+esp --application=eclwatch --auth=ldap --ldapAddress=10.200.1.2 ...
+```
+
+--------------------------------------------------------------------------------------------------------
+## Configure LDAP to use externalized Hashicorp Vault secrets
+
+### Create the vault secret
+   From the CLI, create the LDAP vault "secret" similar to the following.
+   Make note of the secret name, "myVaultAdminCreds" in this example.
+   The "username" and "password" key/values are required, additional properties are allowed but ignored.
+   Make sure the secret name is specified with the "secret/authn/" prefix
+
+```bash
+   vault kv put secret/authn/myVaultAdminCreds username=hpcc_admin password=t0pS3cr3tP@ssw0rd
+   vault kv get secret/authn/myVaultAdminCreds
+```
+
+   For more details on how to create vault secrets, see the "secrets" examples in the "HPCC-Platform\helm\examples\secrets" folder.
+
+### Note that the vault name, my-authn-vault, was defined in the "secrets" tutorial, in the HPCC-Platform\helm\examples\secrets\values-secrets.yaml file as follows
+
+```bash
+  authn:
+    - name: my-authn-vault
+      #Note the data node in the URL is there for the REST APIs use. The path inside the vault starts after /data
+      url: http://${env.VAULT_SERVICE_HOST}:${env.VAULT_SERVICE_PORT}/v1/secret/data/authn/${secret}
+      kind: kv-v2
+```
+
+### Reference the secret key in the LDAP yaml or override
+   The key names "ldapadminsecretkey" and "ldapAdminVaultId" are used by the LDAP security manager to resolve the secret, and must be spelled exactly as follows.
+
+```bash
+    ldapadminsecretkey: "myVaultAdminCreds"
+    ldapAdminVaultId: "my-authn-vault"
+```
+
+### Enable LDAP authentication on the ECLWatch command line
+   Add the following "auth" and "ldapAddress" settings to your ECLWatch command line or override file, ensuring the ldapAddress is the IP of your LDAP server.
+
+```bash
+esp --application=eclwatch --auth=ldap --ldapAddress=10.200.1.2 ...
+```

--- a/helm/examples/secrets/hpcc_vault_policies.hcl
+++ b/helm/examples/secrets/hpcc_vault_policies.hcl
@@ -9,3 +9,7 @@ path "secret/data/ecl-user/*" {
 path "secret/data/storage/*" {
     capabilities = ["read"]
 }
+
+path "secret/data/authn/*" {
+    capabilities = ["read"]
+}

--- a/helm/examples/secrets/values-secrets.yaml
+++ b/helm/examples/secrets/values-secrets.yaml
@@ -18,6 +18,12 @@ vaults:
       url: http://${env.VAULT_SERVICE_HOST}:${env.VAULT_SERVICE_PORT}/v1/secret/data/ecl/${secret}
       kind: kv-v2
 
+  authn:
+    - name: my-authn-vault
+      #Note the data node in the URL is there for the REST APIs use. The path inside the vault starts after /data
+      url: http://${env.VAULT_SERVICE_HOST}:${env.VAULT_SERVICE_PORT}/v1/secret/data/authn/${secret}
+      kind: kv-v2
+
     #vault using provided token auth
 #    - name: ecl-vault-direct-auth
        #Note the data node in the URL is there for the REST APIs use. The path inside the vault starts after /data

--- a/helm/hpcc/templates/esp.yaml
+++ b/helm/hpcc/templates/esp.yaml
@@ -71,7 +71,7 @@ data:
 {{- if not .disabled -}}
 {{- $env := concat ($.Values.global.env | default list) (.env | default list) -}}
 {{- $application := .application | default "eclwatch" -}}
-{{- $secretsCategories := ternary (list "storage" "esp" "codeSign" "codeVerify")  (list "storage" "esp") (eq $application "eclwatch") -}}
+{{- $secretsCategories := ternary (list "storage" "esp" "codeSign" "codeVerify" "authn")  (list "storage" "esp") (eq $application "eclwatch") -}}
 {{- $includeStorageLabels := ternary (list "lz" "data" "") (list "data" "") (eq $application "eclwatch") -}}
 {{- $commonCtx := dict "root" $ "me" . "secretsCategories" $secretsCategories  "includeLabels" $includeStorageLabels "env" $env -}}
 {{- $configSHA := include "hpcc.getConfigSHA" ($commonCtx | merge (dict "configMapHelper" "hpcc.espConfigMap" "component" "esp" "excludeKeys" "global,esp.queues")) }}

--- a/helm/hpcc/values.schema.json
+++ b/helm/hpcc/values.schema.json
@@ -84,6 +84,9 @@
         "storage": {
           "$ref": "#/definitions/secrets"
         },
+        "authn": {
+          "$ref": "#/definitions/secrets"
+        },
         "ecl": {
           "$ref": "#/definitions/secrets"
         },
@@ -107,6 +110,9 @@
           "type": "integer"
         },
         "storage": {
+          "$ref": "#/definitions/vaultCategory"
+        },
+        "authn": {
           "$ref": "#/definitions/vaultCategory"
         },
         "esp": {

--- a/helm/hpcc/values.yaml
+++ b/helm/hpcc/values.yaml
@@ -205,7 +205,7 @@ certificates:
 ## The secrets section contains a set of categories, each of which contain a list of secrets.  The categories determine which
 ## components have access to the secrets.
 ## For each secret:
-##   name is the name that is is accessed by within the platform
+##   name is the name that it is accessed by within the platform
 ##   secret is the name of the secret that should be published
 secrets:
   #timeout: 300 # timeout period for cached secrets.  Should be similar to the k8s refresh period.
@@ -216,6 +216,9 @@ secrets:
     ## likely be restricted to esp (when it becomes the meta-data provider)
     ## For example, to set the secret associated with the azure storage account "mystorageaccount" use
     ##azure-mystorageaccount: storage-myazuresecret
+
+  authn: {}
+    ## Category to deploy LDAP and other credential secrets to container
 
   ecl: {}
     ## Category for secrets published to all components that run ecl
@@ -237,7 +240,7 @@ secrets:
 ## by system components and not exposed directly to ECL code.
 ##
 ## For each vault:
-##   name is the name that is is accessed by within the platform
+##   name is the name that it is accessed by within the platform
 ##   url is the url used to read a secret from the vault.
 ##   kind is the type of vault being accessed, or the protocol to use to access the secrets
 ##   client_secret a kubernetes level secret that contains the client_token used to retrive secrets.
@@ -245,6 +248,8 @@ secrets:
 
 vaults:
   storage:
+
+  authn:
 
   ecl:
 

--- a/system/security/LdapSecurity/ldapconnection.cpp
+++ b/system/security/LdapSecurity/ldapconnection.cpp
@@ -30,6 +30,7 @@
 #include "dautils.hpp"
 #include "dasds.hpp"
 #include "workunit.hpp"
+#include "jsecrets.hpp"
 
 #include <map>
 #include <string>
@@ -351,6 +352,66 @@ public:
 
         m_timeout = cfg->getPropInt(".//@ldapTimeoutSecs", LDAPTIMEOUT);
 
+        //------------------------------------------------
+        //Get LDAP Admin account username and password
+        // Can be specified as
+        //  - Kubernetes secret : lookup key value ldapAdminSecretKey
+        //  - Vault secret : lookup key value ldapAdminVaultId, ldapAdminSecretKey
+        //  - Hardcoded : systemCommonName, systemPassword
+        //------------------------------------------------
+
+        StringBuffer systemUserSecretKey;
+        cfg->getProp(".//@ldapAdminSecretKey", systemUserSecretKey);//vault/secrets LDAP username key
+        if (!systemUserSecretKey.isEmpty())
+        {
+            StringBuffer sb;
+            cfg->getProp(".//@systemCommonName", sb);
+            if (!sb.isEmpty())
+                WARNLOG("Please specify either LDAP systemCommonName or ldapAdminSecretKey in configuration");
+
+            StringBuffer vaultId;
+            cfg->getProp(".//@ldapAdminVaultId", vaultId);//optional HashiCorp vault ID
+
+            DBGLOG("Retrieving LDAP Admin username/password from secrets repo: %s %s", !vaultId.isEmpty() ? vaultId.str() : "", systemUserSecretKey.str());
+            Owned<IPropertyTree> secretTree;
+            if (!isEmptyString(vaultId.str()))
+                secretTree.setown(getVaultSecret("authn", vaultId, systemUserSecretKey.str(), nullptr));
+            else
+                secretTree.setown(getSecret("authn", systemUserSecretKey.str()));
+            if (!secretTree)
+                throw MakeStringException(-1, "Error retrieving LDAP Admin username/password");
+
+            getSecretKeyValue(m_sysuser_commonname, secretTree, "username");
+            getSecretKeyValue(m_sysuser_password, secretTree, "password");
+
+            if (m_sysuser_commonname.isEmpty() || m_sysuser_password.isEmpty())
+            {
+                throw MakeStringException(-1, "Error extracting LDAP Admin username/password");
+            }
+            m_sysuser.set(m_sysuser_commonname);
+        }
+        else
+        {
+            cfg->getProp(".//@systemCommonName", m_sysuser_commonname);
+            if (m_sysuser_commonname.isEmpty())
+                throw MakeStringException(-1, "systemCommonName is empty");
+
+            StringBuffer pwd;
+            cfg->getProp(".//@systemPassword", pwd);
+            if (pwd.isEmpty())
+                throw MakeStringException(-1, "systemPassword is empty");
+            decrypt(m_sysuser_password, pwd.str());//MD5 encrypted in config
+        }
+
+        StringBuffer sysBasedn;
+        cfg->getProp(".//@systemBasedn", sysBasedn);
+        if (sysBasedn.isEmpty())
+            throw MakeStringException(-1, "systemBasedn is empty");
+
+        //----------------------------------------------------
+        //Ensure at least one specified LDAP host is available
+        //----------------------------------------------------
+
         int rc = LDAP_OTHER;
         StringBuffer hostbuf, dcbuf;
         const char * ldapDomain = cfg->queryProp(".//@ldapDomain");
@@ -358,32 +419,14 @@ public:
         {
             getLdapHost(hostbuf);
             unsigned port = strieq("ldaps",m_protocol) ? m_ldap_secure_port : m_ldapport;
-            StringBuffer sysUserDN, decPwd;
 
-            {
-                StringBuffer pwd;
-                cfg->getProp(".//@systemPassword", pwd);
-                if (pwd.isEmpty())
-                    throw MakeStringException(-1, "systemPassword is empty");
-                decrypt(decPwd, pwd.str());
-
-                StringBuffer sysUserCN;
-                cfg->getProp(".//@systemCommonName", sysUserCN);
-                if (sysUserCN.isEmpty())
-                    throw MakeStringException(-1, "systemCommonName is empty");
-
-                StringBuffer sysBasedn;
-                cfg->getProp(".//@systemBasedn", sysBasedn);
-                if (sysBasedn.isEmpty())
-                    throw MakeStringException(-1, "systemBasedn is empty");
-
-                //Guesstimate system user baseDN based on config settings. It will be used if anonymous bind fails
-                sysUserDN.append("cn=").append(sysUserCN.str()).append(",").append(sysBasedn.str());
-            }
+            //Guesstimate system user baseDN based on config settings. It will be used if anonymous bind fails
+            StringBuffer sysUserDN;
+            sysUserDN.append("cn=").append(m_sysuser_commonname.str()).append(",").append(sysBasedn.str());
 
             for(int retries = 0; retries <= LDAPSEC_MAX_RETRIES; retries++)
             {
-                rc = LdapUtils::getServerInfo(hostbuf.str(), sysUserDN.str(), decPwd.str(), m_protocol, port, dcbuf, m_serverType, ldapDomain, m_timeout);
+                rc = LdapUtils::getServerInfo(hostbuf.str(), sysUserDN.str(), m_sysuser_password.str(), m_protocol, port, dcbuf, m_serverType, ldapDomain, m_timeout);
                 if(!LdapServerDown(rc) || retries >= LDAPSEC_MAX_RETRIES)
                     break;
                 sleep(LDAPSEC_RETRY_WAIT);
@@ -511,21 +554,12 @@ public:
         }
 
         m_sysuser_specified = true;
-        cfg->getProp(".//@systemUser", m_sysuser);
         if(m_sysuser.length() == 0)
         {
-            m_sysuser_specified = false;
+            cfg->getProp(".//@systemUser", m_sysuser);
+            if(m_sysuser.length() == 0)
+                m_sysuser_specified = false;
         }
-
-        cfg->getProp(".//@systemCommonName", m_sysuser_commonname);
-        if(m_sysuser_specified && (m_sysuser_commonname.length() == 0))
-        {
-            throw MakeStringException(-1, "SystemUser commonname is empty");
-        }
-
-        StringBuffer passbuf;
-        cfg->getProp(".//@systemPassword", passbuf);
-        decrypt(m_sysuser_password, passbuf.str());
 
         StringBuffer sysuser_basedn;
         cfg->getProp(".//@systemBasedn", sysuser_basedn);


### PR DESCRIPTION
Add support to externalize LDAP and other credentials as Kubernetes secrets
and Hashicorp vault secrets. Added "authn" category to secrets and vault, and
modified ECLWatch ldap.yaml to allow specification of secret name. Added README.md
markdown to document LDAP configuration using plain text yaml, k8s secrets, or
Hashicorp vault

Signed-off-by: Russ Whitehead <william.whitehead@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [x] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [x] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [x] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
