### PR TITLE
HPCC-26636 add suppport for "pod topologySpreadConstraints"

### DIFF
--- a/helm/hpcc/docs/placements.md
+++ b/helm/hpcc/docs/placements.md
@@ -74,6 +74,10 @@ Supported configurations under each "placement"
    Kubernetes 1.20.0 beta and later releases
    Only one "schedulerName" can be applied to a Pod/Job.
 
+5) topologySpreadConstraints
+   Requires Kubernetes v1.19+.
+   Reference https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+
 "nodeSelector" example:
 ```code
 placements:
@@ -124,4 +128,21 @@ placements:
       operator: "Equal"
       value: "true"
       effect: "NoSchedule"
+
+```
+"topologySpreadConstraints" example, there are two node pools which have "hpcc=spot1" and "hpcc=spot2" respectively. The roxie pods will be evenly scheduled on the two node pools. After deployment verify it with
+```code
+kubectl get pod -o wide | grep roxie
+```
+Placements code:
+```code
+- pods: ["type:roxie"]
+  placement:
+    topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: hpcc
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          roxie-cluster: "roxie"
 ```

--- a/helm/hpcc/templates/_helpers.tpl
+++ b/helm/hpcc/templates/_helpers.tpl
@@ -1051,16 +1051,19 @@ Pass in dict with me for current placements and dict with new for the new placem
 */}}
 {{- define "hpcc.mergePlacementSetting" -}}
 {{- if .me.placement.nodeSelector }}
-{{- $_ := set .new "nodeSelector" (mergeOverwrite (.new.nodeSelector | default dict ) .me.placement.nodeSelector)  }}
+ {{- $_ := set .new "nodeSelector" (mergeOverwrite (.new.nodeSelector | default dict ) .me.placement.nodeSelector)  }}
 {{- end -}}
 {{- if .me.placement.tolerations }}
-{{- $_ := set .new "tolerations" (concat (.new.tolerations | default list ) .me.placement.tolerations)  }}
+ {{- $_ := set .new "tolerations" (concat (.new.tolerations | default list ) .me.placement.tolerations)  }}
 {{- end -}}
 {{- if .me.placement.affinity }}
-{{- $_ := set .new "affinity" .me.placement.affinity  }}
+ {{- $_ := set .new "affinity" .me.placement.affinity  }}
 {{- end -}}
 {{- if .me.placement.schedulerName }}
-{{- $_ := set .new "schedulerName" .me.placement.schedulerName }}
+ {{- $_ := set .new "schedulerName" .me.placement.schedulerName }}
+{{- end -}}
+{{- if .me.placement.topologySpreadConstraints }}
+ {{- $_ := set .new "topologySpreadConstraints" (concat (.new.topologySpreadConstraints | default list ) .me.placement.topologySpreadConstraints)  }}
 {{- end -}}
 {{- end -}}
 

--- a/helm/hpcc/values.schema.json
+++ b/helm/hpcc/values.schema.json
@@ -1633,6 +1633,10 @@
         },
         "schedulerName": {
           "type": "string"
+        },
+        "topologySpreadConstraints": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/topologySpreadConstraint" }
         }
       }
     },
@@ -1663,6 +1667,28 @@
         },
         "tolerationSeconds": {
           "type": "integer"
+        }
+      }
+    },
+    "topologySpreadConstraint": {
+      "type": "object",
+      "properties": {
+        "maxSkew": {
+          "type": "integer",
+          "description": "describes the degree to which Pods may be unevenly distributed. It must be greater than zero"
+        },
+        "topologyKey": {
+          "type": "string",
+          "description": "is the key of node labels"
+        },
+        "whenUnsatisfiable": {
+          "type": "string",
+          "enum": ["DoNotSchedule", "ScheduleAnyway"],
+          "description": "indicates how to deal with a Pod if it doesn't satisfy the spread constraint"
+        },
+        "labelSelector": {
+          "type": "object",
+          "description": "labelSelector is used to find matching Pods"
         }
       }
     },

--- a/helm/hpcc/values.yaml
+++ b/helm/hpcc/values.yaml
@@ -510,7 +510,7 @@ roxie:
     numThreads: 30
     visibility: local
   ## replicas indicates the number of replicas per channel
-  replicas: 2  
+  replicas: 2
   numChannels: 2
   ## Set serverReplicas to indicate a separate replicaSet of roxie servers, with agent nodes not acting as servers
   serverReplicas: 0


### PR DESCRIPTION
An example is provided in helm/hpcc/docs/placements.md
Reference official documentation for more detail: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/

Even topology cross nodes mainly rely on the node label. It will be convenient to add labels to the node pools during creation.

Signed off by Xiaoming.Wang@lexisnexis.com 


## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [ ] I have read the CONTRIBUTORS document.
- [ ] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->
Tested on AKS with two user node pools with labels "hpcc=spot1" and "hpcc=spot2" respectly.

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
