### PR TITLE
HPCC-26600 Use resourced memory in k8s in hthor

### DIFF
--- a/common/thorhelper/hpccconfig.cpp
+++ b/common/thorhelper/hpccconfig.cpp
@@ -15,9 +15,13 @@
     limitations under the License.
 ############################################################################## */
 
+#include <string>
+#include <unordered_map>
 
+#include "jlog.hpp"
 #include "jptree.hpp"
 #include "jstring.hpp"
+#include "hpccconfig.hpp"
 
 bool getService(StringBuffer &serviceAddress, const char *serviceName, bool failIfNotFound)
 {
@@ -34,4 +38,55 @@ bool getService(StringBuffer &serviceAddress, const char *serviceName, bool fail
     if (failIfNotFound)
         throw makeStringExceptionV(-1, "Service '%s' not found", serviceName);
     return false;
+}
+
+void getMemorySpecifications(std::unordered_map<std::string, __uint64> &memorySpecifications, const IPropertyTree *config, const char *context, unsigned maxMB, GetJobValueFunction getJobValueFunction)
+{
+    /* fills the memorySpecifications map with memory settings retreived from either
+     * the helper function (typically a workunit value fetch function) or the config.
+     * Helper function values take priority.
+     * "total" is computed and filled with the aggregate sum of all memory settings.
+     * "recommendedMaxMemory" is computed and filled in based on max and the "maxMemPercentage" setting.
+     */
+
+    auto getSetting = [&](const char *setting, StringBuffer &result) -> bool
+    {
+        VStringBuffer workunitSettingName("%s.%s", context, setting); // NB: workunit options are case insensitive
+        if (getJobValueFunction(workunitSettingName, result))
+            return true;
+        VStringBuffer configSettingName("%s/@%s", context, setting);
+        return config->getProp(configSettingName, result);
+    };
+    std::initializer_list<const char *> memorySettings = { "query", "thirdParty" };
+    offset_t totalRequirements = 0;
+    for (auto setting : memorySettings)
+    {
+        StringBuffer value;
+        if (getSetting(setting, value))
+        {
+            offset_t memBytes = friendlyStringToSize(value);
+            memorySpecifications[setting] = memBytes;
+            totalRequirements += memBytes;
+        }
+    }
+    offset_t maxBytes = ((offset_t)maxMB) * 0x100000;
+    if (totalRequirements > maxBytes)
+        throw makeStringExceptionV(0, "The total memory requirements of the query (%u MB) in '%s' exceed the memory limit (%u MB)", (unsigned)(totalRequirements / 0x100000), context, maxMB);
+    memorySpecifications["total"] = totalRequirements;
+
+    float maxPercentage = 100.0;
+    offset_t recommendedMaxMemory = maxBytes;
+    StringBuffer value;
+    if (getSetting("maxMemPercentage", value))
+    {
+        maxPercentage = atof(value);
+        verifyex((maxPercentage > 0.0) && (maxPercentage <= 100.0));
+        if (maxPercentage < 100.0)
+        {
+            recommendedMaxMemory = maxBytes / 100.0 * maxPercentage;
+            if (totalRequirements > recommendedMaxMemory)
+                WARNLOG("The total memory requirements of the query (%u MB) exceed the recommended limits for '%s' (total memory: %u MB, recommended max percentage : %.2f%%)", (unsigned)(totalRequirements / 0x100000), context, maxMB, maxPercentage);
+        }
+    }
+    memorySpecifications["recommendedMaxMemory"] = recommendedMaxMemory;
 }

--- a/common/thorhelper/hpccconfig.hpp
+++ b/common/thorhelper/hpccconfig.hpp
@@ -26,5 +26,8 @@
 
 extern THORHELPER_API bool getService(StringBuffer &serviceAddress, const char *serviceName, bool failIfNotFound);
 
+typedef std::function<bool(const char *prop, StringBuffer &result)> GetJobValueFunction;
+extern THORHELPER_API void getMemorySpecifications(std::unordered_map<std::string, __uint64> &memorySpecifications, const IPropertyTree *config, const char *context, unsigned maxMB, GetJobValueFunction getJobValueFunction);
+
 #endif // _HPCCCONFIG_HPP_
 

--- a/dali/base/dacsds.cpp
+++ b/dali/base/dacsds.cpp
@@ -948,6 +948,18 @@ void CClientRemoteTree::setPropInt64(const char *xpath, __int64 val)
     CRemoteTreeBase::setPropInt64(xpath, val);
 }
 
