### PR TITLE
HPCC-27285 Report correct roxie queue in WsSMC/WsPackageProcess

### DIFF
--- a/common/environment/environment.cpp
+++ b/common/environment/environment.cpp
@@ -2839,6 +2839,11 @@ public:
     {
         return ldapPassword.str();
     }
+    bool isQueriesOnly() const
+    {
+        //In bare metal environment, roxie is not QueriesOnly.
+        return false;
+    }
 };
 
 IStringVal &getProcessQueueNames(IStringVal &ret, const char *process, const char *type, const char *suffix)

--- a/common/environment/environment.hpp
+++ b/common/environment/environment.hpp
@@ -274,6 +274,7 @@ interface IConstWUClusterInfo : extends IInterface
     virtual unsigned getChannelsPerNode() const = 0;
     virtual int getRoxieReplicateOffset() const = 0;
     virtual const char *getAlias() const = 0;
+    virtual bool isQueriesOnly() const = 0;
 };
 
 typedef IArrayOf<IConstWUClusterInfo> CConstWUClusterInfoArray;

--- a/esp/services/ws_smc/ws_smcService.cpp
+++ b/esp/services/ws_smc/ws_smcService.cpp
@@ -282,6 +282,9 @@ void CActivityInfo::readTargetClusterInfo(CConstWUClusterInfoArray& clusters, IP
     ForEachItemIn(c, clusters)
     {
         IConstWUClusterInfo &cluster = clusters.item(c);
+        if (cluster.isQueriesOnly()) //"publish-only" roxie queues not in SDS /JobQueues.
+            continue;
+
         Owned<CWsSMCTargetCluster> targetCluster = new CWsSMCTargetCluster();
         readTargetClusterInfo(cluster, serverStatusRoot, targetCluster);
         if (cluster.getPlatform() == ThorLCRCluster)

--- a/esp/smc/SMCLib/TpContainer.cpp
+++ b/esp/smc/SMCLib/TpContainer.cpp
@@ -496,10 +496,11 @@ class CContainerWUClusterInfo : public CSimpleInterfaceOf<IConstWUClusterInfo>
     ClusterType platform;
     unsigned clusterWidth;
     StringArray thorProcesses;
+    bool queriesOnly = false;
 
 public:
-    CContainerWUClusterInfo(const char* _name, const char* type, unsigned _clusterWidth)
-        : name(_name), clusterWidth(_clusterWidth)
+    CContainerWUClusterInfo(const char* _name, const char* type, unsigned _clusterWidth, bool _queriesOnly)
+        : name(_name), clusterWidth(_clusterWidth), queriesOnly(_queriesOnly)
     {
         StringBuffer queue;
         if (strieq(type, "thor"))
@@ -553,6 +554,10 @@ public:
     virtual bool isLegacyEclServer() const override
     {
         return false;
+    }
+    virtual bool isQueriesOnly() const override
+    {
+        return queriesOnly;
     }
     virtual IStringVal& getScope(IStringVal& str) const override
     {
@@ -624,7 +629,7 @@ extern TPWRAPPER_API unsigned getContainerWUClusterInfo(CConstWUClusterInfoArray
     {
         IPropertyTree& queue = queues->query();
         Owned<IConstWUClusterInfo> cluster = new CContainerWUClusterInfo(queue.queryProp("@name"),
-            queue.queryProp("@type"), (unsigned) queue.getPropInt("@width", 1));
+            queue.queryProp("@type"), (unsigned) queue.getPropInt("@width", 1), queue.getPropBool("@queriesOnly"));
         clusters.append(*cluster.getClear());
     }
 
@@ -649,7 +654,7 @@ extern TPWRAPPER_API IConstWUClusterInfo* getWUClusterInfoByName(const char* clu
         return nullptr;
 
     return new CContainerWUClusterInfo(queue->queryProp("@name"), queue->queryProp("@type"),
-        (unsigned) queue->getPropInt("@width", 1));
+        (unsigned) queue->getPropInt("@width", 1), queue->getPropBool("@queriesOnly"));
 }
 
 extern TPWRAPPER_API void initContainerRoxieTargets(MapStringToMyClass<ISmartSocketFactory>& connMap)

--- a/esp/smc/SMCLib/TpWrapper.cpp
+++ b/esp/smc/SMCLib/TpWrapper.cpp
@@ -1945,6 +1945,11 @@ public:
         str.set(name.get());
         return str;
     }
+    virtual bool isQueriesOnly() const override
+    {
+        //In bare metal environment, roxie is not QueriesOnly.
+        return false;
+    }
     virtual const StringArray & getThorProcesses() const override
     {
         return thorProcesses;


### PR DESCRIPTION
1. The WsSAMC.Activity response, remove the "publish-only" roxie
queues.
2. The WsPackageProcess.GetPackageMapSelectOptions should only
report the roxie queues which support query publish.

Signed-off-by: wangkx <kevin.wang@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
