### PR TITLE
HPCC-26423 Allow the remote default git repo to be configured

### DIFF
--- a/ecl/eclcc/eclcc.cpp
+++ b/ecl/eclcc/eclcc.cpp
@@ -251,6 +251,10 @@ public:
 #ifdef _CONTAINERIZED
         setSecurityOptions();
 #endif
+        const char * defaultGitPrefix = getenv("ECLCC_DEFAULT_GITPREFIX");
+        if (isEmptyString(defaultGitPrefix))
+            defaultGitPrefix = "git+ssh://github.com/";
+        optDefaultGitPrefix.set(defaultGitPrefix);
     }
     ~EclCC()
     {
@@ -372,6 +376,8 @@ protected:
     StringArray deniedPermissions;
     StringAttr optMetaLocation;
     StringBuffer neverSimplifyRegEx;
+    StringAttr optDefaultGitPrefix;
+
     bool defaultAllowed[2];
 
     ClusterType optTargetClusterType = RoxieCluster;
@@ -2166,7 +2172,7 @@ bool EclCC::processFiles()
 
     //Set up the default repository information.  This could be simplified to not use a localRepositoryManager later
     //if eclcc did not have a strange mode for running multiple queries as part of the regression suite testing on windows.
-    repositoryManager.setOptions(eclRepoPath, optFetchRepos, optUpdateRepos, logVerbose);
+    repositoryManager.setOptions(eclRepoPath, optDefaultGitPrefix, optFetchRepos, optUpdateRepos, logVerbose);
     ForEachItemIn(iMapping, repoMappings)
     {
         const char * cur = repoMappings.item(iMapping);
@@ -2640,6 +2646,9 @@ int EclCC::parseCommandLineOptions(int argc, const char* argv[])
         else if (iter.matchOption(tempArg, "--daemon"))
         {
             //Ignore any --daemon option supplied to eclccserver which may be passed onto eclcc
+        }
+        else if (iter.matchOption(optDefaultGitPrefix, "--defaultGitPrefix"))
+        {
         }
         else if (iter.matchOption(optDFS, "-dfs") || /*deprecated*/ iter.matchOption(optDFS, "-dali"))
         {

--- a/ecl/eclcc/eclcc.hpp
+++ b/ecl/eclcc/eclcc.hpp
@@ -85,6 +85,7 @@ const char * const helpText[] = {
     "!   -brk <n>      Trigger a break point in eclcc after nth allocation",
 #endif
     "!   -Dname=value  Override the definition of a global attribute 'name'",
+    "!   --defaultGitPrefix <prefix>  The default prefix used to access git repos when not specified in package.json",
     "!   --deny=all    Disallow use of all named features not specifically allowed using --allow",
     "!   --deny=str    Disallow use of named feature",
     "!   --expand <path> Expand the contents of an archive to a directory",

--- a/ecl/hql/hqlrepository.hpp
+++ b/ecl/hql/hqlrepository.hpp
@@ -55,9 +55,10 @@ public:
 
     void processArchive(IPropertyTree * archiveTree);
     IEclPackage * resolveDependentRepository(IIdAtom * name, const char * defaultUrl, bool requireSHA);
-    void setOptions(const char * _eclRepoPath, bool _fetchRepos, bool _updateRepos, bool _verbose)
+    void setOptions(const char * _eclRepoPath, const char * _defaultGitPrefix, bool _fetchRepos, bool _updateRepos, bool _verbose)
     {
         options.eclRepoPath.set(_eclRepoPath);
+        options.defaultGitPrefix.set(_defaultGitPrefix);
         options.fetchRepos = _fetchRepos;
         options.updateRepos = _updateRepos;
         options.optVerbose = _verbose;
@@ -80,6 +81,7 @@ private:
     //Include all options in a nested struct to make it easy to ensure they are cloned
     struct {
         StringAttr eclRepoPath;
+        StringAttr defaultGitPrefix;
         bool fetchRepos = false;
         bool updateRepos = false;
         bool optVerbose = false;


### PR DESCRIPTION
Signed-off-by: Gavin Halliday <gavin.halliday@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [x] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [ ] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
