### PR TITLE
HPCC-26395 require setting resources requests/limits explicitly.

### DIFF
--- a/helm/hpcc/templates/_helpers.tpl
+++ b/helm/hpcc/templates/_helpers.tpl
@@ -820,8 +820,7 @@ Pass in a dictionary with me defined
 {{- define "hpcc.addResources" }}
 {{- if .me  }}
 resources:
-  limits:
-{{ toYaml .me | indent 4 }}
+{{ toYaml .me | indent 2 }}
 {{- end }}
 {{- end -}}
 

--- a/helm/hpcc/values.yaml
+++ b/helm/hpcc/values.yaml
@@ -498,14 +498,26 @@ thor:
   maxJobs: 4
   maxGraphs: 2
   #managerResources:
-  #  cpu: "1"
-  #  memory: "2G"
+  #  requests:
+  #    cpu: "1"
+  #    memory: "2G"
+  #  limits:
+  #    cpu: "2"
+  #    memory: "4G"
   #workerResources:
-  #  cpu: "4"
-  #  memory: "4G"
+  #  requests:
+  #    cpu: "4"
+  #    memory: "4G"
+  #  limits:
+  #    cpu: "8"
+  #    memory: "8G"
   #eclAgentResources:
-  #  cpu: "1"
-  #  memory: "2G"
+  #  requests:
+  #    cpu: "1"
+  #    memory: "2G"
+  #  limits:
+  #    cpu: "2"
+  #    memory: "4G"
 
 eclscheduler:
 - name: eclscheduler


### PR DESCRIPTION
Previously only limits can be set. Now requests are added.

resources.limits will not guarantee a pod/job will get the required cpu or memory.
If memory allocation failed the pod/job will be in state of "OOMKilled" and will be restarted but normally it will fail again and again.
The fix is to ask user explicitly set "requests" or "limits". If resources.requestes is set the cpu/memory will be allocated when the pod/job is started. User will check with "kubectl describe node -o wide"


Signed off by Xiaoming Wang <xiaoming.wang@lexisnexis.com>

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [x] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [ ] I have read the CONTRIBUTORS document.
- [ ] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->
Tested on Azure and it works
On local even it help eliminate "OOMKilled" for thor-worker but the GNN training still fails when images are more than certain numbers such 350+. It cloud be related each PC resources.

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
