### PR TITLE
HPCC-26292 New ESDL script configuration parsing

### DIFF
--- a/esp/bindings/SOAP/xpp/fxpp/FragmentedXmlAssistant.cpp
+++ b/esp/bindings/SOAP/xpp/fxpp/FragmentedXmlAssistant.cpp
@@ -1,0 +1,374 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2021 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include <cstring>
+#include "fxpp/FragmentedXmlAssistant.hpp"
+#include "jmutex.hpp"
+#include "jstring.hpp"
+
+using namespace xpp;
+
+namespace fxpp
+{
+
+namespace fxa
+{
+
+/**
+ * IAssistant implementation supporting the registration of elements that may represent either
+ * external or embedded fragments.
+ * 
+ * For embedded fragments, the assistant recognizes which elements may contain embedded fragment
+ * data, which of those do contain embedded fragment data, and creates the fragment representing
+ * the embedded fragment data.
+ *
+ * For external fragments, the assistat recognizes which elements may contain external fragment
+ * references. For elements that may contain references, it relies upon a separate detector to
+ * determine if they do, in fact, contain an external reference. For elements that do contain
+ * external references, it relies on a separate loader to resolve the detected key(s) into a
+ * fragment with the requested data.
+ */
+class CAssistant : public CInterfaceOf<IAssistant>
+{
+private:
+    class CInjector : public CInterfaceOf<IExternalContentInjector>
+    {
+    public:
+        virtual bool injectContent(const char* content, int contentLength) override
+        {
+            if (!m_injector)
+                return false;
+            m_injector->injectFragment(m_uid, content, contentLength, m_rules);
+            return true;
+        }
+
+    protected:
+        Linked<IFragmentInjector> m_injector;
+        StringAttr                m_uid;
+        XmlFragmentRules          m_rules;
+
+    public:
+        CInjector(IFragmentInjector& injector, const char* uid, XmlFragmentRules rules)
+            : m_injector(&injector)
+            , m_uid(uid)
+            , m_rules(rules)
+        {
+        }
+    };
+
+protected:
+    struct Registration
+    {
+        bool isExternal = false;
+        XmlFragmentRules externalRules = 0;
+        Linked<const IExternalDetector> externalDetector;
+        bool isEmbedded = false;
+        XmlFragmentRules embeddedRules = 0;
+    };
+    using NameRegistrations = std::map<std::string, Registration>;
+    using UriRegistrations = std::map<std::string, NameRegistrations>;
+
+public:
+    virtual bool resolveExternalFragment(const StartTag& stag, IFragmentInjector& injector) const override
+    {
+        ReadLockBlock block(m_rwLock);
+        const Registration* registration = lookup(stag);
+
+        if (!registration || !registration->isExternal)
+            return false;
+        Owned<IExternalDetection> detected;
+        if (registration->externalDetector)
+            detected.setown(registration->externalDetector->detectExternalReference(stag));
+        else if (m_defaultDetector)
+            detected.setown(m_defaultDetector->detectExternalReference(stag));
+        else
+            throw XmlPullParserException("missing external fragment detector");
+        if (!detected)
+            return false;
+        if (!m_loader)
+            throw XmlPullParserException("missing external fragment loader");
+        CInjector loadInjector(injector, detected->queryUID(), registration->externalRules);
+        if (!m_loader->loadAndInject(*detected, loadInjector))
+            throw XmlPullParserException(VStringBuffer("external fragment load of '%s' failed", detected->queryUID()).str());
+        return true;
+    }
+
+    virtual bool resolveEmbeddedFragment(const StartTag& stag, const char* content, IFragmentInjector& injector) const override
+    {
+        if (!mayBeXml(content))
+            return false;
+        size_t contentLength = strlen(content);
+        if (contentLength > INT_MAX)
+            throw XmlPullParserException("invalid embedded fragment content length");
+
+        ReadLockBlock block(m_rwLock);
+        const Registration* registration = lookup(stag);
+
+        if (!registration || !registration->isEmbedded)
+            return false;
+        injector.injectFragment(nullptr, content, contentLength, registration->embeddedRules);
+        return true;
+    }
+
+    virtual void setExternalDetector(const IExternalDetector* detector) override
+    {
+        WriteLockBlock block(m_rwLock);
+        m_defaultDetector.setown(detector);
+    }
+
+    virtual void setExternalLoader(const IExternalContentLoader* loader) override
+    {
+        WriteLockBlock block(m_rwLock);
+        m_loader.setown(loader);
+    }
+
+    virtual void registerExternalFragment(const char* nsUri,
+                                          const char* name,
+                                          XmlFragmentRules rules) override
+    {
+        if (!nsUri || isEmptyString(name))
+            throw XmlPullParserException("invalid external fragment registration");
+
+        WriteLockBlock block(m_rwLock);
+        Registration& registration = m_uriRegistrations[nsUri][name];
+        registration.isExternal = true;
+        registration.externalRules = rules;
+        registration.externalDetector.clear();
+    }
+
+    virtual void registerExternalFragment(const char* nsUri,
+                                          const char* name,
+                                          XmlFragmentRules rules,
+                                          const IExternalDetector& detector) override
+    {
+        if (!nsUri || isEmptyString(name))
+            throw XmlPullParserException("invalid external fragment registration");
+
+        WriteLockBlock block(m_rwLock);
+        Registration& registration = m_uriRegistrations[nsUri][name];
+        registration.isExternal = true;
+        registration.externalRules = rules;
+        registration.externalDetector.set(&detector);
+    }
+
+    virtual void registerEmbeddedFragment(const char* nsUri,
+                                          const char* name,
+                                          XmlFragmentRules rules) override
+    {
+        if (!nsUri || isEmptyString(name))
+            throw XmlPullParserException("invalid embedded fragment registration");
+
+        WriteLockBlock block(m_rwLock);
+        Registration& registration = m_uriRegistrations[nsUri][name];
+        registration.isEmbedded = true;
+        registration.embeddedRules = rules;
+    }
+
+protected:
+    UriRegistrations m_uriRegistrations;
+    mutable ReadWriteLock m_rwLock;
+    Owned<const IExternalDetector> m_defaultDetector;
+    Owned<const IExternalContentLoader> m_loader;
+
+protected:
+    virtual const Registration* lookup(const StartTag& stag) const
+    {
+        const char* uri = stag.getUri();
+        UriRegistrations::const_iterator uriIt = m_uriRegistrations.find(uri ? uri : "");
+        if (uriIt != m_uriRegistrations.end())
+        {
+            NameRegistrations::const_iterator nameIt = uriIt->second.find(stag.getLocalName());
+            if (nameIt != uriIt->second.end())
+                return &nameIt->second;
+        }
+        return nullptr;
+    }
+
+    virtual bool mayBeXml(const char* content) const
+    {
+        if (!content)
+            return false;
+
+        while (isspace(*content))
+            content++;
+        return ('<' == *content);
+    }
+};
+
+/**
+ * Implementation of `CFragmentedXmlAssistant::IExternalDetector` that relies upon up to three
+ * attribute values to identify an external fragment. External fragments may be located by path
+ * or resource name. The detector refers to one attribute for path values, a second for resource
+ * names, and a third as a secondary key to match a portion of a broader fragment.
+ * 
+ * Fragments must be located by either the path or resource name attribute. If neither is present,
+ * it is assumed that the element does not specify an external fragment. It is an error for both
+ * to be present.
+ *
+ * It is expected that some resources or files will allow a subset of a larger fragment to be
+ * matched. The detector can recognize a secondary key value to be used by an external loader.
+ *
+ * The default resource key attribute is `resource`. The default path key attribute is `path`.
+ * The default secondary key attribute is `match`. All defaults may be independenty replaced to
+ * satisfy markup syntax requirements.
+ */
+class CExternalFragmentDetector : public CInterfaceOf<IExternalDetector>
+{
+protected:
+    /**
+     * Implementation of `CFragmentedXmlAssistant::IExternalDetection` that represents the
+     * identification of a requested external fragment. It holds the identifying information
+     * so that it may be passed on to an external loader to be resolved.
+     */
+    class Detection : public CInterfaceOf<IExternalDetection>
+    {
+    public:
+        virtual int         queryDetectedType() const override
+        {
+            return m_detectedType;
+        }
+        virtual const char* queryContentLocation() const override
+        {
+            return m_location;
+        }
+
+        virtual const char* queryContentLocationSubset() const override
+        {
+            return m_subset;
+        }
+
+        virtual const char* queryUID() const override
+        {
+            return m_uid;
+        }
+
+    protected:
+        int          m_detectedType = ExternalDetectionType::Unknown;
+        StringAttr   m_location;
+        StringAttr   m_subset;
+        StringBuffer m_uid;
+
+    public:
+        Detection(int detectedType, const char* location, const char* subset)
+            : m_detectedType(detectedType)
+            , m_location(location)
+            , m_subset(subset)
+        {
+            m_uid.appendf("%d.%s.%s", detectedType, (location ? location : ""), (subset ? subset : ""));
+        }
+    };
+
+public:
+    virtual Detection* detectExternalReference(const StartTag& stag) const override
+    {
+        const char* location = nullptr;
+        const char* subset = nullptr;
+        int         type = ExternalDetectionType::Unknown;
+        for (const Keys::value_type& lvt : m_keys)
+        {
+            const char* tmpLocation = stag.getValue(lvt.first.c_str());
+            if (!tmpLocation)
+                continue;
+
+            const char* matchedSubset = nullptr;
+            int         matchedType = ExternalDetectionType::Unknown;
+            int         defaultType = ExternalDetectionType::Unknown;
+            for (const std::map<std::string, int>::value_type& svt : lvt.second)
+            {
+                if (svt.first.empty())
+                {
+                    defaultType = svt.second;
+                }
+                else
+                {
+                    const char* tmpSubset = stag.getValue(svt.first.c_str());
+                    if (!tmpSubset)
+                        continue;
+                    if (matchedSubset)
+                        throw XmlPullParserException("invalid markup - ambigous external fragment reference");
+                    matchedSubset = tmpSubset;
+                    matchedType = svt.second;
+                }
+            }
+
+            if ((ExternalDetectionType::Unknown == matchedType) && (ExternalDetectionType::Unknown == defaultType))
+                continue;
+            if (location)
+                throw XmlPullParserException("invalid markup - ambiguous external fragment reference");
+            location = tmpLocation;
+            if (matchedType != ExternalDetectionType::Unknown)
+            {
+                subset = matchedSubset;
+                type = matchedType;
+            }
+            else
+            {
+                subset = nullptr;
+                type = defaultType;
+            }
+        }
+        if (isEmptyString(location))
+            return nullptr;
+        return new Detection(type, location, subset);
+    }
+
+protected:
+    using Keys = std::map<std::string, std::map<std::string, int> >;
+    Keys m_keys;
+
+public:
+    CExternalFragmentDetector(const std::initializer_list<DetectionKey>& keys)
+    {
+        static const std::initializer_list<DetectionKey> defaultKeys({
+            { "resource", "", ExternalDetectionType::Resource },
+            { "resource", "match", ExternalDetectionType::Resource },
+            { "path", "", ExternalDetectionType::Path },
+            { "path", "match", ExternalDetectionType::Path },
+        });
+
+        initializeKeys(keys.size() ? keys : defaultKeys);
+    }
+
+private:
+    void initializeKeys(const std::initializer_list<DetectionKey>& keys)
+    {
+        for (const DetectionKey& k : keys)
+        {
+            if (isEmptyString(k.location) || (ExternalDetectionType::Unknown == k.type))
+                throw XmlPullParserException("invalid fragment detection key");
+            std::map<std::string, int>& subsets = m_keys[k.location];
+            int& type = subsets[k.subset ? k.subset : ""];
+            if (type != ExternalDetectionType::Unknown)
+                throw XmlPullParserException("duplicate detector key");
+            type = k.type;
+        }
+    }
+};
+
+IAssistant* createAssistant()
+{
+    return new CAssistant();
+}
+
+IExternalDetector* createExternalDetector(const std::initializer_list<DetectionKey>& keys)
+{
+    return new CExternalFragmentDetector(keys);
+}
+
+} // namespace fxa
+
+} // namespace fxpp