+void CClientRemoteTree::addPropReal(const char *xpath, double val)
+{
+    CConnectionLock b(connection);
+    CRemoteTreeBase::addPropReal(xpath, val);
+}
+
+void CClientRemoteTree::setPropReal(const char *xpath, double val)
+{
+    CConnectionLock b(connection);
+    CRemoteTreeBase::setPropReal(xpath, val);
+}
+
 void CClientRemoteTree::setPropBin(const char *xpath, size32_t size, const void *data)
 {
     CConnectionLock b(connection);

--- a/dali/base/dacsds.ipp
+++ b/dali/base/dacsds.ipp
@@ -342,6 +342,8 @@ public:
     virtual void setProp(const char *xpath, const char *val) override;
     virtual void addPropInt64(const char *xpath, __int64 val) override;
     virtual void setPropInt64(const char *xpath, __int64 val) override;
+    virtual void addPropReal(const char *xpath, double val) override;
+    virtual void setPropReal(const char *xpath, double val) override;
     virtual void setPropBin(const char *xpath, size32_t size, const void *data) override;
     virtual IPropertyTree *setPropTree(const char *xpath, IPropertyTree *val) override;
     virtual IPropertyTree *addPropTree(const char *xpath, IPropertyTree *val) override;

--- a/helm/hpcc/templates/thor.yaml
+++ b/helm/hpcc/templates/thor.yaml
@@ -30,7 +30,8 @@ Pass in dict with root and me
 {{- $hthorName := printf "%s-%s" .me.name $eclAgentType }}
 {{- $eclAgentScope := dict "name" .eclAgentName "type" $eclAgentType "useChildProcesses" .eclAgentUseChildProcesses "replicas" .eclAgentReplicas "maxActive" .me.maxJobs | merge (pick .me "keepJobs") }}
 {{- $thorAgentScope := dict "name" .thorAgentName "replicas" .thorAgentReplicas "maxActive" .me.maxGraphs | merge (pick .me "keepJobs") }}
-{{- $hthorScope := dict "name" $hthorName | merge (pick .me "multiJobLinger") }}
+{{- $eclAgentResources := .me.eclAgentResources | default dict -}}
+{{- $hthorScope := dict "name" $hthorName "jobMemorySectionName" "eclAgentMemory" | merge (pick .me "multiJobLinger") | merge (dict "resources" (deepCopy $eclAgentResources)) }}
 {{- $thorScope := omit .me "eclagent" "thoragent" "hthor" "logging" "env" "eclAgentResources" "eclAgentUseChildProcesses" "eclAgentReplicas" "thorAgentReplicas" "eclAgentType" }}
 {{- $misc := .root.Values.global.misc | default dict }}
 {{- $postJobCommand := $misc.postJobCommand | default "" }}

--- a/helm/hpcc/values.schema.json
+++ b/helm/hpcc/values.schema.json
@@ -499,9 +499,13 @@
           "type": "string",
           "description": "The amount of overall resourced memory to dedicate to the query"
         },
-        "thirdParties": {
+        "thirdParty": {
           "type": "string",
           "description": "The amount of overall resource memory to reserve for 3rd party use"
+        },
+        "maxMemPercentage": {
+          "type": "number",
+          "description": "The default maximum percentage of resource memory to dedicate to HPCC"
         }
       },
       "additionalProperties": false
@@ -1022,6 +1026,9 @@
         },
         "resources": {
           "$ref": "#/definitions/resources"
+        },
+        "jobMemory": {
+          "$ref": "#/definitions/memory"
         }
       }
     },
