### PR TITLE
HPCC-26680 ESDL tool not honoring exceptions_inline

### DIFF
--- a/esp/services/esdl_svc_engine/esdl_binding.cpp
+++ b/esp/services/esdl_svc_engine/esdl_binding.cpp
@@ -2168,12 +2168,14 @@ void EsdlBindingImpl::initEsdlServiceInfo(IEsdlDefService &srvdef)
 
     IProperties *xsdparams = createProperties(false);
     xsdparams->setProp( "all_annot_Param", "true()" );
+    xsdparams->setProp( "no_exceptions_inline", "true()" );
     m_xsdgen->setTransformParams(EsdlXslToXsd, xsdparams);
 
     IProperties *wsdlparams = createProperties(false);
     wsdlparams->setProp( "location", StringBuffer().append('\'').append(getWsdlAddress()).append('\'').str() );
     wsdlparams->setProp( "create_wsdl", "true()");
     wsdlparams->setProp( "all_annot_Param", "true()" );
+    wsdlparams->setProp( "no_exceptions_inline", "true()" );
     m_xsdgen->setTransformParams(EsdlXslToWsdl, wsdlparams);
 
     StringBuffer xsltpath(getCFD());

--- a/esp/xslt/esxdl2xsd.xslt
+++ b/esp/xslt/esxdl2xsd.xslt
@@ -25,6 +25,7 @@
     <xsl:param name="version" select="/esxdl/@version"/>
     <xsl:param name="no_annot_Param" select="false()"/>
     <xsl:param name="all_annot_Param" select="false()"/>
+    <xsl:param name="no_exceptions_inline" select="false()"/>
 
     <!--
         Note: This version of the stylesheet assumes that the XML input has been processed
@@ -349,6 +350,9 @@
             <xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute>
             <xsd:complexType>
                 <xsd:all>
+                    <xsl:if test="@exceptions_inline and not($no_exceptions_inline)">
+                        <xsd:element name="Exceptions" type="tns:ArrayOfEspException" minOccurs="0" maxOccurs="1"/>
+                    </xsl:if>
                     <xsl:apply-templates select="EsdlElement|EsdlArray|EsdlList|EsdlEnum"/>
                 </xsd:all>
             </xsd:complexType>
@@ -449,7 +453,7 @@
         </xsd:schema>
     </xsl:template>
     <xsl:template name="CreateWsdl">
-        <wsdl:definitions xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/">
+        <wsdl:definitions xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">
             <xsl:attribute name="targetNamespace"><xsl:value-of select="$tnsParam"/></xsl:attribute>
             <xsl:copy-of select="namespace::tns"/>
             <wsdl:types>

--- a/testing/esp/esdlcmd/esdlcmd-test.py
+++ b/testing/esp/esdlcmd/esdlcmd-test.py
@@ -351,7 +351,32 @@ def main():
 
         # cpp
         TestCaseCode(run_settings, 'wstest-cpp-installdir', 'cpp', 'ws_test.ecm', 'WsTest',
-                     xsl_base_path)
+                     xsl_base_path),
+
+        # Testing exceptions_inline output
+        TestCaseXSD(run_settings, 'wsexctest1-wsdl-default', 'wsdl', 'ws_exc_test_1.ecm', 'WsExcTest1',
+                    xsl_base_path),
+
+        TestCaseXSD(run_settings, 'wsexctest2-wsdl-default', 'wsdl', 'ws_exc_test_2.ecm', 'WsExcTest2',
+                    xsl_base_path),
+
+        TestCaseXSD(run_settings, 'wsexctest3-wsdl-default', 'wsdl', 'ws_exc_test_3.ecm', 'WsExcTest3',
+                    xsl_base_path),
+
+        TestCaseXSD(run_settings, 'wsexctest3-wsdl-no-exc', 'wsdl', 'ws_exc_test_3.ecm', 'WsExcTest3',
+                    xsl_base_path, ['--no-exceptions-inline']),
+
+        TestCaseXSD(run_settings, 'wsexctest1-xsd-default', 'xsd', 'ws_exc_test_1.ecm', 'WsExcTest1',
+                    xsl_base_path),
+
+        TestCaseXSD(run_settings, 'wsexctest2-xsd-default', 'xsd', 'ws_exc_test_2.ecm', 'WsExcTest2',
+                    xsl_base_path),
+
+        TestCaseXSD(run_settings, 'wsexctest3-xsd-default', 'xsd', 'ws_exc_test_3.ecm', 'WsExcTest3',
+                    xsl_base_path),
+
+        TestCaseXSD(run_settings, 'wsexctest3-xsd-no-exc', 'xsd', 'ws_exc_test_3.ecm', 'WsExcTest3',
+                    xsl_base_path, ['--no-exceptions-inline']),
 
     ]
 

--- a/testing/esp/esdlcmd/inputs/ws_exc_test_1.ecm
+++ b/testing/esp/esdlcmd/inputs/ws_exc_test_1.ecm
@@ -1,0 +1,50 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2022 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+// This test contains markup that should not modify the xsd/wsdl with any
+// Exceptions element in the method responses.
+
+ESPrequest SoapFaultExceptionsRequest
+{
+    string RequestString;
+};
+
+ESPresponse SoapFaultExceptionsResponse
+{
+    string ResponseString;
+};
+
+ESPrequest SoapFaultExceptionsTwoRequest
+{
+    string RequestString;
+};
+
+ESPresponse SoapFaultExceptionsTwoResponse
+{
+    string ResponseString;
+};
+
+ESPservice [
+    auth_feature("DEFERRED"),
+    version("1"),
+    default_client_version("1"),
+    exceptions_inline("./smc_xslt/exceptions.xslt"),
+] WsExcTest1
+{
+    ESPmethod SoapFaultExceptions(SoapFaultExceptionsRequest, SoapFaultExceptionsResponse);
+    ESPmethod [exceptions_inline] SoapFaultExceptionsTwo(SoapFaultExceptionsTwoRequest, SoapFaultExceptionsTwoResponse);
+};

