### PR TITLE
HPCC-25904: Add an option to copy files on query deployment

### DIFF
--- a/common/workunit/referencedfilelist.hpp
+++ b/common/workunit/referencedfilelist.hpp
@@ -64,8 +64,8 @@ interface IReferencedFileList : extends IInterface
 
     virtual IReferencedFileIterator *getFiles()=0;
     virtual void resolveFiles(const StringArray &locations, const char *remoteIP, const char * remotePrefix, const char *srcCluster, bool checkLocalFirst, bool addSubFiles, bool trackSubFiles, bool resolveForeign=false)=0;
-    virtual void cloneAllInfo(const char *dstCluster, unsigned updateFlags, IDFUhelper *helper, bool cloneSuperInfo, bool cloneForeign, unsigned redundancy, unsigned channelsPerNode, int replicateOffset, const char *defRepFolder)=0;
-    virtual void cloneFileInfo(const char *dstCluster, unsigned updateFlags, IDFUhelper *helper, bool cloneSuperInfo, bool cloneForeign, unsigned redundancy, unsigned channelsPerNode, int replicateOffset, const char *defRepFolder)=0;
+    virtual void cloneAllInfo(const char *dstCluster, unsigned updateFlags, IDFUhelper *helper, bool cloneSuperInfo, bool cloneForeign, unsigned redundancy, unsigned channelsPerNode, int replicateOffset, const char *defRepFolder, bool copyphysical)=0;
+    virtual void cloneFileInfo(const char *dstCluster, unsigned updateFlags, IDFUhelper *helper, bool cloneSuperInfo, bool cloneForeign, unsigned redundancy, unsigned channelsPerNode, int replicateOffset, const char *defRepFolder, bool copyphysical)=0;
     virtual void cloneRelationships()=0;
 };
 

--- a/dali/dfu/dfuutil.hpp
+++ b/dali/dfu/dfuutil.hpp
@@ -90,7 +90,8 @@ interface IDFUhelper: extends IInterface
                          const char *defReplicateFolder,
                          IUserDescriptor *userdesc,                // user desc for local dali
                          const char *foreigndali,                  // can be omitted if srcname foreign or local
-                         unsigned overwriteFlags                   // overwrite destination options
+                         unsigned overwriteFlags,                   // overwrite destination options
+                         bool dophysicalcopy
                          ) = 0;
 
     virtual void cloneFileRelationships(

--- a/ecl/ecl-package/ecl-package.cpp
+++ b/ecl/ecl-package/ecl-package.cpp
@@ -533,6 +533,8 @@ public:
                 continue;
             if (iter.matchFlag(optPreloadAll, ECLOPT_PRELOAD_ALL_PACKAGES))
                 continue;
+            if (iter.matchFlag(optCopyPhysical, ECLOPT_COPY_PHYSICAL))
+                continue;
             eclCmdOptionMatchIndicator ind = EclCmdCommon::matchCommandLineOption(iter, true);
             if (ind != EclCmdOptionMatch)
                 return ind;
@@ -596,6 +598,7 @@ public:
         request->setUpdateSuperFiles(optUpdateSuperfiles);
         request->setUpdateCloneFrom(optUpdateCloneFrom);
         request->setAppendCluster(!optDontAppendCluster);
+        request->setCopyPhysical(optCopyPhysical);
 
         Owned<IClientAddPackageResponse> resp = packageProcessClient->AddPackage(request);
         int ret = outputMultiExceptionsEx(resp->getExceptions());
@@ -633,7 +636,8 @@ public:
                     "   --replace                Replace existing packagmap"
                     "   --update-super-files     Update local DFS super-files if remote DALI has changed\n"
                     "   --update-clone-from      Update local clone from location if remote DALI has changed\n"
-                    "   --dont-append-cluster    Only use to avoid locking issues due to adding cluster to file\n",
+                    "   --dont-append-cluster    Only use to avoid locking issues due to adding cluster to file\n"
+                    "   --copy-physical          Copy physical files during deployment, not on roxie in the background\n",
                     stdout);
 
         EclCmdCommon::usage();
