### PR TITLE
HPCC-24078 Retrieve Component Logs for K8 job

### DIFF
--- a/esp/bindings/http/platform/httpresponsebuffer.ipp
+++ b/esp/bindings/http/platform/httpresponsebuffer.ipp
@@ -1,0 +1,69 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2022 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ifndef _HTTPRESPONSEBUFFER_IPP__
+#define _HTTPRESPONSEBUFFER_IPP__
+
+#include "http/platform/httptransport.ipp"
+#include "rtlformat.hpp"
+
+static constexpr unsigned defaultResponseFlushThresholdBytes = 8000;
+static constexpr unsigned closingResponseFlushThresholdBytes = 1;
+
+class CFlushingHttpResponseBuffer : public CInterfaceOf<IXmlStreamFlusher>
+{
+    CHttpResponse* response = nullptr;
+    const size32_t responseFlushThreshold = defaultResponseFlushThresholdBytes;
+    StringBuffer responseBuffer;
+
+public:
+    CFlushingHttpResponseBuffer(CHttpResponse* _response, size32_t _flushThreshold) :
+        response(_response),  responseFlushThreshold(_flushThreshold)
+    {
+        if (!response)
+            throw makeStringException(-1, "HttpResponse not specified for CFlushingWUFileBuffer");
+    };
+    ~CFlushingHttpResponseBuffer()
+    {
+        try
+        {
+            if (!responseBuffer.isEmpty())
+                response->sendChunk(responseBuffer);
+        }
+        catch (IException* e)
+        {
+            // Ignore any socket errors that we get at termination - nothing we can do about them anyway...
+            EXCLOG(e, "In ~CFlushingHttpResponseBuffer()");
+            e->Release();
+        }
+    }
+    void flushXML(StringBuffer& current, bool closing)
+    {
+        responseBuffer.append(current);
+        current.clear();
+
+        //When closing, no flushing is needed if responseBuffer.length() < closingResponseFlushThresholdBytes.
+        const size32_t threshold = closing ? closingResponseFlushThresholdBytes : responseFlushThreshold;
+        if (responseBuffer.length() < threshold)
+            return;
+
+        response->sendChunk(responseBuffer);
+        responseBuffer.clear();
+    }
+};
+
+#endif

--- a/esp/bindings/http/platform/httptransport.cpp
+++ b/esp/bindings/http/platform/httptransport.cpp
@@ -501,6 +501,23 @@ IProperties *CHttpMessage::queryParameters()
     return m_queryparams.get();
 }
 