--- a/testing/esp/esdlcmd/inputs/ws_exc_test_2.ecm
+++ b/testing/esp/esdlcmd/inputs/ws_exc_test_2.ecm
@@ -1,0 +1,50 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2022 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+// This test contains markup that should not modify the xsd/wsdl with any
+// Exceptions element in the method responses.
+
+ESPrequest SoapFaultExceptionsRequest
+{
+    string RequestString;
+};
+
+ESPresponse SoapFaultExceptionsResponse
+{
+    string ResponseString;
+};
+
+ESPrequest SoapFaultExceptionsTwoRequest
+{
+    string RequestString;
+};
+
+ESPresponse SoapFaultExceptionsTwoResponse
+{
+    string ResponseString;
+};
+
+ESPservice [
+    auth_feature("DEFERRED"),
+    version("1"),
+    default_client_version("1"),
+    http_exceptions_inline("./smc_xslt/exceptions.xslt"),
+] WsExcTest2
+{
+    ESPmethod SoapFaultExceptions(SoapFaultExceptionsRequest, SoapFaultExceptionsResponse);
+    ESPmethod [exceptions_inline] SoapFaultExceptionsTwo(SoapFaultExceptionsTwoRequest, SoapFaultExceptionsTwoResponse);
+};

--- a/testing/esp/esdlcmd/inputs/ws_exc_test_3.ecm
+++ b/testing/esp/esdlcmd/inputs/ws_exc_test_3.ecm
@@ -1,0 +1,52 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2022 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+// This test contains markup that will modify the xsd/wsdl with an
+// Exceptions element in the selected method responses.
+// It also shows unmodified methods in the same service.
+
+ESPrequest SoapFaultExceptionsRequest
+{
+    string RequestString;
+};
+
+ESPresponse SoapFaultExceptionsResponse
+{
+    string ResponseString;
+};
+
+ESPrequest InlineExceptionsRequest
+{
+    string RequestString;
+};
+
+ESPresponse [exceptions_inline] InlineExceptionsResponse
+{
+    // an Exceptions element should be added here in the xsd/wsdl
+    // when its output is enabled.
+    string ResponseString;
+};
+
+ESPservice [
+    auth_feature("DEFERRED"),
+    version("1"),
+    default_client_version("1"),
+] WsExcTest3
+{
+    ESPmethod SoapFaultExceptions(SoapFaultExceptionsRequest, SoapFaultExceptionsResponse);
+    ESPmethod InlineExceptions(InlineExceptionsRequest, InlineExceptionsResponse);
+};

--- a/testing/esp/esdlcmd/key/wsexctest1-wsdl-default.wsdl
+++ b/testing/esp/esdlcmd/key/wsexctest1-wsdl-default.wsdl
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:tns="urn:hpccsystems:ws:wsexctest1" targetNamespace="urn:hpccsystems:ws:wsexctest1">
+  <wsdl:types>
+    <xsd:schema elementFormDefault="qualified" targetNamespace="urn:hpccsystems:ws:wsexctest1">
+      <xsd:element name="string" nillable="true" type="xsd:string"/>
+      <xsd:complexType name="EspException">
+        <xsd:all>
+          <xsd:element name="Code" type="xsd:string" minOccurs="0"/>
+          <xsd:element name="Audience" type="xsd:string" minOccurs="0"/>
+          <xsd:element name="Source" type="xsd:string" minOccurs="0"/>
+          <xsd:element name="Message" type="xsd:string" minOccurs="0"/>
+        </xsd:all>
+      </xsd:complexType>
+      <xsd:complexType name="ArrayOfEspException">
+        <xsd:sequence>
+          <xsd:element name="Source" type="xsd:string" minOccurs="0"/>
+          <xsd:element name="Exception" type="tns:EspException" minOccurs="0" maxOccurs="unbounded"/>
+        </xsd:sequence>
+      </xsd:complexType>
+      <xsd:element name="Exceptions" type="tns:ArrayOfEspException"/>
+      <xsd:element name="WsExcTest1PingRequest">
+        <xsd:complexType>
+          <xsd:all/>
+        </xsd:complexType>
+      </xsd:element>
+      <xsd:element name="SoapFaultExceptionsRequest">
+        <xsd:complexType>
+          <xsd:all>
+            <xsd:element minOccurs="0" name="RequestString" type="xsd:string"/>
+          </xsd:all>
+        </xsd:complexType>
+      </xsd:element>
+      <xsd:element name="SoapFaultExceptionsTwoRequest">
+        <xsd:complexType>
+          <xsd:all>
+            <xsd:element minOccurs="0" name="RequestString" type="xsd:string"/>
+          </xsd:all>
+        </xsd:complexType>
+      </xsd:element>
+      <xsd:element name="WsExcTest1PingResponse">
+        <xsd:complexType>
+          <xsd:all/>
+        </xsd:complexType>
+      </xsd:element>
+      <xsd:element name="SoapFaultExceptionsResponse">
+        <xsd:complexType>
+          <xsd:all>
+            <xsd:element minOccurs="0" name="ResponseString" type="xsd:string"/>
+          </xsd:all>
+        </xsd:complexType>
+      </xsd:element>
+      <xsd:element name="SoapFaultExceptionsTwoResponse">
+        <xsd:complexType>
+          <xsd:all>
+            <xsd:element minOccurs="0" name="ResponseString" type="xsd:string"/>
+          </xsd:all>
+        </xsd:complexType>
+      </xsd:element>
+    </xsd:schema>
+  </wsdl:types>
+  <wsdl:message name="EspSoapFault">
+    <wsdl:part name="parameters" element="tns:Exceptions"/>
+  </wsdl:message>
+  <wsdl:message name="PingSoapIn">
+    <wsdl:part name="parameters" element="tns:WsExcTest1PingRequest"/>
+  </wsdl:message>
+  <wsdl:message name="PingSoapOut">
+    <wsdl:part name="parameters" element="tns:WsExcTest1PingResponse"/>
+  </wsdl:message>
+  <wsdl:message name="SoapFaultExceptionsSoapIn">
+    <wsdl:part name="parameters" element="tns:SoapFaultExceptionsRequest"/>
+  </wsdl:message>
+  <wsdl:message name="SoapFaultExceptionsSoapOut">
+    <wsdl:part name="parameters" element="tns:SoapFaultExceptionsResponse"/>
+  </wsdl:message>
+  <wsdl:message name="SoapFaultExceptionsTwoSoapIn">
+    <wsdl:part name="parameters" element="tns:SoapFaultExceptionsTwoRequest"/>
+  </wsdl:message>
+  <wsdl:message name="SoapFaultExceptionsTwoSoapOut">
+    <wsdl:part name="parameters" element="tns:SoapFaultExceptionsTwoResponse"/>
+  </wsdl:message>
+  <wsdl:portType name="WsExcTest1ServiceSoap">
+    <wsdl:operation name="Ping">
+      <wsdl:input message="tns:PingSoapIn"/>
+      <wsdl:output message="tns:PingSoapOut"/>
+      <wsdl:fault name="excfault" message="tns:EspSoapFault"/>
+    </wsdl:operation>
+    <wsdl:operation name="SoapFaultExceptions">
+      <wsdl:input message="tns:SoapFaultExceptionsSoapIn"/>
+      <wsdl:output message="tns:SoapFaultExceptionsSoapOut"/>
+      <wsdl:fault name="excfault" message="tns:EspSoapFault"/>
+    </wsdl:operation>
+    <wsdl:operation name="SoapFaultExceptionsTwo">
+      <wsdl:input message="tns:SoapFaultExceptionsTwoSoapIn"/>
+      <wsdl:output message="tns:SoapFaultExceptionsTwoSoapOut"/>
+      <wsdl:fault name="excfault" message="tns:EspSoapFault"/>
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="WsExcTest1ServiceSoap" type="tns:WsExcTest1ServiceSoap">
+    <soap:binding transport="http://schemas.xmlsoap.org/soap/http" style="document"/>
+    <wsdl:operation name="Ping">
+      <soap:operation style="document" soapAction="WsExcTest1/Ping?ver_=0.000000"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+      <wsdl:fault name="excfault">
+        <soap:fault name="excfault" use="literal"/>
+      </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="SoapFaultExceptions">
+      <soap:operation style="document" soapAction="WsExcTest1/SoapFaultExceptions?ver_=0.000000"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+      <wsdl:fault name="excfault">
+        <soap:fault name="excfault" use="literal"/>
+      </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="SoapFaultExceptionsTwo">
+      <soap:operation style="document" soapAction="WsExcTest1/SoapFaultExceptionsTwo?ver_=0.000000"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+      <wsdl:fault name="excfault">
+        <soap:fault name="excfault" use="literal"/>
+      </wsdl:fault>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="WsExcTest1">
+    <wsdl:port name="WsExcTest1ServiceSoap" binding="tns:WsExcTest1ServiceSoap">
+      <soap:address location="localhost"/>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>

