### PR TITLE
HPCC-27619 Fix generated code for embed source activities in child queries

### DIFF
--- a/ecl/hqlcpp/hqlccommon.cpp
+++ b/ecl/hqlcpp/hqlccommon.cpp
@@ -28,6 +28,7 @@ IHqlExpression * activeMatchUtf8Expr;
 IHqlExpression * activeNlpMarkerExpr;
 IHqlExpression * activeProductionMarkerExpr;
 IHqlExpression * activeValidateMarkerExpr;
+IHqlExpression * activityContextMarkerExpr;
 IHqlExpression * classMarkerExpr;
 IHqlExpression * codeContextMarkerExpr;
 IHqlExpression * colocalSameClassPreserveExpr;
@@ -50,6 +51,7 @@ MODULE_INIT(INIT_PRIORITY_STANDARD)
     activeNlpMarkerExpr = createAttribute(activeNlpAtom);
     activeProductionMarkerExpr = createAttribute(activeProductionMarkerAtom);
     activeValidateMarkerExpr = createAttribute(activeValidateMarkerAtom);
+    activityContextMarkerExpr = createQuoted("activityContextMarker", makeVoidType());
     classMarkerExpr = createAttribute(classAtom);
     codeContextMarkerExpr = createQuoted("codeContextMarker", makeVoidType());
     colocalSameClassPreserveExpr = createVariable("internalColocalShouldNeverBeUsed", makeVoidType());
@@ -72,6 +74,7 @@ MODULE_EXIT()
     colocalSameClassPreserveExpr->Release();
     codeContextMarkerExpr->Release();
     classMarkerExpr->Release();
+    activityContextMarkerExpr->Release();
     activeValidateMarkerExpr->Release();
     activeProductionMarkerExpr->Release();
     activeNlpMarkerExpr->Release();

--- a/ecl/hqlcpp/hqlccommon.hpp
+++ b/ecl/hqlcpp/hqlccommon.hpp
@@ -25,6 +25,7 @@ extern IHqlExpression * activeMatchUtf8Expr;
 extern IHqlExpression * activeNlpMarkerExpr;
 extern IHqlExpression * activeProductionMarkerExpr;
 extern IHqlExpression * activeValidateMarkerExpr;
+extern IHqlExpression * activityContextMarkerExpr;
 extern IHqlExpression * classMarkerExpr;
 extern IHqlExpression * codeContextMarkerExpr;
 extern IHqlExpression * colocalSameClassPreserveExpr;

--- a/ecl/hqlcpp/hqlcppds.cpp
+++ b/ecl/hqlcpp/hqlcppds.cpp
@@ -1812,6 +1812,9 @@ void HqlCppTranslator::buildAssignChildDataset(BuildCtx & ctx, const CHqlBoundTa
     {
     case no_call:
     case no_externalcall:
+        if (callIsActivity(expr) && !ctx.queryMatchExpr(activityContextMarkerExpr))
+            break;
+        //fallthrough
     case no_libraryinput:
         buildDatasetAssign(ctx, target, expr);
         return;
@@ -2554,6 +2557,8 @@ void HqlCppTranslator::buildDatasetAssign(BuildCtx & ctx, const CHqlBoundTarget 
         return;
     case no_call:
     case no_externalcall:
+        if (callIsActivity(expr) && !ctx.queryMatchExpr(activityContextMarkerExpr))
+            break;
         doBuildCall(ctx, &target, expr, NULL);
         return;
     case no_getgraphresult:

--- a/ecl/hqlcpp/hqlhtcpp.cpp
+++ b/ecl/hqlcpp/hqlhtcpp.cpp
@@ -9053,11 +9053,13 @@ ABoundActivity * HqlCppTranslator::doBuildActivityEmbed(BuildCtx & ctx, IHqlExpr
     {
         MemberFunction func(*this, instance->startctx, "virtual IRowStream * createOutput(IThorActivityContext * activityContext) override");
         OwnedITypeInfo streamedType = setStreamedAttr(newCall->queryType(), true);
+        func.ctx.associateExpr(activityContextMarkerExpr, queryBoolExpr(true));
         buildReturn(func.ctx, newCall, streamedType);
     }
     else
     {
         MemberFunction func(*this, instance->startctx, "virtual void execute(IThorActivityContext * activityContext) override");
+        func.ctx.associateExpr(activityContextMarkerExpr, queryBoolExpr(true));
         buildStmt(func.ctx, newCall);
     }
 


### PR DESCRIPTION

The code generator needs to create a child activity because only then will
the activityCodeContext be available to pass to the embedded function.

Signed-off-by: Gavin Halliday <gavin.halliday@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [x] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
