### PR TITLE
HPCC-26462 Make ecl command '--poll' parameter configurable via config file.

### DIFF
--- a/testing/regress/ecl-test
+++ b/testing/regress/ecl-test
@@ -368,10 +368,13 @@ class RegressMain:
         self.config.set('preAbort', self.args.preAbort)
 
         if not self.config.has('wuStatusTimeout'):
-            self.config.set('wuStatusTimeout', 30)
+            self.config.set('wuStatusTimeout', "30")
 
         if not self.config.has('wuAbortTimeout'):
-            self.config.set('wuAbortTimeout', 30)
+            self.config.set('wuAbortTimeout', "30")
+
+        if not self.config.has('usePoll'):
+            self.config.set('usePoll', "False")
 
         self.config.set('log',  self.log)
         setConfig(self.config)

--- a/testing/regress/ecl-test-azure.json
+++ b/testing/regress/ecl-test-azure.json
@@ -21,29 +21,32 @@
         "Engines": [
             "hthor",
             "thor",
-            "roxie"
+            "roxie-workunit"
         ],
         "Clusters": {
             "hthor" : "hthor",
             "thor"  : "thor",
-            "roxie" : "roxie"
+            "roxie-workunit" : "roxie-workunit"
         },
         "ClusterNames": {
             "hthor" : "myhthor",
             "thor"  : "mythor",
-            "roxie" : "myroxie"
+            "roxie-workunit" : "myroxie"
         },
-        "timeout":"720",
-        "maxAttemptCount":"3",
-        "wuStatusTimeout":"30",
-        "wuAbortTimeout":"30",
-        "usePoll":"False",
+        "timeout":"3600",
+        "maxAttemptCount":"1",
+        "wuStatusTimeout":"3600",
+        "wuAbortTimeout":"720",
+        "usePoll":"True",
         "defaultSetupTargets": [
+            "hthor",
             "thor",
-            "roxie"
+            "roxie-workunit"
         ],
         "defaultTargets": [
-            "all"
+            "hthor",
+            "thor",
+            "roxie-workunit"
         ],
         "Params":[
             "PassTest.ecl:bla='A value'",
@@ -52,7 +55,8 @@
         ],
         "engineParams":[
             "failOnLeaks",
-            "disableLocalOptimizations"
+            "disableLocalOptimizations",
+            "thorConnectTimeout=36000"
         ],
         "setupExtraParams":{
             "OriginalTextFilesOsPath" : "/opt/HPCCSystems/testing/regress",

--- a/testing/regress/hpcc/regression/regress.py
+++ b/testing/regress/hpcc/regression/regress.py
@@ -251,7 +251,7 @@ class Regression:
                     query.setIgnoreResult(self.args.ignoreResult)
                     query.setJobname(time.strftime("%y%m%d-%H%M%S"))
                     timeout = query.getTimeout()
-                    logger.debug("Query timeout:%d", -1, timeout)
+                    logger.debug("%3d. Query timeout:%d", -1, timeout)
                     oldCnt = cnt
 
                 started = False

--- a/testing/regress/hpcc/util/ecl/file.py
+++ b/testing/regress/hpcc/util/ecl/file.py
@@ -60,6 +60,7 @@ class ECLFile:
 
     def __init__(self, ecl, dir_a, dir_ex, dir_r, dir_inc, cluster, args):
         logger.debug("%3d. ECLFile(ecl: '%s', cluster: '%s').", self.taskId, ecl,  cluster)
+        self.config = getConfig()
         self.dir_ec = os.path.dirname(ecl)
         self.dir_ex = dir_ex
         self.dir_r = dir_r
@@ -87,6 +88,8 @@ class ECLFile:
         self.version=''
         self.versionId=0
         self.timeout = self.checkFileTimeout(int(args.timeout))
+        if self.timeout == -1:
+            self.timeout = int(self.config.timeout) # use default from config
         self.args = args
         self.eclccWarning = ''
         self.eclccWarningChanges = ''
@@ -110,7 +113,6 @@ class ECLFile:
         # -X in the CLI is the highest.
         self.optXHash=self.checkQueryxmlFile()
 
-        self.config = getConfig()
         try:
             # Process definitions of stored input value(s) from config
             for param in self.config.Params:

--- a/testing/regress/hpcc/util/util.py
+++ b/testing/regress/hpcc/util/util.py
@@ -128,6 +128,7 @@ def queryWuid(jobname,  taskId):
     args.append('-v')
     args.append('-n=' + jobname)
     args.append('--wait-read='+ gConfig.wuStatusTimeout )  # Timeout while reading from socket (in seconds)
+    args.append('--wait-connect=%d' % (int(gConfig.wuStatusTimeout) * 1000) )  # Timeout while reading from socket (in milliseconds)
     addCommonEclArgs(args)
 
     res, stderr = shell.command(cmd, *defaults)(*args)


### PR DESCRIPTION

Add 'usePoll' to ecl-test.json config file.

Add code to manage the 'usePoll' when assembly ecl command line.

Filter out extra lines from the result/output  generated by the ecl command
with '--poll' parameter.

Add example config file for azure environment.

Signed-off-by: Attila Vamos <attila.vamos@gmail.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [ ] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [ ] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [ ] I have read the CONTRIBUTORS document.
- [ ] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [x] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->
Tested manually without 'usePoll' in config, with 'usePoll' in config and False or True values.
<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
