### PR TITLE
HPCC-27468 Check root access in ESP session authentication

### DIFF
--- a/esp/bindings/http/platform/httpbinding.cpp
+++ b/esp/bindings/http/platform/httpbinding.cpp
@@ -792,7 +792,7 @@ bool EspHttpBinding::basicAuth(IEspContext* ctx)
                 VStringBuffer msg("Access for user '%s' denied to: %s. Access=%d, Required=%d", user->getName(), desc?desc:"<no-desc>", access, required);
                 ESPLOG(LogMin, "%s", msg.str());
                 ctx->AuditMessage(AUDIT_TYPE_ACCESS_FAILURE, "Authorization", "Access Denied: Not Authorized", "Resource: %s [%s]", curres->getName(), (desc) ? desc : "");
-                ctx->setAuthError(EspAuthErrorNotAuthorized);
+                user->setAuthenticateStatus(AS_ACCOUNT_ROOT_ACCESS_DENIED);
                 ctx->setRespMsg(msg.str());
                 authorized = false;
                 break;

--- a/esp/bindings/http/platform/httpservice.cpp
+++ b/esp/bindings/http/platform/httpservice.cpp
@@ -1524,7 +1524,7 @@ EspAuthState CEspHttpServer::authNewSession(EspAuthRequest& authReq, const char*
     authReq.ctx->setUserID(_userName);
     authReq.ctx->setPassword(_password);
     authReq.authBinding->populateRequest(m_request.get());
-    if (!authReq.authBinding->doAuth(authReq.ctx) && (authReq.ctx->getAuthError() != EspAuthErrorNotAuthorized))
+    if (!authReq.authBinding->doAuth(authReq.ctx))
     {
         authReq.ctx->setAuthStatus(AUTH_STATUS_FAIL);
         ESPLOG(LogMin, "Authentication failed for %s@%s", _userName, peer.str());
@@ -1546,12 +1546,6 @@ EspAuthState CEspHttpServer::authNewSession(EspAuthRequest& authReq, const char*
     addCookie(SESSION_TIMEOUT_COOKIE, cookieStr.str(), 0, false);
     clearCookie(SESSION_AUTH_MSG_COOKIE);
     clearCookie(SESSION_START_URL_COOKIE);
-    if (authReq.ctx->getAuthError() == EspAuthErrorNotAuthorized)
-    {
-        authReq.ctx->setAuthStatus(AUTH_STATUS_NOACCESS);
-        sendAuthorizationMsg(authReq);
-        return authSucceeded;
-    }
 
     authReq.ctx->setAuthStatus(AUTH_STATUS_OK); //May be changed to AUTH_STATUS_NOACCESS if failed in feature level authorization.
     if (unlock)
@@ -2076,6 +2070,9 @@ EspAuthState CEspHttpServer::handleAuthFailed(bool sessionAuth, EspAuthRequest& 
         case AS_ACCOUNT_LOCKED :
             ESPLOG(LogMin, "Account locked for %s", authReq.ctx->queryUserId());
             addCookie(USER_ACCT_ERROR_COOKIE, "Account Locked", 0, false);
+            break;
+        case AS_ACCOUNT_ROOT_ACCESS_DENIED :
+            addCookie(USER_ACCT_ERROR_COOKIE, authReq.ctx->getRespMsg(), 0, false);
             break;
         }
     }

--- a/esp/scm/esp.ecm
+++ b/esp/scm/esp.ecm
@@ -71,8 +71,7 @@ typedef enum AuthError_
     EspAuthErrorUserNotFoundInContext,
     EspAuthErrorNoAuthMechanism,
     EspAuthErrorEmptySecResource,
-    EspAuthErrorNotAuthenticated,
-    EspAuthErrorNotAuthorized
+    EspAuthErrorNotAuthenticated
 } AuthError;
 
 typedef enum LogRequest_

--- a/system/security/shared/seclib.hpp
+++ b/system/security/shared/seclib.hpp
@@ -229,6 +229,7 @@ enum authStatus : int
     AS_ACCOUNT_DISABLED = 6,//valid username and password/credential are supplied but the account has been disabled
     AS_ACCOUNT_EXPIRED = 7,//valid username and password/credential supplied but the account has expired
     AS_ACCOUNT_LOCKED = 8,//valid username is supplied, but the account is locked out
+    AS_ACCOUNT_ROOT_ACCESS_DENIED = 9,//valid username and password/credential supplied but the user does not have the root access to the service.
 };
 
 static const SecFeatureBit SUF_NO_FEATURES                 = 0x00;


### PR DESCRIPTION
In the existing session based authentication, the root access is 
not validated. The code validates a feature access after the 
authentication. This is inconsistent with non-session based 
authentication.

Signed-off-by: wangkx <kevin.wang@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
