### PR TITLE
HPCC-28106 Replace IPs from ZAP report

### DIFF
--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -25,7 +25,7 @@ EspInclude(ws_workunits_queryset_req_resp);
 
 ESPservice [
     auth_feature("DEFERRED"), //This declares that the method logic handles feature level authorization
-    version("1.94"), default_client_version("1.94"), cache_group("ESPWsWUs"),
+    version("1.95"), default_client_version("1.95"), cache_group("ESPWsWUs"),
     noforms,exceptions_inline("./smc_xslt/exceptions.xslt"),use_method_name] WsWorkunits
 {
     ESPmethod [cache_seconds(60), resp_xsl_default("/esp/xslt/workunits.xslt")]     WUQuery(WUQueryRequest, WUQueryResponse);

--- a/esp/scm/ws_workunits_req_resp.ecm
+++ b/esp/scm/ws_workunits_req_resp.ecm
@@ -896,8 +896,10 @@ ESPrequest [nil_remove] WUGetZAPInfoRequest
 ESPresponse [exceptions_inline] WUGetZAPInfoResponse
 {
     string WUID;
-    string ESPIPAddress;
-    string ThorIPAddress;
+    [depr_ver("1.95")] string ESPIPAddress;
+    [min_ver("1.95")] string ESPApplication;
+    [depr_ver("1.95")] string ThorIPAddress;
+    [min_ver("1.95")] string ThorProcesses;
     string BuildVersion;
     string Archive;
     [min_ver("1.73")] string EmailTo;
@@ -907,8 +909,10 @@ ESPresponse [exceptions_inline] WUGetZAPInfoResponse
 ESPrequest [nil_remove] WUCreateZAPInfoRequest
 {
     string Wuid;
-    string ESPIPAddress;
-    string ThorIPAddress;
+    [depr_ver("1.95")] string ESPIPAddress;
+    [min_ver("1.95")] string ESPApplication;
+    [depr_ver("1.95")] string ThorIPAddress;
+    [min_ver("1.95")] string ThorProcesses;
     string BuildVersion;
     string ProblemDescription;
     string WhatChanged;

--- a/esp/services/ws_workunits/ws_workunitsHelpers.cpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.cpp
@@ -3965,7 +3965,7 @@ void CWsWuFileHelper::createThorSlaveLogfile(IConstWorkUnit* cwu, WsWuInfo& winf
 }
 #endif
 
-void CWsWuFileHelper::createZAPInfoFile(const char* url, const char* espIP, const char* thorIP, const char* problemDesc,
+void CWsWuFileHelper::createZAPInfoFile(const char* url, const char* esp, const char* thor, const char* problemDesc,
     const char* whatChanged, const char* timing, IConstWorkUnit* cwu, const char* tempDirName)
 {
     VStringBuffer fileName("%s%c%s.txt", tempDirName, PATHSEPCHAR, cwu->queryWuid());
@@ -3978,19 +3978,11 @@ void CWsWuFileHelper::createZAPInfoFile(const char* url, const char* espIP, cons
     sb.append("User:         ").append(cwu->queryUser()).append("\r\n");
     sb.append("Build Version:").append(getBuildVersion()).append("\r\n");
     sb.append("Cluster:      ").append(cwu->queryClusterName()).append("\r\n");
-    if (!isEmptyString(espIP))
-        sb.append("ESP:          ").append(espIP).append("\r\n");
-    else
-    {
-        StringBuffer espIPAddr;
-        IpAddress ipaddr = queryHostIP();
-        ipaddr.getIpText(espIPAddr);
-        sb.append("ESP:          ").append(espIPAddr.str()).append("\r\n");
-    }
+    sb.append("ESP:          ").append(esp).append("\r\n");
     if (!isEmptyString(url))
         sb.append("URL:          ").append(url).append("\r\n");
-    if (!isEmptyString(thorIP))
-        sb.append("Thor:         ").append(thorIP).append("\r\n");
+    if (!isEmptyString(thor))
+        sb.append("Thor:         ").append(thor).append("\r\n");
     outFile->write(sb.length(), sb.str());
 
     //Exceptions/Warnings/Info
@@ -4360,7 +4352,7 @@ void CWsWuFileHelper::createWUZAPFile(IEspContext& context, IConstWorkUnit* cwu,
     thorSlaveLogThreadPoolSize = _thorSlaveLogThreadPoolSize;
 
     //create WU ZAP files
-    createZAPInfoFile(request.url.str(), request.espIP.str(), request.thorIP.str(), request.problemDesc.str(), request.whatChanged.str(),
+    createZAPInfoFile(request.url.str(), request.esp.str(), request.thor.str(), request.problemDesc.str(), request.whatChanged.str(),
         request.whereSlow.str(), cwu, tempDirName);
     createZAPECLQueryArchiveFiles(cwu, tempDirName);
 

--- a/esp/services/ws_workunits/ws_workunitsHelpers.hpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.hpp
@@ -644,7 +644,7 @@ public:
 
 struct CWsWuZAPInfoReq
 {
-    StringBuffer wuid, espIP, url, thorIP, problemDesc, whatChanged, whereSlow, includeThorSlaveLog, zapFileName, password;
+    StringBuffer wuid, esp, url, thor, problemDesc, whatChanged, whereSlow, includeThorSlaveLog, zapFileName, password;
     StringBuffer emailFrom, emailTo, emailServer, emailSubject, emailBody;
     bool sendEmail, attachZAPReportToEmail;
     unsigned maxAttachmentSize, port;

--- a/esp/services/ws_workunits/ws_workunitsService.hpp
+++ b/esp/services/ws_workunits/ws_workunitsService.hpp
@@ -432,6 +432,7 @@ private:
     Owned<IWorkUnitFactory> wuFactory;
     StringBuffer tempDirectory;
     __uint64 wuResultMaxSize = defaultWUResultMaxSize;
+    StringAttr espApplicationName;
 
 public:
     QueryFilesInUse filesInUse;
@@ -449,6 +450,7 @@ public:
     CWsWorkunitsSoapBindingEx(IPropertyTree *cfg, const char *name, const char *process, http_soap_log_level llevel) : CWsWorkunitsSoapBinding(cfg, name, process, llevel)
     {
         wswService = NULL;
+        espApplicationName.set(process);
         VStringBuffer xpath("Software/EspProcess[@name=\"%s\"]/EspBinding[@name=\"%s\"]/BatchWatch", process, name);
         batchWatchFeaturesOnly = cfg->getPropBool(xpath.str(), false);
         directories.set(cfg->queryPropTree("Software/Directories"));
@@ -503,6 +505,7 @@ private:
     Owned<IPropertyTree> directories;
     unsigned thorSlaveLogThreadPoolSize = THOR_SLAVE_LOG_THREAD_POOL_SIZE;
     size32_t wuResultDownloadFlushThreshold = defaultWUResultDownloadFlushThreshold;
+    StringAttr espApplicationName;
 };
 
 void deploySharedObject(IEspContext &context, StringBuffer &wuid, const char *filename, const char *cluster, const char *name, const MemoryBuffer &obj, const char *dir, const char *xml=NULL, bool protect=false);

--- a/tools/hidl/hidlcomp.cpp
+++ b/tools/hidl/hidlcomp.cpp
@@ -5595,6 +5595,9 @@ void EspServInfo::write_esp_binding_ipp()
     //Method ==> onGetInstantQuery
     outs("\tvirtual int onGetInstantQuery(IEspContext &context, CHttpRequest* request, CHttpResponse* response, const char *service, const char *method);\n");
 
+    //Method ==> getDefaultClientVersion
+    outs("\tbool getDefaultClientVersion(double &ver);\n");
+
     //Method ==> xslTransform
     if (needsXslt)
     {
@@ -6151,18 +6154,24 @@ void EspServInfo::write_esp_binding()
     outs(1, "return NULL;\n");
     outs("}\n");
 
-    //Method ==> onGetInstantQuery
-    outf("\nint C%sSoapBinding::onGetInstantQuery(IEspContext &context, CHttpRequest* request, CHttpResponse* response, const char *service, const char *method)\n", name_);
+    //Method ==> getDefaultClientVersion
+    outf("\nbool C%sSoapBinding::getDefaultClientVersion(double &ver)\n", name_);
     outs("{\n");
     StrBuffer defVer;
     bool hasDefVer = getMetaVerInfo(tags,"default_client_version",defVer);
     if (!hasDefVer)
         hasDefVer = getMetaVerInfo(tags,"version",defVer);
     if (hasDefVer)
-    {
-        outf("\tif (context.getClientVersion()<=0)\n");
-        outf("\t\tcontext.setClientVersion(%s);\n\n", defVer.str());
-    }
+        outf("\tver = %s;\n", defVer.str());
+    outf("\treturn %s;\n", hasDefVer ? "true" : "false");
+    outs("}\n");
+
+    //Method ==> onGetInstantQuery
+    outf("\nint C%sSoapBinding::onGetInstantQuery(IEspContext &context, CHttpRequest* request, CHttpResponse* response, const char *service, const char *method)\n", name_);
+    outs("{\n");
+    outf("\tdouble defaultClientVersion = 0.0;\n");
+    outf("\tif ((context.getClientVersion()<=0) && getDefaultClientVersion(defaultClientVersion))\n");
+    outf("\t\tcontext.setClientVersion(defaultClientVersion);\n\n");
     outs("\tif(request == NULL || response == NULL)\n");
     outs("\t\treturn -1;\n");
     


### PR DESCRIPTION
The existing ZAP report contains the IP address of the ESP where
the report is created. If ECL WU has Thor logs, the ZAP report
also contains the IP addresses of the Thors. In this PR, the ESP
IP is replaced by ESP application name. Thor IPs is replaced by
Thor process names.

Also add the code to set default client version for
CWsWorkunitsSoapBindingEx::onGet().

Signed-off-by: wangkx <kevin.wang@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