--- a/esp/bindings/SOAP/xpp/fxpp/FragmentedXmlAssistant.hpp
+++ b/esp/bindings/SOAP/xpp/fxpp/FragmentedXmlAssistant.hpp
@@ -1,0 +1,175 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2021 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef FXPP_FRAGMENTED_XML_ASSISTANT_H
+#define FXPP_FRAGMENTED_XML_ASSISTANT_H
+
+#include "fxpp/FragmentedXmlPullParser.hpp"
+
+namespace fxpp
+{
+
+namespace fxa
+{
+/**
+ * The `fxpp::fxa` namespace represents one possible implementation of `IFragmentedXmlAssistant`.
+ * All declared interfaces may be reused by alternate implementations if such reuse makes sense,
+ * but this is not required.
+ *
+ * To support the detection of embedded fragment content, one or more calls to
+ * `IAssistant::registerEmbeddedFragment` must be made prior to parsing markup. Each call
+ * designates an additional element URI and name combination that is allowed to contain embedded
+ * content.
+ *
+ * To support the detection of external fragment references, one or more calls to
+ * `IAssistant::registerExternalFragment` must be combined with calls to
+ * `IAssistant::setExternalDetector` and `IAssistant::setExternalLoader`. The assistant knows when
+ * to look for an external reference but delegates locating references to the registered
+ * `IExternalDetector` instance and loading referenced content to the registered
+ * `IExternalContentLoader` instance. `IExternalDetection` is used to report the detector's
+ * findings to the loader. `IExternalContentInjector` is used by the assistant to accept content
+ * from the loader.
+ */
+
+/**
+ * Abstraction representing the "identity" of an external fragment. The identity of a fragment is
+ * the information located by a detector that can be used by a loader to get the fragment data. It
+ * is assumed that a fragment may be uniquely identified by at least one key and at most two keys.
+ * The first, or location, may be a file path or resource bundle identifier. The second, if used,
+ * may be an XPath referring to a nodeset within a broader XML document or some other identifier
+ * used to refine the data identified by the primary key.
+ */
+interface IExternalDetection : extends IInterface
+{
+    virtual int         queryDetectedType() const = 0;
+    virtual const char* queryContentLocation() const = 0;
+    virtual const char* queryContentLocationSubset() const = 0;
+    virtual const char* queryUID() const = 0;
+
+    inline bool matchesType(int type) const { return queryDetectedType() == type; }
+};
+
+/**
+ * A collection of some well known external reference detection types. This collection may not be
+ * comprehensive. It gives names to values with meaning to the implementation and may be extended
+ * to include other values, but such extension is not required.
+ *
+ * - Unknown:  A value has not been assigned. Registered detection keys must not use this value.
+ * - Resource: The location value identifies a resource bundle's resource. The subset value is
+ *             not currently significant.
+ * - Path:     The location value identifies the file system path of an XML file. The subset value
+ *             is not currently significant.
+ */
+enum ExternalDetectionType
+{
+    Unknown,
+    Resource,
+    Path,
+};
+
+/**
+ * Abstraction describing a delegate responsible for locating external fragment reference values
+ * within parser start tag structures.
+ */
+interface IExternalDetector : extends IInterface
+{
+    virtual IExternalDetection* detectExternalReference(const StartTag& stag) const = 0;
+};
+
+/**
+ * Abstraction describing a helper responsible for accepting fragment content from an
+ * `IExternalContentLoader` instance. An assistant will provide an instance of this interface to
+ * a loader instance as the only means of propagating loaded content back to the parser.
+ */
+interface IExternalContentInjector : extends IInterface
+{
+    virtual bool injectContent(const char* content, int contentLength) = 0;
+};
+
+/**
+ * Abstraction describing a delegate responsible for loading detected content for an assistant.
+ * It is separate from the assistant to support alternate sources; a unit test might access in-
+ * memory data while other use cases might load files or perform resource bundle lookups.
+ */
+interface IExternalContentLoader : extends IInterface
+{
+    virtual bool loadAndInject(const IExternalDetection& detected, IExternalContentInjector& injector) const = 0;
+};
+
+/**
+ * Extension of the `IFragmentedXmlAssistant` interface adding awareness of the delegate
+ * interfaces and supported markup knowledge.
+ *
+ * `registerEmbeddedFragment` is the only required method to support embedded fragments.
+ *
+ * `setExternalLoader` and `registerExternalFragment` are required to support external fragment
+ * references. `setExternalDetector` is also required if any registered fragments do not register
+ * an element-specific detector. 
+ */
+interface IAssistant : extends IFragmentedXmlAssistant
+{
+    virtual void setExternalDetector(const IExternalDetector* detector) = 0;
+    virtual void setExternalLoader(const IExternalContentLoader* loader) = 0;
+    virtual void registerExternalFragment(const char* nsUri, const char* name, XmlFragmentRules rules) = 0;
+    virtual void registerExternalFragment(const char* nsUri, const char* name, XmlFragmentRules rules, const IExternalDetector& detector) = 0;
+    virtual void registerEmbeddedFragment(const char* nsUri, const char* name, XmlFragmentRules rules) = 0;
+};
+
+/**
+ * Definition of a single rule used by an external detector to locate external fragment references.
+ * A collection of these may be provided to `createExternalDetector` to initialize the default
+ * detector with alternate rules.
+ */
+struct DetectionKey
+{
+    const char* location = nullptr;
+    const char* subset = nullptr;
+    int         type = ExternalDetectionType::Unknown;
+
+    DetectionKey(const char* _location, const char* _subset, int _type) : location(_location), subset(_subset), type(_type) {}
+};
+
+/**
+ * Create an instance of the default `IAssistant` implementation.
+ */
+extern IAssistant* createAssistant();
+
+/**
+ * Create an instance of the default `IExternalDetector` implementation. The detection keys soecify
+ * all markup-specific detection rules used by the instance. Default rules are not merged with these
+ * keys.
+ */
+extern IExternalDetector* createExternalDetector(const std::initializer_list<DetectionKey>& keys);
+
+/**
+ * Create an instance of the default `IExternalDetector` implementation. The absence of detection
+ * keys implies a default configuration will be used. The default configuration is:
+ *
+ * | Location | Subset | Type |
+ * | :-: | :-: | :- |
+ * | resource | | ExternalDetectionType::Resource |
+ * | resource | match | ExternalDetectionType::Resource |
+ * | path | | ExternalDetectionType::Path |
+ * | path | match | ExternalDetectionType::Path |
+ */
+inline IExternalDetector* createExternalDetector() { return createExternalDetector({}); }
+
+} // namespace fxa
+
+} // namespace fxpp
+
+#endif // FXPP_FRAGMENTED_XML_ASSISTANT_H