@@ -655,6 +659,7 @@ private:
     bool optGlobalScope;
     bool optAllowForeign;
     bool optPreloadAll;
+    bool optCopyPhysical = false;
 };
 
 class EclCmdPackageMapCopy : public EclCmdCommon
@@ -701,6 +706,8 @@ public:
             if (iter.matchFlag(optDontAppendCluster, ECLOPT_DONT_APPEND_CLUSTER))
                 continue;
             if (iter.matchFlag(optPreloadAll, ECLOPT_PRELOAD_ALL_PACKAGES))
+                continue;
+            if (iter.matchFlag(optCopyPhysical, ECLOPT_COPY_PHYSICAL))
                 continue;
             eclCmdOptionMatchIndicator ind = EclCmdCommon::matchCommandLineOption(iter, true);
             if (ind != EclCmdOptionMatch)
@@ -750,6 +757,7 @@ public:
         request->setUpdateSuperFiles(optUpdateSuperfiles);
         request->setUpdateCloneFrom(optUpdateCloneFrom);
         request->setAppendCluster(!optDontAppendCluster);
+        request->setCopyPhysical(optCopyPhysical);
 
         Owned<IClientCopyPackageMapResponse> resp = packageProcessClient->CopyPackageMap(request);
         int ret = outputMultiExceptionsEx(resp->getExceptions());
@@ -787,7 +795,8 @@ public:
                     "   --replace              Replace existing packagmap\n"
                     "   --update-super-files   Update local DFS super-files if remote DALI has changed\n"
                     "   --update-clone-from    Update local clone from location if remote DALI has changed\n"
-                    "   --dont-append-cluster  Only use to avoid locking issues due to adding cluster to file\n",
+                    "   --dont-append-cluster  Only use to avoid locking issues due to adding cluster to file\n"
+                    "   --copy-physical        Copy physical files during deployment, not on roxie in the background\n",
                     stdout);
 
         EclCmdCommon::usage();
@@ -804,6 +813,7 @@ private:
     bool optUpdateCloneFrom = false;
     bool optDontAppendCluster = false; //Undesirable but here temporarily because DALI may have locking issues
     bool optPreloadAll = false;
+    bool optCopyPhysical = false;
 };
 
 class EclCmdPackageValidate : public EclCmdCommon
@@ -1259,6 +1269,8 @@ public:
                 continue;
             if (iter.matchFlag(optDontAppendCluster, ECLOPT_DONT_APPEND_CLUSTER))
                 continue;
+            if (iter.matchFlag(optCopyPhysical, ECLOPT_COPY_PHYSICAL))
+                continue;
             eclCmdOptionMatchIndicator ind = EclCmdCommon::matchCommandLineOption(iter, true);
             if (ind != EclCmdOptionMatch)
                 return ind;
@@ -1319,6 +1331,7 @@ public:
         request->setUpdateSuperFiles(optUpdateSuperfiles);
         request->setUpdateCloneFrom(optUpdateCloneFrom);
         request->setAppendCluster(!optDontAppendCluster);
+        request->setCopyPhysical(optCopyPhysical);
 
         Owned<IClientAddPartToPackageMapResponse> resp = packageProcessClient->AddPartToPackageMap(request);
         int ret = outputMultiExceptionsEx(resp->getExceptions());
@@ -1355,7 +1368,8 @@ public:
                     "   --preload-all               Set preload files option for all packages\n"
                     "   --update-super-files        Update local DFS super-files if remote DALI has changed\n"
                     "   --update-clone-from         Update local clone from location if remote DALI has changed\n"
-                    "   --dont-append-cluster       Only use to avoid locking issues due to adding cluster to file\n",
+                    "   --dont-append-cluster       Only use to avoid locking issues due to adding cluster to file\n"
+                    "   --copy-physical             Copy physical files during deployment, not on roxie in the background\n",
                     stdout);
 
         EclCmdCommon::usage();
@@ -1374,6 +1388,7 @@ private:
     bool optUpdateSuperfiles;
     bool optUpdateCloneFrom;
     bool optDontAppendCluster;
