### PR TITLE
HPCC-h27854 Fix missing Query Associated Files for imported WU

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -5403,7 +5403,7 @@ void CWorkUnitFactory::importWorkUnit(const char *zapReportFileName, const char 
             f->remove();
             return tree.getClear();
         }
-        void updateWUQueryAssociatedFilesAttrs(const char *localIP)
+        void updateWUQueryAssociatedFilesAttrs()
         {
             ICopyArrayOf<IPropertyTree> fileTreesToRemove;
             IPropertyTree *queryAssociatedTreeRoot = wuTree->queryPropTree("Query/Associated");
@@ -5417,7 +5417,9 @@ void CWorkUnitFactory::importWorkUnit(const char *zapReportFileName, const char 
                 fileNameWithPath.append(PATHSEPSTR).append(pathTail(fileName));
                 if (checkFileExists(fileNameWithPath)) //Check if the ZAP report contains this file.
                 {
-                    fileTree.setProp("@ip", localIP);
+#ifndef _CONTAINERIZED
+                    fileTree.setProp("@ip", GetCachedHostName());
+#endif
                     fileTree.setProp("@filename", fileNameWithPath);
                 }
                 else
@@ -5471,7 +5473,7 @@ void CWorkUnitFactory::importWorkUnit(const char *zapReportFileName, const char 
             wuTree->setProp("@scope", scope);
 
             //update QueryAssociatedFiles in WU XML;
-            updateWUQueryAssociatedFilesAttrs(GetCachedHostName());
+            updateWUQueryAssociatedFilesAttrs();
 
             graphProgressTree.setown(readWUXMLFile("ZAPReport_*.graphprogress", true));
         }

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -4552,8 +4552,14 @@ int CWsWorkunitsSoapBindingEx::onStartUpload(IEspContext &ctx, CHttpRequest* req
                 throw MakeStringException(ECLWATCH_INVALID_INPUT, "Only one WU ZAP report is allowed.");
 
             VStringBuffer fileName("%s%s", zipFolder, fileNames.item(0));
+#ifdef _CONTAINERIZED
+            VStringBuffer importDir("%s%simport", wswService->getQueryDirectory(), PATHSEPSTR);
+            wswService->queryWUFactory()->importWorkUnit(fileName, password,
+                importDir, "ws_workunits", ctx.queryUserId(), ctx.querySecManager(), ctx.queryUser());
+#else
             wswService->queryWUFactory()->importWorkUnit(fileName, password,
                 wswService->getTempDirectory(), "ws_workunits", ctx.queryUserId(), ctx.querySecManager(), ctx.queryUser());
+#endif
         }
         else
             throw MakeStringException(ECLWATCH_INVALID_INPUT, "WsWorkunits::%s does not support the upload_ option.", method);

--- a/esp/services/ws_workunits/ws_workunitsService.hpp
+++ b/esp/services/ws_workunits/ws_workunitsService.hpp
@@ -242,6 +242,7 @@ public:
     void checkAndSetClusterQueryState(IEspContext &context, const char* cluster, StringArray& querySetIds, IArrayOf<IEspQuerySetQuery>& queries, bool checkAllNodes);
     IWorkUnitFactory *queryWUFactory() { return wuFactory; };
     const char *getTempDirectory() const { return tempDirectory.str(); };
+    const char *getQueryDirectory() const { return queryDirectory.str(); };
 
     bool onWUQuery(IEspContext &context, IEspWUQueryRequest &req, IEspWUQueryResponse &resp);
     bool onWULightWeightQuery(IEspContext &context, IEspWULightWeightQueryRequest &req, IEspWULightWeightQueryResponse &resp);


### PR DESCRIPTION
When importing ECL WU from a ZAP report in a cloud environment,
1. unzip the WU files into the import folder under the HPCC query folder.
2. keep the ip attribute for WU Query Associated Files as localhost.

Signed-off-by: wangkx <kevin.wang@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