--- a/esp/bindings/SOAP/xpp/fxpp/FragmentedXmlPullParser.cpp
+++ b/esp/bindings/SOAP/xpp/fxpp/FragmentedXmlPullParser.cpp
@@ -1,0 +1,819 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2021 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include <cstring>
+#include "fxpp/FragmentedXmlPullParser.hpp"
+#include <list>
+#include <map>
+#include <memory>
+#include <set>
+#include <vector>
+
+using namespace xpp;
+
+namespace fxpp
+{
+
+/**
+ * Named type for internal parser rules related to fragment injection. Internal rules do not
+ * use bits that overlap potential external rules, to allow an internal combination of both.
+ */
+using XmlInternalFragmentRules = uint16_t;
+
+/**
+ * Instruct the parser to require a non-empty unique identifier for a fragment. The identifier is
+ * used to detect circular references between fragments which means that the same identifier must
+ * be generated for each fragment.
+ *
+ * Identifiers are required for all fragments with the exception of the initial parser input and
+ * embedded fragments. In both of these cases, the fragment content cannot close a loop and content
+ * leading to a loop will be detected when an external fragment is applied.
+ */
+static const XmlInternalFragmentRules FXPP_REQUIRE_FRAGMENT_UID     = 0x0100;
+
+/**
+ * Instruct the parser to enforce the injection restriction requiring an in-progress element.
+ * Fragments set as parser input and requested from an assistant do not not require this check.
+ */
+static const XmlInternalFragmentRules FXPP_REQUIRE_CURRENT_ELEMENT  = 0x0200;
+
+/**
+ * `IFagmentedXmlPullParser` implementation that uses a stack of `XmlPullParser` instances to
+ * support parsing fragments within fragments. To a great extent, it is a wrapper of
+ * `XmlPullParser`, and what works with the original parser should work with this class with no
+ * required changes. There are exceptions:
+ * 
+ * - Mixed content, the ability for an element to contain both text and child element content, is
+ *   explicitly not supported. Attempting to enable this mode will result in an exception.
+ * - Whitespace content events are ignored by default.
+ */
+class CFragmentedXmlPullParser : public IFragmentedXmlPullParser
+{
+protected:
+    struct DataFrame : public CInterface
+    {
+        enum State
+        {
+            New,
+            Pulled,
+            TypeReported,
+            DataReported,
+            FrameIgnored,
+        };
+        int eventType = 0;
+        State state = New;
+        StartTag stag;
+        const char* content = nullptr;
+        bool ignorable = false;
+        EndTag etag;
+    };
+
+    using DataFrames = std::list<Owned<DataFrame> >;
+
+    struct FragmentFrame : extends CInterface
+    {
+        DataFrames                      pendingData;
+        std::shared_ptr<IXmlPullParser> xpp;
+        StringBuffer                    uid;
+        XmlFragmentRules                rules;
+
+        FragmentFrame(std::shared_ptr<IXmlPullParser>& _xpp, const char* _uid, XmlFragmentRules _rules) : xpp(_xpp), uid(_uid), rules(_rules) {}
+        FragmentFrame() : rules(0) {}
+    };
+
+    using FragmentStack = std::list<Owned<FragmentFrame> >;
+    using ParserArchive = std::list<std::shared_ptr<IXmlPullParser> >;
+
+private:
+    /**
+     * Implementation of `IFragmentInjector` for internal use by the parser. The parser passes an
+     * instance to its assistant when requesting injected fragments. It creates at most one
+     * fragment without injecting it; injection is left to the parser.
+     */
+    class CInjector : public CInterfaceOf<IFragmentInjector>
+    {
+    public:
+        virtual void injectFragment(const char* uid, const char* content, int contentLength, XmlFragmentRules rules) override
+        {
+            if (m_frame)
+                throw XmlPullParserException("at most one injection permitted per resolution request");
+            int plen = 0, slen = 0;
+            m_frame.setown(m_parser.spawnFragment(uid, nullptr, plen, content, contentLength, nullptr, slen, m_rules | rules));
+        }
+
+        CFragmentedXmlPullParser& m_parser;
+        Owned<FragmentFrame>      m_frame;
+        XmlInternalFragmentRules  m_rules;
+
+        CInjector(CFragmentedXmlPullParser& parser)
+            : m_parser(parser)
+        {
+        }
+
+        CInjector& withInternalRules(XmlInternalFragmentRules rules)
+        {
+            m_rules = rules & 0xFF00;
+            return *this;
+        }
+    };
+
+public:
+    virtual void setInput(const char* content, int contentLength) override
+    {
+        setInput(nullptr, 0, content, contentLength, nullptr, 0);
+    }
+
+    virtual void setInput(const char* prefix, int prefixLength, const char* body, int bodyLength, const char* suffix, int suffixLength) override
+    {
+        m_activeFragments.clear();
+        m_parsers.clear();
+        m_activeElements.clear();
+        m_deferred.clear();
+        (void)createAndUseFragment(nullptr, prefix, prefixLength, body, bodyLength, suffix, suffixLength, 0);
+    }
+
+    virtual int next() override
+    {
+        if (m_deferred)
+        {
+            pushFragment(m_deferred.getClear());
+        }
+
+        while (true)
+        {
+            FragmentFrame& fragmentRef = fragmentFrameRef();
+            DataFrame* df = nextDataFrame();
+            switch (df->eventType)
+            {
+            case START_TAG:
+                if (streq(df->stag.getLocalName(), reserved::SYNTHESIZED_ROOT))
+                {
+                    pushActiveElement(df, DataFrame::FrameIgnored);
+                    continue;
+                }
+                if (m_assistant)
+                {
+                    XmlInternalFragmentRules internalRules = 0;
+                    uint8_t laIndex = 0;
+                    bool    isEmbedded = false;
+                    DataFrame* la = nullptr;
+                    CInjector injector(*this);
+                    if (m_assistant->resolveExternalFragment(df->stag, injector.withInternalRules(FXPP_REQUIRE_FRAGMENT_UID)))
+                    {
+                        // external fragment is ready for use, if use is allowed
+                    }
+                    else if (((la = peekDataFrame(++laIndex)) != nullptr) &&
+                        (CONTENT == la->eventType) &&
+                        (m_assistant->resolveEmbeddedFragment(df->stag, la->content, injector.withInternalRules(0))))
+                    {
+                        // embedded fragment is ready for use, if use is allowed
+                        la->state = DataFrame::FrameIgnored;
+                        isEmbedded = true;
+                    }
+                    else
+                    {
+                        // no fragment 
+                        pushActiveElement(df, DataFrame::TypeReported);
+                        return df->eventType;
+                    }
+                    // fragment usage is only allowed when the data frame triggering the fragment
+                    // is followed by an end tag
+                    la = peekDataFrame(++laIndex);
+                    if (CONTENT == la->eventType &&
+                        (isEmptyString(la->content) || parserRef().whitespaceContent()))
+                    {
+                        // empty elements that are not self-closing may report an empty or white
+                        // space content event that shouldn't affect the usage check
+                        la = peekDataFrame(++laIndex);
+                    }
+                    if (la->eventType != END_TAG)
+                    {
+                        if (isEmbedded)
+                            throw XmlPullParserException("embedded fragment content must have no siblings");
+                        else
+                            throw XmlPullParserException("external fragment references must have no content");
+                    }
+                    // apply the fragment
+                    if (testRule(FXPP_RETAIN_FRAGMENT_PARENT, injector.m_frame->rules))
+                    {
+                        m_deferred.setown(injector.m_frame.getLink());
+                        pushActiveElement(df, DataFrame::TypeReported);
+                        return df->eventType;
+                    }
+                    else
+                    {
+                        do
+                        {
+                            la = peekDataFrame(laIndex);
+                            if (la)
+                                la->state = DataFrame::FrameIgnored;
+                        }
+                        while (laIndex-- != 0);
+                        pushFragment(injector.m_frame.getLink());
+                    }
+                }
+                else
+                {
+                    pushActiveElement(df, DataFrame::TypeReported);
+                    return df->eventType;
+                }
+                break;
+
+            case CONTENT:
+                df->state = DataFrame::TypeReported;
+                return df->eventType;
+            
+            case END_TAG:
+                if (!m_activeElements.empty())
+                {
+                    Linked<DataFrame> ae(m_activeElements.back());
+                    if (!streq(df->etag.getQName(), ae->stag.getQName()))
+                        throw XmlPullParserException(VStringBuffer("element stack mismatch; %s is not closed by %s", ae->stag.getQName(), df->etag.getQName()).str());
+                    m_activeElements.pop_back();
+                    
+                    switch (ae->state)
+                    {
+                    case DataFrame::DataReported:
+                    case DataFrame::TypeReported:
+                        df->state = DataFrame::TypeReported;
+                        m_reportedElementDepth--;
+                        return df->eventType;
+                    default:
+                        df->state = ae->state;
+                        break;
+                    }
+                }
+                else
+                    throw XmlPullParserException(VStringBuffer("element stack mismatch; unbalanced end tag %s", df->etag.getQName()).str());
+                break;
+
+            case END_DOCUMENT:
+                if (fragmentFrameDepth() == 1)
+                {
+                    df->state = DataFrame::TypeReported;
+                    return df->eventType;
+                }
+                df->state = DataFrame::FrameIgnored;
+                popFragmentFrame();
+                break;
+            }
+        }
+        throw XmlPullParserException("reached unreachable code in next()");
+    }
+    
+    virtual const char* readContent() override
+    {
+        DataFrame* df = peekDataFrame();
+        if (!df)
+            throw XmlPullParserException("no current data frame for content read");
+        if (df->state != DataFrame::TypeReported)
+            throw XmlPullParserException(VStringBuffer("invalid data frame state (%d) for content read", df->state).str());
+        if (df->eventType != CONTENT)
+            throw XmlPullParserException(VStringBuffer("invalid data frame event type (%d) for content read", df->eventType).str());
+        df->state = DataFrame::DataReported;
+        return df->content;
+    }
+    
+    virtual void readEndTag(EndTag& etag) override
+    {
+        DataFrame* df = peekDataFrame();
+        if (!df)
+            throw XmlPullParserException("no current data frame for end tag read");
+        if (df->state != DataFrame::TypeReported)
+            throw XmlPullParserException(VStringBuffer("invalid data frame state (%d) for end tag read", df->state).str());
+        if (df->eventType != END_TAG)
+            throw XmlPullParserException(VStringBuffer("invalid data frame event type (%d) for end tag read", df->eventType).str());
+        df->state = DataFrame::DataReported;
+        etag = df->etag;
+    }
+    
+    virtual void readStartTag(StartTag& stag) override
+    {
+        DataFrame* df = peekDataFrame();
+        if (!df)
+            throw XmlPullParserException("no current data frame for start tag read");
+        if (df->state != DataFrame::TypeReported)
+            throw XmlPullParserException(VStringBuffer("invalid data frame state (%d) for start tag read", df->state).str());
+        if (df->eventType != START_TAG)
+            throw XmlPullParserException(VStringBuffer("invalid data frame event type (%d) for start tag read", df->eventType).str());
+        df->state = DataFrame::DataReported;
+    	stag = df->stag;
+    }
+    
+    virtual void setMixedContent(bool enable) override
+    {
+        throw XmlPullParserException("mixed content mode is unsupported");
+    }
+    
+    virtual const SXT_CHAR* getQNameLocal(const SXT_CHAR* qName) const override
+    {
+        return parserRef().getQNameLocal(qName);
+    }
+    
+    virtual const SXT_CHAR* getQNameUri(const SXT_CHAR* qName) const override
+    {
+        return parserRef().getQNameUri(qName);
+    }
+    
+    virtual int getNsCount() const override
+    {
+        return parserRef().getNsCount();
+    }
+    
+    virtual map<string, const SXT_CHAR*>::const_iterator getNsBegin() const override
+    {
+        return parserRef().getNsBegin();
+    }
+    
+    virtual map<string, const SXT_CHAR*>::const_iterator getNsEnd() const override
+    {
+        return parserRef().getNsEnd();
+    }
+    
+    virtual void setSupportNamespaces(bool enable) override
+    {
+        m_supportNamespaces = enable;
+        IXmlPullParser* cur = parser();
+        if (cur)
+            cur->setSupportNamespaces(enable);
+    }
+    
+    virtual bool skipSubTreeEx() override
+    {
+        bool skippedChildren = false;
+        (void)doSkipSubTree(&skippedChildren);
+        return skippedChildren;
+    }
+    
+    virtual int skipSubTree() override
+    {
+        return doSkipSubTree(nullptr);
+    }
+
+    virtual const SXT_STRING getPosDesc() const override
+    {
+        return parserRef().getPosDesc();
+    }
+    
+    virtual int getLineNumber() const override
+    {
+        return parserRef().getLineNumber();
+    }
+    
+    virtual int getColumnNumber() const override
+    {
+        return parserRef().getColumnNumber();
+    }
+    
+    virtual const bool whitespaceContent() const override
+    {
+        DataFrame* df = peekDataFrame();
+        if (!df)
+            throw XmlPullParserException("no current data frame for whitespace check");
+        if (!(DataFrame::TypeReported == df->state || DataFrame::DataReported == df->state))
+            throw XmlPullParserException(VStringBuffer("invalid data frame state (%d) for whitespace check", df->state).str());
+        if (df->eventType != CONTENT)
+            throw XmlPullParserException(VStringBuffer("invalid data frame event type (%d) for whitespace check", df->eventType).str());
+        return df->ignorable;
+    }
+
+    virtual void keepWhitespace(bool enable) override
+    {
+        m_keepWhitespace = enable;
+    }
+
+    virtual void setIndefiniteEventDataRetention(bool enable) override
+    {
+        m_indefiniteRetention = enable;
+    }
+
+    virtual void setAssistant(const IFragmentedXmlAssistant* assistant) override
+    {
+        m_assistant.set(assistant);
+    }
+
+    virtual void injectFragment(const char* uid, const char* content, int contentLength, XmlFragmentRules rules) override
+    {
+        injectFragment(uid, nullptr, 0, content, contentLength, nullptr, 0, rules);
+    }
+
+    virtual void injectFragment(const char* uid, const char* prefix, int prefixLength, const char* body, int bodyLength, const char* suffix, int suffixLength, XmlFragmentRules rules) override
+    {
+        createAndUseFragment(uid, prefix, prefixLength, body, bodyLength, suffix, suffixLength, FXPP_REQUIRE_FRAGMENT_UID | FXPP_REQUIRE_CURRENT_ELEMENT | rules);
+    }
+
+protected:
+    Linked<const IFragmentedXmlAssistant> m_assistant;
+    FragmentStack                         m_activeFragments;
+    DataFrames                            m_activeElements;
+    ParserArchive                         m_parsers;
+    unsigned                              m_reportedElementDepth = 0;
+    bool                                  m_supportNamespaces = false;
+    bool                                  m_keepWhitespace = false;
+    bool                                  m_indefiniteRetention = true;
+    Owned<FragmentFrame>                  m_deferred;
+    
+public:
+    CFragmentedXmlPullParser()
+    {
+    }
+
+    CFragmentedXmlPullParser(IFragmentedXmlAssistant& assistant)
+        : m_assistant(&assistant)
+    {
+    }
+
+    ~CFragmentedXmlPullParser()
+    {
+    }
+
+protected:
+    void createAndUseFragment(const char* uid, const char* prefix, int& prefixLength, const char* body, int& bodyLength, const char* suffix, int& suffixLength, XmlInternalFragmentRules rules)
+    {
+        m_deferred.setown(spawnFragment(uid, prefix, prefixLength, body, bodyLength, suffix, suffixLength, rules));
+    }
+
+    FragmentFrame* spawnFragment(const char* uid, const char* prefix, int& prefixLength, const char* body, int& bodyLength, const char* suffix, int& suffixLength, XmlInternalFragmentRules rules)
+    {
+        checkProposedFragment(uid, prefix, prefixLength, body, bodyLength, suffix, suffixLength, rules);
+        
+        std::shared_ptr<IXmlPullParser> parser(new XmlPullParser());
+        parser->setMixedContent(false);
+        parser->setSupportNamespaces(m_supportNamespaces);
+
+        StringBuffer prefixBuf, suffixBuf;
+        prepareInputPrefix(prefixBuf, testRule(FXPP_PROPAGATE_NAMESPACES, rules));
+        if (prefix)
+            prefixBuf.append(prefix);
+        if (suffix)
+            suffixBuf.append(suffix);
+        prepareInputSuffix(suffixBuf);
+        parser->setInput(prefixBuf, int(prefixBuf.length()), body, bodyLength, suffixBuf, int(suffixBuf.length()));
+        
+        return (new FragmentFrame(parser, uid, rules));
+    }
+
+    void checkProposedFragment(const char* uid, const char* prefix, int& prefixLength, const char* body, int& bodyLength, const char* suffix, int& suffixLength, XmlInternalFragmentRules rules)
+    {
+        // Accept lengths of `-1` as requests to compute the actual length.
+        #define LENGTH_ADJUSTMENT(c, l) if (-1 == (l) && (c)) l = int(strlen(c))
+        LENGTH_ADJUSTMENT(prefix, prefixLength);
+        LENGTH_ADJUSTMENT(body, bodyLength);
+        LENGTH_ADJUSTMENT(suffix, suffixLength);
+        #undef LENGTH_ADJUSTMENT
+
+        StringBuffer errReason;
+        recordFailure(testRule(FXPP_REQUIRE_FRAGMENT_UID, rules) && isEmptyString(uid), "invalid UID", errReason);
+        recordFailure(isEmptyString(body), "invalid content buffer", errReason);
+        recordFailure(bodyLength <= 0, "invalid content length", errReason);
+        recordFailure((isEmptyString(prefix) != (0 == prefixLength)), "invalid prefix length", errReason);
+        recordFailure((isEmptyString(suffix) != (0 == suffixLength)), "invalid suffix length", errReason);
+        recordFailure((isEmptyString(prefix) != isEmptyString(suffix)), "mismatched prefix and suffix", errReason);
+        recordFailure(m_deferred != nullptr, "invalid double injection", errReason);
+        recordFailure(testRule(FXPP_REQUIRE_CURRENT_ELEMENT, rules) && (0 == m_reportedElementDepth), "invalid injection outside of parent", errReason);
+        if (!isEmptyString(uid))
+        {
+            for (const Owned<FragmentFrame>& ff : m_activeFragments)
+            {
+                if (ff->uid && streq(ff->uid, uid))
+                {
+                    VStringBuffer tmp("circular fragment reference with UID '%s'", uid);
+                    recordFailure(true, tmp, errReason);
+                    break;
+                }
+            }
+        }
+        if (!errReason.isEmpty())
+        {
+            VStringBuffer errMessage("XML fragment injection failed: %s", errReason.str());
+            throw XmlPullParserException(errMessage.str());
+        }
+    }
+
+    inline bool testRule(XmlInternalFragmentRules rule, XmlInternalFragmentRules rules) const
+    {
+        return ((rules & rule) == rule);
+    }
+
+    inline void recordFailure(bool failed, const char* reason, StringBuffer& reasons) const
+    {
+        if (failed)
+        {
+            if (!reasons.isEmpty())
+                reasons.append(", ");
+            reasons.append(reason);
+        }
+    }
+
+    void prepareInputPrefix(StringBuffer& prefix, bool withNamespaces) const
+    {
+        if (withNamespaces && fragmentFrameDepth())
+        {
+            using NsMap = std::map<std::string, const SXT_CHAR*>;
+            IXmlPullParser* parser = m_activeFragments.front()->xpp.get();
+            StringBuffer attrName;
+            appendXMLOpenTag(prefix, reserved::SYNTHESIZED_ROOT, nullptr, false);
+            for (NsMap::const_iterator it = parser->getNsBegin(); it != parser->getNsEnd(); ++it)
+            {
+                if (it->first.compare("xml") == 0)
+                    continue;
+                if (it->first.empty())
+                    attrName.set("xmlns");
+                else
+                    attrName.setf("xmlns:%s", it->first.c_str());
+                appendXMLAttr(prefix, attrName, it->second);
+            }
+            prefix.append('>');
+        }
+        else
+        {
+            appendXMLOpenTag(prefix, reserved::SYNTHESIZED_ROOT, nullptr, true);
+        }
+    }
+
+    void prepareInputSuffix(StringBuffer& suffix) const
+    {
+        appendXMLCloseTag(suffix, reserved::SYNTHESIZED_ROOT);
+    }
+
+    /**
+     * Implement own skip logic to ensure internal state integrity.
+     */
+    int doSkipSubTree(bool* skippedChildren)
+    {
+        bool hasChildren = false;
+        if (m_deferred)
+        {
+            if (fragmentFrameDepth() == 0)
+            {
+                // Deferred with empty stack means we haven't started parsing the input. Install
+                // the fragment so it can be properly skipped.
+                pushFragment(m_deferred.getLink());
+            }
+            else
+            {
+                // Deferred with non-empty stack means we are skipping the deferred fragment's
+                // parent element. The fragment is presumed to represent at least one child but
+                // should not need to be parsed.
+                hasChildren = true;
+            }
+            m_deferred.clear();
+        }
+
+        DataFrame* df = nullptr;
+        // Expect an equal number of start and end tags before a start tag has been read, and one
+        // extra end tag after reading a start tag.
+        int level = (m_activeElements.empty() ? 0 : 1);
+        bool done = false;
+        while (!done)
+        {
+            df = nextDataFrame();
+            df->state = DataFrame::FrameIgnored;
+            switch (df->eventType)
+            {
+            case START_TAG:
+                ++level;
+                hasChildren = true;
+                break;
+            case END_TAG:
+                --level;
+                if (level <= 0)
+                    done = true;
+                break;
+            case END_DOCUMENT:
+                done = true;
+                break;
+            }
+        }
+        if (level < 0)
+            throw XmlPullParserException("unbalanced end tag while skipping");
+        if (level > 0)
+            throw XmlPullParserException("unexpected EOF while skipping");
+        if (!m_activeElements.empty())
+            m_activeElements.pop_back();
+        if (skippedChildren)
+            *skippedChildren = hasChildren;
+        return END_TAG;
+    }
+    
+    size_t fragmentFrameDepth() const
+    {
+        return m_activeFragments.size();
+    }
+
+    FragmentFrame& fragmentFrameRef()
+    {
+        if (m_activeFragments.empty())
+            throw XmlPullParserException("no element markup available");
+        return *m_activeFragments.back();
+    }
+
+    IXmlPullParser* parser() const
+    {
+        if (m_activeFragments.empty())
+            return nullptr;
+        return m_activeFragments.back()->xpp.get();
+    }
+    
+    IXmlPullParser& parserRef() const
+    {
+        if (m_activeFragments.empty())
+            throw XmlPullParserException("no element markup available");
+        IXmlPullParser* xpp = m_activeFragments.back()->xpp.get();
+        if (!xpp)
+            throw XmlPullParserException("invalid parser stack entry");
+        return *xpp;
+    }
+
+    DataFrames& pendingData()
+    {
+        if (m_activeFragments.empty())
+            throw XmlPullParserException("no element markup available");
+        return m_activeFragments.back()->pendingData;
+    }
+
+    const DataFrames& pendingData() const
+    {
+        if (m_activeFragments.empty())
+            throw XmlPullParserException("no element markup available");
+        return m_activeFragments.back()->pendingData;
+    }
+
+    void pushFragment(FragmentFrame* frame)
+    {
+        StringBuffer errReason;
+        recordFailure(!frame, "invalid fragment frame", errReason);
+        recordFailure(frame && !frame->xpp, "invalid embedded parser", errReason);
+        if (!errReason.isEmpty())
+        {
+            VStringBuffer errMessage("XML fragment injection failed: %s", errReason.str());
+            frame->Release();
+            throw XmlPullParserException(errMessage.str());
+        }
+
+        if (m_indefiniteRetention)
+            m_parsers.emplace_back(frame->xpp);
+        m_activeFragments.emplace_back(frame);
+    }
+    
+    void popFragmentFrame()
+    {
+        if (!m_activeFragments.empty())
+            m_activeFragments.pop_back();
+    }
+
+    void pullDataFrame()
+    {
+        IXmlPullParser&  parser = parserRef();
+        Owned<DataFrame> frame(new DataFrame());
+        bool retry;
+        do
+        {
+            retry = false;
+            frame->eventType = parser.next();
+            switch (frame->eventType)
+            {
+            case START_TAG:
+                parser.readStartTag(frame->stag);
+                break;
+            case CONTENT:
+                frame->content = parser.readContent();
+                frame->ignorable = isEmptyString(frame->content) || parser.whitespaceContent();
+                if (!m_keepWhitespace && frame->ignorable)
+                {
+                    frame->content = nullptr;
+                    retry = true; 
+                }
+                break;
+            case END_TAG:
+                parser.readEndTag(frame->etag);
+                break;
+            case END_DOCUMENT:
+                break;
+            default:
+                throw XmlPullParserException(VStringBuffer("unexpected event type %d", frame->eventType).str());
+            }
+        }
+        while (retry);
+        
+        frame->state = DataFrame::Pulled;
+        pendingData().emplace_back(frame.getClear());
+    }
+
+    DataFrame* nextDataFrame()
+    {
+        DataFrames& frames = pendingData();
+        while (!frames.empty() && frames.front()->state > DataFrame::Pulled)
+            frames.pop_front();
+        if (frames.empty())
+            pullDataFrame();
+        DataFrame* df = frames.front();
+        if (df->state != DataFrame::Pulled)
+            throw XmlPullParserException(VStringBuffer("invalid data frame state %d", df->state).str());
+        return df;
+    }
+
+    inline DataFrame* peekDataFrame() const
+    {
+        const DataFrames& frames = pendingData();
+        if (frames.empty())
+            throw XmlPullParserException("no data available");
+        return frames.front();
+    }
+    inline DataFrame* peekDataFrame()
+    {
+        return peekDataFrame(0);
+    }
+    DataFrame* peekDataFrame(uint8_t frameIdx)
+    {
+        DataFrames& frames = pendingData();
+        while (frames.size() < (frameIdx + 1))
+            pullDataFrame();
+        for (Owned<DataFrame>& frame : frames)
+        {
+            if (frameIdx-- == 0)
+            {
+                return frame;
+            }
+        }
+        throw XmlPullParserException("reached unreachable code in peekDataFrame()");
+    }
+
+    void pushActiveElement(DataFrame* df, DataFrame::State state)
+    {
+        if (df)
+        {
+            df->state = state;
+            if (DataFrame::TypeReported == state)
+                m_reportedElementDepth++;
+            m_activeElements.push_back(LINK(df));
+        }
+    }
+
+    void dumpDataFrame(const DataFrame& frame, const char* context) const
+    {
+        fprintf(stdout, "\n%s: ", context ? context : "no context");
+        switch (frame.state)
+        {
+        case DataFrame::New:
+            fprintf(stdout, "New data frame\n");
+            return;
+        case DataFrame::Pulled:
+            fprintf(stdout, "Pulled");
+            break;
+        case DataFrame::TypeReported:
+            fprintf(stdout, "TypeReported");
+            break;
+        case DataFrame::DataReported:
+            fprintf(stdout, "DataReported");
+            break;
+        case DataFrame::FrameIgnored:
+            fprintf(stdout, "FrameIgnored");
+            break;
+        default:
+            fprintf(stdout, "unknown (%d)", frame.state);
+        }
+        fprintf(stdout, " data frame: ");
+        switch (frame.eventType)
+        {
+        case START_TAG:
+            fprintf(stdout, "<%s>", frame.stag.getQName());
+            break;
+        case CONTENT:
+            fprintf(stdout, "<![CDATA[%s]]>", frame.content);
+            break;
+        case END_TAG:
+            fprintf(stdout, "</%s>", frame.etag.getQName());
+            break;
+        case END_DOCUMENT:
+            fprintf(stdout, "EOF");
+            break;
+        default:
+            fprintf(stdout, "unknown (%d)", frame.eventType);
+            break;
+        }
+        fprintf(stdout, "\n");
+    }
+
+};
+
+IFragmentedXmlPullParser* createParser()
+{
+    return new CFragmentedXmlPullParser();
+}
+
+} // namespace fxpp