+    bool optCopyPhysical = false;
 };
 
 class EclCmdPackageRemovePart : public EclCmdCommon

--- a/ecl/eclcmd/eclcmd_common.hpp
+++ b/ecl/eclcmd/eclcmd_common.hpp
@@ -84,6 +84,7 @@ typedef IEclCommand *(*EclCommandFactory)(const char *cmdname);
 #define ECLOPT_OVERWRITE_ENV NULL
 
 #define ECLOPT_DONT_COPY_FILES "--no-files"
+#define ECLOPT_COPY_PHYSICAL "--copy-physical"
 #define ECLOPT_ALLOW_FOREIGN "--allow-foreign"
 
 #define ECLOPT_ACTIVE "--active"

--- a/ecl/eclcmd/eclcmd_core.cpp
+++ b/ecl/eclcmd/eclcmd_core.cpp
@@ -347,6 +347,8 @@ public:
                 continue;
             if (iter.matchFlag(optDontCopyFiles, ECLOPT_DONT_COPY_FILES))
                 continue;
+            if (iter.matchFlag(optCopyPhysical, ECLOPT_COPY_PHYSICAL))
+                continue;
             if (iter.matchFlag(optAllowForeign, ECLOPT_ALLOW_FOREIGN))
                 continue;
             if (iter.matchFlag(optNoActivate, ECLOPT_NO_ACTIVATE))
@@ -469,6 +471,7 @@ public:
         req->setWait(remaining);
         req->setNoReload(optNoReload);
         req->setDontCopyFiles(optDontCopyFiles);
+        req->setCopyPhysical(optCopyPhysical);
         req->setAllowForeignFiles(optAllowForeign);
         req->setUpdateDfs(optUpdateDfs);
         req->setUpdateSuperFiles(optUpdateSuperfiles);
@@ -532,6 +535,7 @@ public:
             "   --protect              protect workunit from deletion\n"
             "   -A-, --no-activate     Do not activate query when published\n"
             "   --no-reload            Do not request a reload of the (roxie) cluster\n"
+            "   --copy-physical        Copy physical files during deployment, not on roxie in the background\n"
             "   --no-files             Do not copy DFS file information for referenced files\n"
             "   --allow-foreign        Do not fail if foreign files are used in query (roxie)\n"
             "   --daliip=<IP>          The IP of the DALI to be used to locate remote files\n"
@@ -566,6 +570,7 @@ private:
     bool activateSet;
     bool optNoReload;
     bool optDontCopyFiles;
+    bool optCopyPhysical=false;
     bool optSuspendPrevious;
     bool optDeletePrevious;
     bool optProtect = false;

--- a/ecl/eclcmd/queries/ecl-queries.cpp
+++ b/ecl/eclcmd/queries/ecl-queries.cpp
@@ -487,6 +487,8 @@ public:
                 continue;
             if (iter.matchFlag(optDontCopyFiles, ECLOPT_DONT_COPY_FILES))
                 continue;
+            if (iter.matchFlag(optCopyPhysical, ECLOPT_COPY_PHYSICAL))
+                continue;
             if (iter.matchFlag(optAllowForeign, ECLOPT_ALLOW_FOREIGN))
                 continue;
             if (iter.matchOption(optMsToWait, ECLOPT_WAIT))
@@ -588,6 +590,7 @@ public:
         req->setUpdateCloneFrom(optUpdateCloneFrom);
         req->setAppendCluster(!optDontAppendCluster);
         req->setDontCopyFiles(optDontCopyFiles);
+        req->setCopyPhysical(optCopyPhysical);
         req->setWait(optMsToWait);
         req->setNoReload(optNoReload);
         req->setAllowForeignFiles(optAllowForeign);
@@ -641,6 +644,7 @@ public:
             "   --source-ssl           Use SSL when connecting to source (default if --ssl is used)\n"
             "   --source-no-ssl        Do not use SSL when connecting to source (default if --ssl is NOT used)\n"
             "   --no-files             Do not copy DFS file information for referenced files\n"
