### PR TITLE
HPCC-27767 Validate requests before searching WUs and queries

### DIFF
--- a/esp/services/ws_fs/ws_fsService.cpp
+++ b/esp/services/ws_fs/ws_fsService.cpp
@@ -939,6 +939,7 @@ bool CFileSprayEx::onGetDFUWorkunits(IEspContext &context, IEspGetDFUWorkunits &
     try
     {
         context.ensureFeatureAccess(DFU_WU_URL, SecAccess_Read, ECLWATCH_DFU_WU_ACCESS_DENIED, "Access to DFU workunit is denied.");
+        CFileSprayValidateHelper::validateGetDFUWorkunitsRequest(req);
 
         StringBuffer wuidStr(req.getWuid());
         const char* wuid = wuidStr.trim().str();
@@ -1392,6 +1393,8 @@ bool CFileSprayEx::onGetDFUWorkunit(IEspContext &context, IEspGetDFUWorkunit &re
         const char* wuid = req.getWuid();
         if (!wuid || !*wuid)
             throw MakeStringException(ECLWATCH_INVALID_INPUT, "Dfu workunit ID not specified.");
+        if (!looksLikeAWuid(wuid, 'D'))
+            throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "GetDFUWorkunit: Invalid Workunit ID: %s", wuid);
 
         bool found = false;
         double version = context.getClientVersion();
@@ -3676,4 +3679,20 @@ bool CFileSprayEx::onGetDFUServerQueues(IEspContext &context, IEspGetDFUServerQu
     }
 
     return true;
+}
+
+void CFileSprayValidateHelper::validateGetDFUWorkunitsRequest(IEspGetDFUWorkunits& req)
+{
+    if (!isEmptyString(req.getWuid()) && !looksLikeAWuid(req.getWuid(), 'D'))
+        throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "GetDFUWorkunits: Invalid Workunit ID: %s", req.getWuid());
+    if (!isEmptyString(req.getOwner()) && !isValidXPathValue(req.getOwner()))
+        throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "GetDFUWorkunits: Invalid Owner %s.", req.getOwner());
+    if (!isEmptyString(req.getCluster()) && !isValidXPathValue(req.getCluster()))
+        throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "GetDFUWorkunits: Invalid Cluster %s.", req.getCluster());
+    if (!isEmptyString(req.getStateReq()) && !isValidXPathValue(req.getStateReq()))
+        throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "GetDFUWorkunits: Invalid StateReq %s.", req.getStateReq());
+    if (!isEmptyString(req.getJobname()) && !isValidXPathValue(req.getJobname()))
+        throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "GetDFUWorkunits: Invalid Jobname %s.", req.getJobname());
+    if (!isEmptyString(req.getPublisherWuid()) && !isValidXPathValue(req.getPublisherWuid()))
+        throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "GetDFUWorkunits: Invalid PublisherWuid %s.", req.getPublisherWuid());
 }

--- a/esp/services/ws_fs/ws_fsService.hpp
+++ b/esp/services/ws_fs/ws_fsService.hpp
@@ -64,6 +64,12 @@ public:
 
 };
 