@@ -1254,6 +1261,9 @@
         "labels": {
           "type": "object",
           "additionalProperties": { "type": "string" }
+        },
+        "eclAgentMemory": {
+          "$ref": "#/definitions/memory"
         },
         "workerMemory": {
           "$ref": "#/definitions/memory"

--- a/system/jlib/jptree.hpp
+++ b/system/jlib/jptree.hpp
@@ -103,6 +103,8 @@ interface jlib_decl IPropertyTree : extends serializable
     virtual void setPropInt64(const char *xpath, __int64 val) = 0;
     virtual void addPropInt64(const char *xpath, __int64 val) = 0;
 
+    virtual void setPropReal(const char *xpath, double val) = 0;
+    virtual void addPropReal(const char *xpath, double val) = 0;
     virtual double getPropReal(const char *xpath, double dft=0.0) const = 0;
 
     virtual bool getPropBin(const char *xpath, MemoryBuffer &ret) const = 0;

--- a/system/jlib/jptree.ipp
+++ b/system/jlib/jptree.ipp
@@ -672,6 +672,8 @@ public:
     virtual __int64 getPropInt64(const char *xpath, __int64 dft=0) const override;
     virtual void setPropInt64(const char * xpath, __int64 val) override;
     virtual void addPropInt64(const char *xpath, __int64 val) override;
+    virtual void setPropReal(const char * xpath, double val) override;
+    virtual void addPropReal(const char *xpath, double val) override;
     virtual int getPropInt(const char *xpath, int dft=0) const override;
     virtual void setPropInt(const char *xpath, int val) override;
     virtual void addPropInt(const char *xpath, int val) override;

--- a/thorlcr/graph/thgraph.hpp
+++ b/thorlcr/graph/thgraph.hpp
@@ -922,7 +922,7 @@ public:
     virtual IGraphTempHandler *createTempHandler(bool errorOnMissing) = 0;
     void addDependencies(IPropertyTree *xgmml, bool failIfMissing=true);
     void addSubGraph(IPropertyTree &xgmml);
-    void applyMemorySettings(float recommendReservePercentage, const char *context);
+    void applyMemorySettings(const char *context);
 
     void checkAndReportLeaks(roxiemem::IRowManager *rowManager);
     bool queryUseCheckpoints() const;

--- a/thorlcr/graph/thgraphmaster.cpp
+++ b/thorlcr/graph/thgraphmaster.cpp
@@ -1347,13 +1347,7 @@ CJobMaster::CJobMaster(IConstWorkUnit &_workunit, const char *graphName, ILoaded
         loadPlugin(pluginMap, pluginsDir.str(), name.str());
     }
 
-    float recommendedMaxPercentage = defaultPctSysMemForRoxie;
-#ifndef _CONTAINERIZED
-    // @localThor mode - 25% is used for manager and 50% is used for workers
-    if (globals->getPropBool("@localThor") && (0 == globals->getPropInt("@masterMemorySize")))
-        recommendedMaxPercentage = 25.0;
-#endif
-    applyMemorySettings(recommendedMaxPercentage, "manager");
+    applyMemorySettings("manager");
     sharedAllocator.setown(::createThorAllocator(queryMemoryMB, 0, 1, memorySpillAtPercentage, *logctx, crcChecking, usePackedAllocator));
     Owned<IMPServer> mpServer = getMPServer();
     CJobChannel *channel = addChannel(mpServer);

--- a/thorlcr/graph/thgraphslave.cpp
+++ b/thorlcr/graph/thgraphslave.cpp
@@ -1687,40 +1687,7 @@ CJobSlave::CJobSlave(ISlaveWatchdog *_watchdog, IPropertyTree *_workUnitInfo, co
     }
     tmpHandler.setown(createTempHandler(true));
 
-    /*
-     * Calculate maximum recommended memory for this worker.
-     * In container mode, there is only ever 1 worker per container,
-     * recommendedMaxPercentage = defaultPctSysMemForRoxie
-     * In bare-metal slavesPerNode is taken into account and @localThor if used.
-     * 
-     * recommendedMaxPercentage is used by applyMemorySettings to calculate the
-     * max amount of meemory that should be used (allowing enough left for heap/OS etc.)
-     */
-#ifdef _CONTAINERIZED
-    float recommendedMaxPercentage = defaultPctSysMemForRoxie;
-#else
-    // bare-metal only
-
-    float recommendedMaxPercentage = defaultPctSysMemForRoxie;
-    unsigned numWorkersPerNode = globals->getPropInt("@slavesPerNode", 1);
-
-    // @localThor mode - 25% is used for manager and 50% is used for workers
-    if (globals->getPropBool("@localThor") && (0 == globals->getPropInt("@masterMemorySize")))
-    {
-        /* In this mode, 25% is reserved for manager,
-         * 50% for the workers.
-         * Meaning this workers' recommendedMaxPercentage is remaining percentage */
-        float pctPerWorker = 50.0 / numWorkersPerNode;
-        recommendedMaxPercentage = pctPerWorker;
-    }
-    else
-    {
-        // deduct percentage for all other workers from max percentage
-        float pctPerWorker = defaultPctSysMemForRoxie / numWorkersPerNode;
-        recommendedMaxPercentage = pctPerWorker;
-    }
-#endif
-    applyMemorySettings(recommendedMaxPercentage, "worker");
+    applyMemorySettings("worker");
 
     unsigned sharedMemoryLimitPercentage = (unsigned)getWorkUnitValueInt("globalMemoryLimitPC", globals->getPropInt("@sharedMemoryLimit", 90));
     unsigned sharedMemoryMB = queryMemoryMB*sharedMemoryLimitPercentage/100;


### PR DESCRIPTION
1) Base default query memory on config resource specifications
(replacing unconfigurable 300MB limit).
2) Add a memory section (like Thor's, see HPCC-26443) to allow
specification of how much memory is user for the "query" vs "thirdParty"
3) Allow options to overriden at workunit level

Also fixes a bug introduced by HPCC-26443 which meant
that when globalMemorySize was specified in Thor (bare-metal),
only a percentage of that specific requirement was
allocated to the query/roxiemem.

Signed-off-by: Jake Smith <jake.smith@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [x] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
