### PR TITLE
HPCC-24691 Convert ESP to use jlog standards

### DIFF
--- a/esp/bindings/SOAP/client/soapclient.cpp
+++ b/esp/bindings/SOAP/client/soapclient.cpp
@@ -124,10 +124,8 @@ int CSoapClient::postRequest(const char* contenttype, const char* soapaction, IR
         multipart->serialize(contenttypestr, requeststr);
     }
 
-    if (getEspLogLevel(rpccall.queryContext())>LogNormal)
-    {
-        DBGLOG("Content type: %s", contenttypestr.str());
-    }
+    auto logCat = (rpccall.queryContext() != nullptr) ? (rpccall.queryContext()->debugTraceEnabled() ? MsgCatEspElevated : LegacyMsgCatMax) : LegacyMsgCatMax;
+    LOG(logCat, "Content type: %s", contenttypestr.str());
 
     Owned<CSoapRequest> soap_request;
     soap_request.setown(new CSoapRequest);

--- a/esp/bindings/http/client/httpclient.cpp
+++ b/esp/bindings/http/client/httpclient.cpp
@@ -416,11 +416,8 @@ HttpClientErrCode CHttpClient::sendRequest(const char* method, const char* conte
         httprequest->addHeader("WWW-Authenticate", authheader.str());
     }
 
-    if (getEspLogLevel()>LogNormal)
-    {
-        DBGLOG("Content type: %s", contenttype);
-        DBGLOG("Request content: %s", request.str());
-    }
+    LOG(LegacyMsgCatMax, "Content type: %s", contenttype);
+    LOG(LegacyMsgCatMax, "Request content: %s", request.str());
 
     httprequest->setContent(request.str());
 
@@ -463,8 +460,7 @@ HttpClientErrCode CHttpClient::sendRequest(const char* method, const char* conte
     m_persistable = httpresponse->getPersistentEligible();
     m_numRequests++;
 
-    if (getEspLogLevel()>LogNormal)
-        DBGLOG("Response content: %s", response.str());
+    LOG(LegacyMsgCatMax,"Response content: %s", response.str());
 
     return HttpClientErrCode::OK;
 }
@@ -596,12 +592,9 @@ HttpClientErrCode CHttpClient::proxyRequest(IHttpMessage *request, IHttpMessage 
     httprequest->setContentType(contentType);
     httprequest->setContent(forwardRequest->queryContent());
 
-    if (getEspLogLevel()>LogNormal)
-    {
-        StringBuffer s;
-        DBGLOG("Content type: %s", forwardRequest->getContentType(s).str());
-        DBGLOG("Request content: %s", forwardRequest->queryContent());
-    }
+    StringBuffer s;
+    LOG(LegacyMsgCatMax, "Content type: %s", forwardRequest->getContentType(s).str());
+    LOG(LegacyMsgCatMax, "Request content: %s", forwardRequest->queryContent());
 
     copyCookies(*httprequest, *forwardRequest, m_host);
 
@@ -629,8 +622,7 @@ HttpClientErrCode CHttpClient::proxyRequest(IHttpMessage *request, IHttpMessage 
     m_persistable = httpresponse->getPersistentEligible();
     m_numRequests++;
 
-    if (getEspLogLevel()>LogNormal)
-        DBGLOG("Response content: %s", httpresponse->queryContent());
+    LOG(LegacyMsgCatMax, "Response content: %s", httpresponse->queryContent());
 
     return HttpClientErrCode::OK;
 }
@@ -708,11 +700,9 @@ IHttpMessage *CHttpClient::sendRequestEx(const char* method, const char* content
         httprequest->addHeader("WWW-Authenticate", authheader.str());
     }
 
-    if (getEspLogLevel()>LogNormal)
-    {
-        DBGLOG("Content type: %s", contenttype);
-        DBGLOG("Request content: %s", content.str());
-    }
+    LOG(LegacyMsgCatMax, "Content type: %s", contenttype);
+    LOG(LegacyMsgCatMax, "Request content: %s", content.str());
+
 
     httprequest->setContent(content.str());
 
@@ -773,8 +763,7 @@ HttpClientErrCode CHttpClient::sendRequest(IProperties *headers, const char* met
     resp->getContent(responseContent);
     resp->getStatus(responseStatus);
 
-    if (getEspLogLevel()>LogNormal)
-        DBGLOG("Response content: %s", responseContent.str());
+    LOG(LegacyMsgCatMax, "Response content: %s", responseContent.str());
 
     return code;
 }
@@ -1025,11 +1014,8 @@ HttpClientErrCode CHttpClient::postRequest(ISoapMessage &req, ISoapMessage& resp
     StringBuffer content;
     httpresponse->getContent(content);
 
-    if (getEspLogLevel()>LogNormal)
-    {
-        if(httpresponse->isTextMessage())
-            DBGLOG("http response content = %s", content.str());
-    }
+    if(httpresponse->isTextMessage())
+        LOG(LegacyMsgCatMax, "http response content = %s", content.str());
 
     response.set_text(content.str());
             

--- a/esp/bindings/http/platform/httpbinding.cpp
+++ b/esp/bindings/http/platform/httpbinding.cpp
@@ -674,14 +674,14 @@ void EspHttpBinding::populateRequest(CHttpRequest *request)
         ISecResourceList* settinglist = m_setting_authmap->getResourceList("*");
         if(settinglist == NULL)
             return ;
-        if (getEspLogLevel()>=LogMax)
+        if (queryLogMsgManager()->rejectsCategory(LegacyMsgCatMax))
         {
             StringBuffer s;
-            DBGLOG("Set security settings: %s", settinglist->toString(s).str());
+            LOG(LegacyMsgCatMax, "Set security settings: %s", settinglist->toString(s).str());
         }
         ctx->setSecuritySettings(settinglist);
     }
-    return ;
+    return;
 }
 
 bool EspHttpBinding::doAuth(IEspContext* ctx)