+int CHttpMessage::getParameterInt(const char* name, int defaultValue)
+{
+    StringBuffer value;
+    getParameter(name, value);
+    if (value.isEmpty())
+        return defaultValue;
+
+    const char* finger = value.str();
+    while (*finger)
+    {
+        if (!isdigit(*finger)) 
+            return defaultValue;
+        ++finger;
+    }
+    return atoi(value.str());
+}
+
 IProperties *CHttpMessage::getParameters()
 {
     if (!m_queryparams)

--- a/esp/bindings/http/platform/httptransport.ipp
+++ b/esp/bindings/http/platform/httptransport.ipp
@@ -174,6 +174,7 @@ public:
     virtual int getAttachmentCount(){return m_attachCount;}
     virtual IProperties *queryParameters();
     virtual IProperties *getParameters();
+    virtual int getParameterInt(const char* name, int defaultValue);
     virtual MapStrToBuf *queryAttachments()
     {
         return &m_attachments;

--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -25,7 +25,7 @@ EspInclude(ws_workunits_queryset_req_resp);
 
 ESPservice [
     auth_feature("DEFERRED"), //This declares that the method logic handles feature level authorization
-    version("1.89"), default_client_version("1.89"), cache_group("ESPWsWUs"),
+    version("1.90"), default_client_version("1.90"), cache_group("ESPWsWUs"),
     noforms,exceptions_inline("./smc_xslt/exceptions.xslt"),use_method_name] WsWorkunits
 {
     ESPmethod [cache_seconds(60), resp_xsl_default("/esp/xslt/workunits.xslt")]     WUQuery(WUQueryRequest, WUQueryResponse);

--- a/esp/scm/ws_workunits_req_resp.ecm
+++ b/esp/scm/ws_workunits_req_resp.ecm
@@ -403,6 +403,7 @@ ESPrequest WULogFileRequest
     [min_ver("1.55")] int64 SizeLimit(0);
     [min_ver("1.77")] ESPenum ErrorMessageFormat ErrorMessageFormat;
     string PlainText;
+    [min_ver("1.90")] ESPStruct WUFileOption FileOptions;
 };
 
 ESPresponse [exceptions_inline] WULogFileResponse

--- a/esp/scm/ws_workunits_struct.ecm
+++ b/esp/scm/ws_workunits_struct.ecm
@@ -16,6 +16,8 @@
 ############################################################################## */
 
 #include "xslprocessor.hpp"
+EspInclude(ws_logaccess);
+
 //  ===========================================================================
 
 EspInclude(common);
@@ -64,6 +66,7 @@ ESPenum WUFileType : string
     ThorSlaveLog("ThorSlaveLog"),
     EclAgentLog("EclAgentLog"),
     ArchiveQuery("ArchiveQuery"),
+    ComponentLog("ComponentLog"),
 };
 
 ESPenum WUFileDownloadOption : int
@@ -522,6 +525,11 @@ ESPStruct WUFileOption
     string PlainText; //XML: optional
     int SlaveNumber(1); //ThorSlaveLog: optional
     int64 SizeLimit(0);
+    [min_ver("1.90"), nil_remove] unsigned MaxLogRecords;
+    [min_ver("1.90"), nil_remove] ESPenum LogSelectColumnMode LogSelectColumnMode;
+    [min_ver("1.90"), nil_remove] ESPenum LogAccessLogFormat LogFormat;
+    [min_ver("1.90"), nil_remove] unsigned LogSearchTimeBuffSecs;
+    [min_ver("1.90"), nil_remove] ESParray<string> LogColumns;
 };
 
 ESPStruct [nil_remove] ScheduledWU

--- a/esp/services/ws_sql/CMakeLists.txt
+++ b/esp/services/ws_sql/CMakeLists.txt
@@ -96,6 +96,9 @@ if(WSSQL_SERVICE AND USE_JAVA)
         ${ESPSCM_GENERATED_DIR}
         ${CMAKE_CURRENT_SOURCE_DIR}/SQL2ECL
         ${HPCC_SOURCE_DIR}/common/thorhelper
+        ${HPCC_SOURCE_DIR}/esp/bindings/http/platform
+        ${HPCC_SOURCE_DIR}/rtl/eclrtl
+        ${HPCC_SOURCE_DIR}/rtl/include
         )
 
     if (CMAKE_COMPILER_IS_CLANG)

--- a/esp/services/ws_workunits/CMakeLists.txt
+++ b/esp/services/ws_workunits/CMakeLists.txt
@@ -88,6 +88,7 @@ include_directories (
          ./../../bindings/http/client
          ./../../smc/SMCLib
          ./../../bindings/SOAP/xpp
+         ${HPCC_SOURCE_DIR}/esp/bindings/http/platform
          ${HPCC_SOURCE_DIR}/dali/dfu
          ${HPCC_SOURCE_DIR}/dali/ft
          ./../../../testing/unittests

--- a/esp/services/ws_workunits/ws_workunitsAuditLogs.cpp
+++ b/esp/services/ws_workunits/ws_workunitsAuditLogs.cpp
@@ -1622,6 +1622,19 @@ int CWsWorkunitsSoapBindingEx::onGet(CHttpRequest* request, CHttpResponse* respo
                 return CWsWorkunitsSoapBinding::onGet(request,response);
             return 0;
         }
+#ifdef _CONTAINERIZED
+        else if (!strnicmp(path.str(), "/WsWorkunits/WUFile", 19))
+        {
+            StringBuffer type;
+            request->getParameter("Type", type);
+            if (strieq(type.str(), File_ComponentLog))
+            {
+                CWsWuFileHelper helper(nullptr);
+                helper.sendWUComponentLogStreaming(request, response);
+                return 0;
+            }
+        }
+#endif
         else if (!strnicmp(path.str(), REQPATH_CREATEANDDOWNLOADZAP, sizeof(REQPATH_CREATEANDDOWNLOADZAP) - 1))
         {
             createAndDownloadWUZAPFile(*ctx, request, response);

--- a/esp/services/ws_workunits/ws_workunitsHelpers.cpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.cpp
@@ -206,8 +206,8 @@ WsWUExceptions::WsWUExceptions(IConstWorkUnit& wu): numerr(0), numwrn(0), numinf
     }
 }
 
