### PR TITLE
HPCC-25885 Add WsDali methods for setprotect, unprotect, and listprotect

### DIFF
--- a/dali/daliadmin/daadmin.cpp
+++ b/dali/daliadmin/daadmin.cpp
@@ -1103,27 +1103,29 @@ int dfsverify(const char *name,CDateTime *cutoff, IUserDescriptor *user)
 
 //=============================================================================
 
-void setprotect(const char *filename, const char *callerid, IUserDescriptor *user)
+void setprotect(const char *filename, const char *callerid, IUserDescriptor *user, StringBuffer &out)
 {
     Owned<IDistributedFile> file = queryDistributedFileDirectory().lookup(filename,user,false,false,false,nullptr,defaultPrivilegedUser);
     file->setProtect(callerid,true);
+    out.appendf("%s is protected", file->queryLogicalName());
 }
 
 //=============================================================================
 
-void unprotect(const char *filename, const char *callerid, IUserDescriptor *user)
+void unprotect(const char *filename, const char *callerid, IUserDescriptor *user, StringBuffer &out)
 {
     Owned<IDistributedFile> file = queryDistributedFileDirectory().lookup(filename,user,false,false,false,nullptr,defaultPrivilegedUser);
     file->setProtect((strcmp(callerid,"*")==0)?NULL:callerid,false);
+    out.appendf("%s is unprotected", file->queryLogicalName());
 }
 //=============================================================================
 
-void listprotect(const char *filename, const char *callerid)
+void listprotect(const char *filename, const char *callerid, StringBuffer &out)
 {
     Owned<IDFProtectedIterator> piter = queryDistributedFileDirectory().lookupProtectedFiles((strcmp(callerid,"*")==0)?NULL:callerid); 
     ForEach(*piter) {
         if (WildMatch(piter->queryFilename(),filename))
-            OUTLOG("%s,%s,%s", piter->isSuper()?"SuperFile":"File", piter->queryFilename(), piter->queryOwner());
+            out.appendf("%s,%s,%s", piter->isSuper()?"SuperFile":"File", piter->queryFilename(), piter->queryOwner());
     }
 }
 

--- a/dali/daliadmin/daadmin.hpp
+++ b/dali/daliadmin/daadmin.hpp
@@ -58,9 +58,9 @@ extern DALIADMIN_API void dfsparents(const char *lname, IUserDescriptor *user, S
 extern DALIADMIN_API void dfsunlink(const char *lname, IUserDescriptor *user);
 extern DALIADMIN_API int dfsverify(const char *name, CDateTime *cutoff, IUserDescriptor *user);
 extern DALIADMIN_API int dfsperm(const char *obj, IUserDescriptor *user);
-extern DALIADMIN_API void setprotect(const char *filename, const char *callerid, IUserDescriptor *user);
-extern DALIADMIN_API void unprotect(const char *filename, const char *callerid, IUserDescriptor *user);
-extern DALIADMIN_API void listprotect(const char *filename, const char *callerid);
+extern DALIADMIN_API void setprotect(const char *filename, const char *callerid, IUserDescriptor *user, StringBuffer &out);
+extern DALIADMIN_API void unprotect(const char *filename, const char *callerid, IUserDescriptor *user, StringBuffer &out);
+extern DALIADMIN_API void listprotect(const char *filename, const char *callerid, StringBuffer &out);
 extern DALIADMIN_API void checksuperfile(const char *lfn, bool fix);
 extern DALIADMIN_API void checksubfile(const char *lfn);
 extern DALIADMIN_API void listexpires(const char * lfnmask, IUserDescriptor *user);

--- a/dali/daliadmin/daliadmin.cpp
+++ b/dali/daliadmin/daliadmin.cpp
@@ -375,16 +375,18 @@ int main(int argc, const char* argv[])
                     }
                     else if (strieq(cmd,"setprotect")) {
                         CHECKPARAMS(2,2);
-                        setprotect(params.item(1),params.item(2),userDesc);
+                        setprotect(params.item(1),params.item(2),userDesc,out);
+                        PROGLOG("%s",out.str());
                     }
                     else if (strieq(cmd,"unprotect")) {
                         CHECKPARAMS(2,2);
-                        unprotect(params.item(1),params.item(2),userDesc);
+                        unprotect(params.item(1),params.item(2),userDesc,out);
+                        PROGLOG("%s",out.str());
                     }
                     else if (strieq(cmd,"listprotect")) {
                         CHECKPARAMS(0,2);
-                        listprotect((np>1)?params.item(1):"*",(np>2)?params.item(2):"*");
-
+                        listprotect((np>1)?params.item(1):"*",(np>2)?params.item(2):"*",out);
+                        PROGLOG("%s",out.str());
                     }
                     else if (strieq(cmd,"checksuperfile")) {
                         CHECKPARAMS(1,1);

--- a/esp/scm/ws_dali.ecm
+++ b/esp/scm/ws_dali.ecm
@@ -117,6 +117,24 @@ ESPrequest [nil_remove]  DFSExistsRequest
     string FileName;
 };
 
