### PR TITLE
HPCC-28069 Default logging to non-dropping mode in K8s.

### DIFF
--- a/docs/EN_US/ContainerizedHPCC/ContainerizedMods/ContainerLogging.xml
+++ b/docs/EN_US/ContainerizedHPCC/ContainerizedMods/ContainerLogging.xml
@@ -476,5 +476,31 @@ ContainerLog
 
       <programlisting>helm install myhpcc ./hpcc --set -f ./examples/logging/esp-eclwatch-low-logging-values.yaml</programlisting>
     </sect2>
+
+    <sect2>
+      <title>Asychronous logging configuration</title>
+
+      <para>By default log entries will be created and logged asynchronously,
+      so as not to block the client that is logging.
+      Log entries will be held in a queue and output on a background thread.
+      This queue has a maximum depth, once hit, the client will block waiting
+      for capacity. Alternatively, the behaviour can be be configured such
+      that when this limit is hit, logging entries are dropped and lost to
+      avoid any potential blocking.</para>
+
+      <para>NB: normally it is expected that the logging stack will keep up
+      and the default queue limit will be sufficient to avoid any blocking.</para>
+
+      <para>The defaults can be configured by setting
+      &lt;section&gt;.logging.queueLen and/or
+      &lt;section&gt;.logging.queueDrop.</para>
+
+      <para>Setting &lt;section&gt;.logging.queueLen to 0, will disabled
+      asynchronous logging, i.e. each log will block until completed.</para>
+
+      <para>Setting &lt;section&gt;.logging.queueDrop to a non-zero (N) value
+      will cause N logging entries from the queue to be discarded if the
+      queueLen is reached.</para>
+    </sect2>
   </sect1>
 </chapter>

--- a/helm/examples/logging/README.md
+++ b/helm/examples/logging/README.md
@@ -103,3 +103,16 @@ Adjustment of per-component logging values can require assertion of multiple com
 
     For example, the ESP component instance 'eclwatch' should output minimal log:
     helm install myhpcc ./hpcc --set -f ./examples/logging/esp-eclwatch-low-logging-values.yaml
+
+### Asychronous logging configuration
+
+By default log entries will be created and logged asynchronously, so as not to block the client that is logging.
+Log entries will be held in a queue and output on a background thread.
+This queue has a maximum depth, once hit, the client will block waiting for capacity.
+Alternatively, the behaviour can be be configured such that when this limit is hit, logging entries are dropped and lost to avoid any potential blocking.
+
+NB: normally it is expected that the logging stack will keep up and the default queue limit will be sufficient to avoid any blocking.
+
+The defaults can be configured by setting `<section>`.logging.queueLen and/or `<section>`.logging.queueDrop.
+Setting `<section>`.logging.queueLen to 0, will disabled asynchronous logging, i.e. each log will block until completed.
+Setting `<section>`.logging.queueDrop to a non-zero (N) value will cause N logging entries from the queue to be discarded if the queueLen is reached.

--- a/helm/hpcc/values.schema.json
+++ b/helm/hpcc/values.schema.json
@@ -928,6 +928,16 @@
         "detail": {
           "type": "integer",
           "description": "Log output verbosity"
+        },
+        "queueLength": {
+          "type": "integer",
+          "description": "Maximum number of log entries to buffer in the log queue. Set to 0 for synchronous logging",
+          "default": 512
+        },
+        "queueDrop": {
+          "type": "integer",
+          "description": "Number of log entries to drop from the log queue when it is full. Disabled if 0, or if queueLength is 0",
+          "default": 0
         }
       },
       "additionalProperties": { "type": ["integer", "string", "boolean"] }

--- a/roxie/roxie/roxie.cpp
+++ b/roxie/roxie/roxie.cpp
@@ -52,7 +52,6 @@ roxie:
   numChannels: 1
   queueNames: roxie.roxie
   logging:
-    detail: 50
     queueDrop: 32
 )!!";
 

--- a/roxie/roxie/roxie.cpp
+++ b/roxie/roxie/roxie.cpp
@@ -51,6 +51,9 @@ roxie:
   localSlave: true
   numChannels: 1
   queueNames: roxie.roxie
+  logging:
+    detail: 50
+    queueDrop: 32
 )!!";
 
 int main(int argc, const char *argv[])

--- a/roxie/topo/toposerver.cpp
+++ b/roxie/topo/toposerver.cpp
@@ -322,6 +322,8 @@ static constexpr const char * defaultYaml = R"!!(
     port: 9004
     stdlog: true
     traceLevel: 1
+    logging:
+      queueDrop: 32
 )!!";
 
 int main(int argc, const char *argv[])

--- a/system/jlib/jlog.cpp
+++ b/system/jlib/jlog.cpp
@@ -2398,21 +2398,14 @@ static constexpr const char * logFieldsAtt = "@fields";
 static constexpr const char * logMsgDetailAtt = "@detail";
 static constexpr const char * logMsgAudiencesAtt = "@audiences";
 static constexpr const char * logMsgClassesAtt = "@classes";
-static constexpr const char * useLogQueueAtt = "@useLogQueue";
 static constexpr const char * logQueueLenAtt = "@queueLen";
 static constexpr const char * logQueueDropAtt = "@queueDrop";
 static constexpr const char * logDisabledAtt = "@disabled";
 static constexpr const char * useSysLogpAtt ="@enableSysLog";
 static constexpr const char * capturePostMortemAtt ="@postMortem";
 
-#ifdef _DEBUG
-static constexpr bool useQueueDefault = false;
-#else
-static constexpr bool useQueueDefault = true;
-#endif
-
 static constexpr unsigned queueLenDefault = 512;
-static constexpr unsigned queueDropDefault = 32;
+static constexpr unsigned queueDropDefault = 0; // disabled by default
 static constexpr bool useSysLogDefault = false;
 
 void setupContainerizedLogMsgHandler()
@@ -2453,14 +2446,21 @@ void setupContainerizedLogMsgHandler()
             theManager->changeMonitorFilter(theStderrHandler, filter);
         }
 
-        bool useLogQueue = logConfig->getPropBool(useLogQueueAtt, useQueueDefault);
-        if (useLogQueue)
+        unsigned queueLen = logConfig->getPropInt(logQueueLenAtt, queueLenDefault);
+        if (queueLen)
         {
-            unsigned queueLen = logConfig->getPropInt(logQueueLenAtt, queueLenDefault);
-            unsigned queueDrop = logConfig->getPropInt(logQueueDropAtt, queueDropDefault);
-
             queryLogMsgManager()->enterQueueingMode();
-            queryLogMsgManager()->setQueueDroppingLimit(queueLen, queueDrop);
+            unsigned queueDrop = logConfig->getPropInt(logQueueDropAtt, queueDropDefault);
+            if (queueDrop)
+            {
+                queryLogMsgManager()->setQueueDroppingLimit(queueLen, queueDrop);
+                PROGLOG("JLog: queuing enabled with dropping: queueLen=%u, queueDrop=%u", queueLen, queueDrop);
+            }
+            else
+            {
+                queryLogMsgManager()->setQueueBlockingLimit(queueLen);
+                PROGLOG("JLog: queuing enabled: queueLen=%u", queueLen);
+            }
         }
 
         if (logConfig->getPropBool(useSysLogpAtt, useSysLogDefault))


### PR DESCRIPTION
To match bare-metal behaviour, logs should not by default drop
logs when queue hits the limit (default behaviour is to block).
In bare-metal - there are couple of exceptions, roxie and
the topology server configure logging to drop logs when queue
is full rather than block.
Preserve that behaviour via default configuration.

Signed-off-by: Jake Smith <jake.smith@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
