### PR TITLE
HPCC-27964 Add code to ensure DataBuffers are in the expected state

### DIFF
--- a/roxie/roxiemem/roxiemem.hpp
+++ b/roxie/roxiemem/roxiemem.hpp
@@ -231,7 +231,7 @@ public:
     {
         return count.load(std::memory_order_acquire);
     }
-    void noteReleased(const void *ptr);
+    inline void noteReleased(const void *ptr) { Release(); }
     void noteLinked(const void *ptr);
     bool attachToRowMgr(IRowManager *rowMgr);
 

--- a/roxie/roxiemem/roxiemem.hpp
+++ b/roxie/roxiemem/roxiemem.hpp
@@ -65,6 +65,8 @@
 
 #define MAX_FRAC_ALLOCATOR              20
 
+#define TRACK_DATABUFF_STATE
+
 //================================================================================
 // Roxie heap
 
@@ -206,6 +208,7 @@ class DataBuffer;
 interface IDataBufferManager;
 interface IRowManager;
 
+enum class DBState : unsigned { zero, unowned, queued, attached, freed, max };
 class roxiemem_decl DataBuffer
 {
     friend class CDataBufferManager;
@@ -232,9 +235,21 @@ public:
     void noteLinked(const void *ptr);
     bool attachToRowMgr(IRowManager *rowMgr);
 
+#ifdef TRACK_DATABUFF_STATE
+    void initState(DBState newState) { state = newState; }
+    void changeState(DBState oldState, DBState newState, const char * func);
+#else
+    void initState(DBState newState) { }
+    void changeState(DBState oldState, DBState newState, const char * func) {}
+#endif
+
 public:
     std::atomic_uint count;
+#ifdef TRACK_DATABUFF_STATE
+    DBState state = DBState::unowned;
+#else
     unsigned filler = 0; // keeps valgrind happy
+#endif
     IRowManager *mgr = nullptr;
     union
     {

--- a/roxie/udplib/udpsha.cpp
+++ b/roxie/udplib/udpsha.cpp
@@ -191,6 +191,7 @@ void queue_t::pushOwn(DataBuffer *buf)
     // potential priority-inversion issues. Or we might consider using PI-aware futexes here?
     assert(!buf->msgNext);
     {
+        buf->changeState(roxiemem::DBState::unowned, roxiemem::DBState::queued, __func__);
         CriticalBlock b(c_region);
         doEnqueue(buf);
     }

--- a/roxie/udplib/udptrr.cpp
+++ b/roxie/udplib/udptrr.cpp
@@ -1501,6 +1501,7 @@ public:
             try
             {
                 DataBuffer *dataBuff = input_queue->pop(true);
+                dataBuff->changeState(roxiemem::DBState::queued, roxiemem::DBState::unowned, __func__);
                 collatePacket(dataBuff);
             }
             catch (IException * e)


### PR DESCRIPTION
Signed-off-by: Gavin Halliday <gavin.halliday@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [x] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [ ] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