--- a/testing/esp/esdlcmd/key/wsexctest1-xsd-default.xsd
+++ b/testing/esp/esdlcmd/key/wsexctest1-xsd-default.xsd
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:tns="urn:hpccsystems:ws:wsexctest1" elementFormDefault="qualified" targetNamespace="urn:hpccsystems:ws:wsexctest1">
+  <xsd:element name="string" nillable="true" type="xsd:string"/>
+  <xsd:complexType name="EspException">
+    <xsd:all>
+      <xsd:element name="Code" type="xsd:string" minOccurs="0"/>
+      <xsd:element name="Audience" type="xsd:string" minOccurs="0"/>
+      <xsd:element name="Source" type="xsd:string" minOccurs="0"/>
+      <xsd:element name="Message" type="xsd:string" minOccurs="0"/>
+    </xsd:all>
+  </xsd:complexType>
+  <xsd:complexType name="ArrayOfEspException">
+    <xsd:sequence>
+      <xsd:element name="Source" type="xsd:string" minOccurs="0"/>
+      <xsd:element name="Exception" type="tns:EspException" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:element name="Exceptions" type="tns:ArrayOfEspException"/>
+  <xsd:element name="WsExcTest1PingRequest">
+    <xsd:complexType>
+      <xsd:all/>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="SoapFaultExceptionsRequest">
+    <xsd:complexType>
+      <xsd:all>
+        <xsd:element minOccurs="0" name="RequestString" type="xsd:string"/>
+      </xsd:all>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="SoapFaultExceptionsTwoRequest">
+    <xsd:complexType>
+      <xsd:all>
+        <xsd:element minOccurs="0" name="RequestString" type="xsd:string"/>
+      </xsd:all>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="WsExcTest1PingResponse">
+    <xsd:complexType>
+      <xsd:all/>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="SoapFaultExceptionsResponse">
+    <xsd:complexType>
+      <xsd:all>
+        <xsd:element minOccurs="0" name="ResponseString" type="xsd:string"/>
+      </xsd:all>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="SoapFaultExceptionsTwoResponse">
+    <xsd:complexType>
+      <xsd:all>
+        <xsd:element minOccurs="0" name="ResponseString" type="xsd:string"/>
+      </xsd:all>
+    </xsd:complexType>
+  </xsd:element>
+</xsd:schema>