@@ -799,7 +799,7 @@ bool EspHttpBinding::basicAuth(IEspContext* ctx)
             {
                 const char *desc=curres->getDescription();
                 VStringBuffer msg("Access for user '%s' denied to: %s. Access=%d, Required=%d", user->getName(), desc?desc:"<no-desc>", access, required);
-                ESPLOG(LogMin, "%s", msg.str());
+                LOG(LegacyMsgCatMin, "%s", msg.str());
                 ctx->AuditMessage(AUDIT_TYPE_ACCESS_FAILURE, "Authorization", "Access Denied: Not Authorized", "Resource: %s [%s]", curres->getName(), (desc) ? desc : "");
                 ctx->setAuthError(EspAuthErrorNotAuthorized);
                 ctx->setRespMsg(msg.str());
@@ -864,11 +864,11 @@ bool EspHttpBinding::sendFromESPCache(IEspCache* cacheClient, CHttpRequest* requ
 {
     StringBuffer content, contentType;
     if (!cacheClient->readResponseCache(cacheID, content.clear(), contentType.clear()))
-        ESPLOG(LogMax, "Failed to read from ESP Cache for %s.", request->queryServiceMethod());
+        LOG(LegacyMsgCatMax, "Failed to read from ESP Cache for %s.", request->queryServiceMethod());
     if (content.isEmpty() || contentType.isEmpty())
         return false;
 
-    ESPLOG(LogMax, "Sending from ESP Cache for %s.", request->queryServiceMethod());
+    LOG(LegacyMsgCatMax, "Sending from ESP Cache for %s.", request->queryServiceMethod());
     response->setContentType(contentType.str());
     response->setContent(content.str());
     response->send();
@@ -881,9 +881,9 @@ void EspHttpBinding::addToESPCache(IEspCache* cacheClient, CHttpRequest* request
     response->getContent(content);
     response->getContentType(contentType);
     if (cacheClient->cacheResponse(cacheID, cacheSeconds, content.str(), contentType.str()))
-        ESPLOG(LogMax, "AddTo ESP Cache for %s.", request->queryServiceMethod());
+        LOG(LegacyMsgCatMax, "AddTo ESP Cache for %s.", request->queryServiceMethod());
     else
-        ESPLOG(LogMax, "Failed to add ESP Cache for %s.", request->queryServiceMethod());
+        LOG(LegacyMsgCatMax, "Failed to add ESP Cache for %s.", request->queryServiceMethod());
 }
 
 void EspHttpBinding::clearCacheByGroupID(const char *ids)
@@ -895,7 +895,7 @@ void EspHttpBinding::clearCacheByGroupID(const char *ids)
     if (!espContainer->hasCacheClient())
         return;
 
-    ESPLOG(LogMax, "clearCacheByGroupID %s.", ids);
+    LOG(LegacyMsgCatMax, "clearCacheByGroupID %s.", ids);
     StringArray errorMsgs;
     espContainer->clearCacheByGroupID(ids, errorMsgs);
     if (errorMsgs.length() > 0)
@@ -946,10 +946,8 @@ int EspHttpBinding::onGet(CHttpRequest* request, CHttpResponse* response)
 
     // At this time, the request is already received and fully passed, and
     // the user authenticated
-    LogLevel level = getEspLogLevel(&context);
-    if (level >= LogNormal)
-        DBGLOG("EspHttpBinding::onGet");
-    
+    LOG(context.debugTraceEnabled() ? MsgCatEspElevated : LegacyMsgCatMax, "EspHttpBinding::onGet");
+
     response->setVersion(HTTP_VERSION);
     response->addHeader("Expires", "0");
 
@@ -1555,8 +1553,8 @@ int EspHttpBinding::onGetIframe(IEspContext &context, CHttpRequest* request, CHt
     if (plainText.length() > 0)
         inner.appendf("&PlainText=%s", plainText.str());
             
-    ESPLOG(LogNormal,"Inner: %s", inner.str());
-    ESPLOG(LogNormal,"Param: %s", request->queryParamStr());
+    LOG(LegacyMsgCatNormal,"Inner: %s", inner.str());
+    LOG(LegacyMsgCatNormal,"Param: %s", request->queryParamStr());
     content.appendf("<frame name=\"imain\" target=\"main\" src=\"%s\" scrolling=\"auto\" frameborder=\"0\" noresize=\"noresize\"/>", inner.str());
     content.append("</frameset>");
     content.append("</body></html>");
@@ -1578,7 +1576,7 @@ int EspHttpBinding::onGetConfig(IEspContext &context, CHttpRequest* request, CHt
     {
         if (getESPContainer() && getESPContainer()->queryApplicationConfig())
         {
-            ESPLOG(LogNormal, "Get config generated during application init");
+            LOG(LegacyMsgCatNormal, "Get config generated during application init");
             StringBuffer content("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
             if (context.queryRequestParameters()->hasProp("display"))
                 content.append("<?xml-stylesheet type=\"text/xsl\" href=\"/esp/xslt/xmlformatter.xsl\"?>");
@@ -1590,7 +1588,7 @@ int EspHttpBinding::onGetConfig(IEspContext &context, CHttpRequest* request, CHt
             return 0;
         }
 
-        ESPLOG(LogNormal, "Get config file: %s", m_configFile.get());
+        LOG(LegacyMsgCatNormal, "Get config file: %s", m_configFile.get());
 
         StringBuffer content;
         xmlContentFromFile(m_configFile, "/esp/xslt/xmlformatter.xsl", content);
@@ -2823,8 +2821,7 @@ void EspHttpBinding::validateResponse(IEspContext& context, CHttpRequest* reques
     getSchema(xsd,context,request,serviceQName,methodQName,true);
             
     // validation
-    if (getEspLogLevel()>LogMax)
-        DBGLOG("[VALIDATE] xml: %s\nxsd: %s\nns: %s",xml.str(), xsd.str(), ns.str());
+    LOG(LegacyMsgCatMax, "[VALIDATE] xml: %s\nxsd: %s\nns: %s",xml.str(), xsd.str(), ns.str());
 
     IXmlValidator* v = getXmlLibXmlValidator();
 
@@ -2859,7 +2856,7 @@ void EspHttpBinding::validateResponse(IEspContext& context, CHttpRequest* reques
 void EspHttpBinding::sortResponse(IEspContext& context, CHttpRequest* request, MemoryBuffer& content, 
                                       const char *serviceName, const char* methodName)
 {
-    ESPLOG(LogNormal,"Sorting Response XML...");
+    LOG(LegacyMsgCatNormal,"Sorting Response XML...");
 
     try {
         StringBuffer result;
@@ -2873,8 +2870,7 @@ void EspHttpBinding::sortResponse(IEspContext& context, CHttpRequest* request, M
 
         xform->setXmlSource(respXML,respXML.length());
         xform->transform(result);
-        if (getEspLogLevel()>LogNormal)
-            DBGLOG("XML sorted: %s", result.str());
+        LOG(LegacyMsgCatMax, "XML sorted: %s", result.str());
         unsigned len = result.length();
         content.setBuffer(len, result.detach(), true);      
     } catch (IException* e) {

--- a/esp/bindings/http/platform/httpprot.cpp
+++ b/esp/bindings/http/platform/httpprot.cpp
@@ -317,7 +317,7 @@ bool CSecureHttpProtocol::notifySelected(ISocket *sock,unsigned selected, IPersi
             {
                 char peername[256];
                 int port = accepted->peer_name(peername, 256);
-                ESPLOG(LogMax, "HTTPS connection from %s:%d on %s socket", peername, port, persistentHandler?"persistent":"new");
+                LOG(LegacyMsgCatMax, "HTTPS connection from %s:%d on %s socket", peername, port, persistentHandler?"persistent":"new");
                 if(m_ssctx != NULL)
                 {
                     if(m_maxConcurrentThreads > 0)
@@ -343,7 +343,7 @@ bool CSecureHttpProtocol::notifySelected(ISocket *sock,unsigned selected, IPersi
                         workthread->setMaxRequestEntityLength(getMaxRequestEntityLength());
                         workthread->setShouldClose(shouldClose);
                         workthread->start();
-                        ESPLOG(LogMax, "Request processing thread started.");
+                        LOG(LegacyMsgCatMax, "Request processing thread started.");
                         workthread->Release();
                     }
                 }
@@ -421,16 +421,16 @@ bool CHttpThread::onRequest()
     Owned<ISecureSocket> secure_sock;
     if(m_is_ssl && m_ssctx && m_persistentHandler == nullptr)
     {
-        ESPLOG(LogMax, "Creating secure socket");
+        LOG(LegacyMsgCatMax, "Creating secure socket");
         secure_sock.setown(m_ssctx->createSecureSocket(m_socket.getLink(), getEspLogLevel()));
         int res = 0;
         try
         {
-            ESPLOG(LogMax, "Accepting from secure socket");
+            LOG(LegacyMsgCatMax, "Accepting from secure socket");
             res = secure_sock->secure_accept();
             if(res < 0)
             {
-                ESPLOG(LogMin, "Error accepting from secure socket");
+                LOG(LegacyMsgCatMin, "Error accepting from secure socket");
                 return false;
             }
         }
@@ -446,7 +446,7 @@ bool CHttpThread::onRequest()
             IERRLOG("Unknown exception accepting from secure socket");
             return false;
         }
-        ESPLOG(LogMax, "Request from secure socket");
+        LOG(LegacyMsgCatMax, "Request from secure socket");
         m_socket.set(secure_sock);
         httpserver.setown(new CEspHttpServer(*secure_sock.get(), m_apport, m_viewConfig, getMaxRequestEntityLength()));
         IEspContext* ctx = httpserver->queryContext();

--- a/esp/bindings/http/platform/httptransport.cpp
+++ b/esp/bindings/http/platform/httptransport.cpp
@@ -606,8 +606,7 @@ int CHttpMessage::receive(bool alwaysReadContent, IMultiException *me)
     if (processHeaders(me)==-1)
         return -1;
 
-    if (getEspLogLevel()>LogNormal)
-        DBGLOG("Headers processed! content_length = %" I64F "d", m_content_length);
+    LOG(LegacyMsgCatMax, "Headers processed! content_length = %" I64F "d", m_content_length);
     StringBuffer expect;
     getHeader("Expect", expect);
     if (expect.length() && strieq(expect, "100-continue"))
@@ -623,15 +622,13 @@ int CHttpMessage::receive(bool alwaysReadContent, IMultiException *me)
     if(m_content_length > 0)
     {
         readContent();
-        if (getEspLogLevel()>LogNormal)
-            DBGLOG("length of content read = %d", m_content.length());
+        LOG(LegacyMsgCatMax, "length of content read = %d", m_content.length());
     }
     else if (alwaysReadContent && m_content_length == -1)
     {
         //HTTP protocol does not require a content length: read until socket closed
         readContentTillSocketClosed();
-        if (getEspLogLevel()>LogNormal)
-            DBGLOG("length of content read = %d", m_content.length());
+        LOG(LegacyMsgCatMax, "length of content read = %d", m_content.length());
     }
     if(m_content_length != m_content.length())
         m_context->addTraceSummaryValue(LogMin, "custom_fields.contRead", m_content.length(), TXSUMMARY_GRP_ENTERPRISE);
@@ -989,9 +986,11 @@ int CHttpMessage::startSend()
 {
     StringBuffer sendbuf;
     constructHeaderBuffer(sendbuf, false);
-    
-    if (getEspLogLevel(queryContext())>LogNormal)
-        DBGLOG("Start Sending chunked HTTP message:\n %s", sendbuf.str());
+
+    auto logCat = (queryContext() != nullptr)
+            ? (queryContext()->debugTraceEnabled() ? MsgCatEspElevated : LegacyMsgCatMax)
+            : LegacyMsgCatMax;
+    LOG(logCat, "Start Sending chunked HTTP message:\n %s", sendbuf.str());
 
     try
     {
@@ -1017,8 +1016,8 @@ int CHttpMessage::startSend()
 
 int CHttpMessage::sendChunk(const char *chunk)
 {
-    if (getEspLogLevel(queryContext())>LogNormal)
-        DBGLOG("Sending HTTP chunk:\n %s", chunk);
+    auto logCat = (queryContext() != nullptr) ? (queryContext()->debugTraceEnabled() ? MsgCatEspElevated : LegacyMsgCatMax) : LegacyMsgCatMax;
+    LOG(logCat, "Sending HTTP chunk:\n %s", chunk);
 
     try
     {
@@ -1044,8 +1043,8 @@ int CHttpMessage::sendChunk(const char *chunk)
 
 int CHttpMessage::sendFinalChunk(const char *chunk)
 {
-    if (getEspLogLevel(queryContext())>LogNormal)
-        DBGLOG("Sending HTTP Final chunk:\n %s", chunk);
+    auto logCat = (queryContext() != nullptr) ? (queryContext()->debugTraceEnabled() ? MsgCatEspElevated : LegacyMsgCatMax) : LegacyMsgCatMax;
+    LOG(logCat, "Sending HTTP Final chunk:\n %s", chunk);
 
     try
     {
@@ -1410,8 +1409,6 @@ void CHttpRequest::parseQueryString(const char* querystr)
 
 int CHttpRequest::parseFirstLine(char* oneline)
 {
-    //if (getEspLogLevel()>LogNormal)
-    //  DBGLOG("First Line of request=%s", oneline);
     DBGLOG("HTTP First Line: %s", oneline);
 
     if(*oneline == 0)
@@ -2352,8 +2349,7 @@ int CHttpResponse::parseFirstLine(char* oneline)
     if(*oneline == 0)
         return -1;
 
-    if (getEspLogLevel()>LogNormal)
-        DBGLOG("http response status = %s", oneline);
+    LOG(LegacyMsgCatMax, "http response status = %s", oneline);
 
     char* ptr = oneline;
     while(*ptr != '\0' && *ptr != ' ')
@@ -2590,10 +2586,8 @@ int CHttpResponse::receive(bool alwaysReadContent, IMultiException *me)
     
     if (processHeaders(me)==-1)
         return -1;
+    LOG(LegacyMsgCatMax, "Response headers processed! content_length = %" I64F "d", m_content_length);
 
-    if (getEspLogLevel()>LogNormal)
-        DBGLOG("Response headers processed! content_length = %" I64F "d", m_content_length);
-    
     char status_class = '2';
     if(m_status.length() > 0)
         status_class = *(m_status.get());
@@ -2601,15 +2595,13 @@ int CHttpResponse::receive(bool alwaysReadContent, IMultiException *me)
     if(m_content_length > 0)
     {
         readContent();
-        if (getEspLogLevel()>LogNormal)
-            DBGLOG("length of response content read = %d", m_content.length());
+        LOG(LegacyMsgCatMax, "length of response content read = %d", m_content.length());
     }
     else if(alwaysReadContent && status_class != '4' && status_class != '5' && m_content_length == -1)
     {
         //HTTP protocol does not require a content length: read until socket closed
         readContentTillSocketClosed();
-        if (getEspLogLevel()>LogNormal)
-            DBGLOG("length of content read = %d", m_content.length());
+        LOG(LegacyMsgCatMax, "length of content read = %d", m_content.length());
     }
 
     bool decompressed = false;

--- a/esp/logging/loggingagent/cassandraloggingagent/cassandralogagent.cpp
+++ b/esp/logging/loggingagent/cassandraloggingagent/cassandralogagent.cpp
@@ -243,7 +243,8 @@ void CCassandraLogAgent::setUpdateLogStatement(const char* dbName, const char* t
 
 void CCassandraLogAgent::executeSimpleStatement(const char* st)
 {
-    CassandraStatement statement(cassSession->prepareStatement(st, getEspLogLevel()>LogNormal));
+    bool trace = !queryLogMsgManager()->rejectsCategory(LegacyMsgCatMin);
+    CassandraStatement statement(cassSession->prepareStatement(st, trace));
     CassandraFuture future(cass_session_execute(cassSession->querySession(), statement));
     future.wait("execute");
 }
@@ -263,7 +264,8 @@ void CCassandraLogAgent::executeUpdateLogStatement(StringBuffer& st)
 
 bool CCassandraLogAgent::executeSimpleSelectStatement(const char* st, unsigned& resultValue)
 {
-    CassandraStatement statement(cassSession->prepareStatement(st, getEspLogLevel()>LogNormal));
+    bool trace = !queryLogMsgManager()->rejectsCategory(LegacyMsgCatMin);
+    CassandraStatement statement(cassSession->prepareStatement(st, trace));
     CassandraFuture future(cass_session_execute(cassSession->querySession(), statement));
     future.wait("execute");
     CassandraResult result(cass_future_get_result(future));

--- a/esp/logging/logginglib/LogFailSafe.cpp
+++ b/esp/logging/logginglib/LogFailSafe.cpp
@@ -78,7 +78,7 @@ CLogFailSafe::CLogFailSafe(IPropertyTree* cfg, const char* pszService, const cha
 
 CLogFailSafe::~CLogFailSafe()
 {
-    ESPLOG(LogMax, "CLogFailSafe::~CLogFailSafe()");
+    DBGLOG("CLogFailSafe::~CLogFailSafe()");
     m_Added.Close();
     if (!decoupledLogging)
         m_Cleared.Close();
@@ -214,7 +214,7 @@ bool CLogFailSafe::PopPendingLogRecord(StringBuffer& GUID, StringBuffer& cache)
 
     unsigned int nPendingLogs = m_PendingLogs.size();
     if (nPendingLogs && (nPendingLogs < TRACE_PENDING_LOGS_MIN || (nPendingLogs % TRACE_PENDING_LOGS_MAX == 0)))
-        ESPLOG(LogNormal, "%u logs pending", nPendingLogs);
+        LOG(LegacyMsgCatNormal, "%u logs pending", nPendingLogs);
 
     return true;
 }

--- a/esp/logging/logginglib/loggingagentbase.cpp
+++ b/esp/logging/logginglib/loggingagentbase.cpp
@@ -181,7 +181,7 @@ IEspUpdateLogRequestWrap* CLogContentFilter::filterLogContent(IEspUpdateLogReque
 
         StringBuffer updateLogRequestXML;
         toXML(filteredLogRequestTree, updateLogRequestXML);
-        ESPLOG(LogMax, "filtered content and option: <%s>", updateLogRequestXML.str());
+        LOG(LegacyMsgCatMax, "filtered content and option: <%s>", updateLogRequestXML.str());
 
         req->setUpdateLogRequest(updateLogRequestXML);
         if (logRequestTree)
@@ -337,7 +337,7 @@ IEspUpdateLogRequestWrap* CLogContentFilter::filterLogContent(IEspUpdateLogReque
 
     StringBuffer updateLogRequestXML;
     toXML(updateLogRequestTree, updateLogRequestXML);
-    ESPLOG(LogMax, "filtered content and option: <%s>", updateLogRequestXML.str());
+    LOG(LegacyMsgCatMax, "filtered content and option: <%s>", updateLogRequestXML.str());
 
     Owned<IEspUpdateLogRequestWrap> newReq = new CUpdateLogRequestWrap(req->getGUID(), req->getOption(), updateLogRequestXML.str());
     if (scriptValues)
@@ -519,7 +519,8 @@ bool CDBLogAgentBase::updateLog(IEspUpdateLogRequestWrap& req, IEspUpdateLogResp
     if (!hasService(LGSTUpdateLOG))
         throw MakeStringException(EspLoggingErrors::UpdateLogFailed, "%s: no updateLog service configured", agentName.get());
 
-    unsigned startTime = (getEspLogLevel()>=LogNormal) ? msTick() : 0;
+    bool isLogging = !queryLogMsgManager()->rejectsCategory(LegacyMsgCatNormal);
+    unsigned startTime = isLogging ? msTick() : 0;
     bool ret = false;
     try
     {
@@ -549,11 +550,11 @@ bool CDBLogAgentBase::updateLog(IEspUpdateLogRequestWrap& req, IEspUpdateLogResp
             if(!buildUpdateLogStatement(logRequestTree, logDB.str(), table, logID, updateDBStatement))
                 throw MakeStringException(EspLoggingErrors::UpdateLogFailed, "Failed in creating SQL statement.");
 
-            ESPLOG(LogNormal, "LAgent UpdateLog BuildStat %d done: %dms\n", i, msTick() -  startTime);
-            ESPLOG(LogMax, "UpdateLog: %s\n", updateDBStatement.str());
+            LOG(LegacyMsgCatNormal, "LAgent UpdateLog BuildStat %d done: %dms\n", i, (isLogging ? msTick() : 0) -  startTime);
+            LOG(LegacyMsgCatMax, "UpdateLog: %s\n", updateDBStatement.str());
 
             executeUpdateLogStatement(updateDBStatement);
-            ESPLOG(LogNormal, "LAgent UpdateLog ExecStat %d done: %dms\n", i, msTick() -  startTime);
+            LOG(LegacyMsgCatNormal, "LAgent UpdateLog ExecStat %d done: %dms\n", i, (isLogging ? msTick() : 0) -  startTime);
         }
         resp.setStatusCode(0);
         ret = true;
@@ -567,7 +568,7 @@ bool CDBLogAgentBase::updateLog(IEspUpdateLogRequestWrap& req, IEspUpdateLogResp
         resp.setStatusCode(-1);
         resp.setStatusMessage(errorMessage.str());
     }
-    ESPLOG(LogNormal, "LAgent UpdateLog total=%dms\n", msTick() -  startTime);
+    LOG(LegacyMsgCatNormal, "LAgent UpdateLog total=%dms\n", (isLogging ? msTick() : 0) -  startTime);
     return ret;
 }
 

--- a/esp/logging/loggingmanager/loggingmanager.cpp
+++ b/esp/logging/loggingmanager/loggingmanager.cpp
@@ -340,7 +340,8 @@ bool CLoggingManager::saveToTankFile(IEspUpdateLogRequestWrap& logRequest, CLogR
         return false;
     }
 
-    unsigned startTime = (getEspLogLevel()>=LogNormal) ? msTick() : 0;
+    bool isLogging = !queryLogMsgManager()->rejectsCategory(LegacyMsgCatNormal);
+    unsigned startTime = isLogging ? msTick() : 0;
 
     StringBuffer GUID;
     logFailSafe->GenerateGUID(GUID, NULL);
@@ -366,7 +367,7 @@ bool CLoggingManager::saveToTankFile(IEspUpdateLogRequestWrap& logRequest, CLogR
         logFailSafe->Add(GUID, nullptr, reqBuf, reqInFile);
     }
 
-    ESPLOG(LogNormal, "LThread:saveToTankFile: %dms\n", msTick() - startTime);
+    LOG(LegacyMsgCatNormal, "LThread:saveToTankFile: %dms\n", (isLogging ? msTick() : 0) - startTime);
     return true;
 }
 
@@ -511,7 +512,7 @@ bool CLoggingManager::getFilteredTransactionID(StringAttrMapping* transFields, S
                 agent->getTransactionID(transFields, transactionID);
                 if (!transactionID.isEmpty())
                 {
-                    ESPLOG(LogMax, "Got TransactionID '%s'", transactionID.str());
+                    LOG(LegacyMsgCatMax, "Got TransactionID '%s'", transactionID.str());
                     return true;
                 }
             }

--- a/esp/logging/test/main.cpp
+++ b/esp/logging/test/main.cpp
@@ -24,7 +24,7 @@
 //Copy the code to esdl_binding.cpp.
 
 #ifdef USE_TEST_RESP
-                ESPLOG(LogMin,"origResp: %s", origResp.str());
+                LOG(LegacyMsgCatMin,"origResp: %s", origResp.str());
                 StringBuffer respWithLodData;
                 respWithLodData.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\"><soap:Body><ExchangeNumbersResponse xmlns=\"urn:hpccsystems:ecl:exchangenumbers\" sequence=\"0\"><Results><Result>\n");
                 respWithLodData.append("<Dataset xmlns=\"urn:hpccsystems:ecl:vin_services.servicevinstandard:result:log_log__vin_intermediate__log\" name=\"LOG_log__vin_intermediate__log\">\n");

--- a/esp/platform/espcache.cpp
+++ b/esp/platform/espcache.cpp
@@ -60,7 +60,7 @@ ESPMemCached::ESPMemCached()
 {
 #if (LIBMEMCACHED_VERSION_HEX < 0x01000010)
     VStringBuffer msg("ESPMemCached: libmemcached version '%s' incompatible with min version>=1.0.10", LIBMEMCACHED_VERSION_STRING);
-    ESPLOG(LogNormal, "%s", msg.str());
+    LOG(LegacyMsgCatNormal, "%s", msg.str());
 #endif
 }
 
@@ -163,7 +163,7 @@ bool ESPMemCached::checkServersUp()
     unsigned int numberOfServers = memcached_server_count(connection);
     if (numberOfServers < 1)
     {
-        ESPLOG(LogMin,"ESPMemCached: no server connected.");
+        LOG(LegacyMsgCatMin,"ESPMemCached: no server connected.");
         return false;
     }
 
@@ -174,12 +174,12 @@ bool ESPMemCached::checkServersUp()
         {
             numberOfServersDown++;
             VStringBuffer msg("ESPMemCached: Failed connecting to entry %u\nwithin the server list: %s", i+1, options.str());
-            ESPLOG(LogMin, "%s", msg.str());
+            LOG(LegacyMsgCatMin, "%s", msg.str());
         }
     }
     if (numberOfServersDown == numberOfServers)
     {
-        ESPLOG(LogMin,"ESPMemCached: Failed connecting to ALL servers. Check memcached on all servers and \"memcached -B ascii\" not used.");
+        LOG(LegacyMsgCatMin,"ESPMemCached: Failed connecting to ALL servers. Check memcached on all servers and \"memcached -B ascii\" not used.");
         return false;
     }
 
@@ -278,7 +278,7 @@ void ESPMemCached::assertOnError(memcached_return_t rc, const char * _msg)
     if (rc != MEMCACHED_SUCCESS)
     {
         VStringBuffer msg("ESPMemCached: %s%s", _msg, memcached_strerror(connection, rc));
-        ESPLOG(LogNormal, "%s", msg.str());
+        LOG(LegacyMsgCatNormal, "%s", msg.str());
     }
 }
 
@@ -288,7 +288,7 @@ void ESPMemCached::assertPool()
     {
         StringBuffer msg("ESPMemCached: Failed to instantiate server pool with:");
         msg.newline().append(options);
-        ESPLOG(LogNormal, "%s", msg.str());
+        LOG(LegacyMsgCatNormal, "%s", msg.str());
     }
 }
 #endif //USE_LIBMEMCACHED

--- a/esp/platform/espcfg.cpp
+++ b/esp/platform/espcfg.cpp
@@ -357,32 +357,32 @@ CEspConfig::CEspConfig(IProperties* inputs, IPropertyTree* envpt, IPropertyTree*
                     }
                     else
                     {
-                        ESPLOG(LogMin, "Could not load DALI Attach state file [%s] for ESP process [%s]", m_daliAttachStateFileName.str(), m_process.str());
+                        LOG(LegacyMsgCatMin, "Could not load DALI Attach state file [%s] for ESP process [%s]", m_daliAttachStateFileName.str(), m_process.str());
                     }
                 }
                 catch (IException* e)
                 {
                     e->Release();
-                    ESPLOG(LogMin, "Could not load DALI Attach state file [%s] for ESP process [%s]", m_daliAttachStateFileName.str(), m_process.str());
+                    LOG(LegacyMsgCatMin, "Could not load DALI Attach state file [%s] for ESP process [%s]", m_daliAttachStateFileName.str(), m_process.str());
                 }
                 catch (...)
                 {
-                    ESPLOG(LogMin, "Could not load DALI Attach state file [%s] for ESP process [%s]", m_daliAttachStateFileName.str(), m_process.str());
+                    LOG(LegacyMsgCatMin, "Could not load DALI Attach state file [%s] for ESP process [%s]", m_daliAttachStateFileName.str(), m_process.str());
                 }
 
                 saveAttachState();
             }
             else
-                ESPLOG(LogMin, "ESP Process [%s] configuration is missing '@directory' attribute, could not read AttachState", m_process.str());
+                LOG(LegacyMsgCatMin, "ESP Process [%s] configuration is missing '@directory' attribute, could not read AttachState", m_process.str());
         }
         catch (IException* e)
         {
             e->Release();
-            ESPLOG(LogMin, "Could not load DALI Attach state file [%s] for ESP process [%s]", m_daliAttachStateFileName.str(), m_process.str());
+            LOG(LegacyMsgCatMin, "Could not load DALI Attach state file [%s] for ESP process [%s]", m_daliAttachStateFileName.str(), m_process.str());
         }
         catch (...)
         {
-           ESPLOG(LogMin, "Could not load DALI Attach state file [%s] for ESP process [%s]", m_daliAttachStateFileName.str(), m_process.str());
+           LOG(LegacyMsgCatMin, "Could not load DALI Attach state file [%s] for ESP process [%s]", m_daliAttachStateFileName.str(), m_process.str());
         }
 
         if (isDetachedFromDali())
@@ -1133,7 +1133,7 @@ bool CEspConfig::reSubscribeESPToDali()
         binding_cfg& bindingConfig = **iter;
         if (bindingConfig.bind)
         {
-            ESPLOG(LogMin, "Requesting binding '%s' to subscribe to DALI notifications", bindingConfig.name.str());
+            LOG(LegacyMsgCatMin, "Requesting binding '%s' to subscribe to DALI notifications", bindingConfig.name.str());
             bindingConfig.bind->subscribeBindingToDali();
         }
         iter++;
@@ -1150,7 +1150,7 @@ bool CEspConfig::unsubscribeESPFromDali()
         binding_cfg& bindingConfig = **iter;
         if (bindingConfig.bind)
         {
-            ESPLOG(LogMin, "Requesting binding '%s' to un-subscribe from DALI notifications", bindingConfig.name.str());
+            LOG(LegacyMsgCatMin, "Requesting binding '%s' to un-subscribe from DALI notifications", bindingConfig.name.str());
             bindingConfig.bind->unsubscribeBindingFromDali();
         }
         iter++;
@@ -1177,7 +1177,7 @@ bool CEspConfig::detachESPFromDali(bool force)
         while (iter!=m_bindings.end())
         {
             binding_cfg& xcfg = **iter;
-            ESPLOG(LogMin, "Detach ESP From DALI: requesting binding: '%s' to detach...", xcfg.name.str());
+            LOG(LegacyMsgCatMin, "Detach ESP From DALI: requesting binding: '%s' to detach...", xcfg.name.str());
             if (xcfg.bind)
             {
                 xcfg.bind->detachBindingFromDali();
@@ -1209,12 +1209,12 @@ bool CEspConfig::attachESPToDali()
         while (iter!=m_bindings.end())
         {
             binding_cfg& xcfg = **iter;
-            ESPLOG(LogMin, "Attach ESP to DALI: requesting binding: '%s' to attach...", xcfg.name.str());
+            LOG(LegacyMsgCatMin, "Attach ESP to DALI: requesting binding: '%s' to attach...", xcfg.name.str());
             if (xcfg.bind)
             {
                 map<string, srv_cfg*>::iterator sit = m_services.find(xcfg.service_name.str());
                 if(sit == m_services.end())
-                    ESPLOG(LogMin, "Warning: Service %s not found for the binding", xcfg.service_name.str());
+                    LOG(LegacyMsgCatMin, "Warning: Service %s not found for the binding", xcfg.service_name.str());
                 else
                     ((*sit).second->srv)->attachServiceToDali();
             }
@@ -1252,4 +1252,3 @@ IEspRpcBinding* CEspConfig::queryBinding(const char* name)
     }
     return nullptr;
 }
-

--- a/esp/platform/espcontext.hpp
+++ b/esp/platform/espcontext.hpp
@@ -31,6 +31,25 @@
 #include "esp.hpp"
 #include "esphttp.hpp"
 
+#ifdef __GNUC__
+//#define ESP_DEPRECATED(X) X __attribute__((deprecated))
+#define ESP_DEPRECATED(X) X
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 7)
+//#define ESP_DEPRECATED2(X, reason) X __attribute__((deprecated(reason)))
+#define ESP_DEPRECATED2(X, reason) X
+#else
+#define ESP_DEPRECATED2(X, reason) LCB_DEPRECATED(X)
+#endif
+#elif defined(_MSC_VER)
+//#define ESP_DEPRECATED(X) __declspec(deprecated) X
+#define ESP_DEPRECATED(X) X
+//#define ESP_DEPRECATED2(X, reason) __declspec(deprecated(reason)) X
+#define ESP_DEPRECATED2(X, reason)
+#else
+#define ESP_DEPRECATED(X) X
+#define ESP_DEPRECATED2(X, reason)
+#endif
+
 #define SESSION_SDS_LOCK_TIMEOUT (30*1000) // 30 seconds
 #define ESP_SESSION_TIMEOUT (120) // 120 Mins
 #define ESP_SESSION_NEVER_TIMEOUT   -1
@@ -125,7 +144,11 @@ esp_http_decl void checkRequest(IEspContext& ctx);
 
 esp_http_decl LogRequest readLogRequest(char const* req);
 esp_http_decl StringBuffer& getLogRequestString(LogRequest req, StringBuffer& out);
+#ifdef _CONTAINERIZED
+esp_http_decl LogLevel ESP_DEPRECATED2 (getEspLogLevel(IEspContext* ), "ESP log level is being deprecated, use logging manager functions instead");
+#else
 esp_http_decl LogLevel getEspLogLevel(IEspContext* );
+#endif
 esp_http_decl LogLevel getEspLogLevel();
 esp_http_decl LogRequest getEspLogRequests();
 esp_http_decl bool getEspLogResponses();
@@ -136,9 +159,15 @@ esp_http_decl const unsigned int getTxSummaryGroup();
 esp_http_decl const unsigned int readTxSummaryGroup(const char* group);
 esp_http_decl bool getTxSummaryResourceReq();
 esp_http_decl unsigned getSlowProcessingTime();
+esp_http_decl LogMsgDetail mapLegacyEspLogLevelToJlogThreshold(LogLevel level);
 
+#ifdef _CONTINEERIZED
+esp_http_decl void ESP_DEPRECATED2(ESPLOG(IEspContext* ctx, LogLevel level, const char* fmt, ...) __attribute__((format(printf, 3, 4))), "Use native JLog fuctions instead");
+esp_http_decl void ESP_DEPRECATED2(ESPLOG(LogLevel level, const char* fmt, ...) __attribute__((format(printf, 2, 3))), "Use native JLog fuctions instead");
+#else
 esp_http_decl void ESPLOG(IEspContext* ctx, LogLevel level, const char* fmt, ...) __attribute__((format(printf, 3, 4)));
 esp_http_decl void ESPLOG(LogLevel level, const char* fmt, ...) __attribute__((format(printf, 2, 3)));
+#endif
 esp_http_decl void setEspContainer(IEspContainer* container);
 
 esp_http_decl IEspContainer* getESPContainer();
@@ -155,4 +184,3 @@ esp_http_decl IEspServer* queryEspServer();
 interface IRemoteConnection;
 esp_http_decl IRemoteConnection* getSDSConnectionWithRetry(const char* xpath, unsigned mode, unsigned timeoutMs);
 #endif
-

--- a/esp/platform/espp.cpp
+++ b/esp/platform/espp.cpp
@@ -15,6 +15,7 @@
     limitations under the License.
 ############################################################################## */
 
+
 #pragma warning (disable : 4786)
 #if defined(_WIN32) && defined(_DEBUG)
 //#include <vld.h>
@@ -120,6 +121,18 @@ bool CEspServer::isSubscribedToDali()
     return m_config->isSubscribedToDali();
 }
 
+void CEspServer::setLogLevel(LogLevel level)
+{
+    m_logLevel = level;
+    unsigned newThreshold = mapLegacyEspLogLevelToJlogThreshold(level);
+    ILogMsgFilter * espfilter = queryLogMsgManager()->queryMonitorFilter(queryStderrLogMsgHandler());
+    Owned<ILogMsgFilter> newfilter = getCategoryLogMsgFilter(espfilter->queryAudienceMask(), espfilter->queryClassMask(),
+                                                       newThreshold, espfilter->queryLocalFlag());
+    queryLogMsgManager()->changeMonitorFilter(queryStderrLogMsgHandler(), newfilter);
+
+    if (m_pLogMsgHandler)
+        queryLogMsgManager()->changeMonitorFilter(m_pLogMsgHandler, newfilter);
+}
 
 #ifdef _WIN32
 /*******************************************
@@ -271,8 +284,9 @@ int work_main(CEspConfig& config, CEspServer& server)
 }
 
 
-void openEspLogFile(IPropertyTree* envpt, IPropertyTree* procpt)
+ILogMsgHandler * openEspLogFile(IPropertyTree* envpt, IPropertyTree* procpt)
 {
+    ILogMsgHandler * pLogMsgHandler = nullptr;
     StringBuffer logdir;
     if(procpt->hasProp("@name"))
     {
@@ -291,6 +305,7 @@ void openEspLogFile(IPropertyTree* envpt, IPropertyTree* procpt)
 
 #ifndef _CONTAINERIZED
     //logDir="-" is the default in application mode and logs to stderr, not to a file
+    unsigned logLevel = LogMin;
     if (logdir.length() && !streq(logdir, "-"))
     {
         long maxLogFileSize = procpt->getPropInt64("@maxLogFileSize", 0);
@@ -298,14 +313,33 @@ void openEspLogFile(IPropertyTree* envpt, IPropertyTree* procpt)
         lf->setName("esp_main");//override default filename
         lf->setAliasName("esp");
         lf->setMaxLogFileSize(maxLogFileSize);
-        lf->beginLogging();
+
+        // If log level defined in legacy config, honor it
+        int loglev = -1;
+        if(procpt->hasProp("@logLevel"))
+            loglev = procpt->getPropInt("@logLevel", LogMin);
+
+        // If log level is valid, set max detail, otherwise use system default set in jlog
+        if (loglev > -1)
+        {
+            lf->setMaxDetail(mapLegacyEspLogLevelToJlogThreshold((unsigned) loglev)); //jlog range set to 1-100
+            logLevel = loglev;
+        }
+        pLogMsgHandler = lf->beginLogging();
     }
+
+    // Replace the standard error message filter with one matching the set level
+    Owned<ILogMsgFilter> filter = getCategoryLogMsgFilter(MSGAUD_all, MSGCLS_all,
+                                                          mapLegacyEspLogLevelToJlogThreshold(logLevel), true);
+    queryLogMsgManager()->changeMonitorFilter(queryStderrLogMsgHandler(), filter);
 #else
     setupContainerizedLogMsgHandler();
 #endif
 
     if (procpt->getPropBool("@enableSysLog", false))
         UseSysLogForOperatorMessages();
+
+    return pLogMsgHandler;  // note, this value is null for containerized builds
 }
 
 
@@ -426,6 +460,7 @@ int init_main(int argc, const char* argv[])
 
     //save off generated config to register with container.  Legacy can always reference the config file, application based ESP needs generated config saved off
     Owned<IPropertyTree> appConfig;
+    ILogMsgHandler * pLogMsgHandler = nullptr;
 
     try
     {
@@ -484,7 +519,7 @@ int init_main(int argc, const char* argv[])
         const char * processName = procpt->queryProp("@name");
         setStatisticsComponentName(SCTesp, processName, true);
 
-        openEspLogFile(envpt.get(), procpt.get());
+        pLogMsgHandler = openEspLogFile(envpt.get(), procpt.get());
 
         DBGLOG("Esp starting %s", hpccBuildInfo.buildTag);
 
@@ -543,6 +578,9 @@ int init_main(int argc, const char* argv[])
             config->loadAll();
             config->bindServer(*server.get(), *server.get());
             config->checkESPCache(*server.get());
+
+            if (pLogMsgHandler)
+                server->setLogMsgHandler(pLogMsgHandler);
 
             initializeMetrics(config);
         }

--- a/esp/platform/espp.hpp
+++ b/esp/platform/espp.hpp
@@ -20,6 +20,7 @@
 
 #include "espthread.hpp"
 #include "espcfg.ipp"
+#include "jlog.ipp"
 
 typedef ISocket * isockp;
 
@@ -69,6 +70,9 @@ private:
     unsigned countCacheClients = 0;
     MapStringToMyClass<IEspCache> cacheClientMap;
     Owned<IPropertyTree> applicationConfig;
+    ILogMsgHandler * m_pLogMsgHandler;
+    PassClassLogMsgFilter *m_elevatedLoggingFilter;
+    CriticalSection m_elevatedLoggingCs;
 
 public:
     IMPLEMENT_IINTERFACE;
@@ -91,6 +95,8 @@ public:
         m_slowProcessingTime = config->m_options.slowProcessingTime;
         m_frameTitle.set(config->m_options.frameTitle);
         m_SEHMappingEnabled = false;
+        m_pLogMsgHandler = nullptr;
+        m_elevatedLoggingFilter = nullptr;
     }
 
     ~CEspServer()
@@ -101,6 +107,8 @@ public:
         }
         m_socketCleanup.kill();
     }
+
+    void setLogMsgHandler(ILogMsgHandler * pLogMsgHandler) { m_pLogMsgHandler = pLogMsgHandler;}
 
     void waitForExit(CEspConfig &config)
     {
@@ -155,7 +163,7 @@ public:
             m_waitForExit.signal();
     }
 
-    void setLogLevel(LogLevel level) { m_logLevel = level; }
+    void setLogLevel(LogLevel level);
     void setLogRequests(LogRequest logReq) { m_logReq = logReq; }
     void setLogResponses(bool logResp) { m_logResp = logResp; }
     void setTxSummaryLevel(LogLevel level) { txSummaryLevel = level; }
@@ -182,14 +190,17 @@ public:
         return applicationConfig.get();
     }
 
-    void log(LogLevel level, const char* fmt, ...) __attribute__((format(printf, 3, 4)))
+    void enableElevatedLogging()
     {
-        if (getLogLevel()>=level)
+        if (m_elevatedLoggingFilter == nullptr)
         {
-            va_list args;
-            va_start(args, fmt);
-            VALOG(MCdebugInfo, unknownJob, fmt, args);
-            va_end(args);
+            CriticalBlock b(m_elevatedLoggingCs);
+            if (m_elevatedLoggingFilter == nullptr)
+            {
+                // Add custom log monitor to handle elevated context based logging
+                m_elevatedLoggingFilter = new PassClassLogMsgFilter(MSGCLS_elevated);
+                queryLogMsgManager()->addMonitorOwn(queryStderrLogMsgHandler(), m_elevatedLoggingFilter);
+            }
         }
     }
 
@@ -379,5 +390,3 @@ public:
 #define MAX_CHILDREN 1
 
 #endif //__ESPP_HPP__
-
-

--- a/esp/platform/sechandler.cpp
+++ b/esp/platform/sechandler.cpp
@@ -117,8 +117,7 @@ bool SecHandler::authorizeSecFeature(const char * pszFeatureUrl, const char* Use
         // if a debit units value has been passed in.
         if(m_user->getStatus() == SecUserStatus_Inhouse && DebitUnits == 0)
         {
-            if (getEspLogLevel() >= LogNormal)
-                DBGLOG("Inhouse primary user and DebitUtits are 0 so not decrementing free trial");
+            LOG(LegacyMsgCatNormal, "Inhouse primary user and DebitUtits are 0 so not decrementing free trial");
             return true;
         }
         if (DebitUnits > 0)

--- a/esp/scm/esp.ecm
+++ b/esp/scm/esp.ecm
@@ -139,6 +139,7 @@ interface IEspContext : extends IInterface
     virtual IAuthMap * queryAuthMap() = 0;
 
     virtual void setSecuritySettings(ISecPropertyList * slist) = 0;
+    virtual bool debugTraceEnabled() = 0;
     virtual ISecPropertyList * querySecuritySettings() = 0;
 
     virtual bool authorizeFeature(const char * pszFeatureUrl, SecAccessFlags & access) = 0;
@@ -262,7 +263,6 @@ interface IEspContainer : extends IInterface
     virtual void setTxSummaryGroup(unsigned int group) = 0;
     virtual bool getTxSummaryResourceReq() = 0;
     virtual void setTxSummaryResourceReq(bool req) = 0;
-    virtual void log(LogLevel level, const char*,...) __attribute__((format(printf, 3, 4))) = 0;
     virtual unsigned getSlowProcessingTime() = 0;
     virtual void setFrameTitle(const char* title) = 0;
     virtual const char* getFrameTitle() = 0;
@@ -278,6 +278,7 @@ interface IEspContainer : extends IInterface
     virtual void clearCacheByGroupID(const char* ids, StringArray& errorMsgs) = 0;
     virtual IPropertyTree *queryApplicationConfig() = 0;
     virtual void setApplicationConfig(IPropertyTree *config) = 0;
+    virtual void enableElevatedLogging() = 0;
 };
 
 interface IEspRpcBinding;
@@ -619,3 +620,15 @@ SCMinterface IEspNgServiceBinding(IInterface)
 
 
 };
+
+#define LogNoneLegacyThreshold   CriticalMsgThreshold
+#define LogMinLegacyThreshold    ErrMsgThreshold
+#define LogNormalLegacyThreshold ProgressMsgThreshold
+#define LogMaxLegacyThreshold    ExtraneousMsgThreshold
+
+constexpr LogMsgCategory LegacyMsgCatMin(MSGAUD_programmer, MSGCLS_information, LogMinLegacyThreshold);
+constexpr LogMsgCategory LegacyMsgCatNormal(MSGAUD_programmer, MSGCLS_information, LogNormalLegacyThreshold);
+constexpr LogMsgCategory LegacyMsgCatMax(MSGAUD_programmer, MSGCLS_information, LogMaxLegacyThreshold);
+constexpr LogMsgCategory LegacyMsgCatForce(MSGAUD_programmer, MSGCLS_information, CriticalMsgThreshold);
+
+constexpr LogMsgCategory MsgCatEspElevated(MSGAUD_all, MSGCLS_elevated, DebugMsgThreshold);

--- a/esp/scm/ws_espcontrol.ecm
+++ b/esp/scm/ws_espcontrol.ecm
@@ -17,12 +17,22 @@
 
 EspInclude(common);
 
+ESPenum LogLevelEnum : int
+{
+    None(0, "none"),
+    Min(1, "min"),
+    Normal(5, "normal"),
+    Max(10, "max"),
+};
+
 ESPrequest [nil_remove] SetLoggingRequest
 {
-    int LoggingLevel;
+    [depr_ver("1.04")] int LoggingLevel;
+    [min_ver("1.04")] ESPenum LogLevelEnum LoggingLevelEnum;
     string LogRequests;
     bool LogResponses;
 };
+
 
 ESPresponse [exceptions_inline, nil_remove, http_encode(0)] SetLoggingResponse
 {
@@ -36,7 +46,8 @@ ESPrequest [nil_remove] GetLoggingSettingsRequest
 
 ESPresponse [exceptions_inline, nil_remove, http_encode(0)] GetLoggingSettingsResponse
 {
-    int LoggingLevel;
+    [depr_ver("1.04")] int LoggingLevel;
+    [min_ver("1.04")] ESPenum LogLevelEnum LoggingLevelEnum;
     string LogRequests;
     bool LogResponses;
     int LoggingLevelSetting;
@@ -149,7 +160,7 @@ ESPresponse [exceptions_inline, nil_remove, http_encode(0)] AttachToDaliResponse
     string Message;
 };
 
-ESPservice [auth_feature("NONE"), version("1.03"), default_client_version("1.03"), exceptions_inline("./smc_xslt/exceptions.xslt")] WSESPControl
+ESPservice [auth_feature("NONE"), version("1.04"), default_client_version("1.04"), exceptions_inline("./smc_xslt/exceptions.xslt")] WSESPControl
 {
     ESPmethod SetLogging(SetLoggingRequest, SetLoggingResponse);
     ESPmethod [min_ver("1.03")] GetLoggingSettings(GetLoggingSettingsRequest, GetLoggingSettingsResponse);

--- a/esp/services/esdl_svc_engine/esdl_binding.cpp
+++ b/esp/services/esdl_svc_engine/esdl_binding.cpp
@@ -143,17 +143,17 @@ IPropertyTree * fetchESDLBindingFromStateFile(const char *process, const char *b
         if (esdlState)
         {
             const char * restoredBindingTS = esdlState->queryProp("@StateSaveTimems");
-            ESPLOG(LogNormal, "ESDL State restored from local state store: %s created epoch: %s", bindingName, restoredBindingTS);
+            LOG(LegacyMsgCatNormal, "ESDL State restored from local state store: %s created epoch: %s", bindingName, restoredBindingTS);
             return esdlState->getPropTree("EsdlBinding/Binding");
         }
         else
         {
-            ESPLOG(LogNormal, "Failed to load DESDL binding state from local file: '%s' for ESP binding %s.%s", stateFileName, process, bindingName);
+            LOG(LegacyMsgCatNormal, "Failed to load DESDL binding state from local file: '%s' for ESP binding %s.%s", stateFileName, process, bindingName);
         }
     }
     catch (...)
     {
-        ESPLOG(LogNormal, "Failed to load DESDL binding state from local file: '%s' for ESP binding %s.%s", stateFileName, process, bindingName);
+        LOG(LegacyMsgCatNormal, "Failed to load DESDL binding state from local file: '%s' for ESP binding %s.%s", stateFileName, process, bindingName);
     }
 
     return nullptr;
@@ -385,10 +385,10 @@ void EsdlServiceImpl::configureUrlMethod(const char *method, IPropertyTree &entr
     }
     catch(IException* ie)
     {
-        ESPLOG(LogMin,"DESDL: Error while setting up connection for method \"%s\" verify its configuration.", method);
+        LOG(LegacyMsgCatMin,"DESDL: Error while setting up connection for method \"%s\" verify its configuration.", method);
         StringBuffer msg;
         ie->errorMessage(msg);
-        ESPLOG(LogMin,"%s",msg.str());
+        LOG(LegacyMsgCatMin,"%s",msg.str());
         connMap.remove(method);
         ie->Release();
     }
@@ -882,11 +882,11 @@ void EsdlServiceImpl::handleServiceRequest(IEspContext &context,
 
             StringBuffer trxidstatus;
             if (!loggingManager()->getTransactionID(&trxidbasics,trxid, trxidstatus))
-                ESPLOG(LogMin,"DESDL: Logging Agent generated Transaction ID failed: %s", trxidstatus.str());
+                LOG(LegacyMsgCatMin,"DESDL: Logging Agent generated Transaction ID failed: %s", trxidstatus.str());
             context.addTraceSummaryTimeStamp(LogNormal, "end-trxid");
         }
         else
-            ESPLOG(LogMin,"DESDL: Transaction ID could not be fetched from logging manager!");
+            LOG(LegacyMsgCatMin,"DESDL: Transaction ID could not be fetched from logging manager!");
     }
 
     if (!trxid.length())                       //either there's no logging agent providing trxid, or it failed to generate an id
@@ -895,7 +895,7 @@ void EsdlServiceImpl::handleServiceRequest(IEspContext &context,
     if (trxid.length())
         context.setTransactionID(trxid.str());
     else
-        ESPLOG(LogMin,"DESDL: Transaction ID could not be generated!");
+        LOG(LegacyMsgCatMin,"DESDL: Transaction ID could not be generated!");
 
     // In the future we could instantiate a profile from the service configuration.
     // For now use a profile created on service initialization.
@@ -1084,7 +1084,7 @@ void EsdlServiceImpl::handleServiceRequest(IEspContext &context,
         }
     }
 
-    ESPLOG(LogMax,"Customer Response: %s", out.str());
+    LOG(LegacyMsgCatMax,"Customer Response: %s", out.str());
 }
 
 bool EsdlServiceImpl::handleResultLogging(IEspContext &espcontext, IEsdlScriptContext *scriptContext, IEsdlDefService &srvdef, IEsdlDefMethod &mthdef, IPropertyTree * reqcontext, IPropertyTree * request,const char *rawreq, const char * rawresp, const char * finalresp, const char * logdata)
@@ -1124,7 +1124,7 @@ bool EsdlServiceImpl::handleResultLogging(IEspContext &espcontext, IEsdlScriptCo
             entry->setOwnScriptValuesTree(scriptContext->createPTreeFromSection(ESDLScriptCtxSection_Logging));
         StringBuffer logresp;
         success = loggingManager()->updateLog(entry, logresp);
-        ESPLOG(LogMin,"ESDLService: Attempted to log ESP transaction: %s", logresp.str());
+        LOG(LegacyMsgCatMin,"ESDLService: Attempted to log ESP transaction: %s", logresp.str());
     }
     espcontext.addTraceSummaryTimeStamp(LogNormal, "end-resLogging", TXSUMMARY_GRP_CORE|TXSUMMARY_GRP_ENTERPRISE);
     return success;
@@ -1158,7 +1158,7 @@ void EsdlServiceImpl::getSoapBody(StringBuffer& out,StringBuffer& soapresp)
     //if for some reason invalid soap, return
     if(finger==end-5)
     {
-        ESPLOG(LogMax,"EsdlServiceImpl - Invalid Soap Response: %s",soapresp.str());
+        LOG(LegacyMsgCatMax,"EsdlServiceImpl - Invalid Soap Response: %s",soapresp.str());
         return;
     }
 
@@ -1175,7 +1175,7 @@ void EsdlServiceImpl::getSoapBody(StringBuffer& out,StringBuffer& soapresp)
 
     if(finger==start)
     {
-        ESPLOG(LogMax,"EsdlServiceImpl - Invalid Soap Response: %s",soapresp.str());
+        LOG(LegacyMsgCatMax,"EsdlServiceImpl - Invalid Soap Response: %s",soapresp.str());
         return;
     }
 
@@ -1220,7 +1220,7 @@ void EsdlServiceImpl::getSoapError( StringBuffer& out,
     //if for some reason invalid soap, return
     if(finger==end-textlen)
     {
-        ESPLOG(LogMax,"EsdlServiceImpl - Could not find Reason, trying for other tags.: %s",soapresp.str());
+        LOG(LegacyMsgCatMax,"EsdlServiceImpl - Could not find Reason, trying for other tags.: %s",soapresp.str());
         return;
     }
 
@@ -1236,7 +1236,7 @@ void EsdlServiceImpl::getSoapError( StringBuffer& out,
 
     if(finger==start)
     {
-        ESPLOG(LogMax,"EsdlServiceImpl - Could not find Reason, trying for other tags.: %s",soapresp.str());
+        LOG(LegacyMsgCatMax,"EsdlServiceImpl - Could not find Reason, trying for other tags.: %s",soapresp.str());
         return;
     }
 
@@ -1267,7 +1267,7 @@ void EsdlServiceImpl::handleFinalRequest(IEspContext &context,
     }
     else
     {
-        ESPLOG(LogMax,"No target URL configured for %s",mthdef.queryMethodName());
+        LOG(LegacyMsgCatMax,"No target URL configured for %s",mthdef.queryMethodName());
         throw makeWsException( ERR_ESDL_BINDING_BADREQUEST, WSERR_CLIENT, "ESP",
                    "No target URL configured for %s!", mthdef.queryMethodName());
     }
@@ -1503,8 +1503,8 @@ void EsdlServiceImpl::sendTargetSOAP(IEspContext & context,
     StringBuffer status;
     StringBuffer clreq(req);
 
-    ESPLOG(LogMax,"OUTGOING Request target: %s", url.str());
-    ESPLOG(LogMax,"OUTGOING Request: %s", clreq.str());
+    LOG(LegacyMsgCatMax,"OUTGOING Request target: %s", url.str());
+    LOG(LegacyMsgCatMax,"OUTGOING Request: %s", clreq.str());
     {
         EspTimeSection timing("Calling out to query");
         context.addTraceSummaryTimeStamp(LogMin, "startcall", TXSUMMARY_GRP_CORE|TXSUMMARY_GRP_ENTERPRISE);
@@ -1543,12 +1543,12 @@ void EsdlServiceImpl::sendTargetSOAP(IEspContext & context,
         throw makeWsException( 3402, WSERR_SERVER, "ESP", "SoapCallStatus:%s", status.str());
     }
 
-    ESPLOG(LogMax,"INCOMING Response: %s", resp.str());
+    LOG(LegacyMsgCatMax,"INCOMING Response: %s", resp.str());
     if (querytype!=NULL && strieq(querytype, "WSECL"))
     {
         StringBuffer decoded;
         decodeXML(resp.str(), decoded);
-        ESPLOG(LogMax,"SOAP Decoded Response: %s", decoded.str());
+        LOG(LegacyMsgCatMax,"SOAP Decoded Response: %s", decoded.str());
         resp.swapWith(decoded);
     }
 }
@@ -1560,7 +1560,7 @@ void EsdlServiceImpl::getTargetResponseFile(IEspContext & context,
 {
     const char * respfile = srvinfo->queryProp("@respfile");
 
-    ESPLOG(LogMax,"Response file: %s", respfile);
+    LOG(LegacyMsgCatMax,"Response file: %s", respfile);
     if (respfile)
         resp.loadFile(respfile);
 }
@@ -2255,7 +2255,7 @@ int EsdlBindingImpl::onGetInstantQuery(IEspContext &context,
                 try
                 {
                     params2xml(m_esdl, srvdef->queryName(), mthdef->queryName(), EsdlTypeRequest, request->queryParameters(), xmlstr, 0, context.getClientVersion());
-                    ESPLOG(LogMax,"params reqxml: %s", xmlstr.str());
+                    LOG(LegacyMsgCatMax,"params reqxml: %s", xmlstr.str());
 
                     StringBuffer out;
                     StringBuffer logdata;
@@ -2291,7 +2291,7 @@ int EsdlBindingImpl::onGetInstantQuery(IEspContext &context,
                     unsigned timetaken = msTick() - context.queryCreationTime();
                     context.addTraceSummaryTimeStamp(LogMin, "respSent", TXSUMMARY_GRP_CORE|TXSUMMARY_GRP_ENTERPRISE);
 
-                    ESPLOG(LogMax,"EsdlBindingImpl:onGetInstantQuery response: %s", out.str());
+                    LOG(LegacyMsgCatMax,"EsdlBindingImpl:onGetInstantQuery response: %s", out.str());
 
                     m_pESDLService->handleResultLogging(context, scriptContext, *srvdef, *mthdef, tgtctx.get(), req_pt.get(), soapmsg.str(), origResp.str(), out.str(), logdata.str());
                     context.addTraceSummaryTimeStamp(LogMin, "respLogged");
@@ -2325,7 +2325,7 @@ int EsdlBindingImpl::onGetInstantQuery(IEspContext &context,
         response->setStatus(HTTP_STATUS_OK);
         response->send();
 
-        ESPLOG(LogMax,"EsdlBindingImpl:onGetInstantQuery response: %s", xml.str());
+        LOG(LegacyMsgCatMax,"EsdlBindingImpl:onGetInstantQuery response: %s", xml.str());
     }
 
     return 0;
@@ -2622,7 +2622,7 @@ int EsdlBindingImpl::HandleSoapRequest(CHttpRequest* request,
 
             m_pESDLService->handleResultLogging(*ctx, scriptContext, *srvdef, *mthdef, tgtctx.get(), pt, soapmsg.str(), origResp.str(), out.str(), logdata.str());
 
-            ESPLOG(LogMax,"EsdlBindingImpl:HandleSoapRequest response: %s", xmlout.str());
+            LOG(LegacyMsgCatMax,"EsdlBindingImpl:HandleSoapRequest response: %s", xmlout.str());
         }
         else
             throw makeWsException( ERR_ESDL_BINDING_BADREQUEST, WSERR_SERVER, request->queryServiceName(), "EsdlBindingImpl could not process SOAP request" );
@@ -2631,7 +2631,7 @@ int EsdlBindingImpl::HandleSoapRequest(CHttpRequest* request,
     {
         StringBuffer text;
         text.appendf("Parsing xml error: %s.", exml.getMessage().c_str());
-        ESPLOG(LogMax, "%s\n", text.str());
+        LOG(LegacyMsgCatMax, "%s\n", text.str());
         ctx->addTraceSummaryTimeStamp(LogMin, "custom_fields.soapRequestEnd", TXSUMMARY_GRP_ENTERPRISE);
         throw makeWsException(  ERR_ESDL_BINDING_BADREQUEST, WSERR_SERVER, "Esp", "%s", text.str() );
     }
@@ -2647,7 +2647,7 @@ int EsdlBindingImpl::HandleSoapRequest(CHttpRequest* request,
     {
         StringBuffer text;
         text.append( "EsdlBindingImpl could not process SOAP request" );
-        ESPLOG(LogMax,"%s", text.str());
+        LOG(LegacyMsgCatMax,"%s", text.str());
         ctx->addTraceSummaryTimeStamp(LogMin, "custom_fields.soapRequestEnd", TXSUMMARY_GRP_ENTERPRISE);
         throw makeWsException( ERR_ESDL_BINDING_INTERNERR, WSERR_SERVER, "ESP", "%s", text.str() );
     }
@@ -3046,7 +3046,7 @@ bool EsdlBindingImpl::getSchema(StringBuffer& schema,
 
     Owned<IEsdlDefObjectIterator> it = m_esdl->getDependencies(service, method, ctx.getClientVersion(), ctx.queryRequestParameters(), ESDLDEP_FLAGS);
     m_xsdgen->toXSD( *it, schema, EsdlXslToXsd, ctx.getClientVersion(), ctx.queryRequestParameters(), ns.str(), ESDLDEP_FLAGS, ctx.queryXslParameters());
-    ESPLOG(LogMax,"EsdlBindingImpl::getSchema schema: %s", schema.str());
+    LOG(LegacyMsgCatMax,"EsdlBindingImpl::getSchema schema: %s", schema.str());
     return true;
 }
 
@@ -3054,7 +3054,7 @@ int EsdlBindingImpl::getQualifiedNames(IEspContext& ctx, MethodInfoArray & metho
 {
     if (!m_esdl)
     {
-        ESPLOG(LogMax,"ESDL definition for service not loaded");
+        LOG(LegacyMsgCatMax,"ESDL definition for service not loaded");
         return -1;
     }
 
@@ -3069,7 +3069,7 @@ int EsdlBindingImpl::getQualifiedNames(IEspContext& ctx, MethodInfoArray & metho
     IEsdlDefService *srv = m_esdl->queryService(servname);
     if (!srv)
     {
-        ESPLOG(LogNone,"Service (%s) not found", servname);
+        PROGLOG("Service (%s) not found", servname);
         return -1;
     }
 
@@ -3095,21 +3095,21 @@ int EsdlBindingImpl::getMethodProperty(IEspContext &context, const char *serv, c
 
     if (!m_esdl)
     {
-        ESPLOG(LogMax,"EsdlBindingImpl::getMethodProperty - ESDL definition for service not loaded");
+        LOG(LegacyMsgCatMax,"EsdlBindingImpl::getMethodProperty - ESDL definition for service not loaded");
         return 0;
     }
 
     IEsdlDefService *srv = m_esdl->queryService(serv);
     if (!srv)
     {
-        ESPLOG(LogMax,"EsdlBindingImpl::getMethodProperty - service (%s) not found", serv);
+        LOG(LegacyMsgCatMax,"EsdlBindingImpl::getMethodProperty - service (%s) not found", serv);
         return 0;
     }
 
     IEsdlDefMethod *mth = srv->queryMethodByName(method);
     if (!mth)
     {
-        ESPLOG(LogMax,"EsdlBindingImpl::getMethodProperty - service (%s) method (%s) not found", serv, method);
+        LOG(LegacyMsgCatMax,"EsdlBindingImpl::getMethodProperty - service (%s) method (%s) not found", serv, method);
         return 0;
     }
 
@@ -3135,14 +3135,14 @@ bool EsdlBindingImpl::qualifyServiceName(IEspContext &context,
 {
     if (!m_esdl)
     {
-        ESPLOG(LogMax,"ESDL definition for service not loaded");
+        LOG(LegacyMsgCatMax,"ESDL definition for service not loaded");
         return false;
     }
 
     IEsdlDefService *srv = m_esdl->queryService(servname);
     if (!srv)
     {
-        ESPLOG(LogMax,"Service (%s) not found", servname);
+        LOG(LegacyMsgCatMax,"Service (%s) not found", servname);
         return false;
     }
 
@@ -3166,7 +3166,7 @@ bool EsdlBindingImpl::qualifyMethodName(IEspContext &context,
 {
     if (!m_esdl)
     {
-        ESPLOG(LogMax,"ESDL definition for service not loaded");
+        LOG(LegacyMsgCatMax,"ESDL definition for service not loaded");
         return false;
     }
 
@@ -3209,7 +3209,7 @@ int EsdlBindingImpl::onGetXForm(IEspContext &context,
         StringBuffer schema;
         context.addOptions(ESPCTX_ALL_ANNOTATION);
         getSchema(schema, context, request, serv, method, true);
-        ESPLOG(LogMax,"Schema: %s", schema.str());
+        LOG(LegacyMsgCatMax,"Schema: %s", schema.str());
 
         Owned<IXslTransform> xform = xslp->createXslTransform();
         xform->loadXslFromFile(StringBuffer(getCFD()).append("./xslt/gen_form.xsl").str());
@@ -3377,8 +3377,7 @@ void EsdlBindingImpl::handleJSONPost(CHttpRequest *request, CHttpResponse *respo
         }
 
         StringBuffer content(request->queryContent());
-        if (getEspLogLevel()>LogNormal)
-            DBGLOG("EsdlBinding::%s::%s: JSON request: %s", serviceName, methodName, content.str());
+        LOG(LegacyMsgCatMax, "EsdlBinding::%s::%s: JSON request: %s", serviceName, methodName, content.str());
 
         Owned<IPropertyTree> contentTree = createPTreeFromJSONString(content.str());
         if (!contentTree)
@@ -3429,8 +3428,7 @@ void EsdlBindingImpl::handleJSONPost(CHttpRequest *request, CHttpResponse *respo
 
         m_pESDLService->handleResultLogging(*ctx, scriptContext, *srvdef, *mthdef, tgtctx.get(), reqTree, soapmsg.str(), origResp.str(), jsonresp.str(), logdata.str());
 
-        if (getEspLogLevel()>LogNormal)
-            DBGLOG("json response: %s", jsonresp.str());
+            LOG(LegacyMsgCatMax, "json response: %s", jsonresp.str());
         return;
     }
     catch (IWsException * iwse)
@@ -3592,7 +3590,7 @@ int EsdlBindingImpl::onRoxieRequest(CHttpRequest* request, CHttpResponse* respon
         response->setStatus(HTTP_STATUS_NOT_ALLOWED);
         response->send();
 
-        ESPLOG(LogMax,"Roxie Test response: %s", xml.str());
+        LOG(LegacyMsgCatMax,"Roxie Test response: %s", xml.str());
     }
 
     return 0;
@@ -3691,7 +3689,7 @@ void EsdlBindingImpl::getRequestContent(IEspContext &context, StringBuffer & req
     {
        StringBuffer xmlstr;
        params2xml(m_esdl, servicename, methodname, EsdlTypeRequest, request->queryParameters(), xmlstr, flags, context.getClientVersion());
-       ESPLOG(LogMax,"params reqxml: %s", xmlstr.str());
+       LOG(LegacyMsgCatMax,"params reqxml: %s", xmlstr.str());
 
        Owned<IPropertyTree> tgtctx;
        Owned<IPropertyTree> req_pt = createPTreeFromXMLString(xmlstr.length(), xmlstr.str(), false);
@@ -3863,7 +3861,7 @@ void EsdlBindingImpl::getSoapMessage(StringBuffer& out,StringBuffer& soapresp,
     //if for some reason invalid soap, return
     if(finger==end-textlen)
     {
-        ESPLOG(LogMax,"getSoapMessage - Could not find start text, trying for other tags.: %s",soapresp.str());
+        LOG(LegacyMsgCatMax,"getSoapMessage - Could not find start text, trying for other tags.: %s",soapresp.str());
         return;
     }
 
@@ -3880,7 +3878,7 @@ void EsdlBindingImpl::getSoapMessage(StringBuffer& out,StringBuffer& soapresp,
 
     if(finger==start)
     {
-        ESPLOG(LogMax,"EsdlServiceImpl - Could not find end text, trying for other tags.: %s",soapresp.str());
+        LOG(LegacyMsgCatMax,"EsdlServiceImpl - Could not find end text, trying for other tags.: %s",soapresp.str());
         return;
     }
 

--- a/esp/services/esdl_svc_engine/esdl_binding.hpp
+++ b/esp/services/esdl_svc_engine/esdl_binding.hpp
@@ -250,7 +250,7 @@ private:
             m_proxyInfo.clear();
 
         //prob need to un-initesdlservinfo as well.
-        ESPLOG(LogNormal, "Warning binding %s.%s is being un-loaded!", m_processName.get(), m_bindingName.get());
+        LOG(LegacyMsgCatNormal, "Warning binding %s.%s is being un-loaded!", m_processName.get(), m_bindingName.get());
     }
 
 public:
@@ -340,7 +340,7 @@ public:
         m_isAttached = true;
         if(m_bindingId.length() != 0)
         {
-            ESPLOG(LogNormal, "Requesting reload of ESDL binding %s...", m_bindingId.get());
+            LOG(LegacyMsgCatNormal, "Requesting reload of ESDL binding %s...", m_bindingId.get());
             reloadBindingFromCentralStore(m_bindingId.get());
         }
         return true;

--- a/esp/services/esdl_svc_engine/esdl_store.cpp
+++ b/esp/services/esdl_svc_engine/esdl_store.cpp
@@ -315,11 +315,11 @@ public:
             Owned<IRemoteConnection> conn = checkQuerySDS().connect(xpath.str(), myProcessSession(), RTM_LOCK_READ, SDS_LOCK_TIMEOUT_DESDL);
             if (!conn)
             {
-                ESPLOG(LogMin, "Unable to connect to ESDL Service binding information in dali %s", xpath.str());
+                LOG(LegacyMsgCatMin, "Unable to connect to ESDL Service binding information in dali %s", xpath.str());
                 return nullptr;
             }
 
-            ESPLOG(LogNormal, "ESDL Binding: Fetching ESDL Binding from Dali %s", xpath.str());
+            LOG(LegacyMsgCatNormal, "ESDL Binding: Fetching ESDL Binding from Dali %s", xpath.str());
             return createPTreeFromIPT(conn->queryRoot());
         }
         catch (IException *E)
@@ -330,7 +330,7 @@ public:
         }
         catch(...)
         {
-            ESPLOG(LogMin, "ESDL Binding: Unknown error encountered while fetching ESDL Binding from Dali %s", xpath.str());
+            LOG(LegacyMsgCatMin, "ESDL Binding: Unknown error encountered while fetching ESDL Binding from Dali %s", xpath.str());
         }
 
         return nullptr;
@@ -344,11 +344,11 @@ public:
             Owned<IRemoteConnection> conn = checkQuerySDS().connect(xpath.str(), myProcessSession(), RTM_LOCK_READ, SDS_LOCK_TIMEOUT_DESDL);
             if (!conn)
             {
-                ESPLOG(LogMin, "Unable to connect to ESDL Service binding information in dali %s", xpath.str());
+                LOG(LegacyMsgCatMin, "Unable to connect to ESDL Service binding information in dali %s", xpath.str());
                 return nullptr;
             }
 
-            ESPLOG(LogNormal, "ESDL Binding: Fetching ESDL Binding from Dali %s", xpath.str());
+            LOG(LegacyMsgCatNormal, "ESDL Binding: Fetching ESDL Binding from Dali %s", xpath.str());
             return createPTreeFromIPT(conn->queryRoot());
         }
         catch (IException *E)
@@ -359,7 +359,7 @@ public:
         }
         catch(...)
         {
-            ESPLOG(LogMin, "ESDL Binding: Unknown error encountered while fetching ESDL Binding from Dali %s", xpath.str());
+            LOG(LegacyMsgCatMin, "ESDL Binding: Unknown error encountered while fetching ESDL Binding from Dali %s", xpath.str());
         }
 
         return nullptr;
@@ -411,14 +411,14 @@ public:
                 else
                 {
                     message.setf("Could not overwrite Definition: '%s.%d'", definitionName, newSeq);
-                    ESPLOG(LogMin, "%s", message.str());
+                    LOG(LegacyMsgCatMin, "%s", message.str());
                     return false;
                 }
             }
             else
             {
                 message.setf("Will not delete previous ESDL definition version because it is referenced in an ESDL binding.");
-                ESPLOG(LogMin, "%s", message.str());
+                LOG(LegacyMsgCatMin, "%s", message.str());
                 return false;
             }
         }
@@ -1007,7 +1007,7 @@ public:
         triggerSubscription(changestr.str());
 
         message.setf("Successfully configured Service '%s', associated with ESDL definition '%s', on ESP '%s' and port '%s'", esdlServiceName, lcId.str(), espProcName, espPort);
-        ESPLOG(LogMin, "ESDL Binding '%s' published by user='%s' overwrite flag: %s", lcId.str(), (user && *user) ? user : "Anonymous", overwrite ? "TRUE" : "FALSE");
+        LOG(LegacyMsgCatMin, "ESDL Binding '%s' published by user='%s' overwrite flag: %s", lcId.str(), (user && *user) ? user : "Anonymous", overwrite ? "TRUE" : "FALSE");
         return 0;
     }
 

--- a/esp/services/ws_dfu/ws_dfuService.cpp
+++ b/esp/services/ws_dfu/ws_dfuService.cpp
@@ -6218,7 +6218,7 @@ static IGroup *getDFUFileIGroup(const char *clusterName, ClusterType clusterType
         if (group->equals(groupFound))
         {
             foundGroup = true;
-            ESPLOG(LogMax, "Found DFUFileIGroup %s", groupName.str());
+            LOG(LegacyMsgCatMax, "Found DFUFileIGroup %s", groupName.str());
             break;
         }
         //The original group name is used by another group. Rename it to: 'original name + _ + a random number'.
@@ -6240,7 +6240,7 @@ static IGroup *getDFUFileIGroup(const char *clusterName, ClusterType clusterType
         ForEachItemIn(l, locations)
             hosts.push_back(locations.item(l));
         queryNamedGroupStore().add(groupName, hosts, false, defaultDir, grpType);
-        ESPLOG(LogMin, "DFUFileIGroup %s added", groupName.str());
+        LOG(LegacyMsgCatMin, "DFUFileIGroup %s added", groupName.str());
     }
     return group.getClear();
 #endif

--- a/esp/services/ws_ecl/ws_ecl_service.cpp
+++ b/esp/services/ws_ecl/ws_ecl_service.cpp
@@ -1618,7 +1618,7 @@ void CWsEclBinding::getWsEcl2XmlRequest(StringBuffer& soapmsg, IEspContext &cont
 
         StringBuffer schemaXml;
         getSchema(schemaXml, context, request, wsinfo);
-        ESPLOG(LogMax,"request schema: %s", schemaXml.str());
+        LOG(LegacyMsgCatMax,"request schema: %s", schemaXml.str());
         Owned<IXmlSchema> schema = createXmlSchemaFromString(schemaXml);
         if (schema.get())
         {
@@ -1654,7 +1654,7 @@ void CWsEclBinding::getWsEclJsonRequest(StringBuffer& jsonmsg, IEspContext &cont
 
         StringBuffer schemaXml;
         getSchema(schemaXml, context, request, wsinfo);
-        ESPLOG(LogMax,"request schema: %s", schemaXml.str());
+        LOG(LegacyMsgCatMax,"request schema: %s", schemaXml.str());
         Owned<IXmlSchema> schema = createXmlSchemaFromString(schemaXml);
         if (schema.get())
         {
@@ -2161,8 +2161,7 @@ int CWsEclBinding::onSubmitQueryOutput(IEspContext &context, CHttpRequest* reque
     {
         StringBuffer soapmsg;
         getSoapMessage(soapmsg, context, request, wsinfo, REQSF_TRIM|REQSF_ROOT, false);
-        if (getEspLogLevel()>LogNormal)
-            DBGLOG("submitQuery soap: %s", soapmsg.str());
+        LOG(LegacyMsgCatMax, "submitQuery soap: %s", soapmsg.str());
 
         unsigned xmlflags = WWV_ADD_RESPONSE_TAG | WWV_INCL_NAMESPACES | WWV_INCL_GENERATED_NAMESPACES;
         if (context.queryRequestParameters()->hasProp("display"))
@@ -2205,8 +2204,7 @@ int CWsEclBinding::onSubmitQueryOutputView(IEspContext &context, CHttpRequest* r
 
     StringBuffer soapmsg;
     getSoapMessage(soapmsg, context, request, wsinfo, REQSF_TRIM|REQSF_ROOT, false);
-    if (getEspLogLevel()>LogNormal)
-        DBGLOG("submitQuery soap: %s", soapmsg.str());
+    LOG(LegacyMsgCatMax, "submitQuery soap: %s", soapmsg.str());
 
     const char *thepath = request->queryPath();
 
@@ -2633,11 +2631,9 @@ int CWsEclBinding::onGet(CHttpRequest* request, CHttpResponse* response)
             soapreq.append("</soap:Body></soap:Envelope>");
             StringBuffer output;
             StringBuffer status;
-            if (getEspLogLevel()>LogNormal)
-                DBGLOG("roxie req: %s", soapreq.str());
+            LOG(LegacyMsgCatMax, "roxie req: %s", soapreq.str());
             sendRoxieRequest(target, soapreq, output, status, qid, parms->getPropBool(".trim", true), "text/xml", request);
-            if (getEspLogLevel()>LogNormal)
-                DBGLOG("roxie resp: %s", output.str());
+            LOG(LegacyMsgCatMax, "roxie resp: %s", output.str());
 
             if (context->queryRequestParameters()->hasProp("display"))
             {
@@ -2827,8 +2823,7 @@ void CWsEclBinding::handleJSONPost(CHttpRequest *request, CHttpResponse *respons
             jsonresp.append(jsonp).append('(');
 
         StringBuffer content(request->queryContent());
-        if (getEspLogLevel()>LogNormal)
-            DBGLOG("json request: %s", content.str());
+        LOG(LegacyMsgCatMax, "json request: %s", content.str());
 
         StringBuffer status;
         if (!forceCreateWorkunit && wsecl->connMap.getValue(queryset.str()))
@@ -2855,8 +2850,7 @@ void CWsEclBinding::handleJSONPost(CHttpRequest *request, CHttpResponse *respons
         }
         if (jsonp && *jsonp)
             jsonresp.append(");");
-        if (getEspLogLevel()>LogNormal)
-            DBGLOG("json response: %s", jsonresp.str());
+        LOG(LegacyMsgCatMax, "json response: %s", jsonresp.str());
 
     }
     catch (IException *e)
@@ -2980,8 +2974,7 @@ int CWsEclBinding::HandleSoapRequest(CHttpRequest* request, CHttpResponse* respo
         submitWsEclWorkunit(*ctx, wsinfo, content.str(), soapresp, xmlflags, request);
     }
 
-    if (getEspLogLevel()>LogNormal)
-        DBGLOG("HandleSoapRequest response: %s", soapresp.str());
+    LOG(LegacyMsgCatMax, "HandleSoapRequest response: %s", soapresp.str());
 
     response->setContent(soapresp.str());
     response->setContentType("text/xml");

--- a/esp/services/ws_esdlconfig/ws_esdlconfigservice.cpp
+++ b/esp/services/ws_esdlconfig/ws_esdlconfigservice.cpp
@@ -361,7 +361,7 @@ bool CWsESDLConfigEx::onPublishESDLDefinition(IEspContext &context, IEspPublishE
         }
 
         msg.appendf("Successfully published %s", newqueryid.str());
-        ESPLOG(LogMin, "ESDL Definition '%s' published by user='%s'", newqueryid.str(), (user && *user) ? user : "Anonymous");
+        LOG(LegacyMsgCatMin, "ESDL Definition '%s' published by user='%s'", newqueryid.str(), (user && *user) ? user : "Anonymous");
 
         double ver = context.getClientVersion();
         if (ver >= 1.2)
@@ -515,7 +515,7 @@ bool CWsESDLConfigEx::onPublishESDLBinding(IEspContext &context, IEspPublishESDL
         }
 
         if (!methodstree || methodstree->getCount("Method") == 0)
-            ESPLOG(LogMin, "Publishing ESDL Binding with no METHODS configured!");
+            LOG(LegacyMsgCatMin, "Publishing ESDL Binding with no METHODS configured!");
 
         if (espProcName.length() == 0)
             throw MakeStringException(-1, "Must provide ESP Process name");
@@ -869,9 +869,9 @@ bool CWsESDLConfigEx::onConfigureESDLBindingMethod(IEspContext &context, IEspCon
                         double ver = context.getClientVersion();
 
                         if (ver >= 1.4)
-                            ESPLOG(LogMin, "ESDL Binding '%s' configured method '%s' by user='%s' overwrite flag: %s", bindingId, username.isEmpty() ? "Anonymous" : username.str(), methodName, override ? "TRUE" : "FALSE");
+                            LOG(LegacyMsgCatMin, "ESDL Binding '%s' configured method '%s' by user='%s' overwrite flag: %s", bindingId, username.isEmpty() ? "Anonymous" : username.str(), methodName, override ? "TRUE" : "FALSE");
                         else
-                            ESPLOG(LogMin, "ESDL Binding '%s.%d' configured method '%s' by user='%s' overwrite flag: %s", esdlDefinitionName.str(), esdlver, username.isEmpty() ? "Anonymous" : username.str(), methodName, override ? "TRUE" : "FALSE");
+                            LOG(LegacyMsgCatMin, "ESDL Binding '%s.%d' configured method '%s' by user='%s' overwrite flag: %s", esdlDefinitionName.str(), esdlver, username.isEmpty() ? "Anonymous" : username.str(), methodName, override ? "TRUE" : "FALSE");
 
                         if (ver >= 1.2)
                         {
@@ -1373,7 +1373,7 @@ void CWsESDLConfigEx::addPublishHistory(IPropertyTree * publishedEntryTree, IEsp
          history.setLastEditTime(publishedEntryTree->queryProp("@lastEdit"));
     }
     else
-        ESPLOG(LogMin, "Could not fetch ESDL publish history!");
+        LOG(LegacyMsgCatMin, "Could not fetch ESDL publish history!");
 }
 
 bool CWsESDLConfigEx::onEcho(IEspContext &context, IEspEchoRequest &req, IEspEchoResponse &resp)
@@ -1411,7 +1411,7 @@ bool CWsESDLConfigEx::onDeleteESDLDefinition(IEspContext &context, IEspDeleteESD
     {
         StringBuffer username;
         context.getUserID(username);
-        ESPLOG(LogMin, "ESDL Definition '%s' Deleted by user='%s'", esdlDefinitionId.str(), username.isEmpty() ? "Anonymous" : username.str());
+        LOG(LegacyMsgCatMin, "ESDL Definition '%s' Deleted by user='%s'", esdlDefinitionId.str(), username.isEmpty() ? "Anonymous" : username.str());
         resp.setDeletedTree(thexml.str());
         resp.updateStatus().setCode(0);
         VStringBuffer desc("Deleted ESDL Definition %s", esdlDefinitionId.str());
@@ -1510,7 +1510,7 @@ bool CWsESDLConfigEx::onDeleteESDLBinding(IEspContext &context, IEspDeleteESDLBi
     {
         StringBuffer username;
         context.getUserID(username);
-        ESPLOG(LogMin, "ESDL binding '%s' Deleted by user='%s'", esdlBindingId.str(), username.isEmpty() ? "Anonymous" : username.str());
+        LOG(LegacyMsgCatMin, "ESDL binding '%s' Deleted by user='%s'", esdlBindingId.str(), username.isEmpty() ? "Anonymous" : username.str());
 
         resp.setDeletedTree(thexml.str());
         resp.updateStatus().setDescription("Service successfully unbound");

--- a/esp/services/ws_fileio/ws_fileioservice.cpp
+++ b/esp/services/ws_fileio/ws_fileioservice.cpp
@@ -149,7 +149,7 @@ bool CWsFileIOEx::CheckServerAccess(const char* targetDZNameOrAddress, const cha
         else
         {
             SCMStringBuffer dropZoneName;
-            ESPLOG(LogMin, "Found LZ '%s' without a directory attribute!", dropZoneInfo->getName(dropZoneName).str());
+            LOG(LegacyMsgCatMin, "Found LZ '%s' without a directory attribute!", dropZoneInfo->getName(dropZoneName).str());
         }
 
     }
@@ -393,5 +393,3 @@ bool CWsFileIOEx::onWriteFileData(IEspContext &context, IEspWriteFileDataRequest
 
     return true;
 }
-
-

--- a/esp/services/ws_machine/ws_machineService.cpp
+++ b/esp/services/ws_machine/ws_machineService.cpp
@@ -1294,10 +1294,7 @@ int Cws_machineEx::invokeProgram(const char *command_line, StringBuffer& respons
     // Run the command so that it writes its output to a pipe. Open this
     // pipe with read text attribute so that we can read it
     // like a text file.
-    if (getEspLogLevel()>LogNormal)
-    {
-        DBGLOG("command_line=<%s>", command_line);
-    }
+    LOG(LegacyMsgCatMax, "command_line=<%s>", command_line);
 #ifndef NO_CONNECTION_DEBUG
     if( (fp = popen( command_line, "r" )) == NULL )
         return -1;
@@ -1313,10 +1310,7 @@ int Cws_machineEx::invokeProgram(const char *command_line, StringBuffer& respons
         if ( fgets( buffer, 128, fp) )
             response.append( buffer );
 
-    if (getEspLogLevel()>LogNormal)
-    {
-        DBGLOG("response=<%s>", response.str());
-    }
+    LOG(LegacyMsgCatMax, "response=<%s>", response.str());
     // Close pipe and print return value of CHKDSK.
 #ifndef NO_CONNECTION_DEBUG
     return pclose( fp );
@@ -2681,7 +2675,7 @@ void Cws_machineEx::getMachineUsage(IEspContext& context, CGetMachineUsageThread
         command.appendf("%s", t.queryProp("@path"));
         pathCount++;
     }
-    ESPLOG(LogMax, "command(%s)", command.str());
+    LOG(LegacyMsgCatMax, "command(%s)", command.str());
 
     StringBuffer response;
     int error = runCommand(context, param->request->queryProp("@netAddress"), nullptr,
@@ -2694,7 +2688,7 @@ void Cws_machineEx::getMachineUsage(IEspContext& context, CGetMachineUsageThread
             param->request->addProp("@error", response);
         return;
     }
-    ESPLOG(LogMax, "response(%s)", response.str());
+    LOG(LegacyMsgCatMax, "response(%s)", response.str());
 
     ForEach(*diskPathList)
     {
@@ -2866,7 +2860,7 @@ bool Cws_machineEx::onGetComponentUsage(IEspContext& context, IEspGetComponentUs
             if (!usage)
                 throw MakeStringException(ECLWATCH_INTERNAL_ERROR, "Failed to get usage. Please try later.");
 
-            ESPLOG(LogMax, "GetComponentUsage: found UsageCache.");
+            LOG(LegacyMsgCatMax, "GetComponentUsage: found UsageCache.");
             uniqueUsages.set(usage->queryUsages());
         }
 
@@ -3005,7 +2999,7 @@ bool Cws_machineEx::onGetTargetClusterUsage(IEspContext& context, IEspGetTargetC
             if (!usage)
                 throw MakeStringException(ECLWATCH_INTERNAL_ERROR, "Failed to get usage. Please try later.");
 
-            ESPLOG(LogMax, "GetTargetClusterUsage: found UsageCache.");
+            LOG(LegacyMsgCatMax, "GetTargetClusterUsage: found UsageCache.");
             uniqueUsages.set(usage->queryUsages());
         }
         readTargetClusterUsageResult(context, usageReq, uniqueUsages, targetClusterUsages);
@@ -3205,7 +3199,7 @@ bool Cws_machineEx::onGetNodeGroupUsage(IEspContext& context, IEspGetNodeGroupUs
             if (!usage)
                 throw MakeStringException(ECLWATCH_INTERNAL_ERROR, "Failed to get usage. Please try later.");
 
-            ESPLOG(LogMax, "GetNodeGroupUsage: found UsageCache.");
+            LOG(LegacyMsgCatMax, "GetNodeGroupUsage: found UsageCache.");
             uniqueUsages.set(usage->queryUsages());
         }
 

--- a/esp/services/ws_sql/SQL2ECL/HPCCFile.cpp
+++ b/esp/services/ws_sql/SQL2ECL/HPCCFile.cpp
@@ -134,7 +134,7 @@ bool setChildColumns(HPCCColumnMetaData * parent, IPropertyTree * fieldtree)
 
     if (parent == nullptr || fieldtree == nullptr)
     {
-        ESPLOG(LogMin, "Could not set HPCC file childcolumns!");
+        LOG(LegacyMsgCatMin, "Could not set HPCC file childcolumns!");
         return false;
     }
 
@@ -169,7 +169,7 @@ bool HPCCFile::setFileColumns(const char * eclString)
        StringBuffer errtext;
        IError *first = errs.firstError();
        first->toString(errtext);
-       ESPLOG(LogNormal, "Could not set HPCC file columns: %s", errtext.str());
+       LOG(LegacyMsgCatNormal, "Could not set HPCC file columns: %s", errtext.str());
        return false;
     }
 

--- a/esp/services/ws_sql/SQL2ECL/HPCCFileCache.cpp
+++ b/esp/services/ws_sql/SQL2ECL/HPCCFileCache.cpp
@@ -20,7 +20,7 @@ limitations under the License.
 
 HPCCFileCache * HPCCFileCache::createFileCache(const char * username, const char * passwd)
 {
-    ESPLOG(LogMax, "WsSQL: Creating new HPCC FILE CACHE");
+    LOG(LegacyMsgCatMax, "WsSQL: Creating new HPCC FILE CACHE");
     return new HPCCFileCache(username,passwd);
 }
 void populateColums(IArrayOf<HPCCColumnMetaData> * cols, IArrayOf<IEspHPCCColumn> & pColumns)

--- a/esp/services/ws_store/ws_storeService.cpp
+++ b/esp/services/ws_store/ws_storeService.cpp
@@ -67,7 +67,7 @@ void CwsstoreEx::init(IPropertyTree *_cfg, const char *_process, const char *_se
 
     if (!m_isDetachedFromDali)
     {
-        ESPLOG(LogMin, "CwsstoreEx: Ensuring configured stores are created:");
+        LOG(LegacyMsgCatMin, "CwsstoreEx: Ensuring configured stores are created:");
         Owned<IPropertyTreeIterator> iter = m_serviceConfig->getElements("Stores/Store");
 
         StringBuffer owner;
@@ -94,11 +94,11 @@ void CwsstoreEx::init(IPropertyTree *_cfg, const char *_process, const char *_se
             VStringBuffer xpath("Stores/Store[%s='%s']", ESP_STORE_NAME_ATT, id.str());
             if (stores && stores->hasProp(xpath.str()))
             {
-                ESPLOG(LogMin, "CwsstoreEx: Detected previously created store '%s'.", id.str());
+                LOG(LegacyMsgCatMin, "CwsstoreEx: Detected previously created store '%s'.", id.str());
             }
             else
             {
-                ESPLOG(LogMin, "CwsstoreEx: Creating Store: '%s'%s", id.str(), isDefault ? " - as Default" : "");
+                LOG(LegacyMsgCatMin, "CwsstoreEx: Creating Store: '%s'%s", id.str(), isDefault ? " - as Default" : "");
 
                 m_storeProvider->createStore(type.str(), id.str(), description.str(), secuser.get(), maxvalsize);
             }
@@ -108,7 +108,7 @@ void CwsstoreEx::init(IPropertyTree *_cfg, const char *_process, const char *_se
                 if (!m_defaultStore.isEmpty())
                    throw MakeStringException(-1, "ws_store init(): Multiple stores erroneously configured as default store!");
 
-                ESPLOG(LogMin, "CwsstoreEx: setting '%s' as default store", id.str());
+                LOG(LegacyMsgCatMin, "CwsstoreEx: setting '%s' as default store", id.str());
                 m_defaultStore.set(id.str());
             }
         }
@@ -223,7 +223,7 @@ bool CwsstoreEx::onDeleteNamespace(IEspContext &context, IEspDeleteNamespaceRequ
 
     if (!global && !isEmptyString(targetUser))
     {
-        ESPLOG(LogMin, "CwsstoreEx::onDeleteNamespace: '%s' requesting to delete namespace on behalf of '%s'", user, targetUser);
+        LOG(LegacyMsgCatMin, "CwsstoreEx::onDeleteNamespace: '%s' requesting to delete namespace on behalf of '%s'", user, targetUser);
         user = targetUser;
     }
 
@@ -407,4 +407,3 @@ bool CwsstoreEx::onFetchAll(IEspContext &context, IEspFetchAllRequest &req, IEsp
     resp.setNamespace(req.getNamespace());
     return true;
 }
-

--- a/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
+++ b/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
@@ -3816,11 +3816,13 @@ bool CWsWorkunitsEx::onWUQueryGetSummaryStats(IEspContext& context, IEspWUQueryG
             return true;
         }
 
-        if (getEspLogLevel() >= LogMax)
         {
             StringBuffer sb;
-            toXML(queryAggregates, sb);
-            DBGLOG("getQueryStats(): '%s' => '%s'", control.str(), sb.str());
+            if (!queryLogMsgManager()->rejectsCategory(LegacyMsgCatMax))
+            {
+                toXML(queryAggregates, sb);
+                LOG(LegacyMsgCatMax, "getQueryStats(): '%s' => '%s'", control.str(), sb.str());
+            }
         }
 
         IArrayOf<IEspQuerySummaryStats> querySummaryStatsList;

--- a/system/jlib/jlog.hpp
+++ b/system/jlib/jlog.hpp
@@ -59,16 +59,22 @@ typedef enum
  * LOG MESSAGE CLASS:                                                                   */
 typedef enum
 {
-    MSGCLS_unknown     = 0x00, // Invalid/unknown log message class
-    MSGCLS_disaster    = 0x01, // Any unrecoverable or critical system errors
-    MSGCLS_error       = 0x02, // Recoverable/not critical Errors
-    MSGCLS_warning     = 0x04, // Warnings
-    MSGCLS_information = 0x08, // Config, environmental and internal status  info
-    MSGCLS_progress    = 0x10, // Progress of workunits. Status of file operations
-    MSGCLS_metric      = 0x20, // A metric line
-    MSGCLS_addid       = 0x40, // Internal use within log system
-    MSGCLS_removeid    = 0x80, // Internal use within log system
-    MSGCLS_all         = 0xFF  // Use as a filter to select all messages
+    MSGCLS_unknown     = 0x000, // Invalid/unknown log message class
+    MSGCLS_disaster    = 0x001, // Any unrecoverable or critical system errors
+    MSGCLS_error       = 0x002, // Recoverable/not critical Errors
+    MSGCLS_warning     = 0x004, // Warnings
+    MSGCLS_information = 0x008, // Config, environmental and internal status  info
+    MSGCLS_progress    = 0x010, // Progress of workunits. Status of file operations
+    MSGCLS_metric      = 0x020, // A metric line
+    MSGCLS_addid       = 0x040, // Internal use within log system
+    MSGCLS_removeid    = 0x080, // Internal use within log system
+    MSGCLS_all         = 0x0FF, // Use as a filter to select all messages EXCEPT those below
+
+    // All classes below are for special purposes as indicated. They are not selected
+    // using the MSGCLS_all mask so that custom filters can be used as needed
+
+    // For use with a PassClassLogMsgFilter filter to pass log messages using this class
+    MSGCLS_elevated    = 0x800, // Use for component custom elevated logging
 } LogMsgClass;
 /* ------------------------------------------------------------------------------------ *
  * NOTES:                                                                               *
@@ -195,6 +201,8 @@ inline const char * LogMsgClassToVarString(LogMsgClass msgClass)
         return("Progress");
     case MSGCLS_metric:
         return("Metric");
+    case MSGCLS_elevated:
+        return("Elevated");
     default:
         return("UNKNOWN");
     }
@@ -216,6 +224,8 @@ inline const char * LogMsgClassToFixString(LogMsgClass msgClass)
         return("PRO");
     case MSGCLS_metric:
         return("MET");
+    case MSGCLS_elevated:
+        return("ELE");
     default:
         return("UNK");
     }
@@ -237,6 +247,8 @@ inline LogMsgClass LogMsgClassFromAbbrev(char const * abbrev)
         return MSGCLS_metric;
     if(strnicmp(abbrev, "ALL", 3)==0)
         return MSGCLS_all;
+    if(strnicmp(abbrev, "ELE", 3)==0)
+        return MSGCLS_elevated;
     return MSGCLS_unknown;
 }
 
@@ -249,6 +261,7 @@ typedef unsigned LogMsgDetail;
  * It represents the lowest logging level (detail) required to output
  * messages of the given category.
  */
+
 constexpr LogMsgDetail CriticalMsgThreshold    = 1;  //Use to declare categories reporting critical events (log level => 1)
 constexpr LogMsgDetail FatalMsgThreshold       = 1;  //Use to declare categories reporting Fatal events (log level => 1)
 constexpr LogMsgDetail ErrMsgThreshold         = 10; //Use to declare categories reporting Err messages (log level => 10)

--- a/system/jlib/jlog.ipp
+++ b/system/jlib/jlog.ipp
@@ -137,6 +137,27 @@ protected:
     bool                      localFlag;
 };
 
+//
+// Implementation of a filter that passes messages solely based on the category's class
+// Audience and detail are set to not affect filtering
+
+class PassClassLogMsgFilter : public CLogMsgFilter
+{
+public:
+    PassClassLogMsgFilter(unsigned _cMask) : classMask(_cMask) {}
+
+    bool                      includeMessage(const LogMsg & msg) const { return mayIncludeCategory(msg.queryCategory()); }
+    bool                      mayIncludeCategory(const LogMsgCategory & cat) const { return cat.queryClass() & classMask; }
+    unsigned                  queryAudienceMask() const { return MSGAUD_unknown; }
+    unsigned                  queryClassMask() const { return classMask; }
+    LogMsgDetail              queryMaxDetail() const { return 0; }
+    void                      serialize(MemoryBuffer & out, bool preserveLocal) const { out.append(MSGFILTER_category).append(MSGAUD_programmer).append(classMask).append(0); out.append(false); }
+    void                      addToPTree(IPropertyTree * tree) const {}
+    void                      orWithFilter(const ILogMsgFilter * filter) {};
+protected:
+    unsigned                  classMask;
+};
+
 // Implementations of filters using sysInfo
 
 class PIDLogMsgFilter : public CLogMsgFilter


### PR DESCRIPTION
Converted code for container builds to use log category set
in config yaml files. Legacy bare metal continues to use
existing ESP log level.

Signed-off-by: Ken Rowland kenneth.rowland@lexisnexisrisk.com

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [x] Scalability
  - [x] Performance
  - [x] Security
  - [x] Thread-safety
  - [x] Cloud-compatibility
  - [x] Premature optimization
  - [x] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [x] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
