### PR TITLE
HPCC-26202 Certificate and MTLS related fixes

### DIFF
--- a/helm/hpcc/templates/_helpers.tpl
+++ b/helm/hpcc/templates/_helpers.tpl
@@ -138,7 +138,9 @@ Pass in root as .
 {{- $planes := ($storage.planes | default list) -}}
 {{- $certificates := (.Values.certificates | default dict) -}}
 {{- $issuers := ($certificates.issuers | default dict) -}}
-mtls: {{ and ($certificates.enabled) (hasKey $issuers "local") }}
+{{- $security := .Values.security | default dict -}}
+{{- $mtls := hasKey $security "mtls" | ternary $security.mtls true -}}
+mtls: {{ (and $mtls (and ($certificates.enabled) (hasKey $issuers "local"))) }}
 imageVersion: {{ .Values.global.image.version | default .Chart.Version }}
 singleNode: {{ .Values.global.singleNode | default false }}
 {{ if .Values.global.defaultEsp -}}
@@ -1126,26 +1128,28 @@ There are separate certificate issuers for local and public certificates
 by default public certificates are self-signed and local certificates are signed
 by our own certificate authority.  A CA certificate is also provided to the pod
 so that we can recognize the signature of our own CA.
+NB: if optional 'issuer' passed in use it, otherwise base on visibility and
+use "public" or "local" 
 */}}
 {{- define "hpcc.addCertificate" }}
 {{- if (.root.Values.certificates | default dict).enabled -}}
 {{- $externalCert := or (and (hasKey . "external") .external) (ne (include "hpcc.isVisibilityPublic" .) "") -}}
-{{- $issuer := ternary .root.Values.certificates.issuers.public .root.Values.certificates.issuers.local $externalCert -}}
+{{- $issuerName := .issuer | default (ternary "public" "local" $externalCert) -}}
+{{- $issuer := get .root.Values.certificates.issuers $issuerName -}}
 {{- if $issuer -}}
 {{- $namespace := .root.Release.Namespace -}}
 {{- $service := (.service | default dict) -}}
 {{- $domain := ( $service.domain | default $issuer.domain | default $namespace | default "default" ) -}}
-{{- $exposure := ternary "public" "local" $externalCert -}}
 {{- $name := .name }}
 
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: {{ .component }}-{{ $exposure }}-{{ $name }}-cert
+  name: {{ .component }}-{{ $issuerName }}-{{ $name }}-cert
   namespace: {{ $namespace }}
 spec:
   # Secret names are always required.
-  secretName: {{ .component }}-{{ $exposure }}-{{ $name }}-tls
+  secretName: {{ .component }}-{{ $issuerName }}-{{ $name }}-tls
   duration: 2160h # 90d
   renewBefore: 360h # 15d
   subject:
@@ -1168,7 +1172,7 @@ spec:
  {{- else if .service -}}
    {{- $public := and (hasKey .service "visibility") (not (eq .service.visibility "cluster")) -}}
    {{- if eq $public $externalCert }}
-  - {{ .service.name }}.{{ $domain }}
+  - {{ $name }}.{{ $domain }}
    {{- end }}
  {{- /* if services parameter is passed the component has an array of services to configure */ -}}
  {{- else if .services -}}
@@ -1245,46 +1249,50 @@ spec:
 
 {{/*
 Add a certficate volume mount for a component
+NB: if optional 'issuer' passed in use it, otherwise base on visibility and
+use "public" or "local" 
 */}}
 {{- define "hpcc.addCertificateVolumeMount" -}}
 {{- $externalCert := or (and (hasKey . "external") .external) (ne (include "hpcc.isVisibilityPublic" .) "") -}}
-{{- $exposure := ternary "public" "local" $externalCert }}
+{{- $issuerName := .issuer | default (ternary "public" "local" $externalCert) -}}
 {{- /*
     A .certificate parameter means the user explictly configured a certificate to use
     otherwise check if certificate generation is enabled
 */ -}}
 {{- if .certificate -}}
-- name: certificate-{{ .component }}-{{ $exposure }}-{{ .name }}
-  mountPath: /opt/HPCCSystems/secrets/certificates/{{ $exposure }}
+- name: certificate-{{ .component }}-{{ $issuerName }}-{{ .name }}
+  mountPath: /opt/HPCCSystems/secrets/certificates/{{ $issuerName }}
 {{- else if (.root.Values.certificates | default dict).enabled -}}
