### PR TITLE
HPCC-27648 Automatically make simple child queries sequential

### DIFF
--- a/roxie/ccd/ccd.hpp
+++ b/roxie/ccd/ccd.hpp
@@ -277,9 +277,13 @@ interface IQueryDll;
 
 enum class SinkMode : byte
 {
-    Parallel = 0,           // Execute sinks in parallel - this is the default
+    Parallel = 0,           // Execute sinks in parallel
     ParallelPersistent = 1, // Execute sinks in parallel using persistent threads. May be faster for a heavily-reused child query, but lead to higher thread usage
-    Sequential = 2          // Execute sinks sequentially - sometimes faster if sinks not doing much work
+    Sequential = 2,         // Execute sinks sequentially - sometimes faster if sinks not doing much work
+    // NOTE - all values from here on are considered "automatic"
+    Automatic = 3,          // Combine simple sinks into a single sequential sink, execute remaining sinks in parallel using default threading (default)
+    AutomaticPersistent = 4,// Combine simple sinks into a single sequential sink, execute remaining sinks in parallel using persistent threads
+    AutomaticParallel = 5,  // Combine simple sinks into a single parallel sink, execute remaining sinks in parallel using standard threads
 };
 
 
@@ -340,6 +344,7 @@ extern bool prestartAgentThreads;
 extern unsigned preabortKeyedJoinsThreshold;
 extern unsigned preabortIndexReadsThreshold;
 extern bool traceStartStop;
+extern bool traceActivityCharacteristics;
 extern unsigned actResetLogPeriod;
 extern bool traceRoxiePackets;
 extern bool delaySubchannelPackets;
@@ -389,6 +394,8 @@ extern bool preloadOnceData;
 extern bool reloadRetriesFailed;
 extern bool selfTestMode;
 extern bool defaultCollectFactoryStatistics;
+extern bool defaultExecuteDependenciesSequentially;
+extern bool defaultStartInputsSequentially;
 extern bool oneShotRoxie;
 extern bool traceStrands;
 

--- a/roxie/ccd/ccddebug.cpp
+++ b/roxie/ccd/ccddebug.cpp
@@ -141,6 +141,10 @@ public:
     {
         return *this;
     }
