### PR TITLE
HPCC-27176 Fix incorrect warning about udp configuration on startup

### DIFF
--- a/roxie/ccd/ccdmain.cpp
+++ b/roxie/ccd/ccdmain.cpp
@@ -1012,7 +1012,8 @@ int CCD_API roxie_main(int argc, const char *argv[], const char * defaultYaml)
         unsigned __int64 defaultNetworkSpeed = 10 * U64C(0x40000000); // 10Gb/s
         unsigned __int64 networkSpeed = topology->getPropInt64("@udpNetworkSpeed", defaultNetworkSpeed);   // only used to sanity check the different udp options
         unsigned udpQueueSize = topology->getPropInt("@udpQueueSize", UDP_QUEUE_SIZE);
-        sanityCheckUdpSettings(udpQueueSize, numChannels, networkSpeed);
+        unsigned udpSendQueueSize = topology->getPropInt("@udpSendQueueSize", UDP_SEND_QUEUE_SIZE);
+        sanityCheckUdpSettings(udpQueueSize, udpSendQueueSize, numChannels, networkSpeed);
 
         int ttlTmp = topology->getPropInt("@multicastTTL", 1);
         if (ttlTmp < 0)

--- a/roxie/udplib/udpsha.cpp
+++ b/roxie/udplib/udpsha.cpp
@@ -483,7 +483,7 @@ void PacketTracker::dump() const
 
 //---------------------------------------------------------------------------------------------------------------------
 
-void sanityCheckUdpSettings(unsigned receiveQueueSize, unsigned numSenders, __uint64 networkSpeedBitsPerSecond)
+void sanityCheckUdpSettings(unsigned receiveQueueSize, unsigned sendQueueSize, unsigned numSenders, __uint64 networkSpeedBitsPerSecond)
 {
     unsigned maxDataPacketSize = 0x2000;    // assume jumbo frames roxiemem::DATA_ALIGNMENT_SIZE;
     __uint64 bytesPerSecond = networkSpeedBitsPerSecond / 10;
@@ -516,10 +516,11 @@ void sanityCheckUdpSettings(unsigned receiveQueueSize, unsigned numSenders, __ui
         trace("udpRequestTimeout", udpRequestTimeout, (2 * minLatencyNs + minTimeForPermitPackets) * 2 / 5, 10);
         trace("udpResendDelay", udpResendDelay, minTimeForAllPackets, 10);
         DBGLOG("udpMaxPendingPermits: %u [%u..%u]", udpMaxPendingPermits, udpMaxPendingPermits, udpMaxPendingPermits);
-        DBGLOG("udpMaxClientPercent: %u [%u..%u]", udpMaxClientPercent, 100, 500);
+        DBGLOG("udpMaxClientPercent: %u [%u..%u]", udpMaxClientPercent, 100, udpMaxPendingPermits * 100);
         DBGLOG("udpMaxPermitDeadTimeouts: %u [%u..%u]", udpMaxPermitDeadTimeouts, 2, 10);
         DBGLOG("udpRequestDeadTimeout: %u [%u..%u]", udpRequestDeadTimeout, 10000, 120000);
         DBGLOG("udpMinSlotsPerSender: %u [%u..%u]", udpMinSlotsPerSender, 1, 5);
+        DBGLOG("Queue sizes: send(%u) receive(%u)", sendQueueSize, receiveQueueSize);
     }
 
     // Some sanity checks
@@ -558,7 +559,7 @@ void sanityCheckUdpSettings(unsigned receiveQueueSize, unsigned numSenders, __ui
         WARNLOG("udpMaxPendingPermits=1: only one sender can send at a time");
     if (udpMaxClientPercent < 100)
         ERRLOG("udpMaxClientPercent should be >= 100");
-    else if (maxSlotsPerClient * udpMaxClientPercent / 100 > receiveQueueSize)
+    else if (maxSlotsPerClient > receiveQueueSize)
         ERRLOG("maxSlotsPerClient * udpMaxClientPercent exceeds the queue size => all slots will be initially allocated to the first sender");
     if (udpMinSlotsPerSender > 10)
         ERRLOG("udpMinSlotsPerSender of %u is higher than recommended", udpMinSlotsPerSender);

--- a/roxie/udplib/udpsha.hpp
+++ b/roxie/udplib/udpsha.hpp
@@ -278,7 +278,7 @@ inline bool checkTraceLevel(unsigned category, unsigned level)
     return (udpTraceLevel >= level);
 }
 
-extern UDPLIB_API void sanityCheckUdpSettings(unsigned receiveQueueSize, unsigned numSenders, __uint64 networkSpeedBitsPerSecond);
+extern UDPLIB_API void sanityCheckUdpSettings(unsigned receiveQueueSize, unsigned sendQueueSize, unsigned numSenders, __uint64 networkSpeedBitsPerSecond);
 
 
 #define SOCKET_SIMULATION

--- a/roxie/udplib/udpsim.cpp
+++ b/roxie/udplib/udpsim.cpp
@@ -226,7 +226,7 @@ void initOptions(int argc, const char **argv)
     if (options->getPropBool("sanityCheckUdpSettings", true))
     {
         unsigned __int64 networkSpeed = options->getPropInt64("@udpNetworkSpeed", 10 * U64C(0x40000000));
-        sanityCheckUdpSettings(numReceiveSlots, numThreads, networkSpeed);
+        sanityCheckUdpSettings(numReceiveSlots, 100, numThreads, networkSpeed);
     }
 }
 


### PR DESCRIPTION
Signed-off-by: Gavin Halliday <gavin.halliday@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [ ] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [x] Existing deployed queries will not be broken
  - [x] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
