### PR TITLE
HPCC-28151 Enable sasha file-expiry and dfurecovery-archiver by default

### DIFF
--- a/helm/hpcc/values.schema.json
+++ b/helm/hpcc/values.schema.json
@@ -2266,177 +2266,14 @@
       }
     },
     "sasha-coalescer": {
-      "oneOf": [
+      "type": "object",
+      "allOf": [
+        { "$ref": "#/definitions/sashacommon" },
         {
-          "type": "object",
-          "allOf": [
-            { "$ref": "#/definitions/sashacommon" },
-            {
-              "properties": {
-                "minDeltaSize": {
-                  "type": "integer",
-                  "description": "Coalescing will only begin, if the delta size is above this threshold (K)"
-                },
-                "disabled": {},
-                "interval": {},
-                "service": {},
-                "at" : {},
-                "throttle": {},
-                "image": {},
-                "plane": {},
-                "resources": {},
-                "env": {},
-                "annotations": {},
-                "labels": {}
-              },
-              "additionalProperties": false
-            }
-          ]
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "sasha-wu-archiver": {
-      "oneOf": [
-        {
-          "type": "object",
-          "required": [ "plane" ],
-          "allOf": [
-            { "$ref": "#/definitions/sashacommon" },
-            { "$ref": "#/definitions/sasha-limitcutoff" },
-            {
-              "properties": 
-              {
-                "backup": {
-                  "type": "integer",
-                  "description": "minimum workunit age to backup (days, 0 disables)",
-                  "default": "0"
-                },
-                "duration": {
-                  "type": "integer",
-                  "description": "Maximum duration to run WorkUnit archiving session (hours, 0 unlimited)",
-                  "default": "0"
-                },
-                "keepResultFiles": {
-                  "type": "boolean",
-                  "description": "option to keep result files owned by workunits after workunit is archived",
-                  "default": "false"
-                },
-                "retryinterval": {
-                  "type": "integer",
-                  "description": "minimal time before retrying archive of failed WorkUnits (days)",
-                  "default": "7"
-                },
-                "disabled": {},
-                "interval": {},
-                "service": {},
-                "at" : {},
-                "throttle": {},
-                "image": {},
-                "plane": {},
-                "resources": {},
-                "env": {},
-                "annotations": {},
-                "labels": {},
-                "limit": {},
-                "cutoff": {}    
-              },
-              "additionalProperties": false
-            }
-          ]
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "sasha-dfuwu-archiver": {
-      "oneOf": [
-        {
-          "type": "object",
-          "required": [ "plane" ],
-          "allOf": [ 
-            { "$ref": "#/definitions/sashacommon" },
-            { "$ref": "#/definitions/sasha-limitcutoff" },
-            {
-              "properties": 
-              {
-                "disabled": {},
-                "interval": {},
-                "service": {},
-                "at" : {},
-                "throttle": {},
-                "image": {},
-                "plane": {},
-                "resources": {},
-                "env": {},
-                "annotations": {},
-                "labels": {},
-                "limit": {},
-                "cutoff": {}
-              },
-              "additionalProperties": false
-            }
-          ]
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "sasha-dfurecovery-archiver": {
-      "oneOf": [
-        {
-          "type": "object",
-          "allOf": [
-            { "$ref": "#/definitions/sashacommon" },
-            { "$ref": "#/definitions/sasha-limitcutoff" },
-            {
-              "properties": {
-                "disabled": {},
-                "interval": {},
-                "service": {},
-                "at" : {},
-                "throttle": {},
-                "image": {},
-                "plane": {},
-                "resources": {},
-                "env": {},
-                "annotations": {},
-                "labels": {},
-                "limit": {},
-                "cutoff": {}    
-              },
-              "additionalProperties": false
-            }
-          ]
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "sasha-file-expiry": {
-      "oneOf": [
-        {
-          "type": "object",
-          "allOf": [{ "$ref": "#/definitions/sashacommon" }],
           "properties": {
-            "persistExpiryDefault": {
+            "minDeltaSize": {
               "type": "integer",
-              "description": "Default number of days to delete unused persist files",
-              "default": "7"
-            },
-            "expiryDefault": {
-              "type": "integer",
-              "description": "Default number of days to delete unused standard files that are flagged with EXPIRY",
-              "default": "14"
-            },
-            "user": {
-              "type": "string",
-              "description": "A username authorized to access and remove expired files"
+              "description": "Coalescing will only begin, if the delta size is above this threshold (K)"
             },
             "disabled": {},
             "interval": {},
@@ -2446,15 +2283,143 @@
             "image": {},
             "plane": {},
             "resources": {},
+            "env": {},
             "annotations": {},
             "labels": {}
           },
           "additionalProperties": false
-        },
-        {
-          "type": "null"
         }
       ]
+    },
+    "sasha-wu-archiver": {
+      "type": "object",
+      "required": [ "plane" ],
+      "allOf": [
+        { "$ref": "#/definitions/sashacommon" },
+        { "$ref": "#/definitions/sasha-limitcutoff" },
+        {
+          "properties": 
+          {
+            "backup": {
+              "type": "integer",
+              "description": "minimum workunit age to backup (days, 0 disables)",
+              "default": "0"
+            },
+            "duration": {
+              "type": "integer",
+              "description": "Maximum duration to run WorkUnit archiving session (hours, 0 unlimited)",
+              "default": "0"
+            },
+            "keepResultFiles": {
+              "type": "boolean",
+              "description": "option to keep result files owned by workunits after workunit is archived",
+              "default": "false"
+            },
+            "retryinterval": {
+              "type": "integer",
+              "description": "minimal time before retrying archive of failed WorkUnits (days)",
+              "default": "7"
+            },
+            "disabled": {},
+            "interval": {},
+            "service": {},
+            "at" : {},
+            "throttle": {},
+            "image": {},
+            "plane": {},
+            "resources": {},
+            "env": {},
+            "annotations": {},
+            "labels": {},
+            "limit": {},
+            "cutoff": {}    
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "sasha-dfuwu-archiver": {
+      "type": "object",
+      "required": [ "plane" ],
+      "allOf": [ 
+        { "$ref": "#/definitions/sashacommon" },
+        { "$ref": "#/definitions/sasha-limitcutoff" },
+        {
+          "properties": 
+          {
+            "disabled": {},
+            "interval": {},
+            "service": {},
+            "at" : {},
+            "throttle": {},
+            "image": {},
+            "plane": {},
+            "resources": {},
+            "env": {},
+            "annotations": {},
+            "labels": {},
+            "limit": {},
+            "cutoff": {}
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "sasha-dfurecovery-archiver": {
+      "type": "object",
+      "allOf": [
+        { "$ref": "#/definitions/sashacommon" },
+        { "$ref": "#/definitions/sasha-limitcutoff" },
+        {
+          "properties": {
+            "disabled": {},
+            "interval": {},
+            "service": {},
+            "at" : {},
+            "throttle": {},
+            "image": {},
+            "plane": {},
+            "resources": {},
+            "env": {},
+            "annotations": {},
+            "labels": {},
+            "limit": {},
+            "cutoff": {}    
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "sasha-file-expiry": {
+      "type": "object",
+      "allOf": [{ "$ref": "#/definitions/sashacommon" }],
+      "properties": {
+        "persistExpiryDefault": {
+          "type": "integer",
+          "description": "Default number of days to delete unused persist files",
+          "default": "7"
+        },
+        "expiryDefault": {
+          "type": "integer",
+          "description": "Default number of days to delete unused standard files that are flagged with EXPIRY",
+          "default": "14"
+        },
+        "user": {
+          "type": "string",
+          "description": "A username authorized to access and remove expired files"
+        },
+        "disabled": {},
+        "interval": {},
+        "service": {},
+        "at" : {},
+        "throttle": {},
+        "image": {},
+        "plane": {},
+        "resources": {},
+        "annotations": {},
+        "labels": {}
+      },
+      "additionalProperties": false
     },
     "sashaservice": {
       "oneOf": [

--- a/helm/hpcc/values.yaml
+++ b/helm/hpcc/values.yaml
@@ -438,14 +438,14 @@ sasha:
     #duration: 0 # (maxDuration) maximum duration to run DFU WorkUnit archiving session (hours, 0 unlimited)
     #throttle: 0 # throttle ratio (0-99, 0 no throttling, 50 is half speed)
 
-  dfurecovery-archiver:
+  dfurecovery-archiver: {} # NB: no properties defined, use defaults
     #disabled: true
     #limit: 20 # threshold number of DFU recovery items before archiving starts (0 disables)
     #cutoff: 4 # minimum DFU recovery item age to archive (days)
     #interval: 12 # minimum interval between running DFU recovery archiver(in hours, 0 disables)
     #at: "* * * * *" # schedule to run DFU recovery archiver (cron format)
 
-  file-expiry:
+  file-expiry: {} # NB: no properties defined, use defaults
     #disabled: true
     #interval: 1
     #at: "* 3 * * *"

--- a/testing/helm/tests/env.yaml
+++ b/testing/helm/tests/env.yaml
@@ -77,7 +77,7 @@ dali:
 - name: mydali
   auth: none
   services: # internal house keeping services
-    coalescer:
+    coalescer: {}
   env:
   - name: dlv1
     value: dlv1v

--- a/testing/helm/tests/labels.yaml
+++ b/testing/helm/tests/labels.yaml
@@ -92,4 +92,4 @@ dali:
   labels:
     dl1: dlv1
   services: # internal house keeping services
-    coalescer:
+    coalescer: {}


### PR DESCRIPTION
These services were unintentionally disabled by default, because
they had no properties definition and instead of being a dictionary
with 0 properties, were being treated as null.
Remove option to have a null dictionary entry for sasha services,
they should instead be disabled if required or defined as a
dictionary with no properties, i.e. {}

Signed-off-by: Jake Smith <jake.smith@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