+ESPrequest [nil_remove] SetProtectedRequest
+{
+    string FileName;
+    string CallerId;
+};
+
+ESPrequest [nil_remove] SetUnprotectedRequest
+{
+    string FileName;
+    string CallerId;
+};
+
+ESPrequest [nil_remove] GetProtectedListRequest
+{
+    string FileName;
+    string CallerId;
+};
+
 ESPservice [auth_feature("NONE"), //This declares that the method logic handles feature level authorization
     version("1.04"), default_client_version("1.04"), exceptions_inline("./smc_xslt/exceptions.xslt")] WSDali
 {
@@ -135,6 +153,9 @@ ESPservice [auth_feature("NONE"), //This declares that the method logic handles 
     ESPmethod [min_ver("1.04")] DFSCheck(DFSCheckRequest, ResultResponse);
     ESPmethod [min_ver("1.04")] DFSLS(DFSLSRequest, ResultResponse);
     ESPmethod [min_ver("1.04")] DFSExists(DFSExistsRequest, BooleanResponse);
+    ESPmethod [min_ver("1.04")] SetProtected(SetProtectedRequest, ResultResponse);
+    ESPmethod [min_ver("1.04")] SetUnprotected(SetUnprotectedRequest, ResultResponse);
+    ESPmethod [min_ver("1.04")] GetProtectedList(GetProtectedListRequest, ResultResponse);
 };
 
 SCMexportdef(WSDali);

--- a/esp/services/ws_dali/ws_daliservice.cpp
+++ b/esp/services/ws_dali/ws_daliservice.cpp
@@ -460,3 +460,82 @@ bool CWSDaliEx::onDFSCheck(IEspContext& context, IEspDFSCheckRequest& req, IEspR
     }
     return true;
 }
+
+bool CWSDaliEx::onSetProtected(IEspContext& context, IEspSetProtectedRequest& req, IEspResultResponse& resp)
+{
+    try
+    {
+        checkAccess(context);
+                
+        const char* fileName = req.getFileName();
+        if (isEmptyString(fileName))
+            throw makeStringException(ECLWATCH_INVALID_INPUT, "File name not specified.");
+
+        const char* callerId = req.getCallerId();
+        if (isEmptyString(callerId))
+            throw makeStringException(ECLWATCH_INVALID_INPUT, "Caller Id not specified.");
+
+        Owned<IUserDescriptor> userDesc = createUserDesc(context);
+
+        StringBuffer result;
+        setprotect(fileName, callerId, userDesc, result);
+        resp.setResult(result);
+    }
+    catch(IException* e)
+    {
+        FORWARDEXCEPTION(context, e, ECLWATCH_INTERNAL_ERROR);
+    }
+    return true;
+}
+
+bool CWSDaliEx::onSetUnprotected(IEspContext& context, IEspSetUnprotectedRequest& req, IEspResultResponse& resp)
+{
+    try
+    {
+        checkAccess(context);
+
+        const char* fileName = req.getFileName();
+        if (isEmptyString(fileName))
+            throw makeStringException(ECLWATCH_INVALID_INPUT, "File name not specified.");
+
+        const char* callerId = req.getCallerId();
+        if (isEmptyString(callerId))
+            throw makeStringException(ECLWATCH_INVALID_INPUT, "Caller Id not specified.");
+
+        Owned<IUserDescriptor> userDesc = createUserDesc(context);
+
+        StringBuffer result;
+        unprotect(fileName, callerId, userDesc, result);
+        resp.setResult(result);
+    }
+    catch(IException* e)
+    {
+        FORWARDEXCEPTION(context, e, ECLWATCH_INTERNAL_ERROR);
+    }
+    return true;
+}
+
+bool CWSDaliEx::onGetProtectedList(IEspContext& context, IEspGetProtectedListRequest& req, IEspResultResponse& resp)
+{
+    try
+    {
+        checkAccess(context);
+
+        const char* fileName = req.getFileName();
+        if (isEmptyString(fileName))
+            throw makeStringException(ECLWATCH_INVALID_INPUT, "File name not specified.");
+
+        const char* callerId = req.getCallerId();
+        if (isEmptyString(callerId))
+            throw makeStringException(ECLWATCH_INVALID_INPUT, "Caller Id not specified.");
+
+        StringBuffer result;
+        listprotect(fileName, callerId, result);
+        resp.setResult(result);
+    }
+    catch(IException* e)
+    {
+        FORWARDEXCEPTION(context, e, ECLWATCH_INTERNAL_ERROR);
+    }
+    return true;
+}

--- a/esp/services/ws_dali/ws_daliservice.hpp
+++ b/esp/services/ws_dali/ws_daliservice.hpp
@@ -65,6 +65,9 @@ public:
     virtual bool onGetDFSMap(IEspContext& context, IEspGetDFSMapRequest& req, IEspResultResponse& resp) override;
     virtual bool onGetDFSParents(IEspContext& context, IEspGetDFSParentsRequest& req, IEspResultResponse& resp) override;
     virtual bool onDFSCheck(IEspContext& context, IEspDFSCheckRequest& req, IEspResultResponse& resp) override;
+    virtual bool onSetProtected(IEspContext& context, IEspSetProtectedRequest& req, IEspResultResponse& resp) override;
+    virtual bool onSetUnprotected(IEspContext& context, IEspSetUnprotectedRequest& req, IEspResultResponse& resp) override;
+    virtual bool onGetProtectedList(IEspContext& context, IEspGetProtectedListRequest& req, IEspResultResponse& resp) override;
 };
 
 class CWSDaliSoapBindingEx : public CWSDaliSoapBinding


### PR DESCRIPTION

Signed-off-by: Michael Gardner <michael.gardner@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [ ] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [x] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
