### PR TITLE
HPCC-27182 Ensure dataset assignments in TRANSFORMs are hoisted

### DIFF
--- a/ecl/hqlcpp/hqlcpp.cpp
+++ b/ecl/hqlcpp/hqlcpp.cpp
@@ -1787,6 +1787,7 @@ void HqlCppTranslator::cacheOptions()
         DebugOption(options.serializeRowsetInExtract,"serializeRowsetInExtract", false),
         DebugOption(options.testIgnoreMaxLength,"testIgnoreMaxLength", false),
         DebugOption(options.trackDuplicateActivities,"trackDuplicateActivities", false),
+        DebugOption(options.trackRemoveInputs,"trackRemoveInputs", false),
         DebugOption(options.showActivitySizeInGraph,"showActivitySizeInGraph", false),
         DebugOption(options.addLocationToCpp,"addLocationToCpp", false),
         DebugOption(options.alwaysCreateRowBuilder,"alwaysCreateRowBuilder", false),

--- a/ecl/hqlcpp/hqlcpp.ipp
+++ b/ecl/hqlcpp/hqlcpp.ipp
@@ -761,6 +761,7 @@ struct HqlCppOptions
     bool                serializeRowsetInExtract;
     bool                testIgnoreMaxLength;
     bool                trackDuplicateActivities;               // for diagnosing problems with code becoming duplicated
+    bool                trackRemoveInputs;
     bool                showActivitySizeInGraph;
     bool                addLocationToCpp;
     bool                alwaysCreateRowBuilder;                 // allow paranoid check to ensure builders are built everywhere

--- a/ecl/hqlcpp/hqlresource.cpp
+++ b/ecl/hqlcpp/hqlresource.cpp
@@ -432,16 +432,12 @@ protected:
 
     void findSplitPoints(IHqlExpression * expr, unsigned pass)
     {
-        //containsNonActiveDataset() would be nice - but that isn't percolated outside assigns etc.
-        if (containsAnyDataset(expr) || containsMustHoist(expr) || !expr->isIndependentOfScope())
+        if (!gathered)
         {
-            if (!gathered)
-            {
-                gatherAmbiguousSelectors(original);
-                gathered = true;
-            }
-            analyse(expr, pass);
+            gatherAmbiguousSelectors(original);
+            gathered = true;
         }
+        analyse(expr, pass);
     }
 
     bool queryHoistDataset(IHqlExpression * ds)
@@ -617,8 +613,11 @@ protected:
                 //if rhs is a new, evaluatable, dataset then we want to add it
                 if ((rhs->isDataset() || rhs->isDictionary()) && isEvaluateable(rhs))
                 {
-                    if (queryNoteDataset(rhs))
-                        return;
+                    if (!rhs->isConstant())
+                    {
+                        if (queryNoteDataset(rhs))
+                            return;
+                    }
                 }
                 break;
             }


### PR DESCRIPTION
Signed-off-by: Gavin Halliday <gavin.halliday@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [x] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