+            "   --copy-physical        Copy physical files during deployment, not on roxie in the background\n"
             "   --daliip=<ip>          Remote Dali DFS to use for copying file information\n"
             "                          (only required if remote environment version < 3.8)\n"
             "   --source-process       Process cluster to copy files from\n"
@@ -688,6 +692,7 @@ private:
     bool optUpdateCloneFrom;
     bool optDontAppendCluster; //Undesirable but here temporarily because DALI may have locking issues
     bool optDontCopyFiles;
+    bool optCopyPhysical = false; //copy files during deployment, not on roxie in the background
     bool optAllowForeign;
     bool optSourceSSL = false; //user explicitly turning on SSL for accessing the remote source location (ssl defaults to use SSL if we are hitting ESP via SSL)
     bool optSourceNoSSL = false; //user explicitly turning OFF SSL for accessing the remote source location (ssl defaults to not use SSL if we are not hitting ESP via SSL)
@@ -732,6 +737,8 @@ public:
             if (iter.matchFlag(optCloneActiveState, ECLOPT_CLONE_ACTIVE_STATE))
                 continue;
             if (iter.matchFlag(optDontCopyFiles, ECLOPT_DONT_COPY_FILES))
+                continue;
+            if (iter.matchFlag(optCopyPhysical, ECLOPT_COPY_PHYSICAL))
                 continue;
             if (iter.matchFlag(optAllQueries, ECLOPT_ALL))
                 continue;
@@ -789,6 +796,7 @@ public:
         req->setUpdateCloneFrom(optUpdateCloneFrom);
         req->setAppendCluster(!optDontAppendCluster);
         req->setCopyFiles(!optDontCopyFiles);
+        req->setCopyPhysical(optCopyPhysical);
         req->setAllowForeignFiles(optAllowForeign);
         req->setIncludeFileErrors(true);
 
@@ -843,6 +851,7 @@ public:
             "   --source-no-ssl        Do not use SSL when connecting to source (default if --ssl is NOT used)\n"
             "   --all                  Copy both active and inactive queries\n"
             "   --no-files             Do not copy DFS file information for referenced files\n"
+            "   --copy-physical        Copy physical files during deployment, not on roxie in the background\n"
             "   --daliip=<ip>          Remote Dali DFS to use for copying file information\n"
             "   --source-process       Process cluster to copy files from\n"
             "   --clone-active-state   Make copied queries active if active on source\n"
@@ -866,6 +875,7 @@ private:
     bool optUpdateCloneFrom;
     bool optDontAppendCluster; //Undesirable but here temporarily because DALI may have locking issues
     bool optDontCopyFiles;
+    bool optCopyPhysical = false; //copy files during deployment, not on roxie in the background
     bool optAllowForeign;
     bool optAllQueries;
     bool optSourceSSL = false; //user explicitly turning on SSL for accessing the remote source location (ssl defaults to use SSL if we are hitting ESP via SSL)
@@ -1059,6 +1069,8 @@ public:
                 continue;
             if (iter.matchFlag(optDontCopyFiles, ECLOPT_DONT_COPY_FILES))
                 continue;
+            if (iter.matchFlag(optCopyPhysical, ECLOPT_COPY_PHYSICAL))
+                continue;
             if (iter.matchFlag(optAllowForeign, ECLOPT_ALLOW_FOREIGN))
                 continue;
             if (iter.matchFlag(optNoActivate, ECLOPT_NO_ACTIVATE))
@@ -1172,6 +1184,7 @@ public:
         req->setNoReload(optNoReload);
         req->setRepublish(!optNoPublish);
         req->setDontCopyFiles(optDontCopyFiles);
+        req->setCopyPhysical(optCopyPhysical);
         req->setAllowForeignFiles(optAllowForeign);
         req->setUpdateDfs(optUpdateDfs);
         req->setUpdateSuperFiles(optUpdateSuperfiles);
@@ -1235,6 +1248,7 @@ public:
             "   --no-publish           Create a recompiled workunit, but do not publish it\n"
             "   --no-reload            Do not request a reload of the (roxie) cluster\n"
             "   --no-files             Do not copy DFS file information for referenced files\n"