-{{- $issuer := ternary .root.Values.certificates.issuers.public .root.Values.certificates.issuers.local $externalCert -}}
+{{- $issuer := get .root.Values.certificates.issuers $issuerName -}}
 {{- if $issuer -}}
-- name: certificate-{{ .component }}-{{ $exposure }}-{{ .name }}
-  mountPath: /opt/HPCCSystems/secrets/certificates/{{ $exposure }}
+- name: certificate-{{ .component }}-{{ $issuerName }}-{{ .name }}
+  mountPath: /opt/HPCCSystems/secrets/certificates/{{ $issuerName }}
 {{- end }}
 {{- end -}}
 {{- end -}}
 
 {{/*
 Add a secret volume for a certificate
+NB: if optional 'issuer' passed in use it, otherwise base on visibility and
+use "public" or "local" 
 */}}
 {{- define "hpcc.addCertificateVolume" -}}
 {{- $externalCert := or (and (hasKey . "external") .external) (ne (include "hpcc.isVisibilityPublic" .) "") -}}
-{{- $exposure := ternary "public" "local" $externalCert -}}
+{{- $issuerName := .issuer | default (ternary "public" "local" $externalCert) -}}
 {{- /*
     A .certificate parameter means the user explictly configured a certificate to use
     otherwise check if certificate generation is enabled
 */ -}}
 {{- if .certificate -}}
-- name: certificate-{{ .component }}-{{ $exposure }}-{{ .name }}
+- name: certificate-{{ .component }}-{{ $issuerName }}-{{ .name }}
   secret:
     secretName: {{ .certificate }}
 {{- else if (.root.Values.certificates | default dict).enabled -}}
-{{- $issuer := ternary .root.Values.certificates.issuers.public .root.Values.certificates.issuers.local $externalCert -}}
+{{- $issuer := get .root.Values.certificates.issuers $issuerName -}}
 {{- if $issuer -}}
-- name: certificate-{{ .component }}-{{ $exposure }}-{{ .name }}
+- name: certificate-{{ .component }}-{{ $issuerName }}-{{ .name }}
   secret:
-    secretName: {{ .component }}-{{ $exposure }}-{{ .name }}-tls
+    secretName: {{ .component }}-{{ $issuerName }}-{{ .name }}-tls
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/helm/hpcc/templates/dali.yaml
+++ b/helm/hpcc/templates/dali.yaml
@@ -89,22 +89,23 @@ spec:
 {{ include "hpcc.addSecretVolumeMounts" (dict "root" $ "secretsCategories" $daliSecretsCategories) | indent 8 }}
 {{ include "hpcc.addCertificateVolumeMount" (dict "root" $ "name" .name "component" "dali" "external" false) | indent 8 }}
 {{- if not $sashaServices.disabled -}}
-{{- range $sashaName, $_sasha := $dali.services -}}
-{{- $sasha := ($_sasha | default dict) -}}
-{{- if not $sasha.disabled -}}
-{{- $_ := set $sasha "name" $sashaName -}}
-{{- $sashaAccess := splitList " " (include "hpcc.getSashaServiceAccess" $sasha) -}}
-{{- $sashaServiceSecretsCategories := append ((or (has "data" $sashaAccess) (has "dalidata" $sashaAccess)) | ternary (list "storage") list) "system" -}}
-{{- $_ := set $tmpDaliScope "aggregateSashaAccess" ((concat $tmpDaliScope.aggregateSashaAccess $sashaAccess) | uniq) -}}
-{{- $_ := set $tmpDaliScope "aggregateSashaSecretsCategories" ((concat $tmpDaliScope.aggregateSashaSecretsCategories $sashaServiceSecretsCategories) | uniq) -}}
-{{- with ($sasha | merge (dict "access" $sashaAccess)) -}}
-{{ include "hpcc.addSashaContainer" (dict "root" $ "me" . "dali" $dali) | indent 6 }}
+ {{- range $sashaName, $_sasha := $dali.services -}}
+  {{- $sasha := ($_sasha | default dict) -}}
+  {{- if not $sasha.disabled -}}
+   {{- $_ := set $sasha "name" $sashaName -}}
+   {{- $sashaAccess := splitList " " (include "hpcc.getSashaServiceAccess" $sasha) -}}
+   {{- $sashaServiceSecretsCategories := append ((or (has "data" $sashaAccess) (has "dalidata" $sashaAccess)) | ternary (list "storage") list) "system" -}}
+   {{- $_ := set $tmpDaliScope "aggregateSashaAccess" ((concat $tmpDaliScope.aggregateSashaAccess $sashaAccess) | uniq) -}}
+   {{- $_ := set $tmpDaliScope "aggregateSashaSecretsCategories" ((concat $tmpDaliScope.aggregateSashaSecretsCategories $sashaServiceSecretsCategories) | uniq) -}}
+   {{- with ($sasha | merge (dict "access" $sashaAccess)) -}}
+    {{- include "hpcc.addSashaContainer" (dict "root" $ "me" . "dali" $dali) | nindent 6 }}
         volumeMounts:
