### PR TITLE
HPCC-27250 Remove mutex protecting exception from CAsyncFor code

### DIFF
--- a/system/jlib/jscm.hpp
+++ b/system/jlib/jscm.hpp
@@ -155,10 +155,26 @@ public:
     }
     inline bool setownIfNull(CLASS * _ptr)
     {
+        if (!_ptr)
+            return false;
+
         CLASS * expected = nullptr;
         if (ptr.compare_exchange_strong(expected, _ptr))
             return true;
-        ::Release(_ptr);
+        _ptr->Release();
+        return false;
+    }
+    inline bool setIfNull(CLASS * _ptr)
+    {
+        if (!_ptr)
+            return false;
+
+        CLASS * expected = nullptr;
+        if (ptr.compare_exchange_strong(expected, _ptr))
+        {
+            _ptr->Link();
+            return true;
+        }
         return false;
     }
     inline void setown(CLASS * _ptr)

--- a/system/jlib/jthread.cpp
+++ b/system/jlib/jthread.cpp
@@ -673,8 +673,7 @@ void CAsyncFor::For(unsigned num,unsigned maxatonce,bool abortFollowingException
             Do(0);
         return;
     }
-    Mutex errmutex;
-    IException *e=NULL;
+    AtomicShared<IException> e;
     Owned<IShuffledIterator> shuffler;
     if (shuffled) {
         shuffler.setown(createShuffledIterator(num));
@@ -689,10 +688,7 @@ void CAsyncFor::For(unsigned num,unsigned maxatonce,bool abortFollowingException
             }
             catch (IException * _e)
             {
-                if (e)
-                    _e->Release();  // only return first
-                else
-                    e = _e;
+                e.setownIfNull(_e);
                 if (abortFollowingException) 
                     break;
             }
@@ -706,15 +702,13 @@ void CAsyncFor::For(unsigned num,unsigned maxatonce,bool abortFollowingException
             class cdothread: public Thread
             {
             public:
-                Mutex *errmutex;
                 Semaphore &ready;
-                IException *&erre;
+                AtomicShared<IException> &erre;
                 unsigned idx;
                 CAsyncFor *self;
-                cdothread(CAsyncFor *_self,unsigned _idx,Semaphore &_ready,Mutex *_errmutex,IException *&_e)
+                cdothread(CAsyncFor *_self,unsigned _idx,Semaphore &_ready,AtomicShared<IException> &_e)
                     : Thread("CAsyncFor"),ready(_ready),erre(_e)
                 {
-                    errmutex =_errmutex;
                     idx = _idx;
                     self = _self;
                 }
@@ -725,18 +719,12 @@ void CAsyncFor::For(unsigned num,unsigned maxatonce,bool abortFollowingException
                     }
                     catch (IException * _e)
                     {
-                        synchronized block(*errmutex);
-                        if (erre)
-                            _e->Release();  // only return first
-                        else
-                            erre = _e;
+                        erre.setownIfNull(_e);
                     }
     #ifndef NO_CATCHALL
                     catch (...)
                     {
-                        synchronized block(*errmutex);
-                        if (!erre)
-                            erre = MakeStringException(0, "Unknown exception in Thread %s", getName());
+                        erre.setownIfNull(MakeStringException(0, "Unknown exception in Thread %s", getName()));
                     }
     #endif
                     ready.signal();
@@ -750,8 +738,8 @@ void CAsyncFor::For(unsigned num,unsigned maxatonce,bool abortFollowingException
             started.ensureCapacity(num);
             for (i=0;i<num;i++) {
                 ready.wait();
-                if (abortFollowingException && e) break;
-                Owned<Thread> thread = new cdothread(this,shuffled?shuffler->lookup(i):i,ready,&errmutex,e);
+                if (abortFollowingException && e.isSet()) break;
+                Owned<Thread> thread = new cdothread(this,shuffled?shuffler->lookup(i):i,ready,e);
                 thread->start();
                 started.append(*thread.getClear());
             }
@@ -767,14 +755,12 @@ void CAsyncFor::For(unsigned num,unsigned maxatonce,bool abortFollowingException
             class cdothread: public Thread
             {
             public:
-                Mutex *errmutex;
-                IException *&erre;
+                AtomicShared<IException> &erre;
                 unsigned idx;
                 CAsyncFor *self;
-                cdothread(CAsyncFor *_self,unsigned _idx,Mutex *_errmutex,IException *&_e)
+                cdothread(CAsyncFor *_self,unsigned _idx,AtomicShared<IException>&_e)
                     : Thread("CAsyncFor"),erre(_e)
                 {
-                    errmutex =_errmutex;
                     idx = _idx;
                     self = _self;
                 }
@@ -785,18 +771,12 @@ void CAsyncFor::For(unsigned num,unsigned maxatonce,bool abortFollowingException
                     }
                     catch (IException * _e)
                     {
-                        synchronized block(*errmutex);
-                        if (erre)
-                            _e->Release();  // only return first
-                        else
-                            erre = _e;
+                        erre.setownIfNull(_e);
                     }
     #ifndef NO_CATCHALL
                     catch (...)
                     {
-                        synchronized block(*errmutex);
-                        if (!erre)
-                            erre = MakeStringException(0, "Unknown exception in Thread %s", getName());
+                        erre.setownIfNull(MakeStringException(0, "Unknown exception in Thread %s", getName()));
                     }
     #endif
                     return 0;
@@ -806,7 +786,7 @@ void CAsyncFor::For(unsigned num,unsigned maxatonce,bool abortFollowingException
             started.ensureCapacity(num);
             for (i=0;i<num-1;i++)
             {
-                Owned<Thread> thread = new cdothread(this,i,&errmutex,e);
+                Owned<Thread> thread = new cdothread(this,i,e);
                 thread->start();
                 started.append(*thread.getClear());
             }
@@ -816,18 +796,12 @@ void CAsyncFor::For(unsigned num,unsigned maxatonce,bool abortFollowingException
             }
             catch (IException * _e)
             {
-                synchronized block(errmutex);
-                if (e)
-                    _e->Release();  // only return first
-                else
-                    e = _e;
+                e.setownIfNull(_e);
             }
 #ifndef NO_CATCHALL
             catch (...)
             {
-                synchronized block(errmutex);
-                if (!e)
-                    e = MakeStringException(0, "Unknown exception in main Thread");
+                e.setownIfNull(MakeStringException(0, "Unknown exception in main Thread"));
             }
 #endif
 
@@ -837,8 +811,8 @@ void CAsyncFor::For(unsigned num,unsigned maxatonce,bool abortFollowingException
             }
         }
     }
-    if (e)
-        throw e;
+    if (e.isSet())
+        throw e.getClear();
 }
 
 //---------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Signed-off-by: Gavin Halliday <gavin.halliday@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [x] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [ ] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
