### PR TITLE
HPCC-25041 Fold ftslave functionality into dafilesrv

### DIFF
--- a/dali/dfu/dfurun.cpp
+++ b/dali/dfu/dfurun.cpp
@@ -530,6 +530,7 @@ class CDFUengine: public CInterface, implements IDFUengine
         }
     }
 
+    Linked<const IPropertyTree> config;
     Owned<IScheduleEventPusher> eventpusher;
     IArrayOf<cDFUlistener> listeners;
 
@@ -540,7 +541,7 @@ class CDFUengine: public CInterface, implements IDFUengine
 public:
     IMPLEMENT_IINTERFACE;
 
-    CDFUengine()
+    CDFUengine(const IPropertyTree *_config) : config(_config)
     {
         defaultTransferBufferSize = 0;
         runningflag = 1;
@@ -1104,6 +1105,12 @@ public:
         IConstDFUfileSpec *destination = wu->queryDestination();
         IConstDFUoptions *options = wu->queryOptions();
         Owned<IPropertyTree> opttree = createPTreeFromIPT(options->queryTree());
+
+        // in bare-metal continue by default to use ftslave
+        bool defaultUseFtSlave = isContainerized() ? false : true;
+        bool useFtSlave = config->getPropBool("@useFtSlave", defaultUseFtSlave);
+        opttree->setPropBool("@useFtSlave", useFtSlave);
+        opttree->setProp("@sprayServiceName", config->queryProp("@sprayServiceName"));
         StringAttr encryptkey;
         StringAttr decryptkey;
         if (options->getEncDec(encryptkey,decryptkey)) {
@@ -1808,9 +1815,9 @@ public:
 };
 
 
-IDFUengine *createDFUengine()
+IDFUengine *createDFUengine(const IPropertyTree *config)
 {
-    return new CDFUengine;
+    return new CDFUengine(config);
 }
 
 void stopDFUserver(const char *qname)

--- a/dali/dfu/dfuserver.cpp
+++ b/dali/dfu/dfuserver.cpp
@@ -191,7 +191,7 @@ int main(int argc, const char *argv[])
             startLogMsgParentReceiver();    // for auditing
             connectLogMsgManagerToDali();
 
-            engine.setown(createDFUengine());
+            engine.setown(createDFUengine(globals));
             engine->setDFUServerName(name);
             addAbortHandler(exitDFUserver);
 

--- a/dali/ft/CMakeLists.txt
+++ b/dali/ft/CMakeLists.txt
@@ -21,6 +21,7 @@ project (all)
 if ( PLATFORM )
     include (ftslave.cmake)
 endif()
+include (ftslavelib.cmake)
 include (dalift.cmake)
 
 

--- a/dali/ft/daftformat.hpp
+++ b/dali/ft/daftformat.hpp
@@ -99,6 +99,7 @@ typedef IArrayOf<IFormatPartitioner> FormatPartitionerArray;
 extern DALIFT_API IFormatProcessor * createFormatProcessor(const FileFormat & srcFormat, const FileFormat & tgtFormat, bool calcOutput);
 extern DALIFT_API IOutputProcessor * createOutputProcessor(const FileFormat & format);
 
-extern DALIFT_API IFormatPartitioner * createFormatPartitioner(const SocketEndpoint & ep, const FileFormat & srcFormat, const FileFormat & tgtFormat, bool calcOutput, const char * slave, const char *wuid);
+class FileSprayer;
+extern DALIFT_API IFormatPartitioner * createFormatPartitioner(FileSprayer &sprayer, const SocketEndpoint & ep, const FileFormat & srcFormat, const FileFormat & tgtFormat, bool calcOutput, const char * slave, const char *wuid);
 
 #endif

--- a/dali/ft/daftformat.ipp
+++ b/dali/ft/daftformat.ipp
@@ -700,10 +700,11 @@ protected:
 
 //---------------------------------------------------------------------------
 
+class FileSprayer;
 class DALIFT_API CRemotePartitioner : public Thread, public IFormatPartitioner
 {
 public:
-    CRemotePartitioner(const SocketEndpoint & _ep, const FileFormat & _srcFormat, const FileFormat & _tgtFormat, const char * _slave, const char *_wuid);
+    CRemotePartitioner(FileSprayer &sprayer, const SocketEndpoint & _ep, const FileFormat & _srcFormat, const FileFormat & _tgtFormat, const char * _slave, const char *_wuid);
     IMPLEMENT_IINTERFACE_USING(Thread);
 
     virtual int  run();
@@ -715,14 +716,16 @@ public:
     virtual void setTarget(IOutputProcessor * _target) { UNIMPLEMENTED; }
     virtual void setRecordStructurePresent(bool _recordStructurePresent);
     virtual void getRecordStructure(StringBuffer & _recordStructure);
-    virtual void setAbort(IAbortRequestCallback * _abort) { UNIMPLEMENTED; }
+    virtual void setAbort(IAbortRequestCallback * _abort) { /*UNIMPLEMENTED;*/ }
 
 protected:
     void callRemote();
+    void prepareCmd(MemoryBuffer &msg);
 
     virtual bool isAborting() { UNIMPLEMENTED; };
 
 protected:
+    FileSprayer                 &sprayer;
     SocketEndpoint              ep;
     FileFormat                  srcFormat;
     FileFormat                  tgtFormat;

--- a/dali/ft/filecopy.cpp
+++ b/dali/ft/filecopy.cpp
@@ -98,6 +98,8 @@ inline void setCanAccessDirectly(RemoteFilename & file)
 #define ANencryptKey        "@encryptKey"
 #define ANdecryptKey        "@decryptKey"
 #define ANumask             "@umask"
+#define ANuseFtSlave        "@useFtSlave"
+#define ANsprayServiceName  "@sprayServiceName"
 
 #define PNpartition         "partition"
 #define PNprogress          "progress"
@@ -114,8 +116,6 @@ inline void setCanAccessDirectly(RemoteFilename & file)
 const unsigned operatorUpdateFrequency = 5000;      // time between updates in ms
 const unsigned abortCheckFrequency = 20000;         // time between updates in ms
 const unsigned sdsUpdateFrequency = 20000;          // time between updates in ms
-const unsigned maxSlaveUpdateFrequency = 1000;      // time between updates in ms - small number of nodes.
-const unsigned minSlaveUpdateFrequency = 5000;      // time between updates in ms - large number of nodes.
 
 
 bool TargetLocation::canPull()
@@ -293,10 +293,161 @@ bool FileTransferThread::catchReadBuffer(ISocket * socket, MemoryBuffer & msg, u
     }
 }
 
+void FileTransferThread::prepareCmd(MemoryBuffer &msg, unsigned version)
+{
+    //Send message and wait for response...
+    msg.append(action);
+
+    if (0 == version) // 0 indicates command is destined to ftslave not dafilesrv
+    {
+        // send 0 for password info that was in <= 7.6 versions
+        unsigned zero = 0;
+        msg.append(zero);
+    }
+    ep.serialize(msg);
+    sprayer.srcFormat.serialize(msg);
+    sprayer.tgtFormat.serialize(msg);
+    msg.append(sprayer.calcInputCRC());
+    msg.append(calcCRC);
+    serialize(partition, msg);
+    msg.append(sprayer.numParallelSlaves());
+    msg.append(sprayer.slaveUpdateFrequency);
+    msg.append(sprayer.replicate); // NB: controls whether FtSlave copies source timestamp
+    msg.append(sprayer.mirroring);
+    msg.append(sprayer.isSafeMode);
+
+    msg.append(progress.ordinality());
+    ForEachItemIn(i, progress)
+        progress.item(i).serializeCore(msg);
+
+    msg.append(sprayer.throttleNicSpeed);
+    msg.append(sprayer.compressedInput);
+    msg.append(sprayer.compressOutput);
+    msg.append(sprayer.copyCompressed);
+    msg.append(sprayer.transferBufferSize);
+    msg.append(sprayer.encryptKey);
+    msg.append(sprayer.decryptKey);
+
+    sprayer.srcFormat.serializeExtra(msg, 1);
+    sprayer.tgtFormat.serializeExtra(msg, 1);
+
+    ForEachItemIn(i2, progress)
+        progress.item(i2).serializeExtra(msg, 1);
+
+    //NB: Any extra data must be appended at the end...
+
+    msg.append(sprayer.fileUmask);
+
+    ForEachItemIn(i3, progress)
+        progress.item(i3).serializeExtra(msg, 2);
+}
+
+bool FileTransferThread::launchFtSlaveCmd(const SocketEndpoint &ep)
+{
+    SocketEndpoint connectEP(ep);
+#ifdef _CONTAINERIZED
+    if (sprayer.useFtSlave)
+    {
+        //In containerized world all processes are executed locally, so make sure we try and connect to a local instance
+        connectEP.set("localhost");
+    }
+    else
+    {
+        Owned<IPropertyTree> serviceTree;
+        if (!isEmptyString(sprayer.sprayServiceName))
+        {
+            VStringBuffer serviceQualifier("services[@name='%s']", sprayer.sprayServiceName.get());
+            serviceTree.setown(getGlobalConfigSP()->getPropTree(serviceQualifier));
+            if (!serviceTree)
+                throw makeStringExceptionV(0, "launchFtSlaveCmd: failed to find dafilesrv service named: '%s'", sprayer.sprayServiceName.get());
+            const char *serviceAppType = serviceTree->queryProp("@application");
+            if (!strsame("spray", serviceAppType))
+                throw makeStringExceptionV(0, "launchFtSlaveCmd: configured service '%s' is of application type '%s' ('spray' type required)", sprayer.sprayServiceName.get(), nullIfEmptyString(serviceAppType));
+        }
+        else // find 1st of type 'spray'
+        {
+            Owned<IPropertyTreeIterator> directIOServices = getGlobalConfigSP()->getElements("services[@type='spray']");
+            if (directIOServices->first())
+                serviceTree.set(&directIOServices->query());
+            else
+                throw makeStringException(0, "launchFtSlaveCmd: no 'spray' dafilesrv services found");
+        }
+        connectEP.set(serviceTree->queryProp("@name"), serviceTree->getPropInt("@port"));
+    }
+#endif
+
+    StringBuffer url;
+    ep.getUrlStr(url);
+
+    Owned<ISocket> socket;
+    MemoryBuffer msg;
+    msg.setEndian(__BIG_ENDIAN);
+    if (sprayer.useFtSlave)
+    {
+        StringBuffer tmp;
+        socket.setown(spawnRemoteChild(SPAWNdfu, sprayer.querySlaveExecutable(ep, tmp), connectEP, DAFT_VERSION, queryFtSlaveLogDir(), this, wuid));
+        if (!socket)
+            throwError1(DFTERR_FailedStartSlave, url.str());
+
+        prepareCmd(msg, 0);
+        if (!catchWriteBuffer(socket, msg))
+            throwError1(RFSERR_TimeoutWaitConnect, url.str());
+    }
+    else
+    {
+        setDafsEndpointPort(connectEP);
+        if (connectEP.isNull())
+            return false;
+        socket.setown(connectDafs(connectEP, 5000));
+        if (!socket)
+            throwError1(DFTERR_FailedStartSlave, url.str());
+        prepareCmd(msg, daFileSrvCommandVersion);
+        sendDaFsFtSlaveCmd(socket, msg);
+    }
+    bool done;
+    for (;;)
+    {
+        msg.clear();
+        if (!catchReadBuffer(socket, msg, FTTIME_PROGRESS))
+            throwError1(RFSERR_TimeoutWaitSlave, url.str());
+
+        msg.setEndian(__BIG_ENDIAN);
+        msg.read(done);
+        if (done)
+            break;
+
+        OutputProgress newProgress;
+        newProgress.deserializeCore(msg);
+        newProgress.deserializeExtra(msg, 1);
+        newProgress.deserializeExtra(msg, 2);
+        sprayer.updateProgress(newProgress);
+
+        LOG(MCdebugProgress(10000), job, "Update %s: %d %" I64F "d->%" I64F "d", url.str(), newProgress.whichPartition, newProgress.inputLength, newProgress.outputLength);
+        if (isAborting())
+        {
+            if (!sendRemoteAbort(socket))
+                throwError1(RFSERR_TimeoutWaitSlave, url.str());
+        }
+    }
+    msg.read(ok);
+    setErrorOwn(deserializeException(msg));
+
+    LOG(MCdebugProgressDetail, job, "Finished generating part %s [%p] ok(%d) error(%d)", url.str(), this, (int)ok, (int)(error!=NULL));
+
+    // if communicating with ftslave, the process has a final ack wait
+    if (sprayer.useFtSlave)
+    {
+        // ftslave sends back a final ack.
+        msg.clear().append(true);
+        catchWriteBuffer(socket, msg);
+        if (sprayer.options->getPropInt("@fail", 0)) // JCSMORE - legacy? not set anywhere afaics
+            throwError(DFTERR_CopyFailed);
+    }
+    return ok;
+}
 
 bool FileTransferThread::performTransfer()
 {
-    bool ok = false;
     StringBuffer url;
     ep.getUrlStr(url);
 
@@ -341,104 +492,7 @@ bool FileTransferThread::performTransfer()
     }
 
     LOG(MCdebugProgressDetail, job, "Start generate part %s [%p]", url.str(), this);
-    StringBuffer tmp;
-    Owned<ISocket> socket = spawnRemoteChild(SPAWNdfu, sprayer.querySlaveExecutable(ep, tmp), ep, DAFT_VERSION, queryFtSlaveLogDir(), this, wuid);
-    if (socket)
-    {
-        MemoryBuffer msg;
-        msg.setEndian(__BIG_ENDIAN);
-
-        //MORE: Allow this to be configured by an option.
-        unsigned slaveUpdateFrequency = minSlaveUpdateFrequency;
-        if (sprayer.numParallelSlaves() < 5)
-            slaveUpdateFrequency = maxSlaveUpdateFrequency;
-
-        //Send message and wait for response...
-        msg.append(action);
-
-        // send 0 for password info that was in <= 7.6 versions
-        unsigned zero = 0;
-        msg.append(zero);
-
-        ep.serialize(msg);
-        sprayer.srcFormat.serialize(msg);
-        sprayer.tgtFormat.serialize(msg);
-        msg.append(sprayer.calcInputCRC());
-        msg.append(calcCRC);
-        serialize(partition, msg);
-        msg.append(sprayer.numParallelSlaves());
-        msg.append(slaveUpdateFrequency);
-        msg.append(sprayer.replicate); // NB: controls whether FtSlave copies source timestamp
-        msg.append(sprayer.mirroring);
-        msg.append(sprayer.isSafeMode);
-
-        msg.append(progress.ordinality());
-        ForEachItemIn(i, progress)
-            progress.item(i).serializeCore(msg);
-
-        msg.append(sprayer.throttleNicSpeed);
-        msg.append(sprayer.compressedInput);
-        msg.append(sprayer.compressOutput);
-        msg.append(sprayer.copyCompressed);
-        msg.append(sprayer.transferBufferSize);
-        msg.append(sprayer.encryptKey);
-        msg.append(sprayer.decryptKey);
-
-        sprayer.srcFormat.serializeExtra(msg, 1);
-        sprayer.tgtFormat.serializeExtra(msg, 1);
-
-        ForEachItemIn(i2, progress)
-            progress.item(i2).serializeExtra(msg, 1);
-
-        //NB: Any extra data must be appended at the end...
-
-        msg.append(sprayer.fileUmask);
-
-        ForEachItemIn(i3, progress)
-            progress.item(i3).serializeExtra(msg, 2);
-
-        if (!catchWriteBuffer(socket, msg))
-            throwError1(RFSERR_TimeoutWaitConnect, url.str());
-
-        bool done;
-        for (;;)
-        {
-            msg.clear();
-            if (!catchReadBuffer(socket, msg, FTTIME_PROGRESS))
-                throwError1(RFSERR_TimeoutWaitSlave, url.str());
-
-            msg.setEndian(__BIG_ENDIAN);
-            msg.read(done);
-            if (done)
-                break;
-
-            OutputProgress newProgress;
-            newProgress.deserializeCore(msg);
-            newProgress.deserializeExtra(msg, 1);
-            newProgress.deserializeExtra(msg, 2);
-            sprayer.updateProgress(newProgress);
-
-            LOG(MCdebugProgress(10000), job, "Update %s: %d %" I64F "d->%" I64F "d", url.str(), newProgress.whichPartition, newProgress.inputLength, newProgress.outputLength);
-            if (isAborting())
-            {
-                if (!sendRemoteAbort(socket))
-                    throwError1(RFSERR_TimeoutWaitSlave, url.str());
-            }
-        }
-        msg.read(ok);
-        setErrorOwn(deserializeException(msg));
-
-        LOG(MCdebugProgressDetail, job, "Finished generating part %s [%p] ok(%d) error(%d)", url.str(), this, (int)ok, (int)(error!=NULL));
-
-        msg.clear().append(true);
-        catchWriteBuffer(socket, msg);
-        if (sprayer.options->getPropInt("@fail", 0))
-            throwError(DFTERR_CopyFailed);
-    }
-    else
-    {
-        throwError1(DFTERR_FailedStartSlave, url.str());
-    }
+    bool ok = launchFtSlaveCmd(ep);
     LOG(MCdebugProgressDetail, job, "Stopped generate part %s [%p]", url.str(), this);
 
     allDone = true;
@@ -632,6 +686,8 @@ FileSprayer::FileSprayer(IPropertyTree * _options, IPropertyTree * _progress, IR
     progressDone = false;
     encryptKey.set(options->queryProp(ANencryptKey));
     decryptKey.set(options->queryProp(ANdecryptKey));
+    useFtSlave = options->getPropBool(ANuseFtSlave);
+    sprayServiceName.set(options->queryProp(ANsprayServiceName));
 
     fileUmask = -1;
     const char *umaskStr = options->queryProp(ANumask);
@@ -1283,7 +1339,7 @@ IFormatPartitioner * FileSprayer::createPartitioner(aindex_t index, bool calcOut
 
     srcFormat.quotedTerminator = options->getPropBool("@quotedTerminator", true);
     const SocketEndpoint & ep = cur.filename.queryEndpoint();
-    IFormatPartitioner * partitioner = createFormatPartitioner(ep, srcFormat, tgtFormat, calcOutput, queryFixedSlave(), wuid);
+    IFormatPartitioner * partitioner = createFormatPartitioner(*this, ep, srcFormat, tgtFormat, calcOutput, queryFixedSlave(), wuid);
 
     // CSV record structure discovery of the first source
     bool isRecordStructurePresent = options->getPropBool("@recordStructurePresent", false);
@@ -2400,6 +2456,11 @@ unsigned FileSprayer::numParallelSlaves()
 
 void FileSprayer::performTransfer()
 {
+    //MORE: Allow this to be configured by an option.
+    slaveUpdateFrequency = minSlaveUpdateFrequency;
+    if (numParallelSlaves() < 5)
+        slaveUpdateFrequency = maxSlaveUpdateFrequency;
+
     unsigned numSlaves = transferSlaves.ordinality();
     unsigned maxConnections = numParallelSlaves();
     unsigned failure = options->getPropInt("@fail", 0);

--- a/dali/ft/filecopy.ipp
+++ b/dali/ft/filecopy.ipp
@@ -61,6 +61,8 @@ public:
     void go(Semaphore & _sem);
     void logIfRunning(StringBuffer &list);
     void setErrorOwn(IException * e);
+    void prepareCmd(MemoryBuffer &mb, unsigned version);
+    bool launchFtSlaveCmd(const SocketEndpoint &_ep);
 
     virtual int run();
     virtual bool abortRequested() { return isAborting(); }
@@ -172,11 +174,16 @@ protected:
 
 typedef Linked<IDistributedFile> DistributedFileAttr;
 
+constexpr unsigned maxSlaveUpdateFrequency = 1000;      // time between updates in ms - small number of nodes.
+constexpr unsigned minSlaveUpdateFrequency = 5000;      // time between updates in ms - large number of nodes.
+
+constexpr unsigned daFileSrvCommandVersion = 1;
 class FileSprayer : public IFileSprayer, public CInterface
 {
     friend class FileTransferThread;
     friend class AsyncAfterTransfer;
     friend class AsyncExtractBlobInfo;
+    friend class CRemotePartitioner;
 public:
     FileSprayer(IPropertyTree * _options, IPropertyTree * _progress, IRemoteConnection * _recoveryConnection, const char *_wuid);
     IMPLEMENT_IINTERFACE
@@ -335,6 +342,7 @@ protected:
     bool                    compressedInput;
     bool                    compressOutput;
     bool                    copyCompressed;
+    bool                    useFtSlave;
     unsigned __int64        totalLengthRead;
     unsigned __int64        totalNumReads;
     unsigned __int64        totalNumWrites;
@@ -352,6 +360,8 @@ protected:
     Owned<IPropertyTree>    srcHistory;
     dfu_operation           operation = dfu_unknown;
     CAbortRequestCallback   fileSprayerAbortChecker;
+    unsigned slaveUpdateFrequency = minSlaveUpdateFrequency;
+    StringAttr              sprayServiceName;
 };
 
 

--- a/dali/ft/ftslavelib.cmake
+++ b/dali/ft/ftslavelib.cmake
@@ -1,5 +1,5 @@
 ################################################################################
-#    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems®.
+#    HPCC SYSTEMS software Copyright (C) 2022 HPCC Systems®.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -15,41 +15,36 @@
 ################################################################################
 
 
-# Component: ftslave 
+# Component: ftslavelib
 #####################################################
 # Description:
 # ------------
-#    Cmake Input File for ftslave
+#    Cmake Input File for ftslavelib
 #####################################################
 
-project( ftslave ) 
+project( ftslavelib ) 
 
 set (    SRCS 
-         ftslave.cpp 
+         ftslavelib.cpp 
     )
 
 include_directories ( 
+         ${HPCC_SOURCE_DIR}/dali/base 
          ${HPCC_SOURCE_DIR}/include 
          ${HPCC_SOURCE_DIR}/jlib
-         ${HPCC_SOURCE_DIR}/dali/base 
-         ${HPCC_SOURCE_DIR}/mp 
-         ${HPCC_SOURCE_DIR}/remote 
          ${HPCC_SOURCE_DIR}/security/shared
+         ${HPCC_SOURCE_DIR}/system/mp 
     )
 
-HPCC_ADD_EXECUTABLE ( ftslave ${SRCS} )
-set_target_properties (ftslave PROPERTIES COMPILE_FLAGS -D_CONSOLE)
-install ( TARGETS ftslave RUNTIME DESTINATION ${EXEC_DIR} )
-target_link_libraries ( ftslave
+ADD_DEFINITIONS( -D_USRDLL -DFTSLAVELIB_EXPORTS )
+
+HPCC_ADD_LIBRARY ( ftslavelib SHARED ${SRCS} )
+install ( TARGETS ftslavelib RUNTIME DESTINATION ${EXEC_DIR} LIBRARY DESTINATION ${LIB_DIR} )
+target_link_libraries ( ftslavelib
          dalibase 
          dalift 
-         ftslavelib
-         hrpc 
+         hrpc
          jlib
          mp 
          remote 
     )
-
-if (NOT CONTAINERIZED)
-    target_link_libraries ( ftslave environment )
-endif()

--- a/dali/ft/ftslavelib.cpp
+++ b/dali/ft/ftslavelib.cpp
@@ -1,0 +1,135 @@
+/*##############################################################################
+
+    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include "jliball.hpp"
+#include "platform.h"
+#include "jlib.hpp"
+#include "jio.hpp"
+#include "jmutex.hpp"
+#include "jfile.hpp"
+#include "jsocket.hpp"
+#include "jdebug.hpp"
+
+#include "fterror.hpp"
+#include "dadfs.hpp"
+#include "rmtspawn.hpp"
+#include "filecopy.hpp"
+#include "fttransform.ipp"
+#include "daftformat.hpp"
+#include "daftcfg.hpp"
+#include "mptag.hpp"
+#include "ftslavelib.hpp"
+
+
+bool processPullCommand(ISocket * masterSocket, MemoryBuffer & msg)
+{
+    srand((int)get_cycles_now());
+    TransferServer server(masterSocket);
+    server.deserializeAction(msg, FTactionpull);
+    return server.pull();
+}
+
+
+bool processPushCommand(ISocket * masterSocket, MemoryBuffer & msg)
+{
+    srand((int)get_cycles_now());
+    TransferServer server(masterSocket);
+    server.deserializeAction(msg, FTactionpush);
+    return server.push();
+}
+
+
+bool processPartitionCommand(ISocket * masterSocket, MemoryBuffer & msg, MemoryBuffer & results)
+{
+    FileFormat srcFormat;
+    FileFormat tgtFormat;
+    unsigned whichInput;
+    RemoteFilename fullPath;
+    offset_t totalSize;
+    offset_t thisOffset;
+    offset_t thisSize;
+    unsigned thisHeaderSize;
+    unsigned numParts;
+    bool compressedInput = false;
+    unsigned compatflags = 0;  
+
+    srcFormat.deserialize(msg);
+    tgtFormat.deserialize(msg);
+    msg.read(whichInput);
+    fullPath.deserialize(msg);
+    msg.read(totalSize);
+    msg.read(thisOffset);
+    msg.read(thisSize);
+    msg.read(thisHeaderSize);
+    msg.read(numParts);
+    if (msg.remaining())
+        msg.read(compressedInput);
+    if (msg.remaining())
+        msg.read(compatflags); // not yet used
+    StringAttr decryptkey;
+    if (msg.remaining())
+        msg.read(decryptkey);
+    if (msg.remaining())
+    {
+        srcFormat.deserializeExtra(msg, 1);
+        tgtFormat.deserializeExtra(msg, 1);
+    }
+
+    StringBuffer text;
+    fullPath.getRemotePath(text);
+    LOG(MCdebugProgress, unknownJob, "Process partition %d(%s)", whichInput, text.str());
+    Owned<IFormatProcessor> processor = createFormatProcessor(srcFormat, tgtFormat, true);
+    Owned<IOutputProcessor> target = createOutputProcessor(tgtFormat);
+    processor->setTarget(target);
+
+    processor->setPartitionRange(totalSize, thisOffset, thisSize, thisHeaderSize, numParts);
+    processor->setSource(whichInput, fullPath, compressedInput, decryptkey);
+    processor->calcPartitions(NULL);
+
+    PartitionPointArray partition;
+    processor->getResults(partition);
+
+    serialize(partition, results);
+    return true;
+}
+
+bool processFtCommand(byte action, ISocket * masterSocket, MemoryBuffer & msg, MemoryBuffer & results)
+{
+    switch (action)
+    {
+    case FTactionpartition:
+        return processPartitionCommand(masterSocket, msg, results);
+    case FTactionpull:
+        return processPullCommand(masterSocket, msg);
+    case FTactionpush:
+        return processPushCommand(masterSocket, msg);
+    default:
+        UNIMPLEMENTED;
+    }
+    return false;
+}
+
+class FtSlave : public CRemoteSlave
+{
+public:
+    FtSlave() : CRemoteSlave("ftslave", MPTAG_FT_SLAVE, DAFT_VERSION, false) {}
+
+    virtual bool processCommand(byte action, ISocket * masterSocket, MemoryBuffer & msg, MemoryBuffer & results)
+    {
+        return processFtCommand(action, masterSocket, msg, results);
+    }
+};

--- a/dali/ft/ftslavelib.cpp
+++ b/dali/ft/ftslavelib.cpp
@@ -37,7 +37,6 @@
 
 bool processPullCommand(ISocket * masterSocket, MemoryBuffer & msg)
 {
-    srand((int)get_cycles_now());
     TransferServer server(masterSocket);
     server.deserializeAction(msg, FTactionpull);
     return server.pull();
@@ -46,7 +45,6 @@ bool processPullCommand(ISocket * masterSocket, MemoryBuffer & msg)
 
 bool processPushCommand(ISocket * masterSocket, MemoryBuffer & msg)
 {
-    srand((int)get_cycles_now());
     TransferServer server(masterSocket);
     server.deserializeAction(msg, FTactionpush);
     return server.push();

--- a/dali/ft/ftslavelib.hpp
+++ b/dali/ft/ftslavelib.hpp
@@ -1,6 +1,6 @@
 /*##############################################################################
 
-    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems®.
+    HPCC SYSTEMS software Copyright (C) 2022 HPCC Systems®.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -15,27 +15,16 @@
     limitations under the License.
 ############################################################################## */
 
-#ifndef DFURUN_HPP
-#define DFURUN_HPP
+#ifndef FTSLAVELIB_HPP
+#define FTSLAVELIB_HPP
 
-class CSDSServerStatus;
-
-#include "dfuwu.hpp"
-
-
-interface IDFUengine: extends IInterface
-{
-    virtual void startListener(const char *queuename,CSDSServerStatus *status)=0;
-    virtual void startMonitor(const char *queuename,CSDSServerStatus *status,unsigned timeout)=0;
-    virtual void joinListeners()=0;
-    virtual void abortListeners()=0;
-    virtual DFUstate runWU(const char *dfuwuid)=0;
-    virtual void setDefaultTransferBufferSize(size32_t size) = 0;
-    virtual void setDFUServerName(const char* name) = 0;
-};
-
-IDFUengine *createDFUengine(const IPropertyTree *config);
-void stopDFUserver(const char *qname);
-
+#ifdef FTSLAVELIB_EXPORTS
+#define FTSLAVELIB_API DECL_EXPORT
+#else
+#define FTSLAVELIB_API DECL_IMPORT
 #endif
 
+
+extern FTSLAVELIB_API bool processFtCommand(byte action, ISocket * masterSocket, MemoryBuffer & msg, MemoryBuffer & results);
+
+#endif

--- a/dali/ft/fttransform.cpp
+++ b/dali/ft/fttransform.cpp
@@ -604,8 +604,7 @@ void TransferServer::deserializeAction(MemoryBuffer & msg, unsigned action)
     msg.read(mirror);
     msg.read(isSafeMode);
 
-    srand((unsigned)get_cycles_now());
-    int adjust = fastRand() % updateFrequency - (updateFrequency/2);
+    int adjust = get_cycles_now() % updateFrequency - (updateFrequency/2);
     lastTick = msTick() + adjust;
 
     StringBuffer localFilename;

--- a/fs/dafilesrv/dafilesrv.cpp
+++ b/fs/dafilesrv/dafilesrv.cpp
@@ -391,8 +391,8 @@ int main(int argc, const char* argv[])
     unsigned short  sslport;
     unsigned dedicatedRowServicePort = DEFAULT_ROWSERVICE_PORT;
 #ifdef _CONTAINERIZED
-    bool directIO = strsame(config->queryProp("@application"), "directio");
-    connectMethod = directIO ? SSLNone : SSLOnly;
+    bool stream = strsame(config->queryProp("@application"), "stream");
+    connectMethod = stream ? SSLOnly : SSLNone;
     dedicatedRowServicePort = 0; // row service always runs on same secure ssl port in containerized mode
     port = 0;
     sslport = config->getPropInt("service/@port", SECURE_DAFILESRV_PORT);

--- a/fs/dafsclient/dafscommon.hpp
+++ b/fs/dafsclient/dafscommon.hpp
@@ -19,7 +19,7 @@
 #define DAFSCOMMON_HPP
 
 #define DAFILESRV_VERSION_MAJOR 2
-#define DAFILESRV_VERSION_MINOR 5
+#define DAFILESRV_VERSION_MINOR 6
 #define MAJORMINOR(MAJOR, MINOR) MAJOR ## MINOR
 #define DAFILESRV_VERSION_JOIN(X, Y) MAJORMINOR(X, Y)
 #define DAFILESRV_VERSION DAFILESRV_VERSION_JOIN(DAFILESRV_VERSION_MAJOR, DAFILESRV_VERSION_MINOR)
@@ -91,6 +91,8 @@ enum
 // 2.5
     RFCStreamGeneral,                              // 45
     RFCStreamReadJSON = '{',
+// 2.6
+    RFCFtSlaveCmd,
     RFCmaxnormal,
     RFCmax,
     RFCunknown = 255 // 0 would have been more sensible, but can't break backward compatibility
@@ -107,7 +109,7 @@ enum DAFS_ERROR_CODES {
     DAFSERR_cmdstream_unsupported_recfmt    = -8,
     DAFSERR_cmdstream_openfailure           = -9,
     DAFSERR_cmdstream_protocol_failure      = -10,
-    DAFSERR_cmdstream_unauthorized          = -11,
+    DAFSERR_cmd_unauthorized                = -11,
     DAFSERR_cmdstream_unknownwritehandle    = -12,
     DAFSERR_cmdstream_generalwritefailure   = -13
 };

--- a/fs/dafsclient/rmtclient.cpp
+++ b/fs/dafsclient/rmtclient.cpp
@@ -1408,6 +1408,18 @@ int getDafsInfo(ISocket * socket, unsigned level, StringBuffer &retstr)
     return -1;
 }
 
+void sendDaFsFtSlaveCmd(ISocket *socket, MemoryBuffer &cmdMsg)
+{
+    assertex(socket);
+    
+    MemoryBuffer sendbuf;
+    initSendBuffer(sendbuf);
+    sendbuf.append((RemoteFileCommandType)RFCFtSlaveCmd).append(cmdMsg);
+    MemoryBuffer replybuf;
+    sendDaFsBuffer(socket, sendbuf);
+    receiveDaFsBuffer(socket, replybuf, 1);
+}
+
 
 struct CDafsOsCacheEntry
 {

--- a/fs/dafsclient/rmtclient.hpp
+++ b/fs/dafsclient/rmtclient.hpp
@@ -68,6 +68,7 @@ extern DAFSCLIENT_API unsigned getDaliServixVersion(const IpAddress &ip,StringBu
 extern DAFSCLIENT_API unsigned getDaliServixVersion(const SocketEndpoint &ep,StringBuffer &ver);
 extern DAFSCLIENT_API DAFS_OS getDaliServixOs(const SocketEndpoint &ep);
 extern DAFSCLIENT_API bool testDaliServixPresent(const IpAddress &ip);
+extern DAFSCLIENT_API void sendDaFsFtSlaveCmd(ISocket *socket, MemoryBuffer &cmdBuffer);
 
 
 

--- a/fs/dafsserver/CMakeLists.txt
+++ b/fs/dafsserver/CMakeLists.txt
@@ -29,21 +29,21 @@ set (    SRCS
     )
 
 include_directories (
+         ${HPCC_SOURCE_DIR}/common/deftype
+         ${HPCC_SOURCE_DIR}/common/thorhelper
+         ${HPCC_SOURCE_DIR}/dali/base
+         ${HPCC_SOURCE_DIR}/dali/ft
+         ${HPCC_SOURCE_DIR}/ecl/hql
+         ${HPCC_SOURCE_DIR}/fs/dafsclient
+         ${HPCC_SOURCE_DIR}/rtl/eclrtl
+         ${HPCC_SOURCE_DIR}/rtl/include
          ${HPCC_SOURCE_DIR}/system/include 
          ${HPCC_SOURCE_DIR}/system/jlib 
          ${HPCC_SOURCE_DIR}/system/jhtree
          ${HPCC_SOURCE_DIR}/system/mp
-         ${HPCC_SOURCE_DIR}/rtl/eclrtl
          ${HPCC_SOURCE_DIR}/system/security/shared
          ${HPCC_SOURCE_DIR}/system/security/securesocket
          ${HPCC_SOURCE_DIR}/system/security/cryptohelper
-         ${HPCC_SOURCE_DIR}/rtl/include
-         ${HPCC_SOURCE_DIR}/rtl/eclrtl
-         ${HPCC_SOURCE_DIR}/ecl/hql
-         ${HPCC_SOURCE_DIR}/common/deftype
-         ${HPCC_SOURCE_DIR}/common/thorhelper
-         ${HPCC_SOURCE_DIR}/fs/dafsclient
-         ${HPCC_SOURCE_DIR}/dali/base
          ${HPCC_SOURCE_DIR}/testing/unittests
          ${CMAKE_BINARY_DIR}
          ${CMAKE_BINARY_DIR}/oss
@@ -63,6 +63,7 @@ target_link_libraries ( dafsserver
     dafsclient
     dalibase
     thorhelper
+    ftslavelib
     ${CPPUNIT_LIBRARIES}
     )
 

--- a/helm/hpcc/values.schema.json
+++ b/helm/hpcc/values.schema.json
@@ -194,6 +194,15 @@
           "maxJobs": {
             "type": "integer"
           },
+          "sprayServiceName": {
+            "description": "Optional name of the dafilesrv spray service to use (will default to 1st 'spray' dafilesrv)",
+            "type": "string"
+          },
+          "useFtSlave": {
+            "description": "Use legacy ftslave processes (ran within dfuserver pod)",
+            "type": "boolean",
+            "default": false
+          },
           "env": {
             "$ref": "#/definitions/env"
           },
@@ -2445,12 +2454,17 @@
     },
     "dafilesrv": {
       "type": "object",
-      "required": [ "name", "service" ],
+      "required": [ "name", "application", "service" ],
       "additionalProperties": { "type": ["integer", "string", "boolean"] },
       "properties": {
         "name": {
           "type": "string",
           "description": "The name of the dafilesrv process"
+        },
+        "application": {
+          "type": "string",
+          "enum": ["stream", "directio", "spray"],
+          "description": "Application type"
         },
         "service": {
           "$ref": "#/definitions/service"

--- a/helm/hpcc/values.yaml
+++ b/helm/hpcc/values.yaml
@@ -375,6 +375,12 @@ dafilesrv:
     servicePort: 7200
     visibility: local
     
+- name: spray-service
+  application: spray
+  service:
+    servicePort: 7300
+    visibility: local
+    
 
 dali:
 - name: mydali


### PR DESCRIPTION
Make dfuserver/filesprayer send commands to dafilesrv for ftslave
functionality, instead of spinning up ftslave processes.

Default on in containerized mode, for now default off in bare-metal.

Signed-off-by: Jake Smith <jake.smith@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
