### PR TITLE
HPCC-26155 allow some placement elements appending

### DIFF
--- a/helm/hpcc/docs/placements.md
+++ b/helm/hpcc/docs/placements.md
@@ -5,11 +5,10 @@ through placement to include an array of objects to configure the Kubernetes Sch
 It must have a "pods" list which tells it which pod the settings will be applied to.<br/>
 The syntax is:
 ```code
-   global
-     placements:
-     - pods [list]
-       placement:
-         <supported configurations>
+   placements:
+   - pods: [list]
+     placement:
+       <supported configurations>
 ```
 The list item in "pods" can be one of the following:
 1) HPCC Systems component types in format: "type:<type name>". <type name> includes
@@ -23,12 +22,57 @@ The list item in "pods" can be one of the following:
 
 Supported configurations under each "placement"
 1) nodeSelector
+   Multiple nodeSelectors can be applied. For example
+   placements:
+   - pods: ["all"]
+     placement:
+       nodeSelector:
+         group: "hpcc"
+   - pods: ["type:dali"]
+     placement:
+       nodeSelector:
+         spot: "false"
+   All dali pods will have:
+     spec:
+       nodeSelector:
+         group: "hpcc"
+         spot: "false"
+   If duplicated keys are defined only the last one will prevail.
+
 2) taints/tolerations
+   Multiple taints/tolerations can be applied. For example
+   placements:
+   - pods: ["all"]
+     tolerations:
+     - key: "group"
+       operator: "Equal"
+       value: "hpcc"
+       effect: "NoSchedule"
+   - pods: ["type:thor"]
+     tolerations:
+     - key: "gpu"
+       operator: "Equal"
+       value: "true"
+       effect: "NoSchedule"
+   All thor pods will have:
+     tolerations:
+     - key: "group"
+       operator: "Equal"
+       value: "hpcc"
+       effect: "NoSchedule"
+     - key: "gpu"
+       operator: "Equal"
+       value: "true"
+       effect: "NoSchedule"
+
 3) affinity
    There is no schema check for the content of affinity. Reference
    https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
+   Only one "affinity" can be applied to a Pod/Job. If a Pod/Job matches multiple placement 'pods' lists, then only the last "affinity" definition will apply.
+
 4) schedulerName: profile names. "affinity" defined in scheduler profile  requires
    Kubernetes 1.20.0 beta and later releases
