### PR TITLE
HPCC-28036 Fix k8s despray issues from plane with hosts

### DIFF
--- a/dali/dfu/dfuserver.cpp
+++ b/dali/dfu/dfuserver.cpp
@@ -197,6 +197,8 @@ int main(int argc, const char *argv[])
 
             IPropertyTree * config = nullptr;
             installDefaultFileHooks(config);
+
+            initializeStorageGroups(true);
         }
         StringBuffer queue, monitorQueue;
 #ifndef _CONTAINERIZED

--- a/dali/dfuxref/dfuxrefmain.cpp
+++ b/dali/dfuxref/dfuxrefmain.cpp
@@ -76,6 +76,7 @@ int main(int argc, char* argv[])
     try
     {
         initClientProcess(group, DCR_XRef);
+        initializeStorageGroups(true);
         StringArray args, clusters;
         bool backupcheck = false;
         unsigned mode = PMtextoutput|PMcsvoutput|PMtreeoutput;

--- a/dali/sasha/saserver.cpp
+++ b/dali/sasha/saserver.cpp
@@ -19,6 +19,7 @@
 #include "thirdparty.h"
 #include "portlist.h"
 #include "jlib.hpp"
+#include "jfile.hpp"
 #include "jlog.hpp"
 #include "jptree.hpp"
 #include "jmisc.hpp"
@@ -29,6 +30,7 @@
 #include "mplog.hpp"
 #include "dasess.hpp"
 #include "dasds.hpp"
+#include "dafdesc.hpp"
 #include "daclient.hpp"
 #include "environment.hpp"
 #include "dllserver.hpp"
@@ -407,6 +409,7 @@ int main(int argc, const char* argv[])
             else
             {
                 addAbortHandler(actionOnAbort);
+                initializeStorageGroups(true);
 #ifdef _CONTAINERIZED
                 service = serverConfig->queryProp("@service");
                 if (isEmptyString(service))

--- a/dockerfiles/startall.sh
+++ b/dockerfiles/startall.sh
@@ -160,6 +160,7 @@ if [[ -n ${PERSIST} ]] ; then
   grep "##" lsfull.yaml  && \
   helm ${CMD} $CLUSTERNAME $scriptdir/../helm/hpcc/ --set global.image.root="${DOCKER_REPO}" --set global.image.version=$LABEL $DEVELOPER_OPTIONS ${restArgs[@]} -f localstorage.yaml ${PROMETHEUS_METRICS_SINK_ARG} ${ELASTIC_LOG_ACCESS_ARG}
 else
+  echo helm ${CMD} $CLUSTERNAME $scriptdir/../helm/hpcc/ --set global.image.root="${DOCKER_REPO}" --set global.image.version=$LABEL $DEVELOPER_OPTIONS ${restArgs[@]} ${PROMETHEUS_METRICS_SINK_ARG} ${ELASTIC_LOG_ACCESS_ARG}
   helm ${CMD} $CLUSTERNAME $scriptdir/../helm/hpcc/ --set global.image.root="${DOCKER_REPO}" --set global.image.version=$LABEL $DEVELOPER_OPTIONS ${restArgs[@]} ${PROMETHEUS_METRICS_SINK_ARG} ${ELASTIC_LOG_ACCESS_ARG}
 fi
 

--- a/esp/platform/espp.cpp
+++ b/esp/platform/espp.cpp
@@ -544,7 +544,8 @@ int init_main(int argc, const char* argv[])
             config->bindServer(*server.get(), *server.get());
             config->checkESPCache(*server.get());
 
-            initializeMetrics(config);
+            initializeMetrics(config);        
+            initializeStorageGroups(daliClientActive());
         }
         catch(IException* e)
         {

--- a/esp/smc/SMCLib/TpContainer.cpp
+++ b/esp/smc/SMCLib/TpContainer.cpp
@@ -109,14 +109,7 @@ static void gatherDropZoneMachines(IArrayOf<IEspTpMachine> & tpMachines, IProper
 {
     const char * prefix = plane.queryProp("@prefix");
     if (plane.hasProp("hosts"))
-    {
         gatherDropZoneMachinesFromHosts(tpMachines, plane, prefix);
-    }
-    else if (plane.hasProp("@hostGroup"))
-    {
-        Owned<IPropertyTree> hostGroup = getHostGroup(plane.queryProp("@hostGroup"), true);
-        gatherDropZoneMachinesFromHosts(tpMachines, *hostGroup, prefix);
-    }
     else
         tpMachines.append(*createHostTpMachine("localhost", prefix));
 }


### PR DESCRIPTION
Trying to despray from a plane with hosts (e.g. for despraying
to baremetal) failed because the service code expected to see
a @hostsGroup attribute in the plane.
Instead if should look for 'hosts', which are generated
automatically at initialization time for any planes that have
@hostGroup definitions.

This PR:
1) changes service code to universally look for "hosts" not
@hostGroup
2) Ensures all client programs call initializeStorageGroups()
which ensures that planes populate "hosts" where needed.

Signed-off-by: Jake Smith <jake.smith@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
