### PR TITLE
HPCC-27769 Avoid query lfn clashes

### DIFF
--- a/testing/regress/ecl/childsink.ecl
+++ b/testing/regress/ecl/childsink.ecl
@@ -93,7 +93,7 @@ Layout SimpleRollup(Layout r, DATASET(Layout) rs) := TRANSFORM
   SELF := r;
 END;
 SimpleResult := ROLLUP(GROUP(Source, UID), GROUP, SimpleRollup(LEFT, ROWS(LEFT)));
-IF(Simple, OUTPUT(SimpleResult, , '~tmp::kel::rollupslowdown::simple', OVERWRITE, EXPIRE(1)));
+IF(Simple, OUTPUT(SimpleResult, , '~tmp::' + WORKUNIT + '::kel::rollupslowdown::simple', OVERWRITE, EXPIRE(1)));
 
 Layout FullRollup(Layout r, DATASET(Layout) rs) := TRANSFORM
   SELF.F1 := TOPN(TABLE(rs, {F1,UNSIGNED C:=COUNT(GROUP)}, F1, FEW), 1, -C)[1].F1;  

--- a/testing/regress/ecl/loopvar.ecl
+++ b/testing/regress/ecl/loopvar.ecl
@@ -19,13 +19,13 @@
 #option('warnOnImplicitJoinLimit', false);
 import Std;
 
-filename1 := '~someflatfile1';
-filename2 := '~someflatfile2';
-keyname1 := '~somekey' : STORED('keyname1');
-keyname2 := '~someotherkey' : STORED('keyname2');
+filename1 := '~' + WORKUNIT+ '::someflatfile1';
+filename2 := '~' + WORKUNIT+ '::someflatfile2';
+keyname1 := '~' + WORKUNIT+ '::somekey' : STORED('keyname1');
+keyname2 := '~' + WORKUNIT+ '::someotherkey' : STORED('keyname2');
 
 dummy := 0;
-keynamecalc := IF(Std.System.thorlib.Daliserver() = 'dummy', '~somekey' , '~someotherkey');
+keynamecalc := IF(Std.System.thorlib.Daliserver() = 'dummy', '~' + WORKUNIT + '::somekey' , '~' + WORKUNIT + '::someotherkey');
 
 lVal := RECORD
  INTEGER id := 0;

--- a/testing/regress/ecl/multilfn.ecl
+++ b/testing/regress/ecl/multilfn.ecl
@@ -616,13 +616,13 @@ ds := DATASET([
 
 dds := DISTRIBUTE(ds,hash(album));
 sds := SORT(dds,song);
-o1 := output(sample(sds,5,1),,'A',overwrite);
-o2 := output(sample(sds,5,2),,'~regress::BB',overwrite);
-o3 := output(sample(sds,5,3),,'testscope::another::CCCC',overwrite);
-o4 := output(sample(sds,5,4),,'~    regress :: DD DDD ',overwrite);   // space between DD and DDD significant
+o1 := output(sample(sds,5,1),,WORKUNIT + '::A',overwrite);
+o2 := output(sample(sds,5,2),,'~regress::' + WORKUNIT + '::BB',overwrite);
+o3 := output(sample(sds,5,3),,WORKUNIT + '::testscope::another::CCCC',overwrite);
+o4 := output(sample(sds,5,4),,'~    regress :: ' + WORKUNIT + '::DD DDD ',overwrite);   // space between DD and DDD significant
 o5 := output(sample(sds,5,5),,'e^Ee^Ee',overwrite);
 
-i1 := DATASET('{A,~regress::BB,testscope::another::cccc,~regress::dd ddd,e^Ee^Ee}',rec,flat);
+i1 := DATASET('{' + WORKUNIT + '::A,~regress::' + WORKUNIT + '::BB,' + WORKUNIT + '::testscope::another::cccc,~regress::' + WORKUNIT + '::dd ddd,e^Ee^Ee}',rec,flat);
 o6 := OUTPUT(COUNT(ds)-COUNT(i1));
 o7 := OUTPUT(COUNT(JOIN(i1,sds,left.song=right.song,FULL ONLY,LOCAL)));
 
@@ -637,7 +637,7 @@ i2 := DATASET('nhtest_'+WORKUNIT+'::{???*}',rec,flat);
 o14 := OUTPUT(COUNT(JOIN(i2,sds,left.song=right.song,FULL ONLY,LOCAL)));
 o15 := OUTPUT(COUNT(i2)-COUNT(ds));
 
-i3 := DATASET('~regress::{BB,dd ddd}',rec,flat);
+i3 := DATASET('~regress::' + WORKUNIT + '::' + '{BB,dd ddd}',rec,flat);
 o16 := OUTPUT(COUNT(JOIN(i3,sample(sds,5,2)+sample(sds,5,4),left.song=right.song,FULL ONLY)));
 
 lfl1 := FileServices.LogicalFileList(str.ToLowerCase(thorlib.getExpandLogicalName('nhtest_'+WORKUNIT+'::*')));

--- a/testing/regress/ecl/superfile2.ecl
+++ b/testing/regress/ecl/superfile2.ecl
@@ -18,9 +18,9 @@
 import Std.File AS FileServices;
 // Super File regression test 2 (RemoveSuperFile)
 
-string fsuper := '~superfile3';
-string fsub := '~superfile4';
-string fsample := '~subfile6';
+string fsuper := '~' + WORKUNIT + '::superfile3';
+string fsub := '~' + WORKUNIT + '::superfile4';
+string fsample := '~' + WORKUNIT + '::subfile6';
 ds := DATASET ([{'aaa'}, {'bbb'}, {'ccc'}, {'ddd'}], {string name});
 
 sequential (


### PR DESCRIPTION
Change regression suite queries that are not using unique lfn
names to ones based on WORKUNIT name.
This prevents multiple copies of the same query running in parallel
(e.g. from different engines) clashing with one another.

Signed-off-by: Jake Smith <jake.smith@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