--- a/testing/esp/esdlcmd/key/wsexctest2-wsdl-default.wsdl
+++ b/testing/esp/esdlcmd/key/wsexctest2-wsdl-default.wsdl
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:tns="urn:hpccsystems:ws:wsexctest2" targetNamespace="urn:hpccsystems:ws:wsexctest2">
+  <wsdl:types>
+    <xsd:schema elementFormDefault="qualified" targetNamespace="urn:hpccsystems:ws:wsexctest2">
+      <xsd:element name="string" nillable="true" type="xsd:string"/>
+      <xsd:complexType name="EspException">
+        <xsd:all>
+          <xsd:element name="Code" type="xsd:string" minOccurs="0"/>
+          <xsd:element name="Audience" type="xsd:string" minOccurs="0"/>
+          <xsd:element name="Source" type="xsd:string" minOccurs="0"/>
+          <xsd:element name="Message" type="xsd:string" minOccurs="0"/>
+        </xsd:all>
+      </xsd:complexType>
+      <xsd:complexType name="ArrayOfEspException">
+        <xsd:sequence>
+          <xsd:element name="Source" type="xsd:string" minOccurs="0"/>
+          <xsd:element name="Exception" type="tns:EspException" minOccurs="0" maxOccurs="unbounded"/>
+        </xsd:sequence>
+      </xsd:complexType>
+      <xsd:element name="Exceptions" type="tns:ArrayOfEspException"/>
+      <xsd:element name="WsExcTest2PingRequest">
+        <xsd:complexType>
+          <xsd:all/>
+        </xsd:complexType>
+      </xsd:element>
+      <xsd:element name="SoapFaultExceptionsRequest">
+        <xsd:complexType>
+          <xsd:all>
+            <xsd:element minOccurs="0" name="RequestString" type="xsd:string"/>
+          </xsd:all>
+        </xsd:complexType>
+      </xsd:element>
+      <xsd:element name="SoapFaultExceptionsTwoRequest">
+        <xsd:complexType>
+          <xsd:all>
+            <xsd:element minOccurs="0" name="RequestString" type="xsd:string"/>
+          </xsd:all>
+        </xsd:complexType>
+      </xsd:element>
+      <xsd:element name="WsExcTest2PingResponse">
+        <xsd:complexType>
+          <xsd:all/>
+        </xsd:complexType>
+      </xsd:element>
+      <xsd:element name="SoapFaultExceptionsResponse">
+        <xsd:complexType>
+          <xsd:all>
+            <xsd:element minOccurs="0" name="ResponseString" type="xsd:string"/>
+          </xsd:all>
+        </xsd:complexType>
+      </xsd:element>
+      <xsd:element name="SoapFaultExceptionsTwoResponse">
+        <xsd:complexType>
+          <xsd:all>
+            <xsd:element minOccurs="0" name="ResponseString" type="xsd:string"/>
+          </xsd:all>
+        </xsd:complexType>
+      </xsd:element>
+    </xsd:schema>
+  </wsdl:types>
+  <wsdl:message name="EspSoapFault">
+    <wsdl:part name="parameters" element="tns:Exceptions"/>
+  </wsdl:message>
+  <wsdl:message name="PingSoapIn">
+    <wsdl:part name="parameters" element="tns:WsExcTest2PingRequest"/>
+  </wsdl:message>
+  <wsdl:message name="PingSoapOut">
+    <wsdl:part name="parameters" element="tns:WsExcTest2PingResponse"/>
+  </wsdl:message>
+  <wsdl:message name="SoapFaultExceptionsSoapIn">
+    <wsdl:part name="parameters" element="tns:SoapFaultExceptionsRequest"/>
+  </wsdl:message>
+  <wsdl:message name="SoapFaultExceptionsSoapOut">
+    <wsdl:part name="parameters" element="tns:SoapFaultExceptionsResponse"/>
+  </wsdl:message>
+  <wsdl:message name="SoapFaultExceptionsTwoSoapIn">
+    <wsdl:part name="parameters" element="tns:SoapFaultExceptionsTwoRequest"/>
+  </wsdl:message>
+  <wsdl:message name="SoapFaultExceptionsTwoSoapOut">
+    <wsdl:part name="parameters" element="tns:SoapFaultExceptionsTwoResponse"/>
+  </wsdl:message>
+  <wsdl:portType name="WsExcTest2ServiceSoap">
+    <wsdl:operation name="Ping">
+      <wsdl:input message="tns:PingSoapIn"/>
+      <wsdl:output message="tns:PingSoapOut"/>
+      <wsdl:fault name="excfault" message="tns:EspSoapFault"/>
+    </wsdl:operation>
+    <wsdl:operation name="SoapFaultExceptions">
+      <wsdl:input message="tns:SoapFaultExceptionsSoapIn"/>
+      <wsdl:output message="tns:SoapFaultExceptionsSoapOut"/>
+      <wsdl:fault name="excfault" message="tns:EspSoapFault"/>
+    </wsdl:operation>
+    <wsdl:operation name="SoapFaultExceptionsTwo">
+      <wsdl:input message="tns:SoapFaultExceptionsTwoSoapIn"/>
+      <wsdl:output message="tns:SoapFaultExceptionsTwoSoapOut"/>
+      <wsdl:fault name="excfault" message="tns:EspSoapFault"/>
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="WsExcTest2ServiceSoap" type="tns:WsExcTest2ServiceSoap">
+    <soap:binding transport="http://schemas.xmlsoap.org/soap/http" style="document"/>
+    <wsdl:operation name="Ping">
+      <soap:operation style="document" soapAction="WsExcTest2/Ping?ver_=0.000000"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+      <wsdl:fault name="excfault">
+        <soap:fault name="excfault" use="literal"/>
+      </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="SoapFaultExceptions">
+      <soap:operation style="document" soapAction="WsExcTest2/SoapFaultExceptions?ver_=0.000000"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+      <wsdl:fault name="excfault">
+        <soap:fault name="excfault" use="literal"/>
+      </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="SoapFaultExceptionsTwo">
+      <soap:operation style="document" soapAction="WsExcTest2/SoapFaultExceptionsTwo?ver_=0.000000"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+      <wsdl:fault name="excfault">
+        <soap:fault name="excfault" use="literal"/>
+      </wsdl:fault>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="WsExcTest2">
+    <wsdl:port name="WsExcTest2ServiceSoap" binding="tns:WsExcTest2ServiceSoap">
+      <soap:address location="localhost"/>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>