-{{- include "hpcc.addSashaVolumeMounts" (dict "root" $ "me" .) | indent 8 }}
-{{ include "hpcc.addSecretVolumeMounts" (dict "root" $ "secretsCategories" $sashaServiceSecretsCategories) | indent 8 }}
-{{- end }}
-{{- end }}
-{{- end }}
+    {{- include "hpcc.addSashaVolumeMounts" (dict "root" $ "me" .) | indent 8 }}
+    {{- include "hpcc.addSecretVolumeMounts" (dict "root" $ "secretsCategories" $sashaServiceSecretsCategories) | nindent 8 }}
+    {{- include "hpcc.addCertificateVolumeMount" (dict "root" $ "name" $dali.name "component" "dali" "external" false) | nindent 8 }}
+   {{- end }}
+  {{- end }}
+ {{- end }}
 {{- end }}
       volumes:
 {{ include "hpcc.addConfigMapVolume" $dali | indent 6 }}
@@ -177,7 +178,7 @@ spec:
     server: {{ .name | quote }}
   type: ClusterIP
 ---
-{{ include "hpcc.addCertificate" (dict "root" $ "name" .name "service" . "component" "dali" "external" false) }}
+{{ include "hpcc.addCertificate" (dict "root" $ "name" .name "service" .service "component" "dali" "external" false) }}
 
 {{- end }}
 {{- end }}

--- a/helm/hpcc/templates/dfuserver.yaml
+++ b/helm/hpcc/templates/dfuserver.yaml
@@ -88,12 +88,15 @@ spec:
         volumeMounts:
 {{- include "hpcc.addVolumeMounts" $commonCtx | indent 8 }}
 {{ include "hpcc.addConfigMapVolumeMount" . | indent 8 }}
+{{ include "hpcc.addCertificateVolumeMount" (dict "root" $ "name" .name "component" "dfuserver" "external" false) | indent 8 }}
       volumes:
 {{ include "hpcc.addConfigMapVolume" . | indent 6 }}
 {{- include "hpcc.addVolumes" $commonCtx | indent 6 }}
+{{ include "hpcc.addCertificateVolume" (dict "root" $ "name" .name "component" "dfuserver" "external" false) | indent 6 }}
 ---
 kind: ConfigMap
 {{ include "hpcc.generateConfig" ($commonCtx | merge (dict "configMapHelper" "hpcc.dfuServerConfigMap")) }}
 ---
+{{ include "hpcc.addCertificate" (dict "root" $ "name" .name "component" "dfuserver" "external" false) }}
 {{- end }}
 {{- end }}

--- a/helm/hpcc/templates/esp.yaml
+++ b/helm/hpcc/templates/esp.yaml
@@ -74,8 +74,12 @@ data:
 {{- $secretsCategories := ternary (list "storage" "esp" "codeSign" "codeVerify")  (list "storage" "esp") (eq $application "eclwatch") -}}
 {{- $includeStorageCategories := ternary (list "lz" "data") (list "data") (eq $application "eclwatch") -}}
 {{- $commonCtx := dict "root" $ "me" . "secretsCategories" $secretsCategories  "includeCategories" $includeStorageCategories "env" $env -}}