--- a/esp/bindings/SOAP/xpp/fxpp/FragmentedXmlPullParser.hpp
+++ b/esp/bindings/SOAP/xpp/fxpp/FragmentedXmlPullParser.hpp
@@ -1,0 +1,228 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2021 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef FXPP_FRAGMENTED_XML_FULL_PARSER_H_
+#define FXPP_FRAGMENTED_XML_FULL_PARSER_H_
+
+#include "xpp/XmlPullParser.h"
+
+using namespace xpp;
+
+namespace fxpp
+{
+
+/**
+ * A collection of interfaces and classes used to parse an XML fragment. A fragment, in this
+ * context, may be a simple, well-formed document that could be parsed by `xpp::XmlPullParser`,
+ * or it may be more complex:
+ *
+ * - A fragment may contain a reference to externally defined markup. Such a reference may be
+ *   detected by the parser and the referenced content is seamlessly injected into the sequence
+ *   of events returned by the parser. The external fragment controls whether it replaces the
+ *   referencing element or descends from it.
+ * - A fragment may contain embedded markup, which is either CDATA-enclosed or XML-encoded XML
+ *   content that a traditional parser would treat as text. Such embedded markup may be detected
+ *   by the parser and the content is seamlessly injected into the sequence of events returned
+ *   by the parser. The embedded fragment controls whether it replaces the parent of the embedded
+ *   text or remains descended from that element.
+ * - A parser event consumer may define locations within a fragment where external content should
+ *   be injected into the parser's sequence of events. The parser can be compelled to parse such
+ *   content on demand. The caller cannot control how existing content is handled.
+ * - A fragment may be a sequence of XML elements with no root element.
+ *
+ * `xpp::IXmlPullParser` declares the entire public interface of `xpp::XmlPullParser`. It is also
+ * the base of `fxpp::IFragmentedXmlPullparser`. Migration of existing code to use the framework
+ * requires replacing references to `xpp::XmlPullParser` with the appropriate interface,
+ * `xpp::IXmlPullParser` when framework extensions are not required and
+ * `fxpp::IFragmentedXmlPullParser` when framework extensions are required. Additional changes may
+ * be necessary, but such details depend upon individual implementations of the interface.
+ *
+ * To parse a single fragment, as is currently done using `xpp::XmlPullParser`, an instance of
+ * `fxpp::IFragmentedXmlPullParser`, which extends `xpp::IXmlPullParser`, supports parsing similar
+ * to `xpp::XmlPullParser`. Each implementation is free to deviate from the expected behavior, and
+ * the default implementation prohibits the use of mixed content.
+ *
+ * To parse multiple fragments with manual control of additional fragments, an instance of
+ * `fxpp::IFragmentedXmlPullParser` will accept new fragments with the `injectFragment` method.
+ * This method cannot be called before the first `START_TAG` is reported, nor can it be called
+ * after the balancing `END_TAG` is reported.
+ *
+ * To parse multiple fragments with automatic detection of external fragment references, an instance
+ * of `fxpp::IFragmentedXmlAssistant` must be registered with the `fxpp::IFragmentedXmlPullParser`
+ * instance. The assistant implementation is responsible for recognizing which markup elements may
+ * specify external fragment references, which of those that may specify a reference actually do
+ * specify external fragment references, loading the referenced markup, and passing it back to the
+ * parser.
+ * 
+ * To parse multiple fragments with automatic detection of embedded fragment content, an instance
+ * of `fxpp::IFragmentedXmlAssistant` must be registered with the `fxpp::IFragmentedXmlPullParser`
+ * instance. The assistant implementation is responsible for recognizing which markup elements may
+ * contain embedded fragment content, which of those that may contain a fragment actually do contain
+ * embedded fragment content, and passing it back to the parser as a new fragment.
+ * 
+ * A default implementation of `fxpp::IFragmentedXmlAssistant` is provided which includes
+ * handling of both automatic scenarios. Refer to `fxpp::fxa::IAssistant` for more details.
+ */
+
+/**
+ * Named type for externally set parser rules related to fragment injection.
+ */
+using XmlFragmentRules = uint8_t;
+
+/**
+ * Abstraction providing indirect access to a parser to inject content. A parser will provide an
+ * instance of this interface to its assistant to facilitate acceptance of fragment content from
+ * the assistant.
+ */
+interface IFragmentInjector : extends IInterface
+{
+    /**
+     * Receive fragment data from a caller. Action applied varies by implementation.
+     *
+     * @param uid Unique identifier associated with the fragment markup. May be NULL.
+     * @param content XML markup to be parsed next. Must not be NULL.
+     * @param contentLength Actual length of `content` buffer or `-1` if content is NULL terminated.
+     * @param rules Instructions for integrating new markup within existing markup.
+     */
+    virtual void injectFragment(const char* uid, const char* content, int contentLength, XmlFragmentRules rules) = 0;
+};
+
+/**
+ * Abstraction providing external and embedded fragment recognition to an IFragmentedXmlPullParser
+ * instance. The parser cannot detect fragments without an assistant.
+ *
+ * Implementations should prepare and inject fragment content through the `IFragmentInjector`
+ * instance provided to each request. Implementations should not attempt to inject content
+ * directly into a parser instance in response to these requests. 
+ */
+interface IFragmentedXmlAssistant : extends IInterface
+{
+    virtual bool resolveExternalFragment(const StartTag& stag, IFragmentInjector& injector) const = 0;
+    virtual bool resolveEmbeddedFragment(const StartTag& stag, const char* content, IFragmentInjector& injector) const = 0;
+};
+
+/**
+ * Abstraction of a pull parser capable of recognizing and parsing externally referenced and
+ * embedded XML fragments as if they are part of the initial input document being parsed.
+ *
+ * Fragments may be detected by a parser implementation or its assigned IFragmentedXmlAssistamt
+ * instance. In the event that this combination does not detect all fragments, parser consumers
+ * may forcibly inject fragments into the parser. If such injection is not needed, an initialized
+ * parser may be used interchangeably with any IXmlPullParser implementation (including the
+ * original XmlPullParser).
+ */
+interface IFragmentedXmlPullParser : extends IXmlPullParser
+{
+    /**
+     * Manual injection of data between the first START_TAG and final END_TAG reported from the
+     * parser's base input. When parsing without a registered assistant, this is the only option
+     * for expanding upon the parser's base input. When parsing with a registered assistant, this
+     * option should rarely be necessary.
+     *
+     * @param uid Unique identifier associated with the fragment markup. May be NULL.
+     * @param content XML markup to be parsed next. Must not be NULL.
+     * @param contentLength Actual length of `content` buffer or `-1` if content is NULL terminated.
+     * @param rules Instructions for integrating new markup within existing markup.
+     */
+    virtual void injectFragment(const char* uid, const char* content, int contentLength, XmlFragmentRules rules) = 0;
+
+    /**
+     * Manual injection of data between the first START_TAG and final END_TAG reported from the
+     * parser's base input. When parsing without a registered assistant, this is the only option
+     * for expanding upon the parser's base input. When parsing with a registered assistant, this
+     * option should rarely be necessary.
+     *
+     * Combines `prefix`, `body`, and `suffix` into a single XML snippet. No single parameter is
+     * required to be well-formed, but the conmbination of all three parameters must be well-
+     * formed. Generally, `prefix` and `suffix` will be used to define start and end tags for
+     * elements that make `body` well-formed or that propagate namespaces from the current fragment
+     * into the new fragment.
+     *
+     * @param uid Unique identifier associated with the fragment markup. May be NULL.
+     * @param prefix XML markup to be parsed next. May be NULL.
+     * @param prefixLength Actual length of `prefix` buffer or `-1` if prefix is NULL terminated.
+     * @param body XML markup to be parsed next. Must not be NULL.
+     * @param bodyLength Actual length of `body` buffer or `-1` if body is NULL terminated.
+     * @param suffix XML markup to be parsed next. May be NULL.
+     * @param suffixength Actual length of `suffix` buffer or `-1` if suffix is NULL terminated.
+     * @param rules Instructions for integrating new markup within existing markup.
+     */
+    virtual void injectFragment(const char* uid, const char* prefix, int prefixLength, const char* body, int bodyLength, const char* suffix, int suffixLength, XmlFragmentRules rules) = 0;
+
+    /**
+     * Parser extension controlling whether content events for content containing whitespace
+     * characters only are ignored (false) or retained (true).
+     */
+    virtual void keepWhitespace(bool enable) = 0;
+
+    /**
+     * Parser extension controlling whether event data returned from `readStartTag`, `readContent`,
+     * and `readEndTag` remains valid until the parser is destroyed or its input is reset. If true,
+     * pointers returned from these methods are guaranteed to remain valid while parsing. If false,
+     * the caller should not rely on the pointers after the next call to `next`.
+     */
+    virtual void setIndefiniteEventDataRetention(bool enable) = 0;
+
+    /**
+     * Provides the parser with an assistant instance for automatic fragment detection.
+     */
+    virtual void setAssistant(const IFragmentedXmlAssistant* assistant) = 0;
+};
+
+/**
+ * Instruct the parser to retain a fragment's parent element. When an element identifies a fragment
+ * the parser's default behavior is to replace the original element, in its entirety, with the
+ * fragment. This instructs the parser to retain the fragment identifying element and inject the
+ * fragment markup as descendents of that element.
+ */
+static const XmlFragmentRules FXPP_RETAIN_FRAGMENT_PARENT   = 0x01;
+
+/**
+ * Make all namespaces in effect at the time of injection available to the injected content. Each
+ * namespace URI and prefix is defined in the fragment, eliminating the need to repeat definitions
+ * in each fragment. In the following example, the use of `foo` in `foo:child` is only valid if
+ * `foo:root` explicitly requests namespace propagation. Without propagation, the declaration of
+ * `foo` must be repeated in fragment markup.
+ *
+ *      <foo:root xmlns:foo="urn:foo">
+ *        <![CDATA[<foo:child/>]]>
+ *      </foo:root>
+ * 
+ * By default, namespaces are not propagated. Any fragment requiring propagation must request it
+ * when constructed.
+ */
+static const XmlFragmentRules FXPP_PROPAGATE_NAMESPACES     = 0x04;
+
+/**
+ * Reserved element name(s) used internally by the parser. Use outside of the parser is permitted
+ * subject to the constraints imposed by the parser.
+ */
+namespace reserved
+{
+    /**
+     * The parser assumes elements with this name are created by the parser for the parser's own
+     * use. Neither `START_TAG` nor `END_TAG` events will be reported by the parser to the
+     * parser's event consumer.
+     */
+    constexpr static const char* SYNTHESIZED_ROOT = "synthesized_root";
+}
+
+extern IFragmentedXmlPullParser* createParser();
+
+} // namespace fxpp
+
+#endif // FXPP_FRAGMENTED_XML_FULL_PARSER_H_

