### PR TITLE
HPCC-26341 Increase client side network timeout and rationalize timeout parameters in couchbase-simple.ecl

### DIFF
--- a/testing/regress/ecl/couchbase-simple.ecl
+++ b/testing/regress/ecl/couchbase-simple.ecl
@@ -35,6 +35,8 @@ server := '127.0.0.1' : STORED('CouchbaseServerIp');
 thebucket := 'travel-sample';
 user := 'traveluser' : STORED('CouchbaseBucketUser');
 password := 'travelpass' : STORED('CouchbaseBucketPass');
+operationTimeoutMs := 15.0 : STORED('CouchbaseOperationTimeoutMs');
+configTotalTimeoutMs := 45.0 : STORED('CouchbaseConfigTotalTimeoutMs');
 
 namerec := RECORD
   string name;
@@ -174,55 +176,55 @@ END;
 
 /* Due to inconsistencies found in couchbase travel-sample, some queries explicitly omit records of type landmark and hotel */
 
-integer countAllRecords() := EMBED(couchbase : server(server), user(user), password(password), bucket(thebucket), detailed_errcodes(1), operation_timeout(5.5), config_total_timeout(15))
+integer countAllRecords() := EMBED(couchbase : server(server), user(user), password(password), bucket(thebucket), detailed_errcodes(1), operation_timeout(operationTimeoutMs), config_total_timeout(configTotalTimeoutMs))
   SELECT count(*) from `travel-sample` as mybucketalias where mybucketalias.type != 'landmark' and mybucketalias.type != 'hotel';
 ENDEMBED;
 
-integer countTypes() := EMBED(couchbase : server(server), user(user), password(password), bucket(thebucket), detailed_errcodes(1), operation_timeout(5.5), config_total_timeout(15))
+integer countTypes() := EMBED(couchbase : server(server), user(user), password(password), bucket(thebucket), detailed_errcodes(1), operation_timeout(operationTimeoutMs), config_total_timeout(configTotalTimeoutMs))
   SELECT COUNT(DISTINCT mybucketalias.type) from `travel-sample` as mybucketalias where mybucketalias.type != 'landmark' and mybucketalias.type != 'hotel';
 ENDEMBED;
 
-dataset(typerec) allTypes() := EMBED(couchbase : server(server), user(user), password(password), bucket(thebucket), detailed_errcodes(1), operation_timeout(5.5), config_total_timeout(15))
+dataset(typerec) allTypes() := EMBED(couchbase : server(server), user(user), password(password), bucket(thebucket), detailed_errcodes(1), operation_timeout(operationTimeoutMs), config_total_timeout(configTotalTimeoutMs))
   SELECT DISTINCT mybucketalias.type from `travel-sample` as mybucketalias where mybucketalias.type IS NOT NULL and mybucketalias.type != 'landmark' and mybucketalias.type != 'hotel';
 ENDEMBED;
 
-dataset(travelrec) fulltravelrecords() := EMBED(couchbase : server(server), user(user), password(password), bucket(thebucket), detailed_errcodes(1), operation_timeout(5.5), config_total_timeout(15))
+dataset(travelrec) fulltravelrecords() := EMBED(couchbase : server(server), user(user), password(password), bucket(thebucket), detailed_errcodes(1), operation_timeout(operationTimeoutMs), config_total_timeout(configTotalTimeoutMs))
   select mybucketalias.* from `travel-sample` as mybucketalias where callsign = 'MILE-AIR' limit 1;
 ENDEMBED;
 
-dataset(namerec) airlinenames() := EMBED(couchbase : server(server), user(user), password(password), bucket(thebucket), detailed_errcodes(1), operation_timeout(5.5), config_total_timeout(15))
+dataset(namerec) airlinenames() := EMBED(couchbase : server(server), user(user), password(password), bucket(thebucket), detailed_errcodes(1), operation_timeout(operationTimeoutMs), config_total_timeout(configTotalTimeoutMs))
   select mybucketalias.name from `travel-sample` as mybucketalias where mybucketalias.type = 'airline' limit 1;
 ENDEMBED;
 
-dataset(airportrec) airportrecords() := EMBED(couchbase : server(server), user(user), password(password), bucket(thebucket), detailed_errcodes(1), operation_timeout(5.5), config_total_timeout(15))
+dataset(airportrec) airportrecords() := EMBED(couchbase : server(server), user(user), password(password), bucket(thebucket), detailed_errcodes(1), operation_timeout(operationTimeoutMs), config_total_timeout(configTotalTimeoutMs))
   select mybucketalias.* from `travel-sample` as mybucketalias where mybucketalias.type = 'airport' limit 1;
 ENDEMBED;
 
