### PR TITLE
HPCC-28115 Expose k8s connections for predefined k8s services

### DIFF
--- a/esp/scm/ws_resources.ecm
+++ b/esp/scm/ws_resources.ecm
@@ -25,11 +25,39 @@ ESPStruct HPCCService
     bool TLSSecure;
 };
 
+ESPStruct ServicePorts
+{
+    string Name;
+    string Protocol;
+    unsigned Port;
+};
+
+ESPenum ExternalIPStatus : string
+{
+    Unknown("Unknown"),
+    None("None"),
+    Pending("Pending")
+};
+
+//The ExternalIPsEx or ClusterIPsEx is used when ExternalIPs or ClusterIPs is empty.
+//The value is based on the existing https://github.com/kubernetes/kubernetes.
+ESPStruct ServiceConnection
+{
+    string Type;
+    ESParray<string> ExternalIPs;
+    ESPenum ExternalIPStatus ExternalIPStatus; //Use this field when ExternalIPs is empty. 
+                                               //Set to 'none' for spec type 'ClusterIP' and spec type 'NodePort';
+                                               //set to 'pending' for spec type 'LoadBalancer'; leave it empty for spec type 'ExternalName';
+                                               //set to 'unknown' for unknown spec types.
+    ESParray<ESPstruct ServicePorts> Ports;
+};
+
 ESPStruct DiscoveredWebLink
 {
     string ServiceName;
     string NameSpace;
     ESParray<ESPstruct NamedValue> Annotations;
+    [min_ver("1.02")] ESPstruct ServiceConnection Connection;
 };
 
 ESPStruct ConfiguredWebLink
@@ -60,7 +88,7 @@ ESPresponse [nil_remove, exceptions_inline] WebLinksQueryResponse
     ESParray<ESPstruct ConfiguredWebLink> ConfiguredWebLinks;
 };
 
-ESPservice [auth_feature("ResourceQueryAccess:ACCESS"), version("1.01"), exceptions_inline("./smc_xslt/exceptions.xslt")] WsResources
+ESPservice [auth_feature("ResourceQueryAccess:ACCESS"), version("1.02"), exceptions_inline("./smc_xslt/exceptions.xslt")] WsResources
 {
     ESPmethod [auth_feature("ResourceQueryAccess:READ")] ServiceQuery(ServiceQueryRequest, ServiceQueryResponse);
     ESPmethod [auth_feature("ResourceQueryAccess:READ"), min_ver("1.01")] WebLinksQuery(WebLinksQueryRequest, WebLinksQueryResponse);

--- a/esp/services/ws_resources/ws_resourcesService.hpp
+++ b/esp/services/ws_resources/ws_resourcesService.hpp
@@ -29,6 +29,10 @@ class CWsResourcesEx : public CWsResources
 {
     CTpWrapper tpWrapper;
 
+    void getServiceConnection(IPropertyTree& rawDataTree, IEspServiceConnection& connection);
+    void getServiceExternalIP(IPropertyTree& rawDataTree, IEspServiceConnection& connection);
+    void getServiceConnectionPorts(IPropertyTree* specTree, IEspServiceConnection& connection);
+
 public:
     virtual ~CWsResourcesEx() {};
     virtual void init(IPropertyTree* cfg, const char* process, const char* service) override {};


### PR DESCRIPTION
Expose service type, IPs and ports for a k8s service if the
annotation hpcc.eclwatch.io/enabled for the service is configured
to be true.

Signed-off-by: wangkx <kevin.wang@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
