### PR TITLE
HPCC-26563 Fix sub dir per parts issues

### DIFF
--- a/common/thorhelper/roxiehelper.cpp
+++ b/common/thorhelper/roxiehelper.cpp
@@ -2399,7 +2399,7 @@ void ClusterWriteHandler::getPhysicalName(StringBuffer & name, const char * clus
 {
     Owned<IStoragePlane> plane = getDataStoragePlane(cluster, false);
     const char * prefix = plane ? plane->queryPrefix() : nullptr;
-    makePhysicalPartName(logicalName.get(), 1, 1, name, 0, DFD_OSdefault, prefix);
+    makePhysicalPartName(logicalName.get(), 1, 1, name, 0, DFD_OSdefault, prefix, false);
 }
 
 void ClusterWriteHandler::addCluster(char const * cluster)

--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -4247,16 +4247,19 @@ public:
             myBase = newbasedir;
         }
         else
+        {
             myBase = queryBaseDirectory(grp_unknown, 0, os);
+            diroverride = myBase;
+        }
 
         StringBuffer baseDir, newPath;
-        makePhysicalPartName(logicalName.get(), 0, 0, newPath, false, os, diroverride);
+        getLFNDirectoryUsingBaseDir(newPath, logicalName.get(), diroverride);
         if (!getBase(directory, newPath, baseDir))
             baseDir.append(myBase); // getBase returns false, if directory==newPath, so have common base
         getPartMask(newmask,newname,width);
         if (newmask.length()==0)
             return false;
-        makePhysicalPartName(newname, 0, 0, newPath.clear(), false, os, diroverride);
+        getLFNDirectoryUsingBaseDir(newPath.clear(), newname, diroverride);
         if (newPath.length()==0)
             return false;
         if (isPathSepChar(newPath.charAt(newPath.length()-1)))
@@ -4270,7 +4273,7 @@ public:
             newNames.append(*new CIStringArray);
             CDistributedFilePart &part = parts.item(i);
             for (unsigned copy=0; copy<part.numCopies(); copy++) {
-                makePhysicalPartName(newname, i+1, width, newPath.clear(), false, os, myBase);
+                makePhysicalPartName(newname, i+1, width, newPath.clear(), 0, os, myBase, hasDirPerPart());
                 newPath.remove(0, strlen(myBase));
 
                 StringBuffer copyDir(baseDir);

--- a/dali/base/dafdesc.hpp
+++ b/dali/base/dafdesc.hpp
@@ -322,15 +322,19 @@ extern da_decl StringBuffer &makePhysicalPartName(
                                 unsigned partno,                    // part number (1..)
                                 unsigned partmax,                   // number of parts (1..)
                                 StringBuffer &result,               // result filename (or directory name if part 0)
-                                unsigned replicateLevel = 0,       // uses replication directory
-                                DFD_OS os=DFD_OSdefault,            // os must be specified if no dir specified
-                                const char *diroverride=NULL);      // override default directory
+                                unsigned replicateLevel,            // uses replication directory
+                                DFD_OS os,                          // os must be specified if no dir specified
+                                const char *diroverride,            // override default directory
+                                bool dirPerPart);                   // generate a subdirectory per part
 extern da_decl StringBuffer &makeSinglePhysicalPartName(const char *lname, // single part file
                                                         StringBuffer &result,
                                                         bool allowospath,   // allow an OS (absolute) file path
                                                         bool &wasdfs,       // not OS path
                                                         const char *diroverride=NULL
                                                         );
+// 
+extern da_decl StringBuffer &getLFNDirectoryUsingBaseDir(StringBuffer &result, const char *lname, const char *baseDir);
+extern da_decl StringBuffer &getLFNDirectoryUsingDefaultBaseDir(StringBuffer &result, const char *lname, DFD_OS os);
 
 // set/get defaults
 extern da_decl const char *queryBaseDirectory(GroupType groupType, unsigned replicateLevel=0, DFD_OS os=DFD_OSdefault);

--- a/dali/base/dautils.cpp
+++ b/dali/base/dautils.cpp
@@ -3262,7 +3262,7 @@ public:
 #endif
             // MORE - should we create the IDistributedFile here ready for publishing (and/or to make sure it's locked while we write)?
             StringBuffer physicalPath;
-            makePhysicalPartName(lfn.get(), 1, 1, physicalPath, false, DFD_OSdefault, dir); // more - may need to override path for roxie
+            makePhysicalPartName(lfn.get(), 1, 1, physicalPath, 0, DFD_OSdefault, dir, false); // more - may need to override path for roxie
             localpath.set(physicalPath);
             fileExists = (dfile != NULL);
             return write;