+   Only one "schedulerName" can be applied to a Pod/Job.
 
 "nodeSelector" example:
 ```code

--- a/helm/hpcc/templates/_helpers.tpl
+++ b/helm/hpcc/templates/_helpers.tpl
@@ -1061,11 +1061,30 @@ Pass in dict with root, category.  optional name to restrict it to a single name
 
 {{/*
 Create placement related settings
-Pass in dict with placement
+Pass in dict with me for current placements and dict with new for the new placements
+*/}}
+{{- define "hpcc.mergePlacementSetting" -}}
+{{- if .me.placement.nodeSelector }}
+{{- $_ := set .new "nodeSelector" (mergeOverwrite (.new.nodeSelector | default dict ) .me.placement.nodeSelector)  }}
+{{- end -}}
+{{- if .me.placement.tolerations }}
+{{- $_ := set .new "tolerations" (concat (.new.tolerations | default list ) .me.placement.tolerations)  }}
+{{- end -}}
+{{- if .me.placement.affinity }}
+{{- $_ := set .new "affinity" .me.placement.affinity  }}
+{{- end -}}
+{{- if .me.placement.schedulerName }}
+{{- $_ := set .new "schedulerName" .me.placement.schedulerName }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Add placement related settings
+Pass in dict with me, that contains all placements for this entity.
 */}}
 {{- define "hpcc.doPlacement" -}}
-{{- if .me.placement }}
-{{ toYaml .me.placement }}
+{{- if len .me }}
+{{ toYaml .me }}
 {{- end -}}
 {{- end -}}
 
@@ -1078,17 +1097,19 @@ Pass in dict with root, job, target and type
 {{- $job := .job -}}
 {{- $target := (printf "target:%s" .target | default "") -}}
 {{- $type := printf "type:%s" .type -}}
+{{- $placementsDict := dict -}}
 {{- range $placement := .root.Values.placements -}}
 {{- if or (has $target $placement.pods) (has $type $placement.pods) (has "all" $placement.pods) -}}
-{{ include "hpcc.doPlacement" (dict "me" $placement) -}}
+{{ include "hpcc.mergePlacementSetting" (dict "me" $placement "new" $placementsDict) -}}
 {{- else -}}
 {{- range $jobPattern := $placement.pods -}}
 {{- if mustRegexMatch $jobPattern $job -}}
-{{ include "hpcc.doPlacement" (dict "me" $placement) -}}
+{{ include "hpcc.mergePlacementSetting" (dict "me" $placement "new" $placementsDict) -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}
+{{ include "hpcc.doPlacement" (dict "me" $placementsDict) -}}
 {{- end -}}
 {{- end -}}
 
@@ -1101,11 +1122,13 @@ Pass in dict with root, pod, target and type
 {{- $pod := .pod -}}
 {{- $target := (printf "target:%s" .target | default "") -}}
 {{- $type := printf "type:%s" .type -}}
+{{- $placementsDict := dict  -}}
 {{- range $placement := .root.Values.placements -}}
 {{- if or (has $pod $placement.pods) (has $target $placement.pods) (has $type $placement.pods) (has "all"  $placement.pods) -}}
-{{ include "hpcc.doPlacement" (dict "me" $placement) -}}
+{{ include "hpcc.mergePlacementSetting" (dict "me" $placement "new" $placementsDict) -}}
 {{- end -}}
 {{- end -}}
+{{ include "hpcc.doPlacement" (dict "me" $placementsDict) -}}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
Both nodeSelector and tolerations entries can be appended to
existing settings. Reference helm/hpcc/docs/placemnets.md for
examples and detail information.

There is an example in test section

Signed off by xiaoming.wang@lexisnexis.com



## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [ ] I have read the CONTRIBUTORS document.
- [ ] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->
'Tested on Azure.
There are three node pools
1) master pool
   No hpcc pod will be scheduled to the master pool
2) node pool (name=npone)
   Most HPCC pods will be placed here except esp and roxie pods
3) node pool (name=nptwo)
   This is spot instance node pool which has taint:
   kubernetes.azure.com/scalesetpriority=spot:NoSchedule
   I add another taint for test: priority=spot:NoSchedule
   esp and roxie pods will be placed here.

```code
kubectl get nodes -o wide
NAME                               STATUS   ROLES   AGE    VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION     CONTAINER-RUNTIME
aks-masternp-40758588-vmss000000   Ready    agent   134m   v1.19.9   10.240.0.4    <none>        Ubuntu 18.04.5 LTS   5.4.0-1048-azure   containerd://1.4.4+azure
aks-masternp-40758588-vmss000001   Ready    agent   134m   v1.19.9   10.240.0.5    <none>        Ubuntu 18.04.5 LTS   5.4.0-1048-azure   containerd://1.4.4+azure
aks-npone-40758588-vmss000000      Ready    agent   131m   v1.19.9   10.240.0.6    <none>        Ubuntu 18.04.5 LTS   5.4.0-1048-azure   containerd://1.4.4+azure
aks-npone-40758588-vmss000001      Ready    agent   131m   v1.19.9   10.240.0.7    <none>        Ubuntu 18.04.5 LTS   5.4.0-1048-azure   containerd://1.4.4+azure
aks-nptwo-40758588-vmss000000      Ready    agent   128m   v1.19.9   10.240.0.8    <none>        Ubuntu 18.04.5 LTS   5.4.0-1048-azure   containerd://1.4.4+azure
aks-nptwo-40758588-vmss000001      Ready    agent   128m   v1.19.9   10.240.0.9    <none>        Ubuntu 18.04.5 LTS   5.4.0-1048-azure   containerd://1.4.4+azure