-{{- $configSHA := include "hpcc.getConfigSHA" ($commonCtx | merge (dict "configMapHelper" "hpcc.espConfigMap" "component" "esp" "excludeKeys" "global,esp.queues")) }}
-
+{{- $configSHA := include "hpcc.getConfigSHA" ($commonCtx | merge (dict "configMapHelper" "hpcc.espConfigMap" "component" "esp" "excludeKeys" "global,esp.queues")) -}}
+{{- if (ne (include "hpcc.isVisibilityPublic" (dict "root" $ "visibility" .service.visibility)) "") }}
+ {{- $_ := set $commonCtx "externalCert" true -}}
+{{- else -}}
+ {{- $_ := set $commonCtx "externalCert" false -}}
+{{- end -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -126,13 +130,19 @@ spec:
 {{ include "hpcc.addVolumeMounts" $commonCtx | indent 8 }}
 {{ include "hpcc.addDllVolumeMount" $commonCtx | indent 8 }}
 {{ include "hpcc.addSecretVolumeMounts" $commonCtx | indent 8 }}
-{{ include "hpcc.addCertificateVolumeMount" (dict "root" $ "component" $application "name" .name  "certificate" .certificate "visibility" .service.visibility) | indent 8 }}
+{{ include "hpcc.addCertificateVolumeMount" (dict "root" $ "component" $application "name" .name "certificate" .certificate "visibility" .service.visibility) | indent 8 }}
+{{- if $commonCtx.externalCert }}
+ {{- include "hpcc.addCertificateVolumeMount" (dict "root" $ "component" $application "name" .name "external" false) | nindent 8 }}
+{{- end }}
       volumes:
 {{ include "hpcc.addConfigMapVolume" . | indent 6 }}
 {{ include "hpcc.addVolumes" $commonCtx | indent 6 }}
 {{ include "hpcc.addDllVolume" $commonCtx | indent 6 }}
 {{ include "hpcc.addSecretVolumes" $commonCtx | indent 6 }}
 {{ include "hpcc.addCertificateVolume" (dict "root" $ "component" $application "name" .name "certificate" .certificate "visibility" .service.visibility) | indent 6 }}
+{{- if $commonCtx.externalCert }}
+ {{- include "hpcc.addCertificateVolume" (dict "root" $ "component" $application "name" .name "external" false) | nindent 6 }}
+{{- end }}
 ---
 kind: ConfigMap
 {{ include "hpcc.generateConfig" ($commonCtx | merge (dict "configMapHelper" "hpcc.espConfigMap")) }}
@@ -144,6 +154,9 @@ kind: ConfigMap
 {{- end }}
 {{- end }}
 
-{{ include "hpcc.addCertificate" (dict "root" $ "name" .name "service" . "component" $application "visibility" .service.visibility) }}
+{{ include "hpcc.addCertificate" (dict "root" $ "name" .name "service" .service "component" $application "visibility" .service.visibility) }}
+{{- if $commonCtx.externalCert }}
+ {{- include "hpcc.addCertificate" (dict "root" $ "name" .name "service" .service "component" $application "external" false) }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/helm/hpcc/templates/sasha.yaml
+++ b/helm/hpcc/templates/sasha.yaml
@@ -70,9 +70,11 @@ spec:
         volumeMounts:
 {{- include "hpcc.addSashaVolumeMounts" $commonCtx | indent 8 }}
 {{ include "hpcc.addSecretVolumeMounts" $commonCtx | indent 8 }}
+{{ include "hpcc.addCertificateVolumeMount" (dict "root" $ "name" $sashaName "component" "sasha" "external" false) | indent 8 }}
       volumes:
 {{- include "hpcc.addSashaVolumes" $commonCtx | indent 6 }}
 {{- include "hpcc.addSecretVolumes"  $commonCtx | indent 6 }}
+{{ include "hpcc.addCertificateVolume" (dict "root" $ "name" $sashaName "component" "sasha" "external" false) | indent 6 }}
 ---
 {{- if and (not $sasha.disabled) (hasKey $sasha "service") -}}
 {{- if $sasha.service.servicePort -}}
@@ -83,6 +85,7 @@ spec:
 kind: ConfigMap 
 {{ include "hpcc.generateConfig" ($commonCtx | merge (dict "configMapHelper" "hpcc.sashaConfigMap")) }}
 ---
+{{ include "hpcc.addCertificate" (dict "root" $ "name" $sashaName "component" "sasha" "external" false) }}
 {{- end }}
 {{- end }}
 {{- end -}}

--- a/helm/hpcc/templates/thor.yaml
+++ b/helm/hpcc/templates/thor.yaml
@@ -426,8 +426,8 @@ kind: ConfigMap
 {{- $_ := set $local "first" false }}
 ## thorworker and thormanager pods have unique names by workunit not by cluster. So we have to use a global certificate.
 ## create these only once
-{{ include "hpcc.addCertificate" (dict "root" $ "name" "thormanager-w" "component" "thormanager") }}
-{{ include "hpcc.addCertificate" (dict "root" $ "name" "thorworker-w" "component" "thorworker") }}
+{{ include "hpcc.addCertificate" (dict "root" $ "name" .name "component" "thormanager") }}
+{{ include "hpcc.addCertificate" (dict "root" $ "name" .name "component" "thorworker") }}
 {{- end }}
 
 {{- if $commonCtx.eclAgentUseChildProcesses }}

--- a/helm/hpcc/values.schema.json
+++ b/helm/hpcc/values.schema.json
@@ -316,6 +316,11 @@
     "security": {
       "type": "object",
       "properties": {
+        "mtls": {
+          "description": "enable global mtls between clients (except roxie which has own setting). NB: requires certificates.enabled=true",
+          "type": "boolean",
+          "default": true
+        },
         "eclSecurity": {
           "$ref": "#/definitions/eclSecurity"
         }

--- a/helm/hpcc/values.yaml
+++ b/helm/hpcc/values.yaml
@@ -183,7 +183,7 @@ storage:
 ## of this comment.  The default for the public issuer generates self signed certificates. The expectation is that this will be
 ## overridden by the configuration of an external certificate authority or vault in QA and production environments.
 ##
-## The default for the local (mTLS) issuer is designed to act as our own local certificate authority. We need only need to recognize
+## The default for the local (mTLS) issuer is designed to act as our own local certificate authority. We only need to recognize
 ## what a component is, and that it belongs to this cluster.
 ## But a kubernetes secret must be provided for the certificate authority key-pair.  The default name for the secret
 ## is "local-issuer-ca-key-pair". The secret is a standard kubernetes.io/tls secret and should provide data values for

--- a/system/security/securesocket/securesocket.cpp
+++ b/system/security/securesocket/securesocket.cpp
@@ -63,7 +63,6 @@
 
 static JSocketStatistics *SSTATS;
 
-Owned<ISecureSocketContext> server_securesocket_context;
 bool accept_selfsigned = false;
 
 #define CHK_NULL(x) if((x)==NULL) exit(1)
@@ -1824,9 +1823,7 @@ SECURESOCKET_API ISecureSocketContext* createSecureSocketContext(SecureSocketTyp
     }
     else
     {
-        if(server_securesocket_context.get() == NULL)
-            server_securesocket_context.setown(new securesocket::CSecureSocketContext(sockettype));
-        return server_securesocket_context.getLink();
+        return new securesocket::CSecureSocketContext(sockettype);
     }
 }
 
@@ -1839,9 +1836,7 @@ SECURESOCKET_API ISecureSocketContext* createSecureSocketContextEx(const char* c
     }
     else
     {
-        if(server_securesocket_context.get() == NULL)
-            server_securesocket_context.setown(new securesocket::CSecureSocketContext(certfile, privkeyfile, passphrase, sockettype));
-        return server_securesocket_context.getLink();
+        return new securesocket::CSecureSocketContext(certfile, privkeyfile, passphrase, sockettype);
     }
 }
 
@@ -1857,9 +1852,7 @@ SECURESOCKET_API ISecureSocketContext* createSecureSocketContextEx2(IPropertyTre
     }
     else
     {
-        if(server_securesocket_context.get() == NULL)
-            server_securesocket_context.setown(new securesocket::CSecureSocketContext(config, sockettype));
-        return server_securesocket_context.getLink();
+        return new securesocket::CSecureSocketContext(config, sockettype);
     }
 }       
 
@@ -1883,7 +1876,7 @@ SECURESOCKET_API ISecureSocketContext* createSecureSocketContextSecretSrv(const 
     if (info)
         return createSecureSocketContextEx2(info, ServerSocket);
     else
-        throw makeStringException(-101, "TLS secure communication requested but not configured");
+        throw makeStringException(-101, "TLS secure communication requested but not configured (2)");
 }
 
 SECURESOCKET_API ICertificate *createCertificate()


### PR DESCRIPTION
+ Fix a couple of regressions that stem from helm "service" changes,
where the certificate calls need to be passed the service to
use for its name.
+ Missing certificate generation in dfuserver and sasha components
+ Add a mtls option to disabled mtls (default true), so can
enable cetificates, without enabling mtls.
+ Remove global cached ISecureSocketContext server context, which
doesn't make sense if the component is creating multiple contexts.
e.g. in case of esp it creates a context with 1 config for MP,
and another context for public secure esp connections.
The single module global cache instance was not useful anyway,
the creators typically create once or cache themselves.
+ Provide means for a specific issuer to be used with
the addCertificate* calls (this will be used for a signing issuer)

Signed-off-by: Jake Smith <jake.smith@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
