### PR TITLE
HPCC-27348 Use buffered iostream in ESP WsSMC services

### DIFF
--- a/esp/services/ws_workunits/ws_workunitsHelpers.hpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.hpp
@@ -680,7 +680,6 @@ public:
     IFileIOStream* createWUFileIOStream(IEspContext &context, const char *wuid, IArrayOf<IConstWUFileOption> &wuFileOptions,
         CWUFileDownloadOption &downloadOptions, StringBuffer &contentType);
 
-    IFileIOStream* createIOStreamWithFileName(const char *fileNameWithPath, IFOmode mode);
     void validateFilePath(const char *file, WsWuInfo &winfo, CWUFileType wuFileType, bool UNCFileName, const char *fileType, const char *compType, const char *compName);
     bool validateWUFile(const char *file, WsWuInfo &winfo, CWUFileType wuFileType);
 };

--- a/esp/services/ws_workunits/ws_wuresult.cpp
+++ b/esp/services/ws_workunits/ws_wuresult.cpp
@@ -129,8 +129,10 @@ bool CWsWuResultOutHelper::getWUResultStreaming(CHttpRequest* request, CHttpResp
         zipFileNameWithPath.append((outFormat == WUResultOutGZIP) ? ".gz" : ".zip");
         zipResultFile(zipFileNameWithPath);
 
-        CWsWuFileHelper helper(nullptr);
-        response->setContent(helper.createIOStreamWithFileName(zipFileNameWithPath, IFOread));
+        auto stream = createIOStreamFromFile(zipFileNameWithPath, IFOread);
+        if (stream == nullptr)
+            throw makeStringExceptionV(ECLWATCH_INTERNAL_ERROR, "Cannot open stream for zip file %s", zipFileNameWithPath.str());
+        response->setContent(stream);
         if (outFormat == WUResultOutGZIP)
             response->setContentType("application/x-gzip");
         else
@@ -442,5 +444,3 @@ unsigned CWsWuResultOutHelper::getResultXmlStreaming(INewResultSet* result, cons
     Owned<CommonXmlWriter> writer = CreateCommonXmlWriter(XWFexpandempty, 0, flusher);
     return writeResultCursorXml(*writer, cursor, resultName, start, count, schemaName, xmlns, true, &abortCallback);
 }
-
-

--- a/system/jlib/jfile.cpp
+++ b/system/jlib/jfile.cpp
@@ -4331,6 +4331,24 @@ IFileIOStream * createBufferedAsyncIOStream(IFileAsyncIO * io, unsigned bufsize)
     return new CBufferedAsyncIOStream(io, bufsize);
 }
 
+IFileIOStream * createIOStreamFromFile(const char *fileNameWithPath, IFOmode mode)
+{
+    Owned<IFile> iFile = createIFile(fileNameWithPath);
+    Owned<IFileIO> iFileIO = iFile->open(mode);
+    if (!iFileIO)
+        return nullptr;
+    return createIOStream(iFileIO);
+}
+
+IFileIOStream * createBufferedIOStreamFromFile(const char *fileNameWithPath, IFOmode mode, unsigned bufsize)
+{
+    Owned<IFile> iFile = createIFile(fileNameWithPath);
+    Owned<IFileIO> iFileIO = iFile->open(mode);
+    if (!iFileIO)
+        return nullptr;
+    return createBufferedIOStream(iFileIO, bufsize);
+}
+
 IReadSeq *createReadSeq(IFileIOStream * stream, offset_t offset, size32_t size)
 {
     return new CIOStreamReadWriteSeq(stream, offset, size);

--- a/system/jlib/jfile.hpp
+++ b/system/jlib/jfile.hpp
@@ -277,6 +277,9 @@ extern jlib_decl IFileIOStream * createIOStream(IFileIO * file);        // links
 extern jlib_decl IFileIOStream * createNoSeekIOStream(IFileIOStream * stream);  // links argument
 extern jlib_decl IFileIOStream * createBufferedIOStream(IFileIO * file, unsigned bufsize=(unsigned)-1);// links argument
 extern jlib_decl IFileIOStream * createBufferedAsyncIOStream(IFileAsyncIO * file, unsigned bufsize=(unsigned)-1);// links argument
+extern jlib_decl IFileIOStream * createIOStreamFromFile(const char *fileNameWithPath, IFOmode mode);// links argument
+extern jlib_decl IFileIOStream * createBufferedIOStreamFromFile(const char *fileNameWithPath, IFOmode mode, unsigned bufsize=(unsigned)-1);// links argument
+
 
 // Useful for commoning up file and string based processing
 extern jlib_decl IFileIO * createIFileI(unsigned len, const void * buffer);     // input only...


### PR DESCRIPTION
Added support for buffered iostream

Signed-off-by: Ken Rowland kenneth.rowland@lexisnexisrisk.com

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [x] Scalability
  - [x] Performance
  - [x] Security
  - [x] Thread-safety
  - [x] Cloud-compatibility
  - [x] Premature optimization
  - [x] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [x] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
