### PR TITLE
HPCC-25230 Set ldapUser to access file for cloud environment

### DIFF
--- a/esp/services/ws_workunits/ws_workunitsService.hpp
+++ b/esp/services/ws_workunits/ws_workunitsService.hpp
@@ -45,7 +45,6 @@ class QueryFilesInUse : public CInterface, implements ISDSSubscription, implemen
     CThreaded threaded;
     Semaphore sem;
     MapStringTo<IUserDescriptor *> roxieUserMap;
-    IArrayOf<IUserDescriptor> roxieUsers;
 
     Owned<IPropertyTree> tree;
     SubscriptionId qsChange;
@@ -64,25 +63,7 @@ private:
         tree.setown(t.getClear());
     }
 
-    void updateUsers()
-    {
-#ifdef _CONTAINERIZED
-        IERRLOG("CONTAINERIZED(QueryFilesInUse::updateUsers)");
-#else
-        Owned<IStringIterator> clusters = getTargetClusters("RoxieCluster", NULL);
-        ForEach(*clusters)
-        {
-            SCMStringBuffer target;
-            clusters->str(target);
-
-            Owned<IConstWUClusterInfo> info = getTargetClusterInfo(target.str());
-            Owned<IUserDescriptor> user = createUserDescriptor();
-            user->set(info->getLdapUser(), info->getLdapPassword());
-            roxieUserMap.setValue(target.str(), user);
-            roxieUsers.append(*user.getClear());
-        }
-#endif
-    }
+    void updateUsers();
 
 public:
     IMPLEMENT_IINTERFACE;

--- a/esp/smc/SMCLib/TpContainer.cpp
+++ b/esp/smc/SMCLib/TpContainer.cpp
@@ -493,14 +493,16 @@ class CContainerWUClusterInfo : public CSimpleInterfaceOf<IConstWUClusterInfo>
     StringAttr serverQueue;
     StringAttr agentQueue;
     StringAttr thorQueue;
+    StringAttr ldapUser;
     ClusterType platform;
     unsigned clusterWidth;
     StringArray thorProcesses;
     bool queriesOnly = false;
 
 public:
-    CContainerWUClusterInfo(const char* _name, const char* type, unsigned _clusterWidth, bool _queriesOnly)
-        : name(_name), clusterWidth(_clusterWidth), queriesOnly(_queriesOnly)
+    CContainerWUClusterInfo(const char* _name, const char* type, const char* _ldapUser,
+        unsigned _clusterWidth, bool _queriesOnly)
+        : name(_name), ldapUser(_ldapUser), clusterWidth(_clusterWidth), queriesOnly(_queriesOnly)
     {
         StringBuffer queue;
         if (strieq(type, "thor"))
@@ -598,11 +600,11 @@ public:
     }
     virtual const char *getLdapUser() const override
     {
-        UNIMPLEMENTED;
+        return ldapUser.get();
     }
     virtual const char *getLdapPassword() const override
     {
-        UNIMPLEMENTED;
+        return nullptr;
     }
     virtual unsigned getRoxieRedundancy() const override
     {
@@ -629,7 +631,8 @@ extern TPWRAPPER_API unsigned getContainerWUClusterInfo(CConstWUClusterInfoArray
     {
         IPropertyTree& queue = queues->query();
         Owned<IConstWUClusterInfo> cluster = new CContainerWUClusterInfo(queue.queryProp("@name"),
-            queue.queryProp("@type"), (unsigned) queue.getPropInt("@width", 1), queue.getPropBool("@queriesOnly"));
+            queue.queryProp("@type"), queue.queryProp("@ldapUser"), (unsigned) queue.getPropInt("@width", 1),
+            queue.getPropBool("@queriesOnly"));
         clusters.append(*cluster.getClear());
     }
 
@@ -654,7 +657,8 @@ extern TPWRAPPER_API IConstWUClusterInfo* getWUClusterInfoByName(const char* clu
         return nullptr;
 
     return new CContainerWUClusterInfo(queue->queryProp("@name"), queue->queryProp("@type"),
-        (unsigned) queue->getPropInt("@width", 1), queue->getPropBool("@queriesOnly"));
+        queue->queryProp("@ldapUser"), (unsigned) queue->getPropInt("@width", 1),
+        queue->getPropBool("@queriesOnly"));
 }
 
 extern TPWRAPPER_API void initContainerRoxieTargets(MapStringToMyClass<ISmartSocketFactory>& connMap)

--- a/helm/hpcc/templates/_helpers.tpl
+++ b/helm/hpcc/templates/_helpers.tpl
@@ -808,6 +808,7 @@ Generate instance queue names
   prefix: {{ .prefix }}
   {{- end }}
   queriesOnly: true
+  ldapUser: {{ .ldapUser }}
   dataPlane: {{ .dataPlane | default (include "hpcc.getDefaultDataPlane" $) }}
   {{- if hasKey . "directAccessPlanes" }}
   directAccessPlanes: {{ .directAccessPlanes }}

--- a/helm/hpcc/values.yaml
+++ b/helm/hpcc/values.yaml
@@ -652,6 +652,7 @@ roxie:
   topoServer:
     replicas: 1
   #directAccessPlanes: []  #add direct access planes that roxie will read from without copying the data to its default data plane
+  #ldapUser: roxie_file_access    #add system username for accessing files
 
 ## The [manager/worker/eclAgent]Resources define the resource limits for each pod.
 ## workerMemory defines the memory requirements for each individual worker.

--- a/roxie/ccd/ccddali.cpp
+++ b/roxie/ccd/ccddali.cpp
@@ -467,6 +467,10 @@ public:
         else
         {
             userdesc.setown(createUserDescriptor());
+#ifdef _CONTAINERIZED
+            const char *ldapUser = topology->queryProp("@ldapUser");
+            userdesc->set(isEmptyString(ldapUser) ? "roxie" : ldapUser, "");
+#else
             const char *roxieUser = NULL;
             const char *roxiePassword = NULL;
             if (topology)
@@ -481,6 +485,7 @@ public:
             StringBuffer password;
             decrypt(password, roxiePassword);
             userdesc->set(roxieUser, password.str());
+#endif
         }
         if (fileNameServiceDali.length())
             connectWatcher.start();


### PR DESCRIPTION
1. Add the ldapUser setting for roxie file access.
2. Set the ldapUser setting in containerized environment.
3. Remove the roxieUsers from the QueryFilesInUse.
4. Move QueryFilesInUse::updateUsers() from ws_workunitsService.hpp
to ws_workunitsServiceQuerySets.cpp.
5. In QueryFilesInUse::updateUsers(), add the code to get the ldapUser
setting and set the roxieUserMap.
7. In CRoxieDaliHelper, read the ldapUser setting and set the userdesc.

Signed-off-by: wangkx <kevin.wang@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
