### PR TITLE
HPCC-25635 support CSI driver as default storage implementation on AKS

### DIFF
--- a/helm/examples/azure/README.md
+++ b/helm/examples/azure/README.md
@@ -1,5 +1,7 @@
 # HPCC Azure storage
 
+For Kubernetes server version 1.21+ the Azure Files {standard} Container Storage Interface (CSI) driver is used by Azure Kubernetes Service (AKS) to manage the lifecycle of Azure File shares. Currently most AKS regions are using Kubernetes version 1.21 and above. To "Dynamically generate a storage account and shared volume with Storage Class" choose either "file.csi.azure.com" (CSI based) or "kubernetes.io/azure-file" as a legacy provisioner without CSI, for the older Kubernetes versions.
+
 ## Directory contents
 
 ### values-auto-azurefile.yaml

--- a/helm/examples/azure/hpcc-azurefile/templates/create-pvc.yaml
+++ b/helm/examples/azure/hpcc-azurefile/templates/create-pvc.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   accessModes:
     - {{ $plane.rwmany | default false | ternary "ReadWriteMany" "ReadWriteOnce" }}
-  storageClassName: {{ include "hpcc-azurefile.SCName" (dict "root" $ "plane" $plane) | default "" | quote  }}
+  storageClassName: {{ include "hpcc-azurefile.SCName" (dict "root" $ "plane" $plane) | default "azurefile-csi" | quote  }}
   resources:
     requests:
       storage: {{ $plane.size }}

--- a/helm/examples/azure/hpcc-azurefile/values.schema.json
+++ b/helm/examples/azure/hpcc-azurefile/values.schema.json
@@ -16,6 +16,11 @@
           "description": "Kubernetes namespace for secret",
           "type": "string",
           "default": "default"
+        },
+        "provisioner": {
+          "description": "StorageClass provisioner determines what volume plugin is used for provisioning PVs",
+          "type": "string",
+          "default": "file.csi.azure.com"
         }
       }
     },
@@ -70,6 +75,10 @@
         },
         "shareName": {
           "description": "Azure storage share name",
+          "type": "string"
+        },
+        "volumeId": {
+          "description": "make sure this volumeid is unique in the cluster",
           "type": "string"
         }
       },

--- a/helm/examples/azure/hpcc-azurefile/values.yaml
+++ b/helm/examples/azure/hpcc-azurefile/values.yaml
@@ -3,6 +3,7 @@ common:
   mountPrefix: "/var/lib/HPCCSystems"
   #secretName: "azure-secret"
   #secretNamespace: "default"
+  provisioner: "file.csi.azure.com" # Set to "kubernetes.io/azure-file" if not using the csi driver but it is not recommended.
 
 planes:
 - name: dali
@@ -11,6 +12,7 @@ planes:
   category: dali
   #sku: "Standard_LRS"
   #shareName: dalishare
+  #volumeId: "100-dali"
 - name: dll
   subPath: queries # cannot currently be changed
   size: 1Gi
@@ -18,6 +20,7 @@ planes:
   rwmany: true
   #sku: "Standard_LRS"
   #shareName: dllsshare
+  #volumeId: "100-queries"
 - name: sasha
   subPath: sasha
   size: 1Gi
@@ -25,6 +28,7 @@ planes:
   category: sasha
   #sku: "Standard_LRS"
   #shareName: sashashare
+  #volumeId: "100-sasha"
 - name: data
   subPath: hpcc-data # cannot currently be changed
   size: 3Gi
@@ -32,6 +36,7 @@ planes:
   rwmany: true
   #sku: "Standard_LRS"
   #shareName: datashare
+  #volumeId: "100-data"
 - name: mydropzone
   subPath: dropzone
   size: 1Gi
@@ -39,3 +44,4 @@ planes:
   category: lz
   #sku: "Standard_LRS"
   #shareName: lzshare
+  #volumeId: "100-mydropzone"

--- a/helm/examples/azure/sa/create-sa.sh
+++ b/helm/examples/azure/sa/create-sa.sh
@@ -55,7 +55,7 @@ for shareName in $SHARE_NAMES
 do
   az storage share exists --connection-string "${AZURE_STORAGE_CONNECTION_STRING}" \
     --name  $shareName | grep -q  "\"exists\":[[:space:]]*false"
-  if [ $? -ne 0 ]
+  if [ $? -eq 0 ]
   then
     echo "create share $shareName"
     az storage share create \


### PR DESCRIPTION
The Azure Files Container Storage Interface (CSI) driver is a [CSI specification](https://github.com/container-storage-interface/spec/blob/master/spec.md)-compliant driver used by Azure Kubernetes Service (AKS) to manage the lifecycle of Azure Files shares.

From Kubernetes 1.21+ AKS will automatically install CSI driver on each node and make CSI based storage class as default with provisioner file.csi.azure.com

There are three types of Azurefile we currently support in helm/examples/azure:

1. Auto. We don't need do anything. It will use csi storage class. Lifecycle: HPCC   cluster.
2. create a storage class with dynamic storage account and share drives. We add CSI storage class (file.csi.azure.com provisioner) as default. But you can set as legacy provisioner to "kubernetes.io/azure-file". Lifecycle: AKS if not manually delete
3. Manually create a storage account and shares. We only support CSI storage class. Lifecycle:  storage account. This can survive even the AKS is destroyed. "volumeId" is required and should be unique on cluster. We did have default one for each share so it is optional for user.

Also update examples/azure/README.md

 Signed-off-by: Xiaoming Wang <xiaoming.wang@lexisnexis.com>


## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [ ] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->
Tested all three scenarios on AKS

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