+            "   --copy-physical        Copy physical files during deployment, not on roxie in the background\n"
             "   --allow-foreign        Do not fail if foreign files are used in query (roxie)\n"
             "   --daliip=<IP>          The IP of the DALI to be used to locate remote files\n"
             "   --update-super-files   Update local DFS super-files if remote DALI has changed\n"
@@ -1271,6 +1285,7 @@ private:
     bool optNoReload = false;
     bool optNoPublish = false;
     bool optDontCopyFiles = false;
+    bool optCopyPhysical = false; //copy files during deployment, not on roxie in the background
     bool optSuspendPrevious = false;
     bool optDeletePrevious = false;
     bool optAllowForeign = false;
@@ -1456,6 +1471,8 @@ public:
                 continue;
             if (iter.matchFlag(optDontCopyFiles, ECLOPT_DONT_COPY_FILES))
                 continue;
+            if (iter.matchFlag(optCopyPhysical, ECLOPT_COPY_PHYSICAL))
+                continue;
             if (iter.matchFlag(optAllQueries, ECLOPT_ALL))
                 continue;
             if (iter.matchFlag(optReplace, ECLOPT_REPLACE))
@@ -1512,6 +1529,7 @@ public:
         req->setUpdateCloneFrom(optUpdateCloneFrom);
         req->setAppendCluster(!optDontAppendCluster);
         req->setCopyFiles(!optDontCopyFiles);
+        req->setCopyPhysical(optCopyPhysical);
         req->setAllowForeignFiles(optAllowForeign);
         req->setIncludeFileErrors(true);
 
@@ -1570,6 +1588,7 @@ public:
             "   --replace              Replace entire existing queryset\n"
             "   --queries              Filter query ids to select for import\n"
             "   --no-files             Do not copy DFS file information for referenced files\n"
+            "   --copy-physical        Copy physical files during deployment, not on roxie in the background\n"
             "   --daliip=<ip>          Remote Dali DFS to use for copying file information\n"
             "   --source-process       Process cluster to copy files from\n"
             "   --clone-active-state   Make copied queries active if active on source\n"
@@ -1596,6 +1615,7 @@ private:
     bool optUpdateCloneFrom = false;
     bool optDontAppendCluster = false; //Undesirable but here temporarily because DALI may have locking issues
     bool optDontCopyFiles = false;
+    bool optCopyPhysical = false; //copy files during deployment, not on roxie in the background
     bool optAllowForeign = false;
     bool optAllQueries = false;
 };

--- a/esp/scm/ws_packageprocess.ecm
+++ b/esp/scm/ws_packageprocess.ecm
@@ -42,6 +42,7 @@ ESPrequest AddPackageRequest
     bool UpdateSuperFiles(false); //usually wouldn't be needed, packagemap referencing superfiles?
     bool UpdateCloneFrom(false); //explicitly wan't to change where roxie will grab from
     bool AppendCluster(true); //file exists on other local cluster, add new one, make optional in case of locking issues, but should be made to work
+    bool CopyPhysical(false);
 };
 
 
@@ -68,6 +69,7 @@ ESPrequest CopyPackageMapRequest
     bool UpdateSuperFiles(false); //usually wouldn't be needed, packagemap referencing superfiles?
     bool UpdateCloneFrom(false); //explicitly wan't to change where roxie will grab from
     bool AppendCluster(true); //file exists on other local cluster, add new one, make optional in case of locking issues, but should be made to work
+    bool CopyPhysical(false);
 };
 
 ESPresponse [exceptions_inline] CopyPackageMapResponse
@@ -293,6 +295,7 @@ ESPrequest AddPartToPackageMapRequest
     bool UpdateSuperFiles(false); //usually wouldn't be needed, packagemap referencing superfiles?
     bool UpdateCloneFrom(false); //explicitly wan't to change where roxie will grab from
     bool AppendCluster(true); //file exists on other local cluster, add new one, make optional in case of locking issues, but should be made to work
