### PR TITLE
HPCC-27538 Remove redundant XML encoding

### DIFF
--- a/system/xmllib/CMakeLists.txt
+++ b/system/xmllib/CMakeLists.txt
@@ -59,6 +59,7 @@ include_directories (
          ./../../rtl/include
          ./../../rtl/eclrtl
          ${LIB_INCLUDE_DIR}
+         ${HPCC_SOURCE_DIR}/testing/unittests
     )
 
 ADD_DEFINITIONS( -D_USRDLL -DXMLLIB_EXPORTS )
@@ -70,3 +71,7 @@ target_link_libraries ( xmllib
          eclrtl
          jlib
     )
+
+IF (USE_CPPUNIT)
+  target_link_libraries (xmllib ${CPPUNIT_LIBRARIES})
+ENDIF()

--- a/system/xmllib/libxml_xpathprocessor.cpp
+++ b/system/xmllib/libxml_xpathprocessor.cpp
@@ -262,8 +262,11 @@ public:
     }
     virtual void outputUnicode(unsigned len, const UChar *field, const char *fieldname) override
     {
-        StringBuffer out;
-        outputXmlUnicode(len, field, nullptr, out);
+        char * buff = 0;
+        unsigned bufflen = 0;
+        rtlUnicodeToCodepageX(bufflen, buff, len, field, "utf-8");
+        StringBuffer out(bufflen, buff);
+        rtlFree(buff);
         addNameValue(fieldname, out.str());
     }
     virtual void outputQString(unsigned len, const char *field, const char *fieldname) override
@@ -304,8 +307,8 @@ public:
     }
     virtual void outputUtf8(unsigned len, const char *field, const char *fieldname) override
     {
-        StringBuffer out;
-        outputXmlUtf8(len, field, nullptr, out);
+        unsigned bytes = rtlUtf8Size(len, field);
+        StringBuffer out(bytes, field);
         addNameValue(fieldname, out.str());
     }
     virtual void outputBeginArray(const char *fieldname){} //no op for libxml structure
@@ -1546,7 +1549,7 @@ private:
     inline void sanityCheckSectionName(const char *name)
     {
         //sanity check the name, not a full validation
-        if (strpbrk(name, "/[]()*?"))
+        if (isEmptyString(name) || strpbrk(name, "/[]()*?"))
             throw MakeStringException(-1, "CEsdlScriptContext:removeSection invalid section name %s", name);
     }
     xmlNodePtr getSectionNode(const char *name, const char *xpath="*[1]")
@@ -1897,3 +1900,74 @@ extern IXpathContext* getXpathContext(const char * xmldoc, bool strictParameterD
 {
     return new CLibXpathContext(xmldoc, strictParameterDeclaration, removeDocNamespaces);
 }
+
+#ifdef _USE_CPPUNIT
+#include "unittests.hpp"
+
+class LibXml2XPathProcessorTests : public CppUnit::TestFixture
+{
+    CPPUNIT_TEST_SUITE( LibXml2XPathProcessorTests );
+        CPPUNIT_TEST(testWriteUTF8);
+    CPPUNIT_TEST_SUITE_END();
+
+public:
+    void testWriteUTF8()
+    {
+        bool failed = false;
+        if (!checkXmlWriterUtf8("testWriteUTF8", "an_element", R"!!!(contains "quoted" text)!!!"))
+            failed = true;
+        if (!checkXmlWriterUtf8("testWriteUTF8", "@an_attribute", R"!!!(contains "quoted" text)!!!"))
+            failed = true;
+        CPPUNIT_ASSERT(!failed);
+    }
+
+private:
+    IEsdlScriptContext* createScriptContext(const char* section, const char* content)
+    {
+        Owned<IEsdlScriptContext> ctx(createEsdlScriptContext(nullptr)); // context holds but does not use IEspContext* parameter
+        ctx->setContent(section, content);
+        return ctx.getClear();
+    }
+    IXpathContext* createXPathContext(IEsdlScriptContext* scriptCtx, const char* section)
+    {
+        Owned<IXpathContext> xpathCtx;
+        try
+        {
+            xpathCtx.setown(scriptCtx->createXpathContext(nullptr, section, true));
+        }
+        catch (IException* e)
+        {
+            StringBuffer msg;
+            fprintf(stdout, "\nexception creating XPath context for section '%s' [%s]\n", section, e->errorMessage(msg).str());
+            throw;
+        }
+        catch (...)
+        {
+            fprintf(stdout, "\nunknown exception creating XPath context for section '%s'\n", section);
+            throw;
+        }
+        return xpathCtx.getClear();
+    }
+    bool checkXmlWriterUtf8(const char* test, const char* name, const char* value)
+    {
+        static constexpr const char* section = "writer";
+        Owned<IEsdlScriptContext>    scriptCtx(createScriptContext(section, "<this_node_is_required_to_satisfy_createXPathContext/>"));
+        Owned<IXpathContext>         xpathCtx(createXPathContext(scriptCtx, section));
+        Owned<IXmlWriter>            writer(xpathCtx->createXmlWriter());
+        StringBuffer                 stored;
+    
+        writer->outputUtf8(rtlUtf8Length(unsigned(strlen(value)), value), value, name);
+        if (!xpathCtx->evaluateAsString(name, stored))
+            fprintf(stdout, "\n%s: evaluation of '%s' failed\n", test, name);
+        else if (!streq(stored, value))
+            fprintf(stdout, "\n%s: expected '%s' but got '%s'\n", test, value, stored.str());
+        else
+            return true;
+        return false;
+    }
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION( LibXml2XPathProcessorTests );
+CPPUNIT_TEST_SUITE_NAMED_REGISTRATION( LibXml2XPathProcessorTests, "libxml2xpath" );
+
+#endif // _USE_CPPUNIT


### PR DESCRIPTION
Correct duplicate XML encoding found in ESDL integration scripts using the mysql operation.

- Replace outputXmlUtf8 and outputXmlUnicode function calls to avoid
  unnecessary XML encoding.
- Add unit test for UTF-8 output. Unicode output is unused.

Signed-off-by: Tim Klemm <tim.klemm@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [x] I have added tests to cover my changes.
  - [x] All new and existing tests passed.
  - [x] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
