### PR TITLE
HPCC-27687 Check permission before accessing Others Workunits

### DIFF
--- a/esp/scm/ws_smc.ecm
+++ b/esp/scm/ws_smc.ecm
@@ -46,6 +46,7 @@ ESPStruct ActiveWorkunit
     [min_ver("1.15")] string ClusterType;
     [min_ver("1.15")] string ClusterQueueName;
     [min_ver("1.16")] string TargetClusterName;
+    [min_ver("1.25")] bool NoAccess(false);
 };
 
 ESPStruct TargetCluster
@@ -431,7 +432,7 @@ ESPresponse [exceptions_inline] GetBuildInfoResponse
     ESParray<ESPstruct NamedValue> BuildInfo;
 };
 
-ESPservice [auth_feature("DEFERRED"), noforms, version("1.24"), exceptions_inline("./smc_xslt/exceptions.xslt"), use_method_name] WsSMC
+ESPservice [auth_feature("DEFERRED"), noforms, version("1.25"), exceptions_inline("./smc_xslt/exceptions.xslt"), use_method_name] WsSMC
 {
     ESPmethod Index(SMCIndexRequest, SMCIndexResponse);
     ESPmethod [resp_xsl_default("/esp/xslt/index.xslt")] Activity(ActivityRequest, ActivityResponse);

--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -25,7 +25,7 @@ EspInclude(ws_workunits_queryset_req_resp);
 
 ESPservice [
     auth_feature("DEFERRED"), //This declares that the method logic handles feature level authorization
-    version("1.90"), default_client_version("1.90"), cache_group("ESPWsWUs"),
+    version("1.91"), default_client_version("1.91"), cache_group("ESPWsWUs"),
     noforms,exceptions_inline("./smc_xslt/exceptions.xslt"),use_method_name] WsWorkunits
 {
     ESPmethod [cache_seconds(60), resp_xsl_default("/esp/xslt/workunits.xslt")]     WUQuery(WUQueryRequest, WUQueryResponse);

--- a/esp/scm/ws_workunits_struct.ecm
+++ b/esp/scm/ws_workunits_struct.ecm
@@ -363,6 +363,7 @@ ESPStruct [nil_remove] ECLWorkunitLW
 
     unsigned TotalClusterTime;
     ESParray<ESPstruct ApplicationValue> ApplicationValues;
+    [min_ver("1.91")] bool NoAccess(false);
 };
 
 ESPStruct [nil_remove] ECLWorkunit
@@ -445,6 +446,7 @@ ESPStruct [nil_remove] ECLWorkunit
     [min_ver("1.84")] double ExecuteCost;
     [min_ver("1.85")] double FileAccessCost;
     [min_ver("1.87")] double CompileCost;
+    [min_ver("1.91")] bool NoAccess(false);
 };
 
 ESPStruct [nil_remove] WUECLAttribute

--- a/esp/services/ws_smc/ws_smcService.cpp
+++ b/esp/services/ws_smc/ws_smcService.cpp
@@ -1261,6 +1261,7 @@ void CWsSMCEx::addWUsToResponse(IEspContext &context, const IArrayOf<IEspActiveW
                 cw->setInstance(instanceName); // JCSMORE In thor case at least, if queued it is unknown which instance it will run on..
             if (targetClusterName && *targetClusterName)
                 cw->setTargetClusterName(targetClusterName);
+            cw->setNoAccess(true);
             awsReturned.append(*cw.getClear());
 
             e->Release();
@@ -2523,7 +2524,7 @@ void CWsSMCEx::setActiveWUs(IEspContext &context, IEspActiveWorkunit& wu, IEspAc
             wuToSet->setInstance(instanceName); // JCSMORE In thor case at least, if queued it is unknown which instance it will run on..
         if (targetClusterName && *targetClusterName)
             wuToSet->setTargetClusterName(targetClusterName);
-
+        wuToSet->setNoAccess(true);
         e->Release();
     }
 }

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -1942,6 +1942,7 @@ void doWUQueryWithSort(IEspContext &context, IEspWUQueryRequest & req, IEspWUQue
         if (chooseWuAccessFlagsByOwnership(context.queryUserId(), cw, accessOwn, accessOthers) < SecAccess_Read)
         {
             info->setState("<Hidden>");
+            info->setNoAccess(true);
             results.append(*info.getClear());
             continue;
         }
@@ -2143,6 +2144,7 @@ void doWULightWeightQueryWithSort(IEspContext &context, IEspWULightWeightQueryRe
         if (chooseWuAccessFlagsByOwnership(context.queryUserId(), cw, accessOwn, accessOthers) < SecAccess_Read)
         {
             info->setStateDesc("<Hidden>");
+            info->setNoAccess(true);
             results.append(*info.getClear());
             continue;
         }
@@ -2358,6 +2360,7 @@ class CArchivedWUsReader : public CInterface, implements IArchivedWUsReader
         if (!canAccess)
         {
             info->setState("<Hidden>");
+            info->setNoAccess(true);
             return info.getClear();
         }
 
@@ -2382,6 +2385,7 @@ class CArchivedWUsReader : public CInterface, implements IArchivedWUsReader
         if (!canAccess)
         {
             info->setStateDesc("<Hidden>");
+            info->setNoAccess(true);
             return info.getClear();
         }
 
@@ -2570,7 +2574,11 @@ bool CWsWorkunitsEx::onWUQuery(IEspContext &context, IEspWUQueryRequest & req, I
         if (req.getType() && strieq(req.getType(), "archived workunits"))
             doWUQueryFromArchive(context, sashaServerIp.get(), sashaServerPort, *archivedWuCache, awusCacheMinutes, req, resp);
         else if(notEmpty(wuid) && looksLikeAWuid(wuid, 'W'))
+        {
+            if (!validateWsWorkunitAccess(context, wuid, SecAccess_Read))
+                throw makeStringExceptionV(ECLWATCH_ECL_WU_ACCESS_DENIED, "WorkUnit access denied: %s.", wuid);
             doWUQueryBySingleWuid(context, wuid, resp);
+        }
         else if (notEmpty(req.getLogicalFile()) && req.getLogicalFileSearchType() && strieq(req.getLogicalFileSearchType(), "Created"))
             doWUQueryByFile(context, req.getLogicalFile(), resp);
         else


### PR DESCRIPTION
1. When a WU is specified in WsWorkunits.WUQuery, the user
permission should be verified before accessing Others Workunits.
2. In the WsSMC service and WsWorkunits service, a new flag
CanAccess is added when the services report a list of ECL
workunits. The flag is set to false for Others Workunits if the
ESP client does not have the permission to access Others
Workunits. ECLWatch may use the flag to decide whether a weblink
for workunit details should be added or not.

Signed-off-by: wangkx <kevin.wang@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [ ] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [ ] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [ ] I have read the CONTRIBUTORS document.
- [ ] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