+    bool CopyPhysical(false);
 };
 
 ESPresponse [exceptions_inline] AddPartToPackageMapResponse

--- a/esp/scm/ws_workunits_queryset_req_resp.ecm
+++ b/esp/scm/ws_workunits_queryset_req_resp.ecm
@@ -48,6 +48,7 @@ ESPrequest [nil_remove] WURecreateQueryRequest
     bool IncludeFileErrors(false);
 
     int Wait(-1);
+    bool CopyPhysical(false);
 };
 
 ESPresponse [exceptions_inline, nil_remove] WURecreateQueryResponse
@@ -124,6 +125,7 @@ ESPrequest [nil_remove] WUPublishWorkunitRequest
     bool UpdateCloneFrom(false); //explicity wan't to change where roxie will grab from
     bool AppendCluster(true); //file exists on other local cluster, add new one, make optional in case of locking issues, but should be made to work
     bool IncludeFileErrors(false);
+    bool CopyPhysical(false);
 };
 
 ESPresponse [exceptions_inline] WUPublishWorkunitResponse
@@ -364,6 +366,7 @@ ESPrequest WUQuerysetImportRequest
     bool UpdateCloneFrom(false); //explicity wan't to change where roxie will grab from
     bool AppendCluster(true); //file exists on other local cluster, add new one, make optional in case of locking issues, but should be made to work
     bool IncludeFileErrors(false);
+    bool CopyPhysical(false);
 };
 
 ESPresponse [exceptions_inline] WUQuerysetImportResponse
@@ -441,6 +444,7 @@ ESPrequest [nil_remove] WUQuerySetCopyQueryRequest
     bool AppendCluster(true); //file exists on other local cluster, add new one, make optional in case of locking issues, but should be made to work
     bool IncludeFileErrors(false);
     bool SourceSSL(false);
+    bool CopyPhysical(false);
 };
 
 ESPresponse [exceptions_inline] WUQuerySetCopyQueryResponse
@@ -466,6 +470,7 @@ ESPrequest [nil_remove] WUCopyQuerySetRequest
     bool AppendCluster(true); //file exists on other local cluster, add new one, make optional in case of locking issues, but should be made to work
     bool IncludeFileErrors(false);
     bool SourceSSL(false);
+    bool CopyPhysical(false);
 };
 
 ESPresponse [exceptions_inline] WUCopyQuerySetResponse

--- a/esp/scm/ws_workunits_req_resp.ecm
+++ b/esp/scm/ws_workunits_req_resp.ecm
@@ -1063,6 +1063,7 @@ ESPrequest [nil_remove] WUEclDefinitionActionRequest
     int MsToWait(-1);
     int TimeLimit(-1); //Publish
     int WarnTimeLimit(-1); //Publish
+    bool CopyPhysical(false); //Publish
 };
 
 ESPresponse [exceptions_inline] WUEclDefinitionActionResponse

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -5419,6 +5419,7 @@ void CWsWorkunitsEx::publishEclDefinition(IEspContext &context, const char *targ
     publishReq->setWait(timeLeft);
     publishReq->setNoReload(req.getNoReload());
     publishReq->setDontCopyFiles(req.getDontCopyFiles());
+    publishReq->setCopyPhysical(req.getCopyPhysical());
     publishReq->setAllowForeignFiles(req.getAllowForeign());
     publishReq->setUpdateDfs(req.getUpdateDfs());
     publishReq->setUpdateSuperFiles(req.getUpdateSuperfiles());


### PR DESCRIPTION
First pass draft.

This is a working prototype and shows all the plumbing of the places that
need to change.

To be discussed:
  1. Copy happens in ESP at time of publish query, packagemap,
     query copy, etc.
  2. Currently files not copied in parallel.
  3. No on going status given to user.
  4. Roxie concept of directAccessPlanes.  Not only remote files, but
     files on planes not listed as direct access will be copied.

Signed-off-by: Anthony Fishbeck <anthony.fishbeck@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [ ] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [ ] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [ ] I have read the CONTRIBUTORS document.
- [ ] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