--- a/testing/esp/esdlcmd/key/wsexctest2-xsd-default.xsd
+++ b/testing/esp/esdlcmd/key/wsexctest2-xsd-default.xsd
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:tns="urn:hpccsystems:ws:wsexctest2" elementFormDefault="qualified" targetNamespace="urn:hpccsystems:ws:wsexctest2">
+  <xsd:element name="string" nillable="true" type="xsd:string"/>
+  <xsd:complexType name="EspException">
+    <xsd:all>
+      <xsd:element name="Code" type="xsd:string" minOccurs="0"/>
+      <xsd:element name="Audience" type="xsd:string" minOccurs="0"/>
+      <xsd:element name="Source" type="xsd:string" minOccurs="0"/>
+      <xsd:element name="Message" type="xsd:string" minOccurs="0"/>
+    </xsd:all>
+  </xsd:complexType>
+  <xsd:complexType name="ArrayOfEspException">
+    <xsd:sequence>
+      <xsd:element name="Source" type="xsd:string" minOccurs="0"/>
+      <xsd:element name="Exception" type="tns:EspException" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:element name="Exceptions" type="tns:ArrayOfEspException"/>
+  <xsd:element name="WsExcTest2PingRequest">
+    <xsd:complexType>
+      <xsd:all/>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="SoapFaultExceptionsRequest">
+    <xsd:complexType>
+      <xsd:all>
+        <xsd:element minOccurs="0" name="RequestString" type="xsd:string"/>
+      </xsd:all>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="SoapFaultExceptionsTwoRequest">
+    <xsd:complexType>
+      <xsd:all>
+        <xsd:element minOccurs="0" name="RequestString" type="xsd:string"/>
+      </xsd:all>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="WsExcTest2PingResponse">
+    <xsd:complexType>
+      <xsd:all/>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="SoapFaultExceptionsResponse">
+    <xsd:complexType>
+      <xsd:all>
+        <xsd:element minOccurs="0" name="ResponseString" type="xsd:string"/>
+      </xsd:all>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="SoapFaultExceptionsTwoResponse">
+    <xsd:complexType>
+      <xsd:all>
+        <xsd:element minOccurs="0" name="ResponseString" type="xsd:string"/>
+      </xsd:all>
+    </xsd:complexType>
+  </xsd:element>
+</xsd:schema>

--- a/testing/esp/esdlcmd/key/wsexctest3-wsdl-default.wsdl
+++ b/testing/esp/esdlcmd/key/wsexctest3-wsdl-default.wsdl
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:tns="urn:hpccsystems:ws:wsexctest3" targetNamespace="urn:hpccsystems:ws:wsexctest3">
+  <wsdl:types>
+    <xsd:schema elementFormDefault="qualified" targetNamespace="urn:hpccsystems:ws:wsexctest3">
+      <xsd:element name="string" nillable="true" type="xsd:string"/>
+      <xsd:complexType name="EspException">
+        <xsd:all>
+          <xsd:element name="Code" type="xsd:string" minOccurs="0"/>
+          <xsd:element name="Audience" type="xsd:string" minOccurs="0"/>
+          <xsd:element name="Source" type="xsd:string" minOccurs="0"/>
+          <xsd:element name="Message" type="xsd:string" minOccurs="0"/>
+        </xsd:all>
+      </xsd:complexType>
+      <xsd:complexType name="ArrayOfEspException">
+        <xsd:sequence>
+          <xsd:element name="Source" type="xsd:string" minOccurs="0"/>
+          <xsd:element name="Exception" type="tns:EspException" minOccurs="0" maxOccurs="unbounded"/>
+        </xsd:sequence>
+      </xsd:complexType>
+      <xsd:element name="Exceptions" type="tns:ArrayOfEspException"/>
+      <xsd:element name="InlineExceptionsRequest">
+        <xsd:complexType>
+          <xsd:all>
+            <xsd:element minOccurs="0" name="RequestString" type="xsd:string"/>
+          </xsd:all>
+        </xsd:complexType>
+      </xsd:element>
+      <xsd:element name="WsExcTest3PingRequest">
+        <xsd:complexType>
+          <xsd:all/>
+        </xsd:complexType>
+      </xsd:element>
+      <xsd:element name="SoapFaultExceptionsRequest">
+        <xsd:complexType>
+          <xsd:all>
+            <xsd:element minOccurs="0" name="RequestString" type="xsd:string"/>
+          </xsd:all>
+        </xsd:complexType>
+      </xsd:element>
+      <xsd:element name="InlineExceptionsResponse">
+        <xsd:complexType>
+          <xsd:all>
+            <xsd:element name="Exceptions" type="tns:ArrayOfEspException" minOccurs="0" maxOccurs="1"/>
+            <xsd:element minOccurs="0" name="ResponseString" type="xsd:string"/>
+          </xsd:all>
+        </xsd:complexType>
+      </xsd:element>
+      <xsd:element name="WsExcTest3PingResponse">
+        <xsd:complexType>
+          <xsd:all/>
+        </xsd:complexType>
+      </xsd:element>
+      <xsd:element name="SoapFaultExceptionsResponse">
+        <xsd:complexType>
+          <xsd:all>
+            <xsd:element minOccurs="0" name="ResponseString" type="xsd:string"/>
+          </xsd:all>
+        </xsd:complexType>
+      </xsd:element>
+    </xsd:schema>
+  </wsdl:types>
+  <wsdl:message name="EspSoapFault">
+    <wsdl:part name="parameters" element="tns:Exceptions"/>
+  </wsdl:message>
+  <wsdl:message name="InlineExceptionsSoapIn">
+    <wsdl:part name="parameters" element="tns:InlineExceptionsRequest"/>
+  </wsdl:message>
+  <wsdl:message name="InlineExceptionsSoapOut">
+    <wsdl:part name="parameters" element="tns:InlineExceptionsResponse"/>
+  </wsdl:message>
+  <wsdl:message name="PingSoapIn">
+    <wsdl:part name="parameters" element="tns:WsExcTest3PingRequest"/>
+  </wsdl:message>
+  <wsdl:message name="PingSoapOut">
+    <wsdl:part name="parameters" element="tns:WsExcTest3PingResponse"/>
+  </wsdl:message>
+  <wsdl:message name="SoapFaultExceptionsSoapIn">
+    <wsdl:part name="parameters" element="tns:SoapFaultExceptionsRequest"/>
+  </wsdl:message>
+  <wsdl:message name="SoapFaultExceptionsSoapOut">
+    <wsdl:part name="parameters" element="tns:SoapFaultExceptionsResponse"/>
+  </wsdl:message>
+  <wsdl:portType name="WsExcTest3ServiceSoap">
+    <wsdl:operation name="InlineExceptions">
+      <wsdl:input message="tns:InlineExceptionsSoapIn"/>
+      <wsdl:output message="tns:InlineExceptionsSoapOut"/>
+      <wsdl:fault name="excfault" message="tns:EspSoapFault"/>
+    </wsdl:operation>
+    <wsdl:operation name="Ping">
+      <wsdl:input message="tns:PingSoapIn"/>
+      <wsdl:output message="tns:PingSoapOut"/>
+      <wsdl:fault name="excfault" message="tns:EspSoapFault"/>
+    </wsdl:operation>
+    <wsdl:operation name="SoapFaultExceptions">
+      <wsdl:input message="tns:SoapFaultExceptionsSoapIn"/>
+      <wsdl:output message="tns:SoapFaultExceptionsSoapOut"/>
+      <wsdl:fault name="excfault" message="tns:EspSoapFault"/>
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="WsExcTest3ServiceSoap" type="tns:WsExcTest3ServiceSoap">
+    <soap:binding transport="http://schemas.xmlsoap.org/soap/http" style="document"/>
+    <wsdl:operation name="InlineExceptions">
+      <soap:operation style="document" soapAction="WsExcTest3/InlineExceptions?ver_=0.000000"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+      <wsdl:fault name="excfault">
+        <soap:fault name="excfault" use="literal"/>
+      </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="Ping">
+      <soap:operation style="document" soapAction="WsExcTest3/Ping?ver_=0.000000"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+      <wsdl:fault name="excfault">
+        <soap:fault name="excfault" use="literal"/>
+      </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="SoapFaultExceptions">
+      <soap:operation style="document" soapAction="WsExcTest3/SoapFaultExceptions?ver_=0.000000"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+      <wsdl:fault name="excfault">
+        <soap:fault name="excfault" use="literal"/>
+      </wsdl:fault>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="WsExcTest3">
+    <wsdl:port name="WsExcTest3ServiceSoap" binding="tns:WsExcTest3ServiceSoap">
+      <soap:address location="localhost"/>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>