-dataset(airportrec) usairportrecords() := EMBED(couchbase : server(server), user(user), password(password), bucket(thebucket), detailed_errcodes(1), operation_timeout(5.5), config_total_timeout(15))
+dataset(airportrec) usairportrecords() := EMBED(couchbase : server(server), user(user), password(password), bucket(thebucket), detailed_errcodes(1), operation_timeout(operationTimeoutMs), config_total_timeout(configTotalTimeoutMs))
   select mybucketalias.* from `travel-sample` as mybucketalias where mybucketalias.type = 'airport' and country = 'United States' limit 1;
 ENDEMBED;
 
-dataset(airportrec) airportrecordsbycountry(string m) := EMBED(couchbase : server(server), user(user), password(password), bucket(thebucket), detailed_errcodes(1), operation_timeout(5.5), config_total_timeout(15))
+dataset(airportrec) airportrecordsbycountry(string m) := EMBED(couchbase : server(server), user(user), password(password), bucket(thebucket), detailed_errcodes(1), operation_timeout(operationTimeoutMs), config_total_timeout(configTotalTimeoutMs))
   select mybucketalias.* from `travel-sample` as mybucketalias where mybucketalias.type = 'airport' and country = $m limit 1;
 ENDEMBED;
 
-dataset(airportrec) airportrecordsbyid(integer id) := EMBED(couchbase : server(server), user(user), password(password), bucket(thebucket), detailed_errcodes(1), operation_timeout(5.5), config_total_timeout(15))
+dataset(airportrec) airportrecordsbyid(integer id) := EMBED(couchbase : server(server), user(user), password(password), bucket(thebucket), detailed_errcodes(1), operation_timeout(operationTimeoutMs), config_total_timeout(configTotalTimeoutMs))
   select mybucketalias.* from `travel-sample` as mybucketalias where mybucketalias.type = 'airport' and id = $id limit 1;
 ENDEMBED;
 
-dataset(airportrec) airportrecordsbyaltitude(integer alt) := EMBED(couchbase : server(server), user(user), password(password), bucket(thebucket), detailed_errcodes(1), operation_timeout(5.5), config_total_timeout(15))
+dataset(airportrec) airportrecordsbyaltitude(integer alt) := EMBED(couchbase : server(server), user(user), password(password), bucket(thebucket), detailed_errcodes(1), operation_timeout(operationTimeoutMs), config_total_timeout(configTotalTimeoutMs))
   select mybucketalias.* from `travel-sample` as mybucketalias where mybucketalias.type = 'airport' and geo.alt >= $alt limit 1;
 ENDEMBED;
 
-dataset(airportrec) airportrecordsbycoordinates(row(georec) values) := EMBED(couchbase : server(server), user(user), password(password), bucket(thebucket), detailed_errcodes(1), operation_timeout(5.5), config_total_timeout(15))
+dataset(airportrec) airportrecordsbycoordinates(row(georec) values) := EMBED(couchbase : server(server), user(user), password(password), bucket(thebucket), detailed_errcodes(1), operation_timeout(operationTimeoutMs), config_total_timeout(configTotalTimeoutMs))
   select mybucketalias.* from `travel-sample` as mybucketalias where mybucketalias.type = 'airport' and geo.lat = $lat and geo.lon = $lon limit 10;
 ENDEMBED;
 
-dataset(routerec) fullroute()  := EMBED(couchbase : server(server), user(user), password(password), bucket(thebucket), detailed_errcodes(1), operation_timeout(5.5), config_total_timeout(15))
+dataset(routerec) fullroute()  := EMBED(couchbase : server(server), user(user), password(password), bucket(thebucket), detailed_errcodes(1), operation_timeout(operationTimeoutMs), config_total_timeout(configTotalTimeoutMs))
   SELECT mybucketalias.* FROM `travel-sample` as mybucketalias WHERE type = 'route' and sourceairport IS NOT NULL LIMIT 1
 ENDEMBED;
 
-dataset(routerec) routeschedule(string sair, string dair)  := EMBED(couchbase : server(server), user(user), password(password), bucket(thebucket), detailed_errcodes(1), operation_timeout(5.5), config_total_timeout(15))
+dataset(routerec) routeschedule(string sair, string dair)  := EMBED(couchbase : server(server), user(user), password(password), bucket(thebucket), detailed_errcodes(1), operation_timeout(operationTimeoutMs), config_total_timeout(configTotalTimeoutMs))
   SELECT mybucketalias.schedule  FROM `travel-sample` as mybucketalias WHERE type = 'route' and sourceairport = $sair and destinationairport = $dair  LIMIT 1
 ENDEMBED;
 


### PR DESCRIPTION

Enable to using stored parameter for timeouts.

Increase operation_timeout() and config_total_timeout() values.

Replace hardwired values to variables.

Signed-off-by: Attila Vamos <attila.vamos@gmail.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [x] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->
Tested in OBT for a week (with patched values), locally with changed code.
<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
