### PR TITLE
HPCC-26095 add 'pods:["all"]' for placements assignment

### DIFF
--- a/helm/hpcc/docs/placements.md
+++ b/helm/hpcc/docs/placements.md
@@ -19,6 +19,7 @@ The list item in "pods" can be one of the following:
 3) Pod, "Deployment" metadata name, which usually should be from the name of the array
    item of a type. For example, "eclwatch", "mydali", "thor-thoragent"..
 4) Job name regular expression:  For example "compile-" or "compile-.*" or exact match "^compile-.*$"
+5) set pod: ["all"] for all HPCC Systems components
 
 Supported configurations under each "placement"
 1) nodeSelector

--- a/helm/hpcc/templates/_helpers.tpl
+++ b/helm/hpcc/templates/_helpers.tpl
@@ -1097,7 +1097,7 @@ Pass in dict with root, job, target and type
 {{- $target := (printf "target:%s" .target | default "") -}}
 {{- $type := printf "type:%s" .type -}}
 {{- range $placement := .root.Values.placements -}}
-{{- if or (has $target $placement.pods) (has $type $placement.pods) -}}
+{{- if or (has $target $placement.pods) (has $type $placement.pods) (has "all" $placement.pods) -}}
 {{ include "hpcc.doPlacement" (dict "me" $placement) -}}
 {{- else -}}
 {{- range $jobPattern := $placement.pods -}}
@@ -1120,7 +1120,7 @@ Pass in dict with root, pod, target and type
 {{- $target := (printf "target:%s" .target | default "") -}}
 {{- $type := printf "type:%s" .type -}}
 {{- range $placement := .root.Values.placements -}}
-{{- if or (has $pod $placement.pods) (has $target $placement.pods) (has $type $placement.pods) -}}
+{{- if or (has $pod $placement.pods) (has $target $placement.pods) (has $type $placement.pods) (has "all"  $placement.pods) -}}
 {{ include "hpcc.doPlacement" (dict "me" $placement) -}}
 {{- end -}}
 {{- end -}}

--- a/helm/hpcc/templates/dfuserver.yaml
+++ b/helm/hpcc/templates/dfuserver.yaml
@@ -65,6 +65,7 @@ spec:
 {{ toYaml .annotations | indent 8 }}
 {{- end }}
     spec:
+      {{- include "hpcc.placementsByPodTargetType" (dict "root" $ "pod" .name "target" .name "type" "dfuserver") | indent 6 }}
       serviceAccountName: "hpcc-default"
       initContainers:
         {{- include "hpcc.checkDataMount" $commonCtx | indent 6 }}


### PR DESCRIPTION
This will apply the placement for all HPCC pods/jobs
Add placements support for dfuserver component

This is for application such as tombolo which as web application, database, HPCC and Kafka in the Kubernetes. And HPCC cluster will be assigned to the dedicated node pools.

Signed off by Xiaoming Wang <xiaoming.wang@lexisnexis.com>



## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [ ] I have read the CONTRIBUTORS document.
- [ ] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->
Tested on Azure:

with values.yaml
```code
placements:
- pods: ["all"]
   placement:
      nodeSelector:
          cluster: hpcc
```
node group aks-npone has label "cluster=hpcc"
kubectl get pods --output wide

```console
NAME                                          READY   STATUS    RESTARTS   AGE   IP            NODE                            NOMINATED NODE   READINESS GATES
dfuserver-7c79446c96-hdpx9                    1/1     Running   0          88s   10.244.2.23   aks-npone-40017693-vmss000000   <none>           <none>
eclqueries-7d8bc87c98-d7gsl                   1/1     Running   0          90s   10.244.3.15   aks-npone-40017693-vmss000001   <none>           <none>
eclscheduler-6ddb57f9c5-n29zv                 1/1     Running   0          90s   10.244.2.13   aks-npone-40017693-vmss000000   <none>           <none>
eclservices-68856f8fdd-rh2hx                  1/1     Running   0          89s   10.244.2.20   aks-npone-40017693-vmss000000   <none>           <none>
eclwatch-867647fb5-bz22w                      1/1     Running   0          90s   10.244.2.17   aks-npone-40017693-vmss000000   <none>           <none>
esdl-sandbox-787f6bcfb6-vz76l                 1/1     Running   0          90s   10.244.2.14   aks-npone-40017693-vmss000000   <none>           <none>
hthor-5d5f4ccf85-6kj9d                        1/1     Running   0          88s   10.244.2.15   aks-npone-40017693-vmss000000   <none>           <none>
mydali-67d94c4749-sdnq7                       2/2     Running   0          89s   10.244.3.20   aks-npone-40017693-vmss000001   <none>           <none>
myeclccserver-5cbf569c74-qtjmt                1/1     Running   0          89s   10.244.2.21   aks-npone-40017693-vmss000000   <none>           <none>
roxie-agent-1-85bf489984-j2kf9                1/1     Running   0          90s   10.244.2.19   aks-npone-40017693-vmss000000   <none>           <none>
roxie-agent-1-85bf489984-t4jw7                1/1     Running   0          90s   10.244.3.22   aks-npone-40017693-vmss000001   <none>           <none>
roxie-agent-2-7d89dfc85c-6wmpz                1/1     Running   0          90s   10.244.3.18   aks-npone-40017693-vmss000001   <none>           <none>
roxie-agent-2-7d89dfc85c-8ftcm                1/1     Running   0          90s   10.244.2.16   aks-npone-40017693-vmss000000   <none>           <none>
roxie-toposerver-7fd5f7964c-2l22x             1/1     Running   0          90s   10.244.3.13   aks-npone-40017693-vmss000001   <none>           <none>
roxie-workunit-55b4c96cff-ktf9w               1/1     Running   0          90s   10.244.3.21   aks-npone-40017693-vmss000001   <none>           <none>
sasha-dfurecovery-archiver-76c5cb64c4-7rz85   1/1     Running   0          90s   10.244.2.12   aks-npone-40017693-vmss000000   <none>           <none>
sasha-dfuwu-archiver-5998cd7476-z9kz9         1/1     Running   0          89s   10.244.2.22   aks-npone-40017693-vmss000000   <none>           <none>
sasha-file-expiry-6cf66dbc94-zxk9k            1/1     Running   0          89s   10.244.3.19   aks-npone-40017693-vmss000001   <none>           <none>
sasha-wu-archiver-6c646c464c-j95cd            1/1     Running   0          89s   10.244.3.16   aks-npone-40017693-vmss000001   <none>           <none>
sql2ecl-7b4599b977-2nxfx                      1/1     Running   0          90s   10.244.3.14   aks-npone-40017693-vmss000001   <none>           <none>
thor-eclagent-548f6ff4c4-68h4d                1/1     Running   0          88s   10.244.3.17   aks-npone-40017693-vmss000001   <none>           <none>
thor-thoragent-5d595d654f-lv4qn               1/1     Running   0          90s   10.244.2.18   aks-npone-40017693-vmss000000   <none>           <none>
```

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