--- a/testing/esp/esdlcmd/key/wsexctest3-wsdl-no-exc.wsdl
+++ b/testing/esp/esdlcmd/key/wsexctest3-wsdl-no-exc.wsdl
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:tns="urn:hpccsystems:ws:wsexctest3" targetNamespace="urn:hpccsystems:ws:wsexctest3">
+  <wsdl:types>
+    <xsd:schema elementFormDefault="qualified" targetNamespace="urn:hpccsystems:ws:wsexctest3">
+      <xsd:element name="string" nillable="true" type="xsd:string"/>
+      <xsd:complexType name="EspException">
+        <xsd:all>
+          <xsd:element name="Code" type="xsd:string" minOccurs="0"/>
+          <xsd:element name="Audience" type="xsd:string" minOccurs="0"/>
+          <xsd:element name="Source" type="xsd:string" minOccurs="0"/>
+          <xsd:element name="Message" type="xsd:string" minOccurs="0"/>
+        </xsd:all>
+      </xsd:complexType>
+      <xsd:complexType name="ArrayOfEspException">
+        <xsd:sequence>
+          <xsd:element name="Source" type="xsd:string" minOccurs="0"/>
+          <xsd:element name="Exception" type="tns:EspException" minOccurs="0" maxOccurs="unbounded"/>
+        </xsd:sequence>
+      </xsd:complexType>
+      <xsd:element name="Exceptions" type="tns:ArrayOfEspException"/>
+      <xsd:element name="InlineExceptionsRequest">
+        <xsd:complexType>
+          <xsd:all>
+            <xsd:element minOccurs="0" name="RequestString" type="xsd:string"/>
+          </xsd:all>
+        </xsd:complexType>
+      </xsd:element>
+      <xsd:element name="WsExcTest3PingRequest">
+        <xsd:complexType>
+          <xsd:all/>
+        </xsd:complexType>
+      </xsd:element>
+      <xsd:element name="SoapFaultExceptionsRequest">
+        <xsd:complexType>
+          <xsd:all>
+            <xsd:element minOccurs="0" name="RequestString" type="xsd:string"/>
+          </xsd:all>
+        </xsd:complexType>
+      </xsd:element>
+      <xsd:element name="InlineExceptionsResponse">
+        <xsd:complexType>
+          <xsd:all>
+            <xsd:element minOccurs="0" name="ResponseString" type="xsd:string"/>
+          </xsd:all>
+        </xsd:complexType>
+      </xsd:element>
+      <xsd:element name="WsExcTest3PingResponse">
+        <xsd:complexType>
+          <xsd:all/>
+        </xsd:complexType>
+      </xsd:element>
+      <xsd:element name="SoapFaultExceptionsResponse">
+        <xsd:complexType>
+          <xsd:all>
+            <xsd:element minOccurs="0" name="ResponseString" type="xsd:string"/>
+          </xsd:all>
+        </xsd:complexType>
+      </xsd:element>
+    </xsd:schema>
+  </wsdl:types>
+  <wsdl:message name="EspSoapFault">
+    <wsdl:part name="parameters" element="tns:Exceptions"/>
+  </wsdl:message>
+  <wsdl:message name="InlineExceptionsSoapIn">
+    <wsdl:part name="parameters" element="tns:InlineExceptionsRequest"/>
+  </wsdl:message>
+  <wsdl:message name="InlineExceptionsSoapOut">
+    <wsdl:part name="parameters" element="tns:InlineExceptionsResponse"/>
+  </wsdl:message>
+  <wsdl:message name="PingSoapIn">
+    <wsdl:part name="parameters" element="tns:WsExcTest3PingRequest"/>
+  </wsdl:message>
+  <wsdl:message name="PingSoapOut">
+    <wsdl:part name="parameters" element="tns:WsExcTest3PingResponse"/>
+  </wsdl:message>
+  <wsdl:message name="SoapFaultExceptionsSoapIn">
+    <wsdl:part name="parameters" element="tns:SoapFaultExceptionsRequest"/>
+  </wsdl:message>
+  <wsdl:message name="SoapFaultExceptionsSoapOut">
+    <wsdl:part name="parameters" element="tns:SoapFaultExceptionsResponse"/>
+  </wsdl:message>
+  <wsdl:portType name="WsExcTest3ServiceSoap">
+    <wsdl:operation name="InlineExceptions">
+      <wsdl:input message="tns:InlineExceptionsSoapIn"/>
+      <wsdl:output message="tns:InlineExceptionsSoapOut"/>
+      <wsdl:fault name="excfault" message="tns:EspSoapFault"/>
+    </wsdl:operation>
+    <wsdl:operation name="Ping">
+      <wsdl:input message="tns:PingSoapIn"/>
+      <wsdl:output message="tns:PingSoapOut"/>
+      <wsdl:fault name="excfault" message="tns:EspSoapFault"/>
+    </wsdl:operation>
+    <wsdl:operation name="SoapFaultExceptions">
+      <wsdl:input message="tns:SoapFaultExceptionsSoapIn"/>
+      <wsdl:output message="tns:SoapFaultExceptionsSoapOut"/>
+      <wsdl:fault name="excfault" message="tns:EspSoapFault"/>
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="WsExcTest3ServiceSoap" type="tns:WsExcTest3ServiceSoap">
+    <soap:binding transport="http://schemas.xmlsoap.org/soap/http" style="document"/>
+    <wsdl:operation name="InlineExceptions">
+      <soap:operation style="document" soapAction="WsExcTest3/InlineExceptions?ver_=0.000000"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+      <wsdl:fault name="excfault">
+        <soap:fault name="excfault" use="literal"/>
+      </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="Ping">
+      <soap:operation style="document" soapAction="WsExcTest3/Ping?ver_=0.000000"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+      <wsdl:fault name="excfault">
+        <soap:fault name="excfault" use="literal"/>
+      </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="SoapFaultExceptions">
+      <soap:operation style="document" soapAction="WsExcTest3/SoapFaultExceptions?ver_=0.000000"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+      <wsdl:fault name="excfault">
+        <soap:fault name="excfault" use="literal"/>
+      </wsdl:fault>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="WsExcTest3">
+    <wsdl:port name="WsExcTest3ServiceSoap" binding="tns:WsExcTest3ServiceSoap">
+      <soap:address location="localhost"/>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>

