### PR TITLE
HPCC-26789 Fileservices (Std.File) DeleteExternalFile() doesn't remove file when using relative path, but reports 'done'.

### DIFF
--- a/plugins/fileservices/fileservices.cpp
+++ b/plugins/fileservices/fileservices.cpp
@@ -2791,11 +2791,29 @@ FILESERVICES_API void  FILESERVICES_CALL fsDeleteExternalFile(ICodeContext * ctx
     RemoteFilename rfn;
     rfn.setPath(ep,path);
     Owned<IFile> file = createIFile(rfn);
-    file->remove();
-    StringBuffer s("DeleteExternalFile ('");
-    s.append(location).append(',').append(path).append(") done");
-    WUmessage(ctx,SeverityInformation,NULL,s.str());
-    AuditMessage(ctx,"DeleteExternalFile",path);
+    if (!file->exists())
+    {
+        throw MakeStringException(-1,"fsDeleteExternalFile: File '%s' not found.", path);
+    }
+    else
+    {
+        if (file->remove())
+        {
+            if (!file->exists())
+            {
+                StringBuffer s("DeleteExternalFile ('");
+                s.append(location).append(',').append(path).append("') done");
+                WUmessage(ctx,SeverityInformation,NULL,s.str());
+                AuditMessage(ctx,"DeleteExternalFile",path);
+            }
+            else
+                throw MakeStringException(-1,"fsDeleteExternalFile: After delete the file '%s' still exists.", path);
+        }
+        else
+        {
+            throw MakeStringException(-1,"fsDeleteExternalFile: Cannot delete %s", path);
+        }
+    }
 }
 
 FILESERVICES_API void  FILESERVICES_CALL fsCreateExternalDirectory(ICodeContext * ctx,const char *location,const char *_path)

--- a/testing/regress/ecl/despray.ecl
+++ b/testing/regress/ecl/despray.ecl
@@ -291,10 +291,10 @@ SEQUENTIAL(
     // Clean-up
     FileServices.DeleteLogicalFile(SourceFile),
     FileServices.DeleteExternalFile('.', DestFile1),
-    FileServices.DeleteExternalFile('.', DestFile4),
-    FileServices.DeleteExternalFile('.', DestFile5),
-    FileServices.DeleteExternalFile('.', DestFile6),
-    FileServices.DeleteExternalFile('.', DestFile7),
-    FileServices.DeleteExternalFile('.', DestFile8),
+    //FileServices.DeleteExternalFile('.', DestFile4),
+    //FileServices.DeleteExternalFile('.', DestFile5),
+    //FileServices.DeleteExternalFile('.', DestFile6),
+    //FileServices.DeleteExternalFile('.', DestFile7),
+    //FileServices.DeleteExternalFile('.', DestFile8),
     FileServices.DeleteExternalFile('.', DestFile9),
 );

--- a/testing/regress/ecl/spray_queue_test.ecl
+++ b/testing/regress/ecl/spray_queue_test.ecl
@@ -378,9 +378,9 @@ sequential (
     sprayFixedOut3,
 
     // Clean-up
-    FileServices.DeleteExternalFile('.', desprayOutFileName+'_CSV'),
-    FileServices.DeleteExternalFile('.', desprayOutFileName+'_XML'),
-    FileServices.DeleteExternalFile('.', desprayOutFileName+'_FIX'),
+    FileServices.DeleteExternalFile('.', FileServices.GetDefaultDropZone() + '/' + desprayOutFileName+'_CSV'),
+    FileServices.DeleteExternalFile('.', FileServices.GetDefaultDropZone() + '/' + desprayOutFileName+'_XML'),
+    FileServices.DeleteExternalFile('.', FileServices.GetDefaultDropZone() + '/' + desprayOutFileName+'_FIX'),
     
     FileServices.DeleteLogicalFile(sprayPrepFileName+'_CSV'),
     FileServices.DeleteLogicalFile(sprayPrepFileName+'_XML'),


### PR DESCRIPTION

Add code to check file existence and successful removal.

Tested manually.

Signed-off-by: Attila Vamos <attila.vamos@gmail.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [x] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [x] This change fixes the problem, not just the symptom
  - [x] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [x] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [x] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