--- a/esp/bindings/SOAP/xpp/sxt/XmlTokenizer.h
+++ b/esp/bindings/SOAP/xpp/sxt/XmlTokenizer.h
@@ -143,6 +143,11 @@ namespace sxt {
 
     //void setInput(string s);
     void setInput(const SXT_CHAR* buf_, int size) {
+      setInput(nullptr, 0, buf_, size, nullptr, 0);
+    }
+
+    void setInput(const SXT_CHAR* prefix, int prefixSize, const SXT_CHAR* body, int bodySize, const SXT_CHAR* suffix, int suffixSize) {
+      int size = prefixSize + bodySize + suffixSize;
       reset();
       this->bufEnd = size;
       if(size > this->bufSize - 1) {
@@ -151,7 +156,22 @@ namespace sxt {
         this->bufSize = bufEnd + 1;  //NOTE: +1 to give place for '\0' 
         this->buf = new SXT_CHAR[this->bufSize]; 
       }
-      memcpy(this->buf, buf_, bufEnd * sizeof(this->buf[0]));
+      int offset = 0;
+      if (prefixSize) {
+        int sectionSize = prefixSize * sizeof(SXT_CHAR);
+        memcpy(this->buf, prefix, sectionSize);
+        offset += sectionSize;
+      }
+      if (bodySize) {
+        int sectionSize = bodySize * sizeof(SXT_CHAR);
+        memcpy(this->buf + offset, body, sectionSize);
+        offset += sectionSize;
+      }
+      if (suffixSize) {
+        int sectionSize = suffixSize * sizeof(SXT_CHAR);
+        memcpy(this->buf + offset, suffix, sectionSize);
+        offset += sectionSize;
+      }
       this->buf[bufEnd] = _MYT('\0');
       if(paramPC && bufSize > pcSize) {
         if(pc != NULL)

--- a/esp/bindings/SOAP/xpp/xpp/StartTag.h
+++ b/esp/bindings/SOAP/xpp/xpp/StartTag.h
@@ -39,11 +39,26 @@ namespace xpp {
   public:
     StartTag() { init(); }
 
+    StartTag(const StartTag& src) {
+      *this = src;
+    }
+
     ~StartTag() {
       if(attArr != NULL) {
         delete [] attArr;
       }
       attArr = NULL;
+    }
+
+    StartTag& operator = (const StartTag& src) {
+      uri = src.uri;
+      localName = src.localName;
+      qName = src.qName;
+      attEnd = attSize = src.attEnd;
+      attArr = new Attribute[attEnd];
+      for (int idx = 0; idx < attEnd; idx++)
+        attArr[idx] = src.attArr[idx];
+      return *this;
     }
 
     void clear () { 

--- a/esp/bindings/SOAP/xpp/xpp/xpputils.cpp
+++ b/esp/bindings/SOAP/xpp/xpp/xpputils.cpp
@@ -4,7 +4,7 @@
 
 using namespace xpp;
 
-IMultiException *xppMakeException(XmlPullParser &xppx)
+IMultiException *xppMakeException(IXmlPullParser &xppx)
 {
     StringBuffer msg;
     StringBuffer sourcestr;
@@ -58,7 +58,7 @@ IMultiException *xppMakeException(XmlPullParser &xppx)
 }
 
 
-void xppToXmlString(XmlPullParser &xpp, StartTag &stag, StringBuffer & buffer)
+void xppToXmlString(IXmlPullParser &xpp, StartTag &stag, StringBuffer & buffer)
 {
     int level = 1; //assumed due to the way gotonextdataset works.
     int type = XmlPullParser::END_TAG;
@@ -123,7 +123,7 @@ void xppToXmlString(XmlPullParser &xpp, StartTag &stag, StringBuffer & buffer)
     while (level > 0);
 }
 
-bool xppGotoTag(XmlPullParser &xppx, const char *tagname, StartTag &stag)
+bool xppGotoTag(IXmlPullParser &xppx, const char *tagname, StartTag &stag)
 {
     int level = 1;
     int type = XmlPullParser::END_TAG;

--- a/esp/bindings/SOAP/xpp/xpp/xpputils.h
+++ b/esp/bindings/SOAP/xpp/xpp/xpputils.h
@@ -6,9 +6,9 @@
 
 using namespace xpp;
 
-IMultiException *xppMakeException(XmlPullParser &xppx);
+IMultiException *xppMakeException(IXmlPullParser &xppx);
 
-void xppToXmlString(XmlPullParser &xpp, StartTag &stag, StringBuffer & buffer);
-bool xppGotoTag(XmlPullParser &xppx, const char *tagname, StartTag &stag);
+void xppToXmlString(IXmlPullParser &xpp, StartTag &stag, StringBuffer & buffer);
+bool xppGotoTag(IXmlPullParser &xppx, const char *tagname, StartTag &stag);
 
 #endif // XPP_UTILS_H_

--- a/esp/esdllib/CMakeLists.txt
+++ b/esp/esdllib/CMakeLists.txt
@@ -43,6 +43,7 @@ set ( SRCS
     esdl_transformer2.cpp
     esdl_script.cpp
     params2xml.cpp
+    ${HPCC_SOURCE_DIR}/esp/bindings/SOAP/xpp/fxpp/FragmentedXmlPullParser.cpp;
     ${HPCC_SOURCE_DIR}/esp/bindings/SOAP/xpp/xpp/xpputils.cpp
     ${HPCC_SOURCE_DIR}/esp/services/common/wsexcept.cpp
 )

--- a/testing/unittests/CMakeLists.txt
+++ b/testing/unittests/CMakeLists.txt
@@ -41,6 +41,9 @@ set (    SRCS
          loggingtests.cpp
          txSummarytests.cpp
          accessmaptests.cpp
+         fxpptests.cpp
+         ${HPCC_SOURCE_DIR}/esp/bindings/SOAP/xpp/fxpp/FragmentedXmlPullParser.cpp;
+         ${HPCC_SOURCE_DIR}/esp/bindings/SOAP/xpp/fxpp/FragmentedXmlAssistant.cpp;
     )
 
 if (NOT CONTAINERIZED)

--- a/testing/unittests/esdltests.cpp
+++ b/testing/unittests/esdltests.cpp
@@ -1479,7 +1479,7 @@ constexpr const char * result = R"!!(<soap:Envelope xmlns:soap="http://schemas.x
             <es:if test="es:storedValueExists('myvalue')">
               <es:set-value xpath_target="concat('check-value1-pass-', $testpass)" select="concat('already set as of pass-', $testpass)"/>
               <es:set-value target="myvalue" select="es:getStoredStringValue('myvalue')"/>
-              <es:remove-node target="Name/ID[1]"/> //removing first one changes the index count so each is 1
+              <es:remove-node target="Name/ID[1]"/> <!-- removing first one changes the index count so each is 1 -->
               <es:remove-node target="Name/ID[1]"/>
             </es:if>
             <es:if test="es:storedValueExists('myvalue2')">

--- a/testing/unittests/fxpptests.cpp
+++ b/testing/unittests/fxpptests.cpp
@@ -1,0 +1,977 @@
+/*##############################################################################
+
+    Copyright (C) 2021 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifdef _USE_CPPUNIT
+#include "unittests.hpp"
+#include "fxpp/FragmentedXmlPullParser.hpp"
+#include "fxpp/FragmentedXmlAssistant.hpp"
+#include "xpp/xpputils.h"
+#include "espcontext.hpp"
+#include "xpathprocessor.hpp"
+#include "esdl_script.hpp"
+#include "wsexcept.hpp"
+
+#include <stdio.h>
+#include "dllserver.hpp"
+#include "thorplugin.hpp"
+#include "eclrtl.hpp"
+#include "rtlformat.hpp"
+
+using namespace xpp;
+using namespace fxpp;
+using namespace fxpp::fxa;
+
+static IPTree* getPTree(const char* test, const char* subSection, const char* xml)
+{
+  Owned<IPTree> node;
+  try
+  {
+    node.setown(createPTreeFromXMLString(xml));
+  }
+  catch (IException* e)
+  {
+    StringBuffer msg;
+    msg.appendf("Test(%s", test);
+    if (subSection)
+      msg.appendf("/%s", subSection);
+    msg.append(") exception creating PTree: ");
+    e->errorMessage(msg);
+    e->Release();
+    fprintf(stdout, "\n%s\n", msg.str());
+    CPPUNIT_ASSERT(false);
+  }
+  return node.getClear();
+}
+
+template <typename actual_t, typename expected_t>
+static void compareNumeric(const char* test, const actual_t& actual, const expected_t& expected)
+{
+  if (actual != expected)
+  {
+    StringBuffer msg;
+    msg.appendf("\nTest(%s) actual does not match expected.\n    Actual: ", test)
+       .append(actual)
+       .append("\n  Expected: ")
+       .append(expected)
+       .append("\n");
+    fprintf(stdout, "%s", msg.str());
+    CPPUNIT_ASSERT(false);
+  }
+}
+
+template <>
+void compareNumeric(const char* test, const unsigned long& actual, const unsigned long& expected)
+{
+  if (actual != expected)
+  {
+    char actualBuf[64];
+    char expectedBuf[64];
+    sprintf(actualBuf, "%lu", actual);
+    sprintf(expectedBuf, "%lu", expected);
+    StringBuffer msg;
+    msg.appendf("\nTest(%s) actual does not match expected.\n    Actual: ", test)
+       .append(actualBuf)
+       .append("\n  Expected: ")
+       .append(expectedBuf)
+       .append("\n");
+    fprintf(stdout, "%s", msg.str());
+    CPPUNIT_ASSERT(false);
+  }
+}
+
+static void compareText(const char* test, const char* actual, const char* expected)
+{
+  if (!streq(actual, expected))
+  {
+    fprintf(stdout, "\nTest(%s) actual does not match expected.\n    Actual: %s\n  Expected: %s\n", test, actual, expected);
+    CPPUNIT_ASSERT(false);
+  }
+}
+
+static void compareXml(const char* test, const char* actual, const char* expected)
+{
+  if (!isEmptyString(expected) && isEmptyString(actual))
+  {
+    fprintf(stdout, "\nTest(%s) expected non-empty text.\n", test);
+    CPPUNIT_ASSERT(false);
+  }
+  if (isEmptyString(expected) && !isEmptyString(actual))
+  {
+    fprintf(stdout, "\nTest(%s) expected empty text.\n", test);
+    CPPUNIT_ASSERT(false);
+  }
+  if (!isEmptyString(expected))
+  {
+    Owned<IPTree> actualNode(getPTree(test, "actual", actual));
+    Owned<IPTree> expectedNode(getPTree(test, "expected", expected));
+
+    if (!areMatchingPTrees(actualNode, expectedNode))
+    {
+      fprintf(stdout, "\nTest(%s) actual is not equivalent to expected.\n    Actual: %s\n    Expected: %s\n", test, actual, expected);
+      CPPUNIT_ASSERT(false);
+    }
+  }
+}
+
+class fxppParserTests : public CppUnit::TestFixture
+{
+    class MockLoader : public CInterfaceOf<IExternalContentLoader>
+    {
+    public:
+      virtual bool loadAndInject(const IExternalDetection& detected, IExternalContentInjector& injector) const override
+      {
+        std::string key(detected.queryContentLocation());
+        if (!isEmptyString(detected.queryContentLocationSubset()))
+          key.append(".").append(detected.queryContentLocationSubset());
+        auto it = m_resources.find(key);
+        if (it != m_resources.end())
+          return injector.injectContent(it->second, -1);
+        return false;
+      }
+    private:
+      using ResMap = std::map<std::string, const char*>;
+      ResMap m_resources;
+    public:
+        MockLoader()
+        {
+          m_resources["not-well-formed"] = R"!!(<root><child></root>)!!";
+          m_resources["self-reference"] = R"!!(<ut:ExternalReplace resource="self-reference" xmlns:ut="hpcc:test:esp:xpp"/>)!!";
+          m_resources["foo"] = R"!!(<ut:Foo xmlns:ut="hpcc:test:esp:xpp"/>)!!";
+          m_resources["no-namespace"] = R"!!(<ut:InheritedNS/>)!!";
+          m_resources["nested-1"] = R"!!(<ut:Nested node="2"><![CDATA[<ut:Nested node="3" resource="nested-2"/>]]></ut:Nested>)!!";
+          m_resources["nested-2"] = R"!!(<ut:Nested node="4"><![CDATA[<ut:Nested node="5">&lt;ut:Nested resource="nested-3" node="6"/&gt;</ut:Nested>]]></ut:Nested>)!!";
+          m_resources["nested-3"] = R"!!(<ut:Nested node="7"/>)!!";
+          m_resources["foo.bar"] = R"!!(<Bar/>)!!";
+        }
+    };
+
+    struct TestConfig
+    {
+      bool expectSuccess = true;
+      bool supportNamespaces = true;
+      bool useAssistant = true;
+      bool useExternalDetector = true;
+      bool useExternalLoader = true;
+      bool registerEmbeddedFragments = true;
+      bool registerExternalFragments = true;
+      const char* name;
+      const char* nsUri;
+      const char* primaryDetectionKey;
+      const char* secondaryDetectionKey;
+
+      TestConfig(const char* _name)
+        : name(_name)
+        , nsUri("hpcc:test:esp:xpp")
+        , primaryDetectionKey("resource")
+        , secondaryDetectionKey("section")
+      {
+      }
+    };
+
+    CPPUNIT_TEST_SUITE( fxppParserTests );
+        CPPUNIT_TEST(testNoInput);
+        CPPUNIT_TEST(testNullInput);
+        CPPUNIT_TEST(testEmptyInput);
+        CPPUNIT_TEST(testNotWellFormedInput);
+        CPPUNIT_TEST(testExternalFragmentSansDetector);
+        CPPUNIT_TEST(testExternalFragmentSansLoader);
+        CPPUNIT_TEST(testExternalFragmentDetectionSansLoad);
+        CPPUNIT_TEST(testNotWellFormedExternalFragment);
+        CPPUNIT_TEST(testCircularExternalFragments);
+        CPPUNIT_TEST(testNoEmbeddedNSPropagation);
+        CPPUNIT_TEST(testNoExternalNSPropagation);
+        CPPUNIT_TEST(testNoAssistant);
+        CPPUNIT_TEST(testEmbeddedFragmentReplacement);
+        CPPUNIT_TEST(testExternalFragmentReplaceSelfClosing);
+        CPPUNIT_TEST(testExternalFragmentReplaceEmpty);
+        CPPUNIT_TEST(testExternalFragmentReplaceWithChild);
+        CPPUNIT_TEST(testExternalFragmentReplaceWithText);
+        CPPUNIT_TEST(testExternalFragmentRetainSelfClosingParent);
+        CPPUNIT_TEST(testExternalFragmentRetainEmptyParent);
+        CPPUNIT_TEST(testExternalFragmentRetainWithChild);
+        CPPUNIT_TEST(testExternalFragmentRetainWithText);
+        CPPUNIT_TEST(testEmbeddedNSPropagation);
+        CPPUNIT_TEST(testExternalNSPropagation);
+        CPPUNIT_TEST(testUnrootedInput);
+        CPPUNIT_TEST(testUnrootedEmbedded);
+        CPPUNIT_TEST(testNoNSSupport);
+        CPPUNIT_TEST(testNestedFragments);
+        CPPUNIT_TEST(testSecondaryKey);
+        CPPUNIT_TEST(testSkipDocument);
+        CPPUNIT_TEST(testSkipRoot);
+        CPPUNIT_TEST(testSkipChild);
+        CPPUNIT_TEST(testSkipMalformed);
+    CPPUNIT_TEST_SUITE_END();
+
+public:
+    fxppParserTests(){}
+
+    void testSkipDocument()
+    {
+      const char* test = "skip-document";
+      std::unique_ptr<IFragmentedXmlPullParser> parser(fxpp::createParser());
+      const char* input = R"!!!(<Root><Child/></Root>)!!!";
+      parser->setInput(input, int(strlen(input)));
+      try
+      {
+        parser->skipSubTree();
+        if (parser->next() != XmlPullParser::END_DOCUMENT)
+        {
+          fprintf(stdout, "\nTest(%s) did not leave parser at expected position", test);
+          CPPUNIT_ASSERT(false);
+        }
+      }
+      catch (XmlPullParserException& xe)
+      {
+        fprintf(stdout, "\nTest(%s) failed with exception: %s", test, xe.what());
+        CPPUNIT_ASSERT(false);
+      }
+    }
+
+    void testSkipRoot()
+    {
+      const char* test = "skip-root";
+      std::unique_ptr<IFragmentedXmlPullParser> parser(fxpp::createParser());
+      const char* input = R"!!!(<Root><Child/></Root>)!!!";
+      parser->setInput(input, int(strlen(input)));
+      try
+      {
+        parser->next();
+        parser->skipSubTree();
+        if (parser->next() != XmlPullParser::END_DOCUMENT)
+        {
+          fprintf(stdout, "\nTest(%s) did not leave parser at expected position\n", test);
+          CPPUNIT_ASSERT(false);
+        }
+      }
+      catch (XmlPullParserException& xe)
+      {
+        fprintf(stdout, "\nTest(%s) failed with exception: %s\n", test, xe.what());
+        CPPUNIT_ASSERT(false);
+      }
+    }
+
+    void testSkipMalformed()
+    {
+      const char* test = "skip-malformed";
+      std::unique_ptr<IFragmentedXmlPullParser> parser(fxpp::createParser());
+      const char* input = R"!!!(<Root>)!!!";
+      parser->setInput(input, int(strlen(input)));
+      try
+      {
+        parser->skipSubTree();
+        fprintf(stdout, "\nTest(%s) completed without expected exception expected position\n", test);
+        CPPUNIT_ASSERT(false);
+      }
+      catch (XmlPullParserException& xe)
+      {
+        //fprintf(stdout, "\nTest(%s) passed with exception: %s\n", test, xe.what());
+      }
+    }
+
+    void testSkipChild()
+    {
+      const char* test = "skip-child";
+      std::unique_ptr<IFragmentedXmlPullParser> parser(fxpp::createParser());
+      const char* input = R"!!!(<Root><Child/></Root>)!!!";
+      parser->setInput(input, int(strlen(input)));
+      try
+      {
+        parser->next();
+        parser->next();
+        parser->skipSubTree();
+        if (parser->next() != XmlPullParser::END_TAG)
+        {
+          fprintf(stdout, "\nTest(%s) did not leave parser at expected position\n", test);
+          CPPUNIT_ASSERT(false);
+        }
+      }
+      catch (XmlPullParserException& xe)
+      {
+        fprintf(stdout, "\nTest(%s) failed with exception: %s\n", test, xe.what());
+        CPPUNIT_ASSERT(false);
+      }
+    }
+
+    void testNoInput()
+    {
+      TestConfig cfg("no-input");
+      cfg.expectSuccess = false;
+      cfg.useAssistant = false;
+      runTest(cfg);
+    }
+    void testNullInput()
+    {
+      TestConfig cfg("null-input");
+      cfg.expectSuccess = false;
+      cfg.useAssistant = false;
+      runTest(cfg, nullptr, nullptr);
+    }
+    void testEmptyInput()
+    {
+      TestConfig cfg("empty-input");
+      cfg.expectSuccess = false;
+      cfg.useAssistant = false;
+      runTest(cfg, "");
+    }
+    void testNotWellFormedInput()
+    {
+      TestConfig cfg("not-well-formed-input");
+      cfg.expectSuccess = false;
+      cfg.useAssistant = false;
+      const char* input = R"!!(<?xml version="1.0" encoding="UTF-8"?>
+          <ut:UnitTest xmlns:ut="hpcc:test:esp:xpp">
+            <ut:Incomplete>
+          </ut:UnitTest>)!!";
+      runTest(cfg, input, input);
+    }
+    void testExternalFragmentSansDetector()
+    {
+      TestConfig cfg("external-fragment-sans-detector");
+      cfg.expectSuccess = false;
+      cfg.useExternalDetector = false;
+      const char* input = R"!!(
+          <ut:UnitTest xmlns:ut="hpcc:test:esp:xpp">
+            <ut:ExternalReplace resource="foo"/>
+          </ut:UnitTest>)!!";
+      runTest(cfg, input);
+    }
+    void testExternalFragmentSansLoader()
+    {
+      TestConfig cfg("external-fragment-sans-loader");
+      cfg.expectSuccess = false;
+      cfg.useExternalLoader = false;
+      const char* input = R"!!(
+          <ut:UnitTest xmlns:ut="hpcc:test:esp:xpp">
+            <ut:ExternalReplace resource="foo"/>
+          </ut:UnitTest>)!!";
+      runTest(cfg, input);
+    }
+    void testExternalFragmentDetectionSansLoad()
+    {
+      TestConfig cfg("external-fragment-detection-sans-load");
+      cfg.expectSuccess = false;
+      const char* input = R"!!(
+          <ut:UnitTest xmlns:ut="hpcc:test:esp:xpp">
+            <ut:ExternalReplace resource="unknown"/>
+          </ut:UnitTest>)!!";
+      runTest(cfg, input);
+    }
+    void testNotWellFormedExternalFragment()
+    {
+      TestConfig cfg("not-well-formed-external-fragment");
+      cfg.expectSuccess = false;
+      const char* input = R"!!(
+          <ut:UnitTest xmlns:ut="hpcc:test:esp:xpp">
+            <ut:ExternalReplace resource="not-well-formed"/>
+          </ut:UnitTest>)!!";
+      runTest(cfg, input);
+    }
+    void testCircularExternalFragments()
+    {
+      TestConfig cfg("circular-external-fragments");
+      cfg.expectSuccess = false;
+      const char* input = R"!!(
+          <ut:UnitTest xmlns:ut="hpcc:test:esp:xpp">
+            <ut:ExternalReplace resource="self-reference"/>
+          </ut:UnitTest>)!!";
+      runTest(cfg, input);
+    }
+    void testNoEmbeddedNSPropagation()
+    {
+      TestConfig cfg("no-embedded-ns-propagation");
+      cfg.expectSuccess = false;
+      const char* input = R"!!(
+          <ut:UnitTest xmlns:ut="hpcc:test:esp:xpp">
+            <ut:EmbeddedReplace>
+              <![CDATA[<ut:InheritNS/>]]>
+            </ut:EmbeddedReplace>
+          </ut:UnitTest>)!!";
+      runTest(cfg, input, input);
+    }
+    void testNoExternalNSPropagation()
+    {
+      TestConfig cfg("no-external-ns-propagation");
+      cfg.expectSuccess = false;
+      const char* input = R"!!(
+          <ut:UnitTest xmlns:ut="hpcc:test:esp:xpp">
+            <ut:ExternalReplace resource="no-namespace"/>
+          </ut:UnitTest>)!!";
+      runTest(cfg, input, input);
+    }
+
+    void testNoAssistant()
+    {
+      TestConfig cfg("no-assistant");
+      cfg.useAssistant = false;
+      const char* input = R"!!(<?xml version="1.0" encoding="UTF-8"?>
+      <ut:UnitTest xmlns:ut="hpcc:test:esp:xpp">
+        <ut:EmbeddedReplace>
+          <![CDATA[<ut:Unregistered/>]]>
+        </ut:EmbeddedReplace>
+      </ut:UnitTest>
+      )!!";
+      runTest(cfg, input, input);
+    }
+    void testEmbeddedFragmentReplacement()
+    {
+      TestConfig cfg("embedded-fragment-replacement");
+      const char* input = R"!!(
+          <ut:UnitTest xmlns:ut="hpcc:test:esp:xpp">
+            <ut:EmbeddedReplace this="that">
+              <![CDATA[<ut:Unregistered xmlns:ut="hpcc:test:esp:xpp"/>]]>
+            </ut:EmbeddedReplace>
+          </ut:UnitTest>)!!";
+      const char* equivalent = R"!!(
+          <ut:UnitTest xmlns:ut="hpcc:test:esp:xpp">
+            <ut:Unregistered xmlns:ut="hpcc:test:esp:xpp"/>
+          </ut:UnitTest>)!!";
+      runTest(cfg, input, equivalent);
+    }
+    void testExternalFragmentReplaceSelfClosing()
+    {
+      TestConfig cfg("external-replace-self-closing");
+      const char* input = R"!!(
+          <ut:UnitTest xmlns:ut="hpcc:test:esp:xpp">
+            <ut:ExternalReplace resource="foo"/>
+          </ut:UnitTest>)!!";
+      const char* equivalent = R"!!(
+          <ut:UnitTest xmlns:ut="hpcc:test:esp:xpp">
+            <ut:Foo/>
+          </ut:UnitTest>)!!";
+      runTest(cfg, input, equivalent);
+    }
+    void testExternalFragmentReplaceEmpty()
+    {
+      TestConfig cfg("external-replace-empty");
+      const char* input = R"!!(
+          <ut:UnitTest xmlns:ut="hpcc:test:esp:xpp">
+            <ut:ExternalReplace resource="foo">
+            </ut:ExternalReplace>
+          </ut:UnitTest>)!!";
+      const char* equivalent = R"!!(
+          <ut:UnitTest xmlns:ut="hpcc:test:esp:xpp">
+            <ut:Foo/>
+          </ut:UnitTest>)!!";
+      runTest(cfg, input, equivalent);
+    }
+    void testExternalFragmentReplaceWithChild()
+    {
+      TestConfig cfg("external-replace-with-child");
+      cfg.expectSuccess = false;
+      const char* input = R"!!(
+          <ut:UnitTest xmlns:ut="hpcc:test:esp:xpp">
+            <ut:ExternalReplace resource="foo">
+              <ut:NotAllowed/>
+            </ut:ExternalReplace>
+          </ut:UnitTest>)!!";
+      runTest(cfg, input);
+    }
+    void testExternalFragmentReplaceWithText()
+    {
+      TestConfig cfg("external-replace-with-text");
+      cfg.expectSuccess = false;
+      const char* input = R"!!(
+          <ut:UnitTest xmlns:ut="hpcc:test:esp:xpp">
+            <ut:ExternalReplace resource="foo">
+              NotAllowed
+            </ut:ExternalReplace>
+          </ut:UnitTest>)!!";
+      runTest(cfg, input);
+    }
+    void testExternalFragmentRetainSelfClosingParent()
+    {
+      TestConfig cfg("external-retain-self-closing-parent");
+      const char* input = R"!!(
+          <ut:UnitTest xmlns:ut="hpcc:test:esp:xpp">
+            <ut:ExternalRetainParent resource="foo"/>
+          </ut:UnitTest>)!!";
+      const char* equivalent = R"!!(
+          <ut:UnitTest xmlns:ut="hpcc:test:esp:xpp">
+            <ut:ExternalRetainParent resource="foo"><ut:Foo/></ut:ExternalRetainParent>
+          </ut:UnitTest>)!!";
+      runTest(cfg, input, equivalent);
+    }
+    void testExternalFragmentRetainEmptyParent()
+    {
+      TestConfig cfg("external-retain-empty-parent");
+      const char* input = R"!!(
+          <ut:UnitTest xmlns:ut="hpcc:test:esp:xpp">
+            <ut:ExternalRetainParent resource="foo"></ut:ExternalRetainParent>
+          </ut:UnitTest>)!!";
+      const char* equivalent = R"!!(
+          <ut:UnitTest xmlns:ut="hpcc:test:esp:xpp">
+            <ut:ExternalRetainParent resource="foo"><ut:Foo/></ut:ExternalRetainParent>
+          </ut:UnitTest>)!!";
+      runTest(cfg, input, equivalent);
+    }
+    void testExternalFragmentRetainWithChild()
+    {
+      TestConfig cfg("external-retain-with-child");
+      cfg.expectSuccess = false;
+      const char* input = R"!!(
+          <ut:UnitTest xmlns:ut="hpcc:test:esp:xpp">
+            <ut:ExternalRetainParent resource="foo"><ut:NotAllowed/></ut:ExternalRetainParent>
+          </ut:UnitTest>)!!";
+      runTest(cfg, input);
+    }
+    void testExternalFragmentRetainWithText()
+    {
+      TestConfig cfg("external-retain-with-text");
+      cfg.expectSuccess = false;
+      const char* input = R"!!(
+          <ut:UnitTest xmlns:ut="hpcc:test:esp:xpp">
+            <ut:ExternalRetainParent resource="foo">NotAllowed</ut:ExternalRetainParent>
+          </ut:UnitTest>)!!";
+      runTest(cfg, input);
+    }
+    void testEmbeddedNSPropagation()
+    {
+      TestConfig cfg("embedded-namespace-propagation");
+      const char* input = R"!!(
+          <ut:UnitTest xmlns:ut="hpcc:test:esp:xpp">
+            <ut:ShareNS>
+              <![CDATA[<ut:InheritNS/>]]>
+            </ut:ShareNS>
+          </ut:UnitTest>)!!";
+      const char* equivalent = R"!!(
+          <ut:UnitTest xmlns:ut="hpcc:test:esp:xpp">
+            <ut:InheritNS/>
+          </ut:UnitTest>)!!";
+      runTest(cfg, input, equivalent);
+    }
+    void testExternalNSPropagation()
+    {
+      TestConfig cfg("external-namespace-propagation");
+      const char* input = R"!!(
+          <ut:UnitTest xmlns:ut="hpcc:test:esp:xpp">
+            <ut:ShareNS resource="no-namespace"/>
+          </ut:UnitTest>)!!";
+      const char* equivalent = R"!!(
+          <ut:UnitTest xmlns:ut="hpcc:test:esp:xpp">
+            <ut:InheritedNS/>
+          </ut:UnitTest>)!!";
+      runTest(cfg, input, equivalent);
+    }
+    void testUnrootedInput()
+    {
+      TestConfig cfg("unrooted-input");
+      const char* input = R"!!(<Node1/><Node2/>)!!";
+      runTest(cfg, input);
+    }
+    void testUnrootedEmbedded()
+    {
+      TestConfig cfg("unrooted-embedded");
+      const char* input = R"!!(<ut:UnitTest xmlns:ut="hpcc:test:esp:xpp">
+            <ut:EmbeddedReplace>
+              <![CDATA[<Node1/><Node2/>]]>
+            </ut:EmbeddedReplace>
+          </ut:UnitTest>)!!";
+      const char* equivalent = R"!!(<ut:UnitTest xmlns:ut="hpcc:test:esp:xpp">
+              <Node1/><Node2/>
+          </ut:UnitTest>)!!";
+      runTest(cfg, input, equivalent);
+    }
+    void testNoNSSupport()
+    {
+      TestConfig cfg("no-namespace-support");
+      cfg.supportNamespaces = false;
+      const char* input = R"!!(<ut:UnitTest xmlns:ut="hpcc:test:esp:xpp">
+            <ut:EmbeddedReplace>
+              <![CDATA[<Node1/><Node2/>]]>
+            </ut:EmbeddedReplace>
+          </ut:UnitTest>)!!";
+      const char* equivalent = R"!!(<ut:UnitTest xmlns:ut="hpcc:test:esp:xpp">
+            <Node1/><Node2/>
+          </ut:UnitTest>)!!";
+      runTest(cfg, input, equivalent);
+    }
+    void testNestedFragments()
+    {
+      TestConfig cfg("nested-fragments");
+      const char* input = R"!!(
+        <ut:UnitTest xmlns:ut="hpcc:test:esp:xpp">
+          <ut:Nested node="1" resource="nested-1"/>
+        </ut:UnitTest>
+      )!!";
+      const char* equivalent = R"!!(
+        <ut:UnitTest xmlns:ut="hpcc:test:esp:xpp">
+          <ut:Nested node="1" resource="nested-1">
+            <ut:Nested node="2">
+              <ut:Nested node="3" resource="nested-2">
+                <ut:Nested node="4">
+                  <ut:Nested node="5">
+                    <ut:Nested node="6" resource="nested-3">
+                      <ut:Nested node="7"/>
+                    </ut:Nested>
+                  </ut:Nested>
+                </ut:Nested>
+              </ut:Nested>
+            </ut:Nested>
+          </ut:Nested>
+        </ut:UnitTest>
+      )!!";
+      runTest(cfg, input, equivalent);
+    }
+    void testSecondaryKey()
+    {
+      TestConfig cfg("secondary-key");
+      const char* input = R"!!(<ut:UnitTest xmlns:ut="hpcc:test:esp:xpp">
+            <ut:ExternalReplace resource="foo" match="bar"/>
+          </ut:UnitTest>)!!";
+      const char* equivalent = R"!!(<ut:UnitTest xmlns:ut="hpcc:test:esp:xpp">
+            <Bar/>
+          </ut:UnitTest>)!!";
+      runTest(cfg, input, equivalent);
+    }
+
+    IFragmentedXmlPullParser* createParser(const TestConfig& cfg)
+    {
+      Owned<fxa::IAssistant> assistant;
+      if (cfg.useAssistant)
+      {
+        assistant.setown(fxa::createAssistant());
+        if (cfg.useExternalDetector)
+          assistant->setExternalDetector(fxa::createExternalDetector());
+        if (cfg.useExternalLoader)
+          assistant->setExternalLoader(new MockLoader());
+        if (cfg.registerEmbeddedFragments)
+        {
+          const char* nsUri = cfg.supportNamespaces ? cfg.nsUri : "";
+          assistant->registerEmbeddedFragment(nsUri, "EmbeddedReplace", 0);
+          assistant->registerEmbeddedFragment(nsUri, "EmbeddedRetainSiblings", FXPP_RETAIN_FRAGMENT_PARENT);
+          assistant->registerEmbeddedFragment(nsUri, "ShareNS", FXPP_PROPAGATE_NAMESPACES);
+          assistant->registerEmbeddedFragment(nsUri, "Nested", FXPP_PROPAGATE_NAMESPACES | FXPP_RETAIN_FRAGMENT_PARENT);
+          assistant->registerEmbeddedFragment("", "ut:EmbeddedReplace", 0); // support namespace off
+        }
+        if (cfg.registerExternalFragments)
+        {
+          const char* nsUri = cfg.supportNamespaces ? cfg.nsUri : "";
+          assistant->registerExternalFragment(nsUri, "ExternalReplace", 0);
+          assistant->registerExternalFragment(nsUri, "ExternalRetainParent", FXPP_RETAIN_FRAGMENT_PARENT);
+          assistant->registerExternalFragment(nsUri, "ExternalRetainSiblings", FXPP_RETAIN_FRAGMENT_PARENT);
+          assistant->registerExternalFragment(nsUri, "ShareNS", FXPP_PROPAGATE_NAMESPACES);
+          assistant->registerExternalFragment(nsUri, "Nested", FXPP_PROPAGATE_NAMESPACES | FXPP_RETAIN_FRAGMENT_PARENT);
+        }
+      }
+      IFragmentedXmlPullParser* parser = fxpp::createParser();
+      parser->setSupportNamespaces(cfg.supportNamespaces);
+      parser->setAssistant(assistant.getClear());
+      return parser;
+    }
+
+    void parse(const char* name, IXmlPullParser& xpp, StringBuffer& output)
+    {
+      StartTag stag;
+      switch (xpp.next())
+      {
+      case IXmlPullParser::START_TAG:
+        xpp.readStartTag(stag);
+        serialize(xpp, stag, output.clear());
+        break;
+      case IXmlPullParser::END_TAG:
+        fprintf(stdout, "\nTest(%s) Bad test input; unexpected end tag\n", name);
+        CPPUNIT_ASSERT(false);
+        break;
+      case IXmlPullParser::CONTENT:
+        fprintf(stdout, "\nTest(%s) parse calling whitespaceContent\n", name);
+        if (!xpp.whitespaceContent())
+        {
+          fprintf(stdout, "\nTest(%s) Bad test input; unexpected content\n", name);
+          CPPUNIT_ASSERT(false);
+        }
+        else
+          parse(name, xpp, output);
+        break;
+      case IXmlPullParser::END_DOCUMENT:
+        fprintf(stdout, "\nTest(%s) Bad test input; unexpected end document\n", name);
+        CPPUNIT_ASSERT(false);
+        break;
+      default:
+        fprintf(stdout, "\nTest(%s) Bad test input; unexpected token type\n", name);
+        CPPUNIT_ASSERT(false);
+        break;
+      }
+    }
+
+    void runTest(const TestConfig& cfg)
+    {
+      std::unique_ptr<IFragmentedXmlPullParser> parser(createParser(cfg));
+      try
+      {
+        parser->next();
+      }
+      catch (sxt::XmlTokenizerException& e)
+      {
+        fprintf(stdout, "\nTest(%s) unexpected XmlTokenizerException exception: %s\n", cfg.name, e.what());
+        CPPUNIT_ASSERT(false);
+      }
+      catch (XmlPullParserException& xe)
+      {
+        if (cfg.expectSuccess)
+        {
+          fprintf(stdout, "\nTest(%s) unexpected XmlPullParserException; got %s\n", cfg.name, xe.what());
+          CPPUNIT_ASSERT(false);
+        }
+      }
+      catch (IException* e)
+      {
+        StringBuffer m;
+        fprintf(stdout, "\nTest(%s) unexpected IException; got %d - %s\n", cfg.name, e->errorCode(), e->errorMessage(m).str());
+        e->Release();
+        CPPUNIT_ASSERT(false);
+      }
+      catch (CppUnit::Exception& e)
+      {
+        throw;
+      }
+      catch (std::exception& e)
+      {
+        fprintf(stdout, "\nTest(%s) unexpected standard exception: %s\n", cfg.name, e.what());
+        CPPUNIT_ASSERT(false);
+      }
+      catch (...)
+      {
+        fprintf(stdout, "\nTest(%s) unexpected exception\n", cfg.name);
+        CPPUNIT_ASSERT(false);
+      }
+    }
+
+    void runTest(const TestConfig& cfg, const char* testInput)
+    {
+      std::unique_ptr<IFragmentedXmlPullParser> testParser(createParser(cfg));
+      StringBuffer                              testOutput;
+      try
+      {
+        testParser->setInput(testInput, -1);
+        parse(cfg.name, *testParser, testOutput);
+        if (!cfg.expectSuccess)
+        {
+          fprintf(stdout, "\nTest(%s) did not throw an expected exception\n", cfg.name);
+          fprintf(stdout, "Actual:\n%s\n", testOutput.str());
+          CPPUNIT_ASSERT(false);
+        }
+      }
+      catch (sxt::XmlTokenizerException& e)
+      {
+        fprintf(stdout, "\nTest(%s) unexpected XmlTokenizerException exception: %s\n", cfg.name, e.what());
+        CPPUNIT_ASSERT(false);
+      }
+      catch (XmlPullParserException& xe)
+      {
+        if (cfg.expectSuccess)
+        {
+          fprintf(stdout, "\nTest(%s) unexpected XmlPullParserException with test input; got %s\n", cfg.name, xe.what());
+          fprintf(stdout, "Actual:\n%s\n", testOutput.str());
+          CPPUNIT_ASSERT(false);
+        }
+      }
+      catch (IException* e)
+      {
+        StringBuffer m;
+        fprintf(stdout, "\nTest(%s) unexpected IException with test input; got %d - %s\n", cfg.name, e->errorCode(), e->errorMessage(m).str());
+        fprintf(stdout, "Actual:\n%s\n", testOutput.str());
+        e->Release();
+        CPPUNIT_ASSERT(false);
+      }
+      catch (CppUnit::Exception& e)
+      {
+        throw;
+      }
+      catch (std::exception& e)
+      {
+        fprintf(stdout, "\nTest(%s) unexpected standard exception: %s\n", cfg.name, e.what());
+        CPPUNIT_ASSERT(false);
+      }
+      catch (...)
+      {
+        fprintf(stdout, "\nTest(%s) unexpected exception with test input\n", cfg.name);
+        fprintf(stdout, "Actual:\n%s\n", testOutput.str());
+        CPPUNIT_ASSERT(false);
+      }
+    }
+
+    void runTest(const TestConfig& cfg, const char* testInput, const char* equivalentInput)
+    {
+      std::unique_ptr<IFragmentedXmlPullParser> testParser(createParser(cfg));
+      StringBuffer                              testOutput;
+      bool                                      compareOutput = false;
+      try
+      {
+        testParser->setInput(testInput, -1);
+        parse(cfg.name, *testParser, testOutput);
+        if (!cfg.expectSuccess)
+        {
+          fprintf(stdout, "\nTest(%s) did not throw an expected exception\n", cfg.name);
+          fprintf(stdout, "    Actual: %s\n", testOutput.str());
+          CPPUNIT_ASSERT(false);
+        }
+        else
+          compareOutput = true;
+      }
+      catch (sxt::XmlTokenizerException& e)
+      {
+        fprintf(stdout, "\nTest(%s) unexpected XmlTokenizerException exception: %s\n", cfg.name, e.what());
+        CPPUNIT_ASSERT(false);
+      }
+      catch (XmlPullParserException& xe)
+      {
+        if (cfg.expectSuccess)
+        {
+          fprintf(stdout, "\nTest(%s) unexpected XmlPullParserException with test input; got %s\n", cfg.name, xe.what());
+          fprintf(stdout, "    Actual: %s\n", testOutput.str());
+          CPPUNIT_ASSERT(false);
+        }
+      }
+      catch (IException* e)
+      {
+        StringBuffer m;
+        fprintf(stdout, "\nTest(%s) unexpected IException with test input; got %d - %s\n", cfg.name, e->errorCode(), e->errorMessage(m).str());
+        fprintf(stdout, "    Actual: %s\n", testOutput.str());
+        e->Release();
+        CPPUNIT_ASSERT(false);
+      }
+      catch (CppUnit::Exception& e)
+      {
+        throw;
+      }
+      catch (std::exception& e)
+      {
+        fprintf(stdout, "\nTest(%s) unexpected standard exception: %s\n", cfg.name, e.what());
+        CPPUNIT_ASSERT(false);
+      }
+      catch (...)
+      {
+        fprintf(stdout, "\nTest(%s) unexpected exception with test input\n", cfg.name);
+        fprintf(stdout, "    Actual: %s\n", testOutput.str());
+        CPPUNIT_ASSERT(false);
+      }
+
+      if (compareOutput)
+      {
+        std::unique_ptr<IXmlPullParser> baseParser(new XmlPullParser());
+        StringBuffer                    equivalentOutput;
+        try
+        {
+          baseParser->setSupportNamespaces(cfg.supportNamespaces);
+          baseParser->setInput(equivalentInput, int(strlen(equivalentInput)));
+          parse(cfg.name, *baseParser, equivalentOutput);
+        }
+        catch (sxt::XmlTokenizerException& e)
+        {
+          fprintf(stdout, "\nTest(%s) unexpected XmlTokenizerException exception: %s\n", cfg.name, e.what());
+          CPPUNIT_ASSERT(false);
+        }
+        catch (XmlPullParserException& xe)
+        {
+          fprintf(stdout, "\nTest(%s) unexpected XmlPullParserException with equivalent input; got %s\n", cfg.name, xe.what());
+          fprintf(stdout, "    Actual: %s\n  Expected: %s\n", testOutput.str(), equivalentOutput.str());
+          CPPUNIT_ASSERT(false);
+        }
+        catch (IException* e)
+        {
+          StringBuffer m;
+          fprintf(stdout, "\nTest(%s) unexpected IException with equivalent input; got %d - %s\n", cfg.name, e->errorCode(), e->errorMessage(m).str());
+          fprintf(stdout, "    Actual: %s\n  Expected: %s\n", testOutput.str(), equivalentOutput.str());
+          e->Release();
+          CPPUNIT_ASSERT(false);
+        }
+        catch (CppUnit::Exception& e)
+        {
+          throw;
+        }
+        catch (std::exception& e)
+        {
+          fprintf(stdout, "\nTest(%s) unexpected standard exception: %s\n", cfg.name, e.what());
+          CPPUNIT_ASSERT(false);
+        }
+        catch (...)
+        {
+          fprintf(stdout, "\nTest(%s) unexpected exception with equivalent input\n", cfg.name);
+          fprintf(stdout, "    Actual: %s\n  Expected: %s\n", testOutput.str(), equivalentOutput.str());
+          CPPUNIT_ASSERT(false);
+        }
+
+        compareXml(cfg.name, testOutput, equivalentOutput);
+      }
+    }
+
+    void serialize(StartTag& stag, StringBuffer& buffer)
+    {
+      const char* tag = stag.getLocalName();
+      if (tag)
+      {
+          buffer.appendf("<%s", tag);
+
+          for (int idx=0; idx<stag.getLength(); idx++)
+          {
+              buffer.appendf(" %s=\"", stag.getRawName(idx));
+              buffer.append(stag.getValue(idx));
+              buffer.append('\"');
+          }
+
+          buffer.append(">");
+      }
+    }
+    void serialize(IXmlPullParser &xpp, StartTag &stag, StringBuffer & buffer)
+    {
+        int level = 1; //assumed due to the way gotonextdataset works.
+        int type = XmlPullParser::END_TAG;
+        const char * content = "";
+        const char *tag = NULL;
+        EndTag etag;
+
+        serialize(stag, buffer);
+        do
+        {
+            type = xpp.next();
+            switch(type)
+            {
+                case XmlPullParser::START_TAG:
+                {
+                    xpp.readStartTag(stag);
+                    ++level;
+
+                    serialize(stag, buffer);
+                    break;
+                }
+                case XmlPullParser::END_TAG:
+                    xpp.readEndTag(etag);
+                    tag = etag.getLocalName();
+                    if (tag)
+                        buffer.appendf("</%s>", tag);
+                    --level;
+                break;
+                case XmlPullParser::CONTENT:
+                    content = xpp.readContent();
+                    if (!isEmptyString(content) && !xpp.whitespaceContent())
+                        encodeXML(content, buffer);
+                    break;
+                case XmlPullParser::END_DOCUMENT:
+                    level=0;
+                break;
+            }
+        }
+        while (level > 0);
+    }
+
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION( fxppParserTests );
+CPPUNIT_TEST_SUITE_NAMED_REGISTRATION( fxppParserTests, "fxppParser" );
+
+#endif // _USE_CPPUNIT


### PR DESCRIPTION
Add wrapper of xpp::XmlPullParser to handle complex configuration markup
with minimal impact existing parsing logic.

- Declare an interface from xpp::XmlPullparser's public API and make the
  wrapper extend this interface.
- Support detection and use of external XML fragments based on start tags.
- Support detection and use of embedded XML fragments based on start tags
  and content.
- Support generic conversion of property tree configuration nodes into input
  for the wrapper. Ensure that serialized property tree nodes can be fixed
  up to be compatible with the ESDL service engine's serialization.

Signed-off-by: Tim Klemm <tim.klemm@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [ ] The change has been fully tested:
  - [x] I have added tests to cover my changes.
  - [x] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