--- a/testing/esp/esdlcmd/key/wsexctest3-xsd-default.xsd
+++ b/testing/esp/esdlcmd/key/wsexctest3-xsd-default.xsd
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:tns="urn:hpccsystems:ws:wsexctest3" elementFormDefault="qualified" targetNamespace="urn:hpccsystems:ws:wsexctest3">
+  <xsd:element name="string" nillable="true" type="xsd:string"/>
+  <xsd:complexType name="EspException">
+    <xsd:all>
+      <xsd:element name="Code" type="xsd:string" minOccurs="0"/>
+      <xsd:element name="Audience" type="xsd:string" minOccurs="0"/>
+      <xsd:element name="Source" type="xsd:string" minOccurs="0"/>
+      <xsd:element name="Message" type="xsd:string" minOccurs="0"/>
+    </xsd:all>
+  </xsd:complexType>
+  <xsd:complexType name="ArrayOfEspException">
+    <xsd:sequence>
+      <xsd:element name="Source" type="xsd:string" minOccurs="0"/>
+      <xsd:element name="Exception" type="tns:EspException" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:element name="Exceptions" type="tns:ArrayOfEspException"/>
+  <xsd:element name="InlineExceptionsRequest">
+    <xsd:complexType>
+      <xsd:all>
+        <xsd:element minOccurs="0" name="RequestString" type="xsd:string"/>
+      </xsd:all>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="WsExcTest3PingRequest">
+    <xsd:complexType>
+      <xsd:all/>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="SoapFaultExceptionsRequest">
+    <xsd:complexType>
+      <xsd:all>
+        <xsd:element minOccurs="0" name="RequestString" type="xsd:string"/>
+      </xsd:all>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="InlineExceptionsResponse">
+    <xsd:complexType>
+      <xsd:all>
+        <xsd:element name="Exceptions" type="tns:ArrayOfEspException" minOccurs="0" maxOccurs="1"/>
+        <xsd:element minOccurs="0" name="ResponseString" type="xsd:string"/>
+      </xsd:all>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="WsExcTest3PingResponse">
+    <xsd:complexType>
+      <xsd:all/>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="SoapFaultExceptionsResponse">
+    <xsd:complexType>
+      <xsd:all>
+        <xsd:element minOccurs="0" name="ResponseString" type="xsd:string"/>
+      </xsd:all>
+    </xsd:complexType>
+  </xsd:element>
+</xsd:schema>