+class CFileSprayValidateHelper
+{
+public:
+    static void validateGetDFUWorkunitsRequest(IEspGetDFUWorkunits& req);
+};
+
 class CFileSprayEx : public CFileSpray
 {
     void readAndCheckSpraySourceReq(MemoryBuffer& srcxml, const char* srcIP, const char* srcPath, const char* srcplane,

--- a/esp/services/ws_workunits/ws_workunitsHelpers.cpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.cpp
@@ -4908,4 +4908,56 @@ void CWsWuEmailHelper::send(const char* body, const void* attachment, size32_t l
             attachmentName.get(), mailServer.get(), port, sender.get(), &warnings);
 }
 
+void CWsWuValidateHelper::validateWUQueryRequest(IEspWUQueryRequest& req)
+{
+    validateWUQueryRequestCommon("WUQuery", req);
+    if (!isEmptyString(req.getJobname()) && !isValidXPathValue(req.getJobname()))
+        throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "WUQuery: Invalid Jobname %s.", req.getJobname());
+    if (!isEmptyString(req.getECL()) && !isValidXPathValue(req.getECL()))
+        throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "WUQuery: Invalid ECL search request %s.", req.getECL());
+    if (!isEmptyString(req.getLogicalFile()) && !isValidXPathValue(req.getLogicalFile()))
+        throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "WUQuery: Invalid LogicalFile %s.", req.getLogicalFile());
+}
+
+void CWsWuValidateHelper::validateWULightWeightQueryRequest(IEspWULightWeightQueryRequest& req)
+{
+    validateWUQueryRequestCommon("WULightWeightQuery", req);
+    if (!isEmptyString(req.getJobName()) && !isValidXPathValue(req.getJobName()))
+        throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "WULightWeightQuery: Invalid JobName %s.", req.getJobName());
+}
+
+void CWsWuValidateHelper::validateApplicationValuesRequest(const char* method, IArrayOf<IConstApplicationValue>& applicationValues)
+{
+    ForEachItemIn(i, applicationValues)
+    {
+        IConstApplicationValue& item = applicationValues.item(i);
+        if (isEmpty(item.getApplication()))
+            throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "%s: Application must be specified.", method);
+        if (!isValidXPathValue(item.getApplication()))
+            throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "%s: Invalid Application %s.", method, item.getApplication());
+        if (isEmpty(item.getName()) && isEmpty(item.getValue()))
+            throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "%s: Application %s: Application Name or Value must be specified.", method, item.getApplication());
+        if (!isEmptyString(item.getName()) && !isValidXPathValue(item.getName()))
+            throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "%s: Application %s: Invalid Application Name %s.", method, item.getApplication(), item.getName());
+        if (!isEmptyString(item.getValue()) && !isValidXPathValue(item.getValue()))
+            throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "%s: Application %s: Invalid Application Value %s.", method, item.getApplication(), item.getValue());
+    }
+}
+
+void CWsWuValidateHelper::validateWUListQueriesRequest(IEspWUListQueriesRequest& req)
+{
+    if (!isEmptyString(req.getQuerySetName()) && !isValidXPathValue(req.getQuerySetName()))
+        throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "WUListQueries: Invalid QuerySetName %s.", req.getQuerySetName());
+    if (!isEmptyString(req.getLibraryName()) && !isValidXPathValue(req.getLibraryName()))
+        throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "WUListQueries: Invalid LibraryName %s.",req.getLibraryName());
+    if (!isEmptyString(req.getWUID()) && !looksLikeAWuid(req.getWUID(), 'W'))
+        throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "WUListQueries: Invalid WUID %s.", req.getWUID());
+    if (!isEmptyString(req.getQueryID()) && !isValidXPathValue(req.getQueryID()))
+        throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "WUListQueries: Invalid QueryID %s.", req.getQueryID());
+    if (!isEmptyString(req.getQueryName()) && !isValidXPathValue(req.getQueryName()))
+        throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "WUListQueries: Invalid QueryName %s.", req.getQueryName());
+    if (!isEmptyString(req.getPublishedBy()) && !isValidXPathValue(req.getPublishedBy()))
+        throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "WUListQueries: Invalid PublishedBy %s.", req.getPublishedBy());
+}
+
 }

--- a/esp/services/ws_workunits/ws_workunitsHelpers.hpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.hpp
@@ -717,6 +717,34 @@ public:
     void send(const char *body, const void *attachment, size32_t lenAttachment, StringArray &warnings);
 };
 
