### PR TITLE
HPCC-27211 process dynamic shared lib path for files under lib2 separately

### DIFF
--- a/lib2/CMakeLists.txt
+++ b/lib2/CMakeLists.txt
@@ -107,6 +107,38 @@ if (WIN32)
   endif()
 endif ()
 
+if (APPLE)
+  set (update_dynamic_shared_lib_path  "execute_process (COMMAND bash \"-c\"  \"otool -L \\\"\${file}\\\" | egrep \\\"(\\\\s|/)\${dylib_name_only}(.[0-9]{1,})*.dylib\\\" | sed \\\"s/^[[:space:]]//g\\\" | cut -d' ' -f1\"
+                   OUTPUT_VARIABLE otoolOut
+                   ERROR_VARIABLE  otoolErr
+                   OUTPUT_STRIP_TRAILING_WHITESPACE
+                   )
+                   if (\"\${otoolOut}\" STREQUAL \"\")
+                       continue()
+                   endif()
+                   if (NOT \"\${otoolErr}\" STREQUAL \"\")
+                       message(FATAL_ERROR \"Failed to check dependent lib  \${dylib_name_only} for \${file}\")
+                   endif()
+
+                   set(original_dylib_path \${otoolOut})
+
+                   file(GLOB lib2_dylib \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/lib2/\${dylib_name_only}*.dylib\")
+                   if (\"\${lib2_dylib}\" STREQUAL \"\")
+                       message(FATAL_ERROR \"Cannot find \${dylib_name_only}*.dylib under \$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/lib2\")
+                   endif()
+
+                   get_filename_component(dylib_name_ext \"\${lib2_dylib}\" NAME)
+
+                   execute_process(
+                       COMMAND install_name_tool -change \"\${original_dylib_path}\" \"@loader_path/../lib2/\${dylib_name_ext}\" \"\${file}\"
+                       OUTPUT_VARIABLE out
+                       ERROR_VARIABLE  err
+                   )
+   ")
+
+endif()
+
+
 foreach(dylib ${DYLIBS})
     get_filename_component(dylib_path ${dylib} REALPATH)
     if (WIN32)
@@ -115,37 +147,33 @@ foreach(dylib ${DYLIBS})
         install(PROGRAMS "${dylib_path}" DESTINATION lib2)
         get_filename_component(dylib_name_ext ${dylib_path} NAME)
         get_filename_component(dylib_name_only ${dylib_name_ext} NAME_WE)
-
         install(CODE "
-           file(GLOB files \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${EXEC_DIR}/*\" \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${LIB_DIR}/*.dylib\" \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/plugins/*.dylib\" \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/lib2/*.dylib\")
+           set(dylib_name_only \"${dylib_name_only}\")
+           file(GLOB files \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${EXEC_DIR}/*\" \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${LIB_DIR}/*.dylib\" \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/plugins/*.dylib\")
            foreach(file \${files})
-               execute_process(COMMAND bash \"-c\"  \"otool -L \\\"\${file}\\\" | egrep \\\"(\\\\s|/)${dylib_name_only}(.[0-9]{1,})*.dylib\\\" | sed \\\"s/^[[:space:]]//g\\\" | cut -d' ' -f1\"
-                  OUTPUT_VARIABLE otoolOut
-                  ERROR_VARIABLE  otoolErr
-                  OUTPUT_STRIP_TRAILING_WHITESPACE
-               )
-               if (\"\${otoolOut}\" STREQUAL \"\")
-                  continue()
-               endif()
-               if (NOT \"\${otoolErr}\" STREQUAL \"\")
-                   message(FATAL_ERROR \"Failed to check dependent lib  ${dylib_name_only} for \${file}\")
-               endif()
-
-                  set(original_dylib_path \${otoolOut})
-
-                  file(GLOB lib2_dylib \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/lib2/${dylib_name_only}*.dylib\")
-                  if (\"\${otoolOut}\" STREQUAL \"\")
-                      message(FATAL_ERROR \"Cannot find ${dylib_name_only}*.dylib under lib2\")
-                  endif()
-                  get_filename_component(dylib_name_ext \"\${lib2_dylib}\" NAME)
-
-                  execute_process(
-                      COMMAND install_name_tool -change \"\${original_dylib_path}\" \"@loader_path/../lib2/\${dylib_name_ext}\" \"\${file}\"
-                      OUTPUT_VARIABLE out
-                     ERROR_VARIABLE  err
-                  )
-               endif()
+               ${update_dynamic_shared_lib_path}
            endforeach ()
         ")
    endif()
 endforeach(dylib)
+
+# Update dynamic shared library path for libraries under lib2/
+if (APPLE)
+  foreach(dylib ${DYLIBS})
+    get_filename_component(dylib_path ${dylib} REALPATH)
+    get_filename_component(dylib_name_ext ${dylib_path} NAME)
+    get_filename_component(dylib_name_only ${dylib_name_ext} NAME_WE)
+    install(CODE "
+      set(dylib_name_only \"${dylib_name_only}\")
+      file(GLOB files \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/lib2/*.dylib\")
+      foreach(file \${files})
+        get_filename_component(file_name_ext \${file} NAME)
+        get_filename_component(file_name_only \${file_name_ext} NAME_WE)
+        if (\"\${file_name_only}\" STREQUAL \"\${dylib_name_only}\" )
+          continue()
+        endif()
+        ${update_dynamic_shared_lib_path}
+      endforeach ()
+    ")
+  endforeach(dylib)
+endif()


### PR DESCRIPTION

The root problem of that the files under lib2/ may also depend other libraries in this directory. But the process order may leave some libraries improbably handled. For example libicui18n.60.2.dylib depends on lib2/libicuuc.60.2.dylib. If libicui18n.60.2.dylib is processed before libicuuc.60.2.dylib adding to lib2 directory the dependency of libicuuc.60.2.dylib is not correctly updated.

The current fix is to process all files under lib2 after all of them added to lib2 directory.

Also fixed JIRA HPCC-27193  extra "endif()" in lib2/CMakeLists.txt
Signed-off-by: Xiaoming Wang <xiaoming.wang@lexisnexis.com>


## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [ ] I have read the CONTRIBUTORS document.
- [ ] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->

