### PR TITLE
HPCC-27993 Fix directio regression and striping support

### DIFF
--- a/dali/base/dafdesc.hpp
+++ b/dali/base/dafdesc.hpp
@@ -302,7 +302,7 @@ interface ISuperFileDescriptor: extends IFileDescriptor
 
 // == CLUSTER INFO (currently not exposed outside dali base) =================================================================================
 
-
+interface IStoragePlane;
 interface IClusterInfo: extends IInterface  // used by IFileDescriptor and IDistributedFile
 {
     virtual StringBuffer &getGroupName(StringBuffer &name,IGroupResolver *resolver=NULL)=0;
@@ -319,6 +319,7 @@ interface IClusterInfo: extends IInterface  // used by IFileDescriptor and IDist
     virtual void getBaseDir(StringBuffer &basedir, DFD_OS os)=0;
     virtual void getReplicateDir(StringBuffer &basedir, DFD_OS os)=0;
     virtual StringBuffer &getClusterLabel(StringBuffer &name)=0; // node group name
+    virtual void applyPlane(IStoragePlane *plane) = 0;
 };
 
 interface IStoragePlaneAlias: extends IInterface
@@ -397,6 +398,7 @@ extern da_decl bool getDefaultStoragePlane(StringBuffer &ret);
 extern da_decl bool getDefaultSpillPlane(StringBuffer &ret);
 extern da_decl IStoragePlane * getDataStoragePlane(const char * name, bool required);
 extern da_decl IStoragePlane * getRemoteStoragePlane(const char * name, bool required);
+extern da_decl IStoragePlane * createStoragePlane(IPropertyTree *meta);
 
 extern da_decl IFileDescriptor *createFileDescriptor();
 extern da_decl IFileDescriptor *createFileDescriptor(IPropertyTree *attr);      // ownership of attr tree is taken

--- a/fs/dafsserver/dafsserver.cpp
+++ b/fs/dafsserver/dafsserver.cpp
@@ -4811,7 +4811,7 @@ public:
             }
 
 #ifdef _CONTAINERIZED
-            bool authorizedOnly = hasMask(featureSupport, FeatureSupport::stream);
+            bool authorizedOnly = hasMask(featureSupport, FeatureSupport::stream) && !hasMask(featureSupport, FeatureSupport::directIO);
 #else
             /* NB: In bare-metal, unless client call is on dedicated service, allow non-authorized requests through, e.g. from engines talking to unsecured port
              * In a locked down secure setup, this service will be configured on a dedicated port, and the std. insecure dafilesrv will be unreachable.
@@ -5301,8 +5301,8 @@ public:
                 featureSupport = FeatureSupport::stream;
             else if (strsame("spray", appType))
                 featureSupport = FeatureSupport::spray;
-            else if (strsame("directIO", appType))
-                featureSupport = FeatureSupport::directIO;
+            else if (strsame("directio", appType))
+                featureSupport = FeatureSupport::directIO|FeatureSupport::stream;
         }
 #endif
         if (_connectMethod != SSLOnly)


### PR DESCRIPTION
1) The changes in HPCC-25041 (in 8.8.0) meant the dafilesrv
directio component failed because it's configuration option
was not picked up due to a casing typo in the dafilesrv
type logic.
2) Clients didn't handle striping correctly. Fix by
ensuring the serialized plane is available at the time of
directory manipulation.
3) Dafilesrv unnecessarily rejected streaming requests in a 'directio'
application setup. In a K8s directio application, it should support
all file operations (std i/o and streaming requests).

Signed-off-by: Jake Smith <jake.smith@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