--- a/dali/datest/datest.cpp
+++ b/dali/datest/datest.cpp
@@ -74,7 +74,7 @@ static void addTestFile(const char *name,unsigned n)
     Owned<IPropertyTree> fileInfo = createPTree();
     Owned<IFileDescriptor> fileDesc = createFileDescriptor();
     StringBuffer dir;
-    makePhysicalPartName(name, 0, 0, dir, false, DFD_OSdefault);
+    getLFNDirectoryUsingDefaultBaseDir(dir, name, DFD_OSdefault);
     StringBuffer partmask;
     getPartMask(partmask,name,n);
     StringBuffer path;

--- a/dali/datest/dfuwutest.cpp
+++ b/dali/datest/dfuwutest.cpp
@@ -435,7 +435,7 @@ IFileDescriptor *createRoxieFileDescriptor(const char *cluster, const char *lfn,
             UERRLOG("dataDirectory not specified");
             return NULL;
         }
-        makePhysicalPartName(lfn,i+1,width,filename,false,DFD_OSdefault,dir);
+        makePhysicalPartName(lfn,i+1,width,filename,0,DFD_OSdefault,dir,false);
         RemoteFilename rfn;
         rfn.setPath(grp->queryNode(i).endpoint(),filename.str());
         ret->setPart(i,rfn,NULL);

--- a/dali/dfu/dfuutil.cpp
+++ b/dali/dfu/dfuutil.cpp
@@ -476,10 +476,9 @@ public:
         dstfdesc->setPartMask(dstpartmask.str());
         unsigned np = srcfdesc->numParts();
         dstfdesc->setNumParts(srcfdesc->numParts());
-        DFD_OS os = (getPathSepChar(srcfdesc->queryDefaultDir())=='\\')?DFD_OSwindows:DFD_OSunix;
         StringBuffer dir;
         StringBuffer dstdir;
-        makePhysicalPartName(dstlfn.get(),0,0,dstdir,false,os,spec.defaultBaseDir.get());
+        getLFNDirectoryUsingBaseDir(dstdir, dstlfn.get(), spec.defaultBaseDir.get());
         dstfdesc->setDefaultDir(dstdir.str());
         dstfdesc->addCluster(cluster1,grp1,spec);
         if (iskey&&!cluster2.isEmpty())

--- a/dali/dfu/dfuwu.cpp
+++ b/dali/dfu/dfuwu.cpp
@@ -875,7 +875,7 @@ public:
                 getClusterPartDefaultBaseDir(NULL,baseoverride);
                 bool iswin;
                 getWindowsOS(iswin); // sets os
-                makePhysicalPartName(lfn.get(),0,0,str,false,os,baseoverride.str());
+                getLFNDirectoryUsingBaseDir(str, lfn.get(), baseoverride.str());
             }
         }
         return str;

--- a/ecl/eclagent/eclagent.cpp
+++ b/ecl/eclagent/eclagent.cpp
@@ -3184,7 +3184,7 @@ char *EclAgent::getFilePart(const char *lfn, bool create)
         expandLogicalName(full_lfn, lfn);
 
         StringBuffer physical;
-        makePhysicalPartName(full_lfn.str(), 1, 1, physical, false);//MORE: What do we do if local ?
+        makePhysicalPartName(full_lfn.str(), 1, 1, physical, 0, DFD_OSdefault, nullptr, false);//MORE: What do we do if local ?
 
         StringBuffer dir,base;
         splitFilename(physical.str(), &dir, &dir, &base, &base);

--- a/esp/services/ws_fs/ws_fsService.cpp
+++ b/esp/services/ws_fs/ws_fsService.cpp
@@ -577,7 +577,7 @@ bool CFileSprayEx::ParseLogicalPath(const char * pLogicalPath, const char* group
 #endif
     }
 
-    makePhysicalPartName(pLogicalPath,0,0,folder,false,os,defaultFolder.str());
+    getLFNDirectoryUsingBaseDir(folder, pLogicalPath, defaultFolder.str());
 
     const char *n = pLogicalPath;
     const char* p;

--- a/roxie/ccd/ccd.hpp
+++ b/roxie/ccd/ccd.hpp
@@ -359,6 +359,7 @@ extern StringBuffer roxieName;
 #ifdef _CONTAINERIZED
 extern StringBuffer defaultPlane;
 extern StringBuffer defaultPlaneDirPrefix;
+extern bool defaultPlaneDirPerPart;
 #endif
 extern bool trapTooManyActiveQueries;
 extern unsigned maxEmptyLoopIterations;

--- a/roxie/ccd/ccddali.cpp
+++ b/roxie/ccd/ccddali.cpp
@@ -387,8 +387,7 @@ private:
                     // Due to the really weird code in dadfs, this MUST be set to match the leading portion of cloneFromDir
                     // in order to properly handle remote systems with different default directory locations
                     StringBuffer tail;
