### PR TITLE
HPCC-27168 Ensure eclcc resolves the most recent branch from a package.json

### DIFF
--- a/ecl/hql/hqlrepository.cpp
+++ b/ecl/hql/hqlrepository.cpp
@@ -664,37 +664,36 @@ IEclPackage * EclRepositoryManager::queryDependentRepository(IIdAtom * name, con
                 throw makeStringExceptionV(99, "Semantic versioning not yet supported for dependency '%s'.", defaultUrl);
 
             // Really the version should be a SHA, but for flexibility version could be a sha, a tag or a branch (on origin).
-            // Check for a sha/tag and map it to a version.  If that does not work see if it is a branch.
-            VStringBuffer params("rev-parse --short %s", version.str());
+            // Check for a remote branch first - because it appears that when git clones a repo, it creates a local branch for
+            // remote head.  That never gets updated, and if it matches the branch being resolved it causes problems.
+
+            // Check for a remote branch "origin/<version>"
+            VStringBuffer params("rev-parse --short origin/%s", version.str());
             StringBuffer sha;
             unsigned retCode = runGitCommand(&sha, params, repoPath, false);
-            if (retCode == 0)
+            if (retCode != 0)
             {
-                if (requireSHA)
-                {
-                    //Either version or sha could be longer, but leading characters should match
-                    //should --short=8 be used?
-                    //if (!strncmp(sha, version, 7) != 0)
-                    //    throw makeStringExceptionV(99, "Expected a SHA as the git version for dependency '%s'.", defaultUrl);
-                    //Revisit in HPCC-26423
-                }
-                version.set(sha);
-            }
-            else
-            {
-                if (requireSHA)
-                    throw makeStringExceptionV(99, "Expected a SHA as the git version for dependency '%s'.", defaultUrl);
-
-                //Check for a branch origin/<version>
-                params.clear().appendf("rev-parse --short origin/%s", version.str());
+                //Check for a tag (or local sha)
+                params.clear().appendf("rev-parse --short %s", version.str());
                 unsigned retCode = runGitCommand(&sha.clear(), params, repoPath, false);
-                if (retCode == 0)
-                    version.set(sha);
+                if (retCode != 0)
+                    sha.clear();
             }
-            //Strip any trailing newlines and spaces.
-            version.clip();
 
-            path.append(repoPath).appendf("/.git/{%s}", version.str());
+            //Strip any trailing newlines and spaces.
+            sha.clip();
+
+            if (sha.isEmpty())
+                throw makeStringExceptionV(99, "Branch/tag '%s' could not be found for dependency '%s'.", version.str(), defaultUrl);
+
+            if (requireSHA)
+            {
+                //If version was a valid sha then the version should match it (one should match the leading characters of the other)
+                if (!(hasPrefix(sha, version, false) || hasPrefix(version, sha, false)))
+                    throw makeStringExceptionV(99, "Expected a SHA as the git version for dependency '%s'.", defaultUrl);
+            }
+
+            path.append(repoPath).appendf("/.git/{%s}", sha.str());
             filename = path;
         }
     }


### PR DESCRIPTION

Signed-off-by: Gavin Halliday <gavin.halliday@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
