### PR TITLE
HPCC-28285 Unittests for histogram reveal use of invalid memory

### DIFF
--- a/system/jlib/jmetrics.cpp
+++ b/system/jlib/jmetrics.cpp
@@ -28,11 +28,11 @@ MODULE_EXIT()
 }
 
 
-HistogramMetric::HistogramMetric(const char *name, const char *desc, StatisticMeasure _units, const std::vector<__uint64> &bucketLimits, const MetricMetaData &_metaData) :
-    MetricBase(name, desc, MetricType::METRICS_HISTOGRAM, _units, _metaData)
+HistogramMetric::HistogramMetric(const char *_name, const char *_desc, StatisticMeasure _units, const std::vector<__uint64> &_bucketLimits, const MetricMetaData &_metaData) :
+    MetricBase(_name, _desc, MetricType::METRICS_HISTOGRAM, _units, _metaData)
 {
-    buckets.reserve(bucketLimits.size());
-    for (auto &b: bucketLimits)
+    buckets.reserve(_bucketLimits.size());
+    for (auto &b: _bucketLimits)
     {
         buckets.emplace_back(Bucket{b});
     }
@@ -86,14 +86,14 @@ HistogramMetric::Bucket &HistogramMetric::findBucket(__uint64 measurement)
 }
 
 
-ScaledHistogramMetric::ScaledHistogramMetric(const char *name, const char *desc, StatisticMeasure units, const std::vector<__uint64> &bucketLimits, double limitsToMeasurementUnitsScaleFactor, const MetricMetaData &_metaData) :
-    HistogramMetric{name, desc, units, bucketLimits, metaData}
+ScaledHistogramMetric::ScaledHistogramMetric(const char *_name, const char *_desc, StatisticMeasure _units, const std::vector<__uint64> &_bucketLimits, double _limitsToMeasurementUnitsScaleFactor, const MetricMetaData &_metaData) :
+    HistogramMetric{_name, _desc, _units, _bucketLimits, _metaData}
 {
     for (auto &b: buckets)
     {
-        b.limit = (__uint64)((double)(b.limit) * limitsToMeasurementUnitsScaleFactor);
+        b.limit = (__uint64)((double)(b.limit) * _limitsToMeasurementUnitsScaleFactor);
     }
-    outputScaleFactor = 1.0 / limitsToMeasurementUnitsScaleFactor;
+    outputScaleFactor = 1.0 / _limitsToMeasurementUnitsScaleFactor;
 }
 
 
@@ -321,13 +321,13 @@ const char *MetricsManager::queryUnitsString(StatisticMeasure units) const
 }
 
 
-PeriodicMetricSink::PeriodicMetricSink(const char *name, const char *type, const IPropertyTree *pSettingsTree) :
-    MetricSink(name, type),
+PeriodicMetricSink::PeriodicMetricSink(const char *_name, const char *_type, const IPropertyTree *_pSettingsTree) :
+    MetricSink(_name, _type),
     collectionPeriodSeconds{60}
 {
-    if (pSettingsTree->hasProp("@period"))
+    if (_pSettingsTree->hasProp("@period"))
     {
-        collectionPeriodSeconds = pSettingsTree->getPropInt("@period");
+        collectionPeriodSeconds = _pSettingsTree->getPropInt("@period");
     }
 }
 
@@ -413,7 +413,7 @@ std::shared_ptr<GaugeMetricFromCounters> hpccMetrics::registerGaugeFromCountersM
 }
 
 