```

Here is a sample setting in values.yaml
placements:
  - pods: ["all"]
    placement:
      nodeSelector:
        hpcc: "true"
  - pods: ["type:roxie", "type:esp"]
    placement:
      nodeSelector:
        name: "nptwo"
      tolerations:
        - key: "priority"
          operator: "Equal"
          value:  "spot"
          effect: "NoSchedule"
  - pods: ["type:roxie", "type:esp"]
    placement:
      tolerations:
        - key: "kubernetes.azure.com/scalesetpriority"
          operator: "Equal"
          value:  "spot"
          effect: "NoSchedule"
The output for mydali pod:
    spec:
      nodeSelector:
        hpcc: "true"
The output for one of esp pod:
    spec:
      nodeSelector:
        hpcc: "true"
        name: nptwo
      tolerations:
      - effect: NoSchedule
        key: priority
        operator: Equal
        value: spot
      - effect: NoSchedule
        key: kubernetes.azure.com/scalesetpriority
        operator: Equal
        value: spot
     
```code
kubectl get pods -o wide
NAME                                         READY   STATUS    RESTARTS   AGE   IP            NODE                            NOMINATED NODE   READINESS GATES
dfuserver-d7c77df86-h4ss9                    1/1     Running   0          92m   10.244.3.14   aks-npone-40758588-vmss000001   <none>           <none>
eclqueries-6bdd7cd6f5-gx7z8                  1/1     Running   0          92m   10.244.5.4    aks-nptwo-40758588-vmss000000   <none>           <none>
eclscheduler-7547ff6d55-4kgrv                1/1     Running   0          92m   10.244.3.11   aks-npone-40758588-vmss000001   <none>           <none>
eclservices-67dd9499dc-7cnf2                 1/1     Running   0          92m   10.244.5.6    aks-nptwo-40758588-vmss000000   <none>           <none>
eclwatch-54cf9df86d-vh445                    1/1     Running   0          92m   10.244.4.5    aks-nptwo-40758588-vmss000001   <none>           <none>
esdl-sandbox-6ff668759-v8txf                 1/1     Running   0          92m   10.244.5.2    aks-nptwo-40758588-vmss000000   <none>           <none>
hthor-84c7659fd5-bv79m                       1/1     Running   0          92m   10.244.2.8    aks-npone-40758588-vmss000000   <none>           <none>
mydali-59c5bf5f4b-t65sb                      2/2     Running   0          92m   10.244.2.9    aks-npone-40758588-vmss000000   <none>           <none>
myeclccserver-85dbf4c98b-cjv4t               1/1     Running   0          92m   10.244.2.7    aks-npone-40758588-vmss000000   <none>           <none>
roxie-agent-1-7d999856c6-dmrvm               1/1     Running   0          92m   10.244.4.6    aks-nptwo-40758588-vmss000001   <none>           <none>
roxie-agent-1-7d999856c6-g5pw8               1/1     Running   0          92m   10.244.5.5    aks-nptwo-40758588-vmss000000   <none>           <none>
roxie-agent-2-65fbccd5dc-swfsv               1/1     Running   0          92m   10.244.4.3    aks-nptwo-40758588-vmss000001   <none>           <none>
roxie-agent-2-65fbccd5dc-z2dlr               1/1     Running   0          92m   10.244.5.3    aks-nptwo-40758588-vmss000000   <none>           <none>
roxie-toposerver-5fff4ccdb8-464p8            1/1     Running   0          92m   10.244.4.2    aks-nptwo-40758588-vmss000001   <none>           <none>
roxie-workunit-65dff4d78c-nv8np              1/1     Running   0          92m   10.244.3.16   aks-npone-40758588-vmss000001   <none>           <none>
sasha-dfurecovery-archiver-8dcf46f74-f6gm5   1/1     Running   0          92m   10.244.3.15   aks-npone-40758588-vmss000001   <none>           <none>
sasha-dfuwu-archiver-6f68b4647d-nbwct        1/1     Running   0          92m   10.244.2.11   aks-npone-40758588-vmss000000   <none>           <none>
sasha-file-expiry-774d48bdb-2qp5s            1/1     Running   0          92m   10.244.3.12   aks-npone-40758588-vmss000001   <none>           <none>
sasha-wu-archiver-5dbdc5699f-xkprm           1/1     Running   0          92m   10.244.3.13   aks-npone-40758588-vmss000001   <none>           <none>
sql2ecl-fbc5bbbf6-6jkt7                      1/1     Running   0          92m   10.244.4.4    aks-nptwo-40758588-vmss000001   <none>           <none>
thor-eclagent-65b9cdcfbd-9qvrj               1/1     Running   0          92m   10.244.2.10   aks-npone-40758588-vmss000000   <none>           <none>
thor-thoragent-7b4b8b4f7c-7spc4              1/1     Running   0          92m   10.244.3.10   aks-npone-40758588-vmss000001   <none>           <none>
```

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