-                    DFD_OS os = (getPathSepChar(srcfdesc->queryDefaultDir())=='\\')?DFD_OSwindows:DFD_OSunix;
-                    makePhysicalPartName(dstlfn.get(),0,0,tail,0,os,PATHSEPSTR);  // if lfn is a::b::c, tail will be /a/b/
+                    getLFNDirectoryUsingBaseDir(tail, dstlfn.get(), PATHSEPSTR); // if lfn is a::b::c, tail will be /a/b/
                     assertex(tail.length() > 1);
                     tail.setLength(tail.length()-1);   // strip off the trailing /
                     StringBuffer head(srcfdesc->queryProperties().queryProp("@cloneFromDir")); // Will end with /a/b

--- a/roxie/ccd/ccdfile.cpp
+++ b/roxie/ccd/ccdfile.cpp
@@ -1710,10 +1710,12 @@ public:
                 dlfn.clearForeign();
 #ifdef _CONTAINERIZED
             const char *defaultDir = defaultPlaneDirPrefix;
+            bool defaultDirPerPart = defaultPlaneDirPerPart;
 #else
             const char *defaultDir = nullptr;
+            bool defaultDirPerPart = false;
 #endif
-            makePhysicalPartName(dlfn.get(), partNo, numParts, localLocation, replicationLevel, DFD_OSdefault, defaultDir);
+            makePhysicalPartName(dlfn.get(), partNo, numParts, localLocation, replicationLevel, DFD_OSdefault, defaultDir, defaultDirPerPart);
         }
         Owned<ILazyFileIO> ret;
         try

--- a/roxie/ccd/ccdmain.cpp
+++ b/roxie/ccd/ccdmain.cpp
@@ -180,6 +180,7 @@ StringBuffer roxieName;
 #ifdef _CONTAINERIZED
 StringBuffer defaultPlane;
 StringBuffer defaultPlaneDirPrefix;
+bool defaultPlaneDirPerPart = false;
 #endif
 bool trapTooManyActiveQueries;
 unsigned maxEmptyLoopIterations;
@@ -724,6 +725,7 @@ int CCD_API roxie_main(int argc, const char *argv[], const char * defaultYaml)
         {
             Owned<IStoragePlane> plane = getDataStoragePlane(defaultPlane, true);
             defaultPlaneDirPrefix.set(plane->queryPrefix());
+            defaultPlaneDirPerPart = plane->queryDirPerPart();
         }
 #endif
         installDefaultFileHooks(topology);

--- a/thorlcr/mfilemanager/thmfilemanager.cpp
+++ b/thorlcr/mfilemanager/thmfilemanager.cpp
@@ -477,6 +477,7 @@ public:
             desc->queryProperties().setProp("@job", jobStr.str());
             desc->queryProperties().setProp("@owner", userStr.str());
 
+#ifndef _CONTAINERIZED
             // if supporting different OS's in CLUSTER this should be checked where addCluster called
             DFD_OS os = DFD_OSdefault;
             EnvMachineOS thisOs = queryOS(groups.item(0).queryNode(0).endpoint());
@@ -492,7 +493,7 @@ public:
                 default:
                     break;
             };
-
+#endif
             unsigned offset = 0;
             unsigned total;
             if (restrictedWidth)
@@ -522,7 +523,7 @@ public:
                     }
 #else
                     if (!getConfigurationDirectory(globals->queryPropTree("Directories"), "data", "thor", groupNames.item(gn), thisPlaneDir))
-                        makePhysicalPartName(logicalName, 0, 0, thisPlaneDir, 0, os); // legacy
+                        getLFNDirectoryUsingDefaultBaseDir(thisPlaneDir, logicalName, os); // legacy
 #endif
                     if (!planeDir.length()) // 1st output plane
                     {
@@ -539,11 +540,11 @@ public:
                     }
                 }
                 // places logical filename directory in 'dir'
-                makePhysicalPartName(logicalName, 0, 0, dir, false, os, planeDir.str());
+                getLFNDirectoryUsingBaseDir(dir, logicalName, planeDir.str());
             }
             desc->setDefaultDir(dir.str());
 
-            if (job.getOptBool("subDirPerFilePart", dirPerPart))
+            if (job.getOptBool("subDirPerFilePart", dirPerPart) && total>1)
                 desc->queryProperties().setPropInt("@flags", static_cast<int>(FileDescriptorFlags::dirperpart));
 
             StringBuffer partmask;


### PR DESCRIPTION
1) Roxie wasn't locating file parts locatated in their
own sub-directories
2) renamePhysicalParts was ignoring the subdirperpart flag
and placing the parts outside, causing renamed file parts
not to be found on read.

Signed-off-by: Jake Smith <jake.smith@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