-void WsWuInfo::readWorkunitComponentLogs(const char* outFile, unsigned maxLogRecords,
-                                         LogAccessReturnColsMode retColsMode, LogAccessLogFormat logFormat, unsigned wuLogSearchTimeBuffSecs)
+void WsWuInfo::readWorkunitComponentLogs(const char* outFile, unsigned maxLogRecords, const LogAccessReturnColsMode retColsMode,
+                                         const LogAccessLogFormat logFormat, unsigned wuLogSearchTimeBuffSecs)
 {
     if (!m_remoteLogAccessor)
         throw makeStringException(ECLWATCH_LOGACCESS_UNAVAILABLE, "WsWuInfo: Remote Log Access plug-in not available!");
@@ -216,41 +216,10 @@ void WsWuInfo::readWorkunitComponentLogs(const char* outFile, unsigned maxLogRec
         throw makeStringException(ECLWATCH_INVALID_FILE_NAME, "WsWuInfo: Target filename not provided!");
 
     LogAccessConditions logFetchOptions;
-    logFetchOptions.setFilter(getJobIDLogAccessFilter(wuid.str()));
-
-    struct LogAccessTimeRange range;
-    stat_type timeStamp;
-    if (cw->getStatistic(timeStamp, "", StWhenCreated))
-    {
-        CDateTime startt;
-        startt.set(timeStamp / microSecsToSecDivisor);
-
-        startt.adjustTimeSecs(-wuLogSearchTimeBuffSecs);
-        range.setStart(startt);
-
-        StringBuffer newstart;
-        startt.getString(newstart);
-        DBGLOG("Searching for WUID '%s' log entries starting time: '%s'", wuid.str(), newstart.str());
-    }
-    else
-        throw makeStringExceptionV(ECLWATCH_WU_START_NOT_AVAILABLE, "WsWuInfo: Cound not determine WUID '%s' start time", wuid.str());
-
-    if (cw->getStatistic(timeStamp, "", StWhenFinished))
-    {
-        CDateTime endt;
-        endt.set(timeStamp / microSecsToSecDivisor);
-        endt.adjustTimeSecs(wuLogSearchTimeBuffSecs);
-
-        range.setEnd(endt);
-        StringBuffer newend;
-        endt.getString(newend);
-        DBGLOG("Searching for WUID '%s' log entries ending time: '%s'", wuid.str(), newend.str()); //end + time buffer
-    }
-    else
-        WARNLOG("WsWuInfo: Fetching log entries for '%s' without a 'finished'", wuid.str());
+    logFetchOptions.setFilter(getJobIDLogAccessFilter(wuid));
+    setLogTimeRange(logFetchOptions, wuLogSearchTimeBuffSecs);
 
     logFetchOptions.setReturnColsMode(retColsMode);
-    logFetchOptions.setTimeRange(range);
     logFetchOptions.setLimit(maxLogRecords);
 
     Owned<IFileIOStream> outIOS;
@@ -260,7 +229,7 @@ void WsWuInfo::readWorkunitComponentLogs(const char* outFile, unsigned maxLogRec
     if(!outIOS)
         throw makeStringException(ECLWATCH_CANNOT_OPEN_FILE, "WsWuInfo: Could not create target log file!");
 
-    Owned<IRemoteLogAccessStream> logreader = m_remoteLogAccessor->getLogReader(logFetchOptions, logFormat);
+    Owned<IRemoteLogAccessStream> logReader = m_remoteLogAccessor->getLogReader(logFetchOptions, logFormat);
 
     StringBuffer logcontent;
     unsigned totalRecsRead = 0;
@@ -271,7 +240,7 @@ void WsWuInfo::readWorkunitComponentLogs(const char* outFile, unsigned maxLogRec
     else if (logFormat == LOGACCESS_LOGFORMAT_xml)
         writeStringToStream(*outIOS, "<lines>");
 
-    while (logreader->readLogEntries(logcontent.clear(), recsRead))
+    while (logReader->readLogEntries(logcontent.clear(), recsRead))
     {
         if (logFormat == LOGACCESS_LOGFORMAT_json && totalRecsRead > 0 && recsRead > 0)
         {
@@ -309,6 +278,141 @@ void WsWuInfo::readWorkunitComponentLogs(const char* outFile, unsigned maxLogRec
             writeStringToStream(*outIOS, "</lines>");
     }
 }
+
+void WsWuInfo::setLogTimeRange(LogAccessConditions& logFetchOptions, unsigned wuLogSearchTimeBuffSecs)
+{
+    struct LogAccessTimeRange range;
+    stat_type timeStamp;
+    if (cw->getStatistic(timeStamp, "", StWhenCreated))
+    {
+        CDateTime startt;
+        startt.set(timeStamp / microSecsToSecDivisor);
+
+        startt.adjustTimeSecs(-wuLogSearchTimeBuffSecs);
+        range.setStart(startt);
+
+        StringBuffer newstart;
+        startt.getString(newstart);
+        DBGLOG("Searching for WUID '%s' log entries starting time: '%s'", wuid.get(), newstart.str());
+    }
+    else
+        throw makeStringExceptionV(ECLWATCH_WU_START_NOT_AVAILABLE, "WsWuInfo: Cound not determine WUID '%s' start time", wuid.get());
+
+    if (cw->getStatistic(timeStamp, "", StWhenFinished))
+    {
+        CDateTime endt;
+        endt.set(timeStamp / microSecsToSecDivisor);
+        endt.adjustTimeSecs(wuLogSearchTimeBuffSecs);
+
+        range.setEnd(endt);
+        StringBuffer newend;
+        endt.getString(newend);
+        DBGLOG("Searching for WUID '%s' log entries ending time: '%s'", wuid.get(), newend.str()); //end + time buffer
+    }
+    else
+        WARNLOG("WsWuInfo: Fetching log entries for '%s' without a 'finished' statistics entry", wuid.get());
+
+    logFetchOptions.setTimeRange(range);
+}
+
+#ifdef _CONTAINERIZED
+void WsWuInfo::sendWorkunitComponentLogs(IEspContext* context, CHttpResponse* response, WUComponentLogOptions& options)
+{
+    if (!m_remoteLogAccessor)
+        throw makeStringException(ECLWATCH_LOGACCESS_UNAVAILABLE, "WsWuInfo: Remote Log Access plug-in not available!");
+
+    setLogTimeRange(options.logFetchOptions, options.wuLogSearchTimeBuffSecs);
+    options.logFetchOptions.setFilter(getJobIDLogAccessFilter(wuid));
+
+    response->setStatus(HTTP_STATUS_OK);
+    response->startSend();
+
+    Owned<CFlushingHttpResponseBuffer> flusher = new CFlushingHttpResponseBuffer(response, defaultResponseFlushThresholdBytes); //No need to use a different ResponseFlushThreshold.
+    Owned<IRemoteLogAccessStream> logReader = m_remoteLogAccessor->getLogReader(options.logFetchOptions, options.logFormat);
+    if (options.logFormat == LOGACCESS_LOGFORMAT_csv)
+        sendComponentLogCSV(context, logReader, flusher, options);
+    else if (options.logFormat == LOGACCESS_LOGFORMAT_json)
+        sendComponentLogJSON(context, logReader, flusher, options);
+    else
+        sendComponentLogXML(context, logReader, flusher, options);
+}
+
+void WsWuInfo::sendComponentLogCSV(IEspContext* context, IRemoteLogAccessStream* logReader, IXmlStreamFlusher* flusher, const WUComponentLogOptions& options)
+{
+    unsigned totalRecsRead = sendComponentLogContent(context, logReader, flusher, options);
+    if (totalRecsRead == options.logFetchOptions.getLimit()) //Warn of possible truncation
+    {
+        VStringBuffer truncationWarnmessage("Log query reached record limit (%u). Log report could be incomplete.", options.logFetchOptions.getLimit());
+        LOG(MCuserInfo, "WsWuInfo: %s", truncationWarnmessage.str());
+        flusher->flushXML(truncationWarnmessage, false);
+    }
+}
+
+void WsWuInfo::sendComponentLogJSON(IEspContext* context, IRemoteLogAccessStream* logReader, IXmlStreamFlusher* flusher, const WUComponentLogOptions& options)
+{
+    StringBuffer s("{\"lines\": [");
+    flusher->flushXML(s, false);
+    unsigned totalRecsRead = sendComponentLogContent(context, logReader, flusher, options);
+    if (totalRecsRead == options.logFetchOptions.getLimit()) //Warn of possible truncation
+    {
+        VStringBuffer truncationWarnmessage("Log query reached record limit (%u). Log report could be incomplete.", options.logFetchOptions.getLimit());
+        LOG(MCuserInfo, "WsWuInfo: %s", truncationWarnmessage.str());
+        VStringBuffer jsonMessage("], \"Message\": \"%s\"}", truncationWarnmessage.str()); //close lines array, append Message object
+        flusher->flushXML(jsonMessage, true);
+    }
+    else
+    {
+        s.set("]}");
+        flusher->flushXML(s, true);
+    }
+}
+
+void WsWuInfo::sendComponentLogXML(IEspContext* context, IRemoteLogAccessStream* logReader, IXmlStreamFlusher* flusher, const WUComponentLogOptions& options)
+{
+    StringBuffer s("<lines>");
+    flusher->flushXML(s, false);
+    unsigned totalRecsRead = sendComponentLogContent(context, logReader, flusher, options);
+    if (totalRecsRead == options.logFetchOptions.getLimit()) //Warn of possible truncation
+    {
+        VStringBuffer truncationWarnmessage("Log query reached record limit (%u). Log report could be incomplete.", options.logFetchOptions.getLimit());
+        LOG(MCuserInfo, "WsWuInfo: %s", truncationWarnmessage.str());
+        VStringBuffer xmlMessage("</lines>\n<!-- %s -->", truncationWarnmessage.str()); //close lines element, append comment message
+        flusher->flushXML(xmlMessage, true);
+    }
+    else
+    {
+        s.set("</lines>");
+        flusher->flushXML(s, true);
+    }
+}
+
+unsigned WsWuInfo::sendComponentLogContent(IEspContext* context, IRemoteLogAccessStream* logReader, IXmlStreamFlusher* flusher, const WUComponentLogOptions& options)
+{
+    CESPAbortRequestCallback abortCallback(context);
+
+    StringBuffer logContent;
+    unsigned totalRecsRead = 0;
+    unsigned recsRead = 0;
+    while (logReader->readLogEntries(logContent.clear(), recsRead))
+    {
+        if (options.logFormat == LOGACCESS_LOGFORMAT_json && totalRecsRead > 0 && recsRead > 0)
+        {
+            StringBuffer s(',');
+            flusher->flushXML(s, false);
+        }
+
+        totalRecsRead += recsRead;
+        flusher->flushXML(logContent, false);
+
+        if (abortCallback.abortRequested())
+        {
+            LOG(MCdebugInfo, unknownJob, "WsWuInfo::sendComponentLogContent(): abort requested via callback");
+            break;
+        }
+    }
+    return totalRecsRead;
+}
+#endif
 
 void WsWuInfo::getSourceFiles(IEspECLWorkunit &info, unsigned long flags)
 {
@@ -655,7 +759,16 @@ void WsWuInfo::getHelpers(IEspECLWorkunit &info, unsigned long flags)
             for (unsigned i = 0; i < FileTypeSize; i++)
                 getHelpFiles(query, (WUFileType) i, helpers, flags, helpersCount);
         }
-#ifndef _CONTAINERIZED
+#ifdef _CONTAINERIZED
+        helpersCount++;
+        if ((flags & WUINFO_IncludeHelpers))
+        {
+            Owned<IEspECLHelpFile> h = createECLHelpFile();
+            h->setName(File_ComponentLog);
+            h->setType(File_ComponentLog);
+            helpers.append(*h.getLink());
+        }
+#else
         getWorkunitThorLogInfo(helpers, info, flags, helpersCount);
 
         if (cw->getWuidVersion() > 0)
@@ -3922,6 +4035,127 @@ void CWsWuFileHelper::createWULogFile(IConstWorkUnit *cwu, WsWuInfo &winfo, cons
     }
 }
 
+#ifdef _CONTAINERIZED
+void CWsWuFileHelper::sendWUComponentLogStreaming(CHttpRequest* request, CHttpResponse* response)
+{
+    StringBuffer wuid, fileName;
+    request->getParameter("Wuid", wuid);
+    if (wuid.isEmpty())
+        throw makeStringException(ECLWATCH_INVALID_INPUT, "Empty Wuid detected");
+    request->getParameter("Name", fileName);
+    if (fileName.isEmpty())
+        throw makeStringException(ECLWATCH_INVALID_INPUT, "Empty Name detected");
+
+    IEspContext* ctx = request->queryContext();
+    Owned<CWULogFileRequest> espRequest = new CWULogFileRequest(ctx, "WsWorkunits", request->queryParameters(), request->queryAttachments());
+
+    WUComponentLogOptions options;
+    readWUComponentLogOptionsReq(espRequest->getFileOptions(), options);
+
+    WsWuInfo winfo(*ctx, wuid.str());
+    int option = request->getParameterInt("Option", CWUFileDownloadOption_OriginalText); //0: original content; 1: content as attachment; 2: zip; 3: gzip.
+    if ((option < CWUFileDownloadOption_OriginalText) || (option > CWUFileDownloadOption_GZIP))
+        throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "Invalid WU File Download option detected: '%d'", option);
+
+    CWUFileDownloadOption opt = (CWUFileDownloadOption) option;
+    if ((opt == CWUFileDownloadOption_OriginalText) || (opt == CWUFileDownloadOption_Attachment))
+    {
+        if (opt == CWUFileDownloadOption_OriginalText)
+        {
+            if (options.logFormat == LOGACCESS_LOGFORMAT_csv)
+                ctx->setResponseFormat(ESPSerializationCSV);
+            else if (options.logFormat == LOGACCESS_LOGFORMAT_json)
+                ctx->setResponseFormat(ESPSerializationJSON);
+            else
+                ctx->setResponseFormat(ESPSerializationXML);
+        }
+        else
+        {
+            VStringBuffer headerStr("attachment;filename=%s", fileName.str());
+            if (options.logFormat == LOGACCESS_LOGFORMAT_csv)
+                headerStr.append(".csv");
+            else if (options.logFormat == LOGACCESS_LOGFORMAT_json)
+                headerStr.append(".json");
+            else
+                headerStr.append(".xml");
+            ctx->addCustomerHeader("Content-disposition", headerStr.str());
+        }
+
+        winfo.sendWorkunitComponentLogs(ctx, response, options);
+    }
+    else
+    {   //zip or gzip the WUComponentLog
+        StringBuffer workingFolder, resultFileNameWithPath;
+
+        unsigned currentTime = msTick();
+        workingFolder.setf("%s%sT%xAT%x", TEMPZIPDIR, PATHSEPSTR, (unsigned)(memsize_t)GetCurrentThreadId(), currentTime);
+        resultFileNameWithPath.setf("%s%s%s", workingFolder.str(), PATHSEPSTR, fileName.str());
+        recursiveCreateDirectoryForFile(resultFileNameWithPath);
+        //Read the WUComponentLog into a file
+        winfo.readWorkunitComponentLogs(resultFileNameWithPath, options.logFetchOptions.getLimit(), options.logFetchOptions.getReturnColsMode(), options.logFormat, options.wuLogSearchTimeBuffSecs);
+
+        VStringBuffer headerStr("attachment;filename=%s", fileName.str());
+        if (opt == CWUFileDownloadOption_GZIP)
+            headerStr.append(".gz");
+        else
+            headerStr.append(".zip");
+        ctx->addCustomerHeader("Content-disposition", headerStr.str());
+
+        //zip or gzip
+        StringBuffer zipFileNameWithPath(resultFileNameWithPath);
+        zipFileNameWithPath.append((opt == CWUFileDownloadOption_GZIP) ? ".gz" : ".zip");
+        StringBuffer zipCommand;
+        if (opt == CWUFileDownloadOption_GZIP)
+            zipCommand.setf("tar -czf %s -C %s %s", zipFileNameWithPath.str(), workingFolder.str(), fileName.str());
+        else
+            zipCommand.setf("zip -j %s %s", zipFileNameWithPath.str(), resultFileNameWithPath.str());
+        if (system(zipCommand) != 0)
+            throw makeStringExceptionV(ECLWATCH_CANNOT_COMPRESS_DATA, "Failed to execute system command '%s'. Please make sure that zip utility is installed.",
+                (opt == CWUFileDownloadOption_GZIP) ? "tar" : "zip");
+
+        //Send the zipped file and clean the workingFolder.
+        response->setContent(createIOStreamWithFileName(zipFileNameWithPath, IFOread));
+        if (opt == CWUFileDownloadOption_GZIP)
+            response->setContentType("application/x-gzip");
+        else
+            response->setContentType("application/zip");
+        response->send();
+        recursiveRemoveDirectory(workingFolder);
+    }
+}
+
+void CWsWuFileHelper::readWUComponentLogOptionsReq(IConstWUFileOption& logOptionReq, WUComponentLogOptions& options)
+{
+    //If MaxLogRecords is in logOptionReq, use it; otherwise, default to 100 in LogAccessConditions.
+    if (!logOptionReq.getMaxLogRecords_isNull())
+        options.logFetchOptions.setLimit(logOptionReq.getMaxLogRecords());
+    //If LogSearchTimeBuffSecs is in logOptionReq, use it; otherwise, default to defaultWULogSearchTimeBufferSecs.
+    if (!logOptionReq.getLogSearchTimeBuffSecs_isNull())
+        options.wuLogSearchTimeBuffSecs = logOptionReq.getLogSearchTimeBuffSecs();
+    CLogAccessLogFormat logFormatSetting = logOptionReq.getLogFormat();
+    if (logFormatSetting != LogAccessLogFormat_Undefined)
+        options.logFormat = (LogAccessLogFormat) logFormatSetting;
+    else
+        options.logFormat = LOGACCESS_LOGFORMAT_csv;
+    switch (logOptionReq.getLogSelectColumnMode())
+    {
+    case CLogSelectColumnMode_MIN:
+        options.logFetchOptions.setReturnColsMode(RETURNCOLS_MODE_min);
+        break;
+    case CLogSelectColumnMode_ALL:
+        options.logFetchOptions.setReturnColsMode(RETURNCOLS_MODE_all);
+        break;
+    case CLogSelectColumnMode_CUSTOM:
+        options.logFetchOptions.setReturnColsMode(RETURNCOLS_MODE_custom);
+        options.logFetchOptions.copyLogFieldNames(logOptionReq.getLogColumns());
+        break;
+    default:
+        options.logFetchOptions.setReturnColsMode(RETURNCOLS_MODE_default);
+        break;
+    }
+}
+#endif
+
 void CWsWuFileHelper::createZAPWUGraphProgressFile(const char* wuid, const char* pathNameStr)
 {
     Owned<IPropertyTree> graphProgress = getWUGraphProgress(wuid, true);
@@ -4330,6 +4564,34 @@ void CWsWuFileHelper::readWUFile(const char* wuid, const char* workingFolder, Ws
         fileMimeType.set(HTTP_TYPE_TEXT_PLAIN);
         fileNameWithPath.set(workingFolder).append(PATHSEPCHAR).append(fileName.str());
         winfo.getWorkunitEclAgentLog(nullptr, file, item.getProcess(), mb, fileNameWithPath.str());
+        break;
+    }
+#else
+    case CWUFileType_ComponentLog:
+    {
+        WUComponentLogOptions options;
+        readWUComponentLogOptionsReq(item, options);
+
+        fileName.set(File_ComponentLog);
+        if (options.logFormat == LOGACCESS_LOGFORMAT_csv)
+        {
+            fileMimeType.set(HTTP_TYPE_TEXT_PLAIN);
+            fileName.append(".csv");
+        }
+        else if (options.logFormat == LOGACCESS_LOGFORMAT_json)
+        {
+            fileMimeType.set(HTTP_TYPE_JSON);
+            fileName.append(".json");
+        }
+        else
+        {
+            fileMimeType.set(HTTP_TYPE_APPLICATION_XML);
+            fileName.append(".xml");
+        }
+        fileNameWithPath.set(workingFolder).append(PATHSEPCHAR).append(fileName.str());
+
+        winfo.readWorkunitComponentLogs(fileNameWithPath, options.logFetchOptions.getLimit(), options.logFetchOptions.getReturnColsMode(),
+            options.logFormat, options.wuLogSearchTimeBuffSecs);
         break;
     }
 #endif

--- a/esp/src/eclwatch/HelpersWidget.js
+++ b/esp/src/eclwatch/HelpersWidget.js
@@ -49,6 +49,9 @@ define([
                 case "res":
                     params = "/WUFile/res.txt?Wuid=" + this.wu.Wuid + "&Type=" + item.Orig.Type;
                     break;
+                case "ComponentLog":
+                    params = "/WUFile/" + item.Type + "?Wuid=" + this.wu.Wuid + "&Name=" + item.Orig.Name + "&Type=" + item.Orig.Type;
+                    break;
                 case "EclAgentLog":
                     params = "/WUFile/" + item.Type + "?Wuid=" + this.wu.Wuid + "&Process=" + item.Orig.PID + "&Name=" + item.Orig.Name + "&Type=" + item.Orig.Type;
                     break;

--- a/esp/src/src-react/components/Helpers.tsx
+++ b/esp/src/src-react/components/Helpers.tsx
@@ -30,6 +30,9 @@ function getURL(item: HelperRow, option) {
         case "res":
             params = "/WUFile/res.txt?Wuid=" + item.workunit.Wuid + "&Type=" + item.Orig.Type;
             break;
+        case "ComponentLog":
+            params = "/WUFile/" + item.Type + "?Wuid=" + item.workunit.Wuid + "&Name=" + item.Orig.Name + "&Type=" + item.Orig.Type;
+            break;
         case "EclAgentLog":
             params = "/WUFile/" + item.Type + "?Wuid=" + item.workunit.Wuid + "&Process=" + item.Orig.PID + "&Name=" + item.Orig.Name + "&Type=" + item.Orig.Type;
             break;


### PR DESCRIPTION
1. Report Component Logs in WUInfo response.
2. Send the WUFile request from ECLWatch to ESP.
3. When the WUFile request has a zip option, use the
existing readWorkunitComponentLogs() to read the
Component Logs into a file, zip the file, and send it
out.
4. When the WUFile request has no zip option, use the
IRemoteLogAccessStream to read Component Logs into new
CFlushingHttpResponseBuffer and send the Logs chuck by
chuck.

Signed-off-by: wangkx <kevin.wang@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
