### PR TITLE
HPCC-27651 Compress external string values

### DIFF
--- a/dali/base/dasds.hpp
+++ b/dali/base/dasds.hpp
@@ -141,7 +141,7 @@ interface IExternalHandler : extends IInterface
     virtual void resetAsExternal(IPropertyTree &tree) = 0;
     virtual void write(const char *name, IPropertyTree &tree) = 0;
     virtual void read(const char *name, IPropertyTree &owner, MemoryBuffer &mb, bool withValue=true) = 0;
-    virtual void readValue(const char *name, MemoryBuffer &mb) = 0;
+    virtual void readValue(const char *name, MemoryBuffer &mb, const IPropertyTree &tree) = 0;
     virtual void remove(const char *name) = 0;
     virtual bool isValid(const char *name) = 0;
     virtual StringBuffer &getName(StringBuffer &fName, const char *base) = 0;

--- a/dali/base/dasds.ipp
+++ b/dali/base/dasds.ipp
@@ -30,6 +30,13 @@
 
 #define EXTERNAL_NAME_PREFIX "dalisds_"
 #define EXT_ATTR "@sds:ext"
+#define EXT_ATTR_FLAGS "@sds:ext.flags" // NB: must have common prefix (sds:ext)
+enum class SdsExtFlags
+{
+    none           = 0,
+    compressedText = 1
+};
+BITMASK_ENUM(SdsExtFlags);
 #define EF_LegacyBinaryValue "bin"
 #define EF_BinaryValue       "bv2"
 #define EF_XML         "xml"


### PR DESCRIPTION
Convert string blobs to compressed format, and denote with
extra flag, so that they can be converted back to uncompressed
on read.
This preserves a common format although if Dali was rolled
back, anything accessing these values via the IPT::queryProp
interface, would not see the correct data (i.e. compressed raw
value)

Also fix a minor bug where a property remained flagged as binary,
if it was originally set as binary then set as non-binary,
which had the side effect of returning an extra terminator byte
in the property value.

Signed-off-by: Jake Smith <jake.smith@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [x] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