-std::shared_ptr<HistogramMetric> registerHistogramMetric(const char *name, const char* desc, StatisticMeasure units, const std::vector<__uint64> &bucketLimits, const MetricMetaData &metaData)
+std::shared_ptr<HistogramMetric> hpccMetrics::registerHistogramMetric(const char *name, const char* desc, StatisticMeasure units, const std::vector<__uint64> &bucketLimits, const MetricMetaData &metaData)
 {
     std::shared_ptr<HistogramMetric> pMetric = std::shared_ptr<HistogramMetric>(new HistogramMetric(name, desc, units, bucketLimits, metaData));
     queryMetricsManager().addMetric(pMetric);
@@ -421,7 +421,7 @@ std::shared_ptr<HistogramMetric> registerHistogramMetric(const char *name, const
 }
 
 
-std::shared_ptr<ScaledHistogramMetric> registerScaledHistogramMetric(const char *name, const char* desc, StatisticMeasure units, const std::vector<__uint64> &bucketLimits,
+std::shared_ptr<ScaledHistogramMetric> hpccMetrics::registerScaledHistogramMetric(const char *name, const char* desc, StatisticMeasure units, const std::vector<__uint64> &bucketLimits,
                                                                                double limitsToMeasurementUnitsScaleFactor, const MetricMetaData &metaData)
 {
     std::shared_ptr<ScaledHistogramMetric> pMetric = std::shared_ptr<ScaledHistogramMetric>(new ScaledHistogramMetric(name, desc, units, bucketLimits, limitsToMeasurementUnitsScaleFactor, metaData));
@@ -430,7 +430,7 @@ std::shared_ptr<ScaledHistogramMetric> registerScaledHistogramMetric(const char 
 }
 
 
-std::shared_ptr<ScaledHistogramMetric> registerCyclesToNsScaledHistogramMetric(const char *name, const char* desc, const std::vector<__uint64> &bucketLimits, const MetricMetaData &metaData)
+std::shared_ptr<ScaledHistogramMetric> hpccMetrics::registerCyclesToNsScaledHistogramMetric(const char *name, const char* desc, const std::vector<__uint64> &bucketLimits, const MetricMetaData &metaData)
 {
     double nsToCyclesScaleFactor = 1.0 / getCycleToNanoScale();
     std::shared_ptr<ScaledHistogramMetric> pMetric = std::shared_ptr<ScaledHistogramMetric>(new ScaledHistogramMetric(name, desc, SMeasureTimeNs, bucketLimits, nsToCyclesScaleFactor, metaData));

--- a/system/jlib/jmetrics.hpp
+++ b/system/jlib/jmetrics.hpp
@@ -150,8 +150,8 @@ public:
     virtual __uint64 queryValue() const override { return value; }
 
 protected:
-    MetricVal(const char *name, const char *desc, MetricType metricType, StatisticMeasure _units, const MetricMetaData &_metaData) :
-        MetricBase(name, desc, metricType, _units, _metaData) {}
+    MetricVal(const char *_name, const char *_desc, MetricType _metricType, StatisticMeasure _units, const MetricMetaData &_metaData) :
+        MetricBase(_name, _desc, _metricType, _units, _metaData) {}
 
     RelaxedAtomic<__uint64> value{0};
 };
@@ -163,8 +163,8 @@ protected:
 class jlib_decl CounterMetric : public MetricVal
 {
 public:
-    CounterMetric(const char *name, const char *description, StatisticMeasure _units, const MetricMetaData &_metaData = MetricMetaData()) :
-        MetricVal{name, description, MetricType::METRICS_COUNTER, _units, _metaData}  { }
+    CounterMetric(const char *_name, const char *_description, StatisticMeasure _units, const MetricMetaData &_metaData = MetricMetaData()) :
+        MetricVal{_name, _description, MetricType::METRICS_COUNTER, _units, _metaData}  { }
     void inc(uint64_t val)
     {
         value.fetch_add(val);
@@ -183,8 +183,8 @@ public:
 class jlib_decl GaugeMetric : public MetricVal
 {
 public:
-    GaugeMetric(const char *name, const char *description, StatisticMeasure _units, const MetricMetaData &_metaData = MetricMetaData()) :
-        MetricVal{name, description, MetricType::METRICS_GAUGE, _units, _metaData}  { }
+    GaugeMetric(const char *_name, const char *_description, StatisticMeasure _units, const MetricMetaData &_metaData = MetricMetaData()) :
+        MetricVal{_name, _description, MetricType::METRICS_GAUGE, _units, _metaData}  { }
 
     void adjust(int64_t delta)
     {
@@ -209,10 +209,10 @@ public:
 class jlib_decl GaugeMetricFromCounters : public MetricVal
 {
 public:
-    GaugeMetricFromCounters(const char *name, const char *description, StatisticMeasure _units,
+    GaugeMetricFromCounters(const char *_name, const char *_description, StatisticMeasure _units,
                             const std::shared_ptr<CounterMetric> &_pBeginCounter, const std::shared_ptr<CounterMetric> &_pEndCounter,
                             const MetricMetaData &_metaData = MetricMetaData()) :
-        MetricVal{name, description, MetricType::METRICS_GAUGE, _units, _metaData},
+        MetricVal{_name, _description, MetricType::METRICS_GAUGE, _units, _metaData},
         pBeginCounter{_pBeginCounter},
         pEndCounter{_pEndCounter}
     {
@@ -235,8 +235,8 @@ template<typename T>
 class CustomMetric : public MetricBase
 {
 public:
-    CustomMetric(const char *name, const char *desc, MetricType metricType, T &_value, StatisticMeasure _units, const MetricMetaData &_metaData = MetricMetaData()) :
-        MetricBase(name, desc, metricType, _units, _metaData),
+    CustomMetric(const char *_name, const char *_desc, MetricType _metricType, T &_value, StatisticMeasure _units, const MetricMetaData &_metaData = MetricMetaData()) :
+        MetricBase(_name, _desc, _metricType, _units, _metaData),
         value{_value} { }
 
     virtual __uint64 queryValue() const override
@@ -253,7 +253,7 @@ protected:
 class jlib_decl HistogramMetric : public MetricBase
 {
 public:
-    HistogramMetric(const char *name, const char *desc, StatisticMeasure _units, const std::vector<__uint64> &bucketLimits, const MetricMetaData &_metaData = MetricMetaData());
+    HistogramMetric(const char *_name, const char *_desc, StatisticMeasure _units, const std::vector<__uint64> &_bucketLimits, const MetricMetaData &_metaData = MetricMetaData());
 
     virtual __uint64 queryValue() const override
     {
@@ -285,7 +285,7 @@ protected:
 class jlib_decl ScaledHistogramMetric : public HistogramMetric
 {
 public:
-    ScaledHistogramMetric(const char *name, const char *desc, StatisticMeasure units, const std::vector<__uint64> &bucketLimits, double _limitsToMeasurementUnitsScaleFactor, const MetricMetaData &_metaData = MetricMetaData());
+    ScaledHistogramMetric(const char *_name, const char *_desc, StatisticMeasure _units, const std::vector<__uint64> &_bucketLimits, double _limitsToMeasurementUnitsScaleFactor, const MetricMetaData &_metaData = MetricMetaData());
 
     virtual std::vector<__uint64> queryHistogramBucketLimits() const override;
     virtual __uint64 queryValue() const override
@@ -330,7 +330,7 @@ public:
     virtual void stopCollection() override;
 
 protected:
-    explicit PeriodicMetricSink(const char *name, const char *type, const IPropertyTree *pSettingsTree);
+    explicit PeriodicMetricSink(const char *_name, const char *_type, const IPropertyTree *_pSettingsTree);
     virtual void prepareToStartCollecting() = 0;
     virtual void collectingHasStopped() = 0;
     virtual void doCollection() = 0;


### PR DESCRIPTION
Updated all constructors and initialization of base classes to use leading _ in parameter names.

Signed-Off-By: Kenneth Rowland kenneth.rowland@lexisnexisrisk.com

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [x] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [x] Scalability
  - [x] Performance
  - [x] Security
  - [x] Thread-safety
  - [x] Cloud-compatibility
  - [x] Premature optimization
  - [x] Existing deployed queries will not be broken
  - [x] This change fixes the problem, not just the symptom
  - [x] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