+class CWsWuValidateHelper
+{
+    static void validateApplicationValuesRequest(const char* method, IArrayOf<IConstApplicationValue>& applicationValues);
+    template <class T> static inline void validateWUQueryRequestCommon(const char* method, T& req)
+    {
+        if (!isEmptyString(req.getWuid()) && !looksLikeAWuid(req.getWuid(), 'W'))
+            throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "%s: Invalid Workunit ID: %s", method, req.getWuid());
+        if (!isEmptyString(req.getCluster()) && !isValidXPathValue(req.getCluster()))
+            throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "%s: Invalid Cluster %s.", method, req.getCluster());
+        if (!isEmptyString(req.getOwner()) && !isValidXPathValue(req.getOwner()))
+            throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "%s: Invalid Owner %s.", method, req.getOwner());
+        if (!isEmptyString(req.getState()) && !isValidXPathValue(req.getState()))
+            throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "%s: Invalid State %s.", method, req.getState());
+        validateApplicationValuesRequest(method, req.getApplicationValues());
+    };
+public:
+    static void validateWUQueryRequest(IEspWUQueryRequest& req);
+    static void validateWULightWeightQueryRequest(IEspWULightWeightQueryRequest& req);
+    static void validateWUListQueriesRequest(IEspWUListQueriesRequest& req);
+    template <class T> static inline void validateWUQueryDetailsRequest(const char* method, T& req)
+    {
+        if (!isEmptyString(req.getQuerySet()) && !isValidXPathValue(req.getQuerySet()))
+            throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "%s: Invalid QuerySet %s.", method, req.getQuerySet());
+        if (!isEmptyString(req.getQueryId()) && !isValidXPathValue(req.getQueryId()))
+            throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "%s: Invalid QueryId %s.", method, req.getQueryId());
+    };
+};
+
 #ifndef _CONTAINERIZED
 class CGetThorSlaveLogToFileThreadParam : public CInterface
 {

--- a/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
+++ b/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
@@ -1631,6 +1631,8 @@ void CWsWorkunitsEx::checkAndSetClusterQueryState(IEspContext &context, const ch
 
 bool CWsWorkunitsEx::onWUListQueries(IEspContext &context, IEspWUListQueriesRequest & req, IEspWUListQueriesResponse & resp)
 {
+    CWsWuValidateHelper::validateWUListQueriesRequest(req);
+
     bool descending = req.getDescending();
     const char *sortBy =  req.getSortby();
     WUQuerySortField sortOrder[2] = {WUQSFId, WUQSFterm};
@@ -2232,6 +2234,8 @@ bool CWsWorkunitsEx::onWUQueryDetails(IEspContext &context, IEspWUQueryDetailsRe
 {
     try
     {
+        CWsWuValidateHelper::validateWUQueryDetailsRequest("WUQueryDetails", req);
+
         CWUQueryDetailsReq request(req);
         getWUQueryDetails(context, request, resp);
     }
@@ -2440,6 +2444,8 @@ bool CWsWorkunitsEx::onWUQueryDetailsLightWeight(IEspContext &context, IEspWUQue
 {
     try
     {
+        CWsWuValidateHelper::validateWUQueryDetailsRequest("WUQueryDetailsLightWeight", req);
+
         CWUQueryDetailsReq request(req);
         getWUQueryDetails(context, request, resp);
     }

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -2568,6 +2568,8 @@ bool CWsWorkunitsEx::onWUQuery(IEspContext &context, IEspWUQueryRequest & req, I
 {
     try
     {
+        CWsWuValidateHelper::validateWUQueryRequest(req);
+
         StringBuffer wuidStr(req.getWuid());
         const char* wuid = wuidStr.trim().str();
 
@@ -2638,6 +2640,8 @@ bool CWsWorkunitsEx::onWULightWeightQuery(IEspContext &context, IEspWULightWeigh
 {
     try
     {
+        CWsWuValidateHelper::validateWULightWeightQueryRequest(req);
+
         if (req.getType() && strieq(req.getType(), "archived workunits"))
             doWULightWeightQueryFromArchive(context, sashaServerIp.get(), sashaServerPort, *archivedWuCache, awusCacheMinutes, req, resp);
         else

--- a/system/jlib/jptree.hpp
+++ b/system/jlib/jptree.hpp
@@ -313,6 +313,22 @@ inline static bool isValidXPathChr(char c)
     return ('\0' != c && (isalnum(c) || strchr(validChrs, c)));
 }
 
+static const char *validXPathValueChrs = "!#$%^&()+,-.:;?@_{|}~"; //Do I miss any?
+inline static bool isValidXPathValueChr(char c)
+{
+    return ('\0' != c && (isalnum(c) || strchr(validXPathValueChrs, c)));
+}
+inline static bool isValidXPathValue(const char *v)
+{
+    const char *p = v;
+    do
+    {
+         if (!isValidXPathValueChr(*p++)) return false;
+    }
+    while (*p != '\0');
+    return true;
+}
+
 //export for unit test
 jlib_decl void mergeConfiguration(IPropertyTree & target, const IPropertyTree & source, const char *altNameAttribute=nullptr, bool overwriteAttr=true);
 


### PR DESCRIPTION
The code is added to make sure that search requests do not have
invalid character as xpath values. The changes in this PR focus
on the following ESP services:
1. WsWorkunits.WUQuery
2. WsWorkunits.WULightWeightQuery
3. WsWorkunits.WUListQueries
4. WsWorkunits.WUQueryDetails
5. WsWorkunits.WUQueryDetailsLightWeight
6. FileSpray.GetDFUWorkunits

The code is also added to validate the workunit ID in
FileSpray.GetDFUWorkunit request.

Signed-off-by: wangkx <kevin.wang@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