+    virtual RoxieSourceCharacteristics getSourceCharacteristics() const override
+    {
+        return in->getSourceCharacteristics();
+    }
     virtual void start(unsigned parentExtractSize, const byte *parentExtract, bool paused)
     {
         // NOTE: totalRowCount/maxRowSize not reset, as we want them cumulative when working in a child query.

--- a/roxie/ccd/ccdmain.cpp
+++ b/roxie/ccd/ccdmain.cpp
@@ -83,6 +83,7 @@ unsigned maxBlockSize = 10000000;
 unsigned maxLockAttempts = 5;
 bool pretendAllOpt = false;
 bool traceStartStop = false;
+bool traceActivityCharacteristics = false;
 unsigned actResetLogPeriod = 300;
 bool traceRoxiePackets = false;
 bool delaySubchannelPackets = false;    // For debugging/testing purposes only
@@ -137,12 +138,14 @@ bool preloadOnceData;
 bool reloadRetriesFailed;
 bool selfTestMode = false;
 bool defaultCollectFactoryStatistics = true;
+bool defaultExecuteDependenciesSequentially = false;
+bool defaultStartInputsSequentially = false;
 bool defaultNoSeekBuildIndex = false;
 unsigned parallelQueryLoadThreads = 0;               // Number of threads to use for parallel loading of queries. 0 means don't (may cause CPU starvation on other vms)
 bool alwaysFailOnLeaks = false;
 bool ignoreFileDateMismatches = false;
 int fileTimeFuzzySeconds = 0;
-SinkMode defaultSinkMode = SinkMode::Parallel;
+SinkMode defaultSinkMode = SinkMode::Automatic;
 unsigned continuationCompressThreshold = 1024;
 
 bool useOldTopology = false;
@@ -1112,6 +1115,7 @@ int CCD_API roxie_main(int argc, const char *argv[], const char * defaultYaml)
         roxiemem::setMemoryOptions(topology);
 
         traceStartStop = topology->getPropBool("@traceStartStop", false);
+        traceActivityCharacteristics = topology->getPropBool("@traceActivityCharacteristics", traceActivityCharacteristics);
         actResetLogPeriod = topology->getPropInt("@actResetLogPeriod", 300);
         watchActivityId = topology->getPropInt("@watchActivityId", 0);
         traceRoxiePackets = topology->getPropBool("@traceRoxiePackets", false);
@@ -1141,6 +1145,8 @@ int CCD_API roxie_main(int argc, const char *argv[], const char * defaultYaml)
         maxGraphLoopIterations = topology->getPropInt("@maxGraphLoopIterations", 1000);
         mergeAgentStatistics = topology->getPropBool("@mergeAgentStatistics", topology->getPropBool("@mergeSlaveStatistics", true));  // legacy name
         defaultCollectFactoryStatistics = topology->getPropBool("@collectFactoryStatistics", true);
+        defaultExecuteDependenciesSequentially = topology->getPropBool("@executeDependenciesSequentially", defaultExecuteDependenciesSequentially);
+        defaultStartInputsSequentially = topology->getPropBool("@startInputsSequentially", defaultStartInputsSequentially);
         defaultNoSeekBuildIndex = topology->getPropBool("@noSeekBuildIndex", isContainerized());
         parallelQueryLoadThreads = topology->getPropInt("@parallelQueryLoadThreads", parallelQueryLoadThreads);
         if (!parallelQueryLoadThreads)

--- a/roxie/ccd/ccdquery.cpp
+++ b/roxie/ccd/ccdquery.cpp
@@ -345,6 +345,9 @@ QueryOptions::QueryOptions()
     statsToWorkunit = false; // No global default or workunit setting for this
     failOnLeaks = alwaysFailOnLeaks;
     collectFactoryStatistics = defaultCollectFactoryStatistics;
+    executeDependenciesSequentially = defaultExecuteDependenciesSequentially;
+    startInputsSequentially = defaultStartInputsSequentially;
+    traceActivityCharacteristics = ::traceActivityCharacteristics;
     parallelWorkflow = false;
     sinkMode = defaultSinkMode;
     numWorkflowThreads = 1;
@@ -380,6 +383,9 @@ QueryOptions::QueryOptions(const QueryOptions &other)
     allSortsMaySpill = other.allSortsMaySpill;
     failOnLeaks = other.failOnLeaks;
     collectFactoryStatistics = other.collectFactoryStatistics;
+    executeDependenciesSequentially = other.executeDependenciesSequentially;
+    startInputsSequentially = other.startInputsSequentially;
+    traceActivityCharacteristics = other.traceActivityCharacteristics;
 
     parallelWorkflow = other.parallelWorkflow;
     sinkMode = other.sinkMode;
@@ -426,6 +432,9 @@ void QueryOptions::setFromWorkUnit(IConstWorkUnit &wu, const IPropertyTree *stat
     updateFromWorkUnit(failOnLeaks, wu, "failOnLeaks");
     updateFromWorkUnit(noSeekBuildIndex, wu, "noSeekBuildIndex");
     updateFromWorkUnit(collectFactoryStatistics, wu, "collectFactoryStatistics");
+    updateFromWorkUnit(executeDependenciesSequentially, wu, "executeDependenciesSequentially");
+    updateFromWorkUnit(startInputsSequentially, wu, "startInputsSequentially");
+    updateFromWorkUnit(traceActivityCharacteristics, wu, "traceActivityCharacteristics");
 
     updateFromWorkUnit(parallelWorkflow, wu, "parallelWorkflow");
     updateFromWorkUnit(sinkMode, wu, "sinkMode");
@@ -498,7 +507,10 @@ void QueryOptions::setFromContext(const IPropertyTree *ctx)
         // Note: allSortsMaySpill is not permitted at context level (too late anyway, unless I refactored)
         updateFromContext(failOnLeaks, ctx, "@failOnLeaks", "_FailOnLeaks");
         updateFromContext(collectFactoryStatistics, ctx, "@collectFactoryStatistics", "_CollectFactoryStatistics");
-
+        updateFromContext(executeDependenciesSequentially, ctx, "@executeDependenciesSequentially", "_ExecuteDependenciesSequentially");
+        updateFromContext(startInputsSequentially, ctx, "@startInputsSequentially", "_StartInputsSequentially");
+        updateFromContext(traceActivityCharacteristics, ctx, "@traceActivityCharacteristics", "_TraceActivityCharacteristics");
+        
         updateFromContext(parallelWorkflow, ctx, "@parallelWorkflow", "_parallelWorkflow");
         updateFromContext(numWorkflowThreads, ctx, "@numWorkflowThreads", "_numWorkflowThreads");
         updateFromContext(statsToWorkunit, ctx, "@statsToWorkunit", "_statsToWorkunit");

--- a/roxie/ccd/ccdquery.hpp
+++ b/roxie/ccd/ccdquery.hpp
@@ -111,6 +111,9 @@ public:
     bool noSeekBuildIndex;
     bool parallelWorkflow;
     bool statsToWorkunit = false;
+    bool executeDependenciesSequentially = false;
+    bool startInputsSequentially = false;
+    bool traceActivityCharacteristics = false;
     SinkMode sinkMode;
     unsigned numWorkflowThreads;
 

--- a/roxie/ccd/ccdserver.hpp
+++ b/roxie/ccd/ccdserver.hpp
@@ -91,10 +91,24 @@ interface IStrandJunction;
 
 class ClusterWriteHandler;
 
+enum class RoxieSourceCharacteristics : byte
+{
+    none = 0,
+    urgentStart = 0x01,
+    hasRowLatency = 0x02,
+    hasDependencies = 0x04,
+    slowDependencies = 0x08,
+};
+typedef RoxieSourceCharacteristics RSC;
+extern std::string getText(RoxieSourceCharacteristics flags);
+
+BITMASK_ENUM(RoxieSourceCharacteristics);
+
 class StrandOptions;
 interface IOrderedCallbackCollection;
 interface IFinalRoxieInput : extends IInputBase
 {
+    virtual RoxieSourceCharacteristics getSourceCharacteristics() const = 0;
     virtual void start(unsigned parentExtractSize, const byte *parentExtract, bool paused) = 0;
     virtual void reset() = 0;
 
@@ -149,6 +163,7 @@ interface IRoxieServerActivity : extends IActivityBase
     virtual IFinalRoxieInput *queryInput(unsigned idx) const = 0;
     virtual void execute(unsigned parentExtractSize, const byte *parentExtract) = 0;
     virtual void onCreate(IHThorArg *colocalArg) = 0;
+    virtual RoxieSourceCharacteristics getSourceCharacteristics() const = 0;
     virtual void start(unsigned parentExtractSize, const byte *parentExtract, bool paused) = 0;
     virtual IStrandJunction *getOutputStreams(IRoxieAgentContext *ctx, unsigned idx, PointerArrayOf<IEngineRowStream> &streams, const StrandOptions * consumerOptions, bool consumerOrdered, IOrderedCallbackCollection * orderedCallbacks) = 0;  // Use StrandFlags values for flags
 
@@ -224,6 +239,10 @@ interface IRoxieServerActivityFactory : extends IActivityFactory
     virtual bool isActivityCodeSigned() const = 0;
     virtual RecordTranslationMode getEnableFieldTranslation() const = 0;
     virtual SinkMode getSinkMode() const = 0;
+    virtual bool executeDependenciesSequentially() const = 0;
+    virtual bool startInputsSequentially() const = 0;
+    virtual RoxieSourceCharacteristics getActivityCharacteristics() const = 0;
+    virtual std::string describe() const = 0;
 };
 interface IGraphResult : public IInterface
 {

--- a/system/jlib/jstatcodes.h
+++ b/system/jlib/jstatcodes.h
@@ -253,6 +253,7 @@ enum StatisticKind
     StCycleDependenciesCycles,
     StTimeStart,
     StCycleStartCycles,
+    StEnumActivityCharacteristics,
     StMax,
 
     //For any quantity there is potentially the following variants.

--- a/system/jlib/jstats.cpp
+++ b/system/jlib/jstats.cpp
@@ -917,6 +917,7 @@ static const constexpr StatisticMeta statsMetaData[StMax] = {
     { CYCLESTAT(Dependencies) },
     { TIMESTAT(Start) },
     { CYCLESTAT(Start) },
+    { ENUMSTAT(ActivityCharacteristics) },
 };
 
 //Is a 0 value likely, and useful to be reported if it does happen to be zero?

--- a/testing/regress/ecl/childsink.ecl
+++ b/testing/regress/ecl/childsink.ecl
@@ -20,6 +20,7 @@
 //version childSinkOption='sequential'
 //version childSinkOption='parallel'
 //version childSinkOption='parallelPersistent'
+//version childSinkOption='automatic'
 
 import ^ as root;
 childSinkMode := #IFDEFINED(root.childSinkOption, 'parallel');


### PR DESCRIPTION
Added ability to control automatic sink combining...
Improved caching, return correct value for remotes, soapcall, pipe, etc
Added options to force prior behaviour of parallel starts/dependencies

Signed-off-by: Richard Chapman <rchapman@hpccsystems.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