--- a/testing/esp/esdlcmd/key/wsexctest3-xsd-no-exc.xsd
+++ b/testing/esp/esdlcmd/key/wsexctest3-xsd-no-exc.xsd
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:tns="urn:hpccsystems:ws:wsexctest3" elementFormDefault="qualified" targetNamespace="urn:hpccsystems:ws:wsexctest3">
+  <xsd:element name="string" nillable="true" type="xsd:string"/>
+  <xsd:complexType name="EspException">
+    <xsd:all>
+      <xsd:element name="Code" type="xsd:string" minOccurs="0"/>
+      <xsd:element name="Audience" type="xsd:string" minOccurs="0"/>
+      <xsd:element name="Source" type="xsd:string" minOccurs="0"/>
+      <xsd:element name="Message" type="xsd:string" minOccurs="0"/>
+    </xsd:all>
+  </xsd:complexType>
+  <xsd:complexType name="ArrayOfEspException">
+    <xsd:sequence>
+      <xsd:element name="Source" type="xsd:string" minOccurs="0"/>
+      <xsd:element name="Exception" type="tns:EspException" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:element name="Exceptions" type="tns:ArrayOfEspException"/>
+  <xsd:element name="InlineExceptionsRequest">
+    <xsd:complexType>
+      <xsd:all>
+        <xsd:element minOccurs="0" name="RequestString" type="xsd:string"/>
+      </xsd:all>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="WsExcTest3PingRequest">
+    <xsd:complexType>
+      <xsd:all/>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="SoapFaultExceptionsRequest">
+    <xsd:complexType>
+      <xsd:all>
+        <xsd:element minOccurs="0" name="RequestString" type="xsd:string"/>
+      </xsd:all>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="InlineExceptionsResponse">
+    <xsd:complexType>
+      <xsd:all>
+        <xsd:element minOccurs="0" name="ResponseString" type="xsd:string"/>
+      </xsd:all>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="WsExcTest3PingResponse">
+    <xsd:complexType>
+      <xsd:all/>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="SoapFaultExceptionsResponse">
+    <xsd:complexType>
+      <xsd:all>
+        <xsd:element minOccurs="0" name="ResponseString" type="xsd:string"/>
+      </xsd:all>
+    </xsd:complexType>
+  </xsd:element>
+</xsd:schema>

--- a/tools/esdlcmd/esdlcmd_common.hpp
+++ b/tools/esdlcmd/esdlcmd_common.hpp
@@ -108,6 +108,7 @@ typedef IEsdlCommand *(*EsdlCommandFactory)(const char *cmdname);
 #define ESDLOPT_WSDL_ADDRESS            "--wsdl-address"
 #define ESDLOPT_UNVERSIONED_NAMESPACE   "--unversioned-ns"
 #define ESDLOPT_UNVERSIONED_NAMESPACE_S "-uvns"
+#define ESDLOPT_NO_EXCEPT_INLINE        "--no-exceptions-inline"
 
 #define DEFAULT_NAMESPACE_BASE          "urn:hpccsystems:ws"
 #define ESDLOPTLIST_DELIMITER           ";"

--- a/tools/esdlcmd/esdlcmd_core.cpp
+++ b/tools/esdlcmd/esdlcmd_core.cpp
@@ -113,6 +113,8 @@ public:
         StringAttr oneOption;
         if (iter.matchOption(oneOption, ESDLOPT_INCLUDE_PATH) || iter.matchOption(oneOption, ESDLOPT_INCLUDE_PATH_S))
             return false;  //Return false to negate allowing the include path options from parent class
+        if (iter.matchFlag(optNoExceptionsInline, ESDLOPT_NO_EXCEPT_INLINE))
+            return true;
 
         if (EsdlConvertCmd::parseCommandLineOption(iter))
             return true;
@@ -276,6 +278,7 @@ public:
         puts("   --no-arrayof                         Supresses the use of the arrrayof element. arrayof optimizes the XML output to include 'ArrayOf...'" );
         puts("                                        structure definitions for those EsdlArray elements with no item_tag attribute. Works in conjunction" );
         puts("                                        with an optimized stylesheet that doesn't generate these itself. This defaults to on.");
+        puts("   --no-exceptions-inline               Do not modify the interface to include an Exceptions element inline in the response.");
     }
 
     virtual void usage()
@@ -341,6 +344,11 @@ public:
         if( optNoAnnot )
         {
             params->setProp( "no_annot_Param", "true()" );
+        }
+
+        if( optNoExceptionsInline )
+        {
+            params->setProp( "no_exceptions_inline", "true()" );
         }
     }
 
@@ -449,6 +457,7 @@ public:
     bool optNoCollapse;
     bool optNoArrayOf;
     bool optUnversionedNamespace;
+    bool optNoExceptionsInline;
 
 protected:
     StringBuffer outputBuffer;
@@ -578,6 +587,11 @@ public:
 
         params->setProp( "create_wsdl", "true()" );
         setXpathQuotedParam(params, "location", optWsdlAddress.str());
+
+        if( optNoExceptionsInline )
+        {
+            params->setProp( "no_exceptions_inline", "true()" );
+        }
     }
 
 public:


### PR DESCRIPTION
The esdl command-line tool and ESDL engine-based services do not honor the
exceptions_inline attribute when creating XSD or WSDL output.

Update the esdl transform to honor the exceptions_inline attribute in the
same way that hidl-based services do- when it appears in the EspResponse
element of an ecm file.

Do not change DESDL service wsdl/xsd generation to maintain compatibility
with current DESDL service behavior. This is addressed in HPCC-27342.

Ensure the esdl tool generated wsdl validates by defining the wsdl namespace
prefix it uses.

Signed-off-by: Terrence Asselin <terrence.asselin@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [x] I have added tests to cover my changes.
  - [x] All new and existing tests passed.
  - [x] I have checked that this change does not introduce memory leaks.
  - [x] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [x] Scalability
  - [x] Performance
  - [x] Security
  - [x] Thread-safety
  - [x] Cloud-compatibility
  - [x] Premature optimization
  - [x] Existing deployed queries will not be broken
  - [x] This change fixes the problem, not just the symptom
  - [x] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
