### PR TITLE
HPCC-25279 Fix '#ifdef _CONTAINERIZED's in ESP FileSpray/WsWorkunits

### DIFF
--- a/esp/services/ws_fs/ws_fsBinding.cpp
+++ b/esp/services/ws_fs/ws_fsBinding.cpp
@@ -202,9 +202,6 @@ int CFileSpraySoapBindingEx::onGetInstantQuery(IEspContext &context, CHttpReques
 IPropertyTree* CFileSpraySoapBindingEx::createPTreeForXslt(double clientVersion, const char* method, const char* dfuwuid)
 {
     Owned<IPropertyTree> pRoot = createPTreeFromXMLString("<Environment/>");
-#ifdef _CONTAINERIZED
-    IERRLOG("CONTAINERIZED(CFileSpraySoapBindingEx::createPTreeForXslt)");
-#else
     Owned<IEnvironmentFactory> factory = getEnvironmentFactory(true);
     Owned<IConstEnvironment> constEnv = factory->openEnvironment();
     Owned<IPropertyTree> pEnvRoot = &constEnv->getPTree();
@@ -301,7 +298,6 @@ IPropertyTree* CFileSpraySoapBindingEx::createPTreeForXslt(double clientVersion,
         if (wuxml.length() > 0)
             pSoftware->addPropTree("DfuWorkunit", createPTreeFromXMLString(wuxml.str()));
     }
-#endif
     return pRoot.getClear();
 }
 

--- a/esp/services/ws_fs/ws_fsService.cpp
+++ b/esp/services/ws_fs/ws_fsService.cpp
@@ -679,9 +679,8 @@ bool CFileSprayEx::onDFUWUSearch(IEspContext &context, IEspDFUWUSearchRequest & 
 {
     try
     {
-#ifdef _CONTAINERIZED
-        UNIMPLEMENTED_X("CONTAINERIZED(CFileSprayEx::onDFUWUSearch)");
-#else
+#ifndef _CONTAINERIZED
+        //The code below should be only for legacy ECLWatch.
         context.ensureFeatureAccess(DFU_WU_URL, SecAccess_Read, ECLWATCH_DFU_WU_ACCESS_DENIED, "Access to DFU workunit is denied.");
 
         Owned<IEnvironmentFactory> factory = getEnvironmentFactory(true);

--- a/esp/services/ws_workunits/ws_workunitsHelpers.cpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.cpp
@@ -1072,10 +1072,6 @@ unsigned WsWuInfo::getWorkunitThorLogInfo(IArrayOf<IEspECLHelpFile>& helpers, IE
     IArrayOf<IConstThorLogInfo> thorLogList;
     if (cw->getWuidVersion() > 0)
     {
-#ifdef _CONTAINERIZED
-        IERRLOG("CONTAINERIZED(WsWuInfo::getWorkunitThorLogInfo) not fully implemented");
-        return countThorLog;
-#else
         StringAttr clusterName(cw->queryClusterName());
         if (!clusterName.length()) //Cluster name may not be set yet
             return countThorLog;
@@ -1161,14 +1157,9 @@ unsigned WsWuInfo::getWorkunitThorLogInfo(IArrayOf<IEspECLHelpFile>& helpers, IE
                 thorLogList.append(*thorLog.getLink());
             }
         }
-#endif
     }
     else //legacy wuid
     {
-#ifdef _CONTAINERIZED
-        IERRLOG("CONTAINERIZED(WsWuInfo::getWorkunitThorLogInfo) not fully implemented");
-        return countThorLog;
-#else
         Owned<IStringIterator> thorLogs = cw->getLogs("Thor");
         ForEach (*thorLogs)
         {
@@ -1252,7 +1243,6 @@ unsigned WsWuInfo::getWorkunitThorLogInfo(IArrayOf<IEspECLHelpFile>& helpers, IE
                 thorLogList.append(*thorLog.getLink());
             }
         }
-#endif
     }
 
     if (thorLogList.length() > 0)
@@ -2054,9 +2044,6 @@ void WsWuInfo::getWorkunitThorSlaveLog(IPropertyTree* directories, const char *p
     const char* instanceName, const char *ipAddress, const char* logDate, int slaveNum,
     MemoryBuffer& buf, const char* outFile, bool forDownload)
 {
-#ifdef _CONTAINERIZED
-    UNIMPLEMENTED_X("CONTAINERIZED(WsWuInfo::getWorkunitThorLogInfo)");
-#else
     StringBuffer logDir, groupName;
     getConfigurationDirectory(directories, "log", "thor", process, logDir);
     getClusterThorGroupName(groupName, instanceName);
@@ -2068,7 +2055,6 @@ void WsWuInfo::getWorkunitThorSlaveLog(IPropertyTree* directories, const char *p
         throw MakeStringException(ECLWATCH_INVALID_INPUT, "Node group %s not found", groupName.str());
 
     getWorkunitThorSlaveLog(nodeGroup, ipAddress, process, logDate, logDir.str(), slaveNum, buf, outFile, forDownload);
-#endif
 }
 
 void WsWuInfo::readWorkunitThorLog(const char* processName, const char* log, const char* slaveIPAddress, unsigned slaveNum, MemoryBuffer& buf, const char* outFile)
@@ -3555,10 +3541,7 @@ void CWsWuFileHelper::createThorSlaveLogfile(IConstWorkUnit* cwu, WsWuInfo& winf
     const char* clusterName = cwu->queryClusterName();
     if (isEmptyString(clusterName)) //Cluster name may not be set yet
         return;
-#ifdef _CONTAINERIZED
-    UNIMPLEMENTED_X("CONTAINERIZED(CWsWuFileHelper::createThorSlaveLogfile)");
-    return;
-#else
+
     Owned<IConstWUClusterInfo> clusterInfo = getTargetClusterInfo(clusterName);
     if (!clusterInfo)
     {
@@ -3604,7 +3587,6 @@ void CWsWuFileHelper::createThorSlaveLogfile(IConstWorkUnit* cwu, WsWuInfo& winf
         }
     }
     threadPool->joinAll();
-#endif
 }
 #endif
 

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -4407,9 +4407,6 @@ int CWsWorkunitsSoapBindingEx::onGetForm(IEspContext &context, CHttpRequest* req
         {
             if(strieq(method,"WUQuery"))
             {
-#ifdef _CONTAINERIZED
-                UNIMPLEMENTED_X("CONTAINERIZED(CWsWorkunitsSoapBindingEx::onGetForm)");
-#else
                 Owned<IEnvironmentFactory> factory = getEnvironmentFactory(true);
                 Owned<IConstEnvironment> environment = factory->openEnvironment();
                 Owned<IPropertyTree> root = &environment->getPTree();
@@ -4439,7 +4436,6 @@ int CWsWorkunitsSoapBindingEx::onGetForm(IEspContext &context, CHttpRequest* req
                 }
                 xml.append("</WUQuery>");
                 xslt.append(getCFD()).append("./smc_xslt/wuid_search.xslt");
-#endif
             }
             else if (strieq(method,"WUJobList"))
             {


### PR DESCRIPTION
1. The FileSpray.DFUWUSearch is only used by legacy ECLWatch.
2. Remove multiple '#ifdef _CONTAINERIZED's which are already
inside '#ifndef _CONTAINERIZED'.

Signed-off-by: wangkx <kevin.wang@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
