### PR TITLE
HPCC-28302 Avoid MP clashing by using peer endpoints

### DIFF
--- a/dali/base/dasess.cpp
+++ b/dali/base/dasess.cpp
@@ -541,7 +541,10 @@ public:
         case MSR_REGISTER_PROCESS_SESSION: {
                 acceptConnections.wait();
                 acceptConnections.signal();
-                Owned<INode> node(deserializeINode(mb));
+
+                Owned<INode> node(deserializeINode(mb)); // NB: no longer used. See HPCC-28302.
+                node.setown(createINode(mb.getSender()));
+
                 const SocketEndpoint &peerIP = coven.queryComm().queryChannelPeerEndpoint(mb.getSender());
                 Owned<INode> servernode(deserializeINode(mb));  // hopefully me, but not if forwarded
                 int role=0;
@@ -1972,7 +1975,7 @@ bool registerClientProcess(ICommunicator *comm, IGroup *& retcoven,unsigned time
         if (ok) {
             CMessageBuffer mb;
             mb.append((int)MSR_REGISTER_PROCESS_SESSION);
-            queryMyNode()->serialize(mb);
+            queryMyNode()->serialize(mb); // NB: no longer used/ignored by server. See HPCC-28302.
             comm->queryGroup().queryNode(r).serialize(mb);
             mb.append((int)role);
             if (comm->sendRecv(mb,r,MPTAG_DALI_SESSION_REQUEST,SESSIONREPLYTIMEOUT)) {

--- a/dali/base/dasubs.cpp
+++ b/dali/base/dasubs.cpp
@@ -238,7 +238,8 @@ public:
                 {
                     SubscriptionId sid;
                     mb.read(subtag).read(sid);
-                    Owned<INode> subscriber = deserializeINode(mb);
+                    Owned<INode> subscriber = deserializeINode(mb); // NB: no longer used/ignored by server. See HPCC-28302.
+                    subscriber.setown(createINode(mb.getSender()));
                     size32_t dsize;
                     mb.read(dsize);
                     sub.setown(new CSubscriptionStub(subtag,sid,dsize,mb.readDirect(dsize),subscriber));

--- a/system/jlib/jsocket.cpp
+++ b/system/jlib/jsocket.cpp
@@ -425,7 +425,7 @@ public:
     void        shutdown(unsigned mode=SHUTDOWN_READWRITE);
     void        shutdownNoThrow(unsigned mode);
 
-    ISocket*    accept(bool allowcancel, SocketEndpoint *peerEp=nullptr);
+    ISocket*    accept(bool allowcancel, SocketEndpoint *retPeerEp=nullptr);
     int         wait_read(unsigned timeout);
     int         logPollError(unsigned revents, const char *rwstr);
     int         wait_write(unsigned timeout);
@@ -1565,10 +1565,9 @@ void CSocket::setTraceName()
 void CSocket::setPeerEndpoint(const SocketEndpoint &ep)
 {
     assertex(!peerEpSet);
-    peerEpCrit.enter();
-    peerEpSet = true;
+    CriticalBlock b(peerEpCrit);
     peerEp = ep;
-    peerEpCrit.leave();
+    peerEpSet = true;
 }
 
 ISocket*  ISocket::connect_wait( const SocketEndpoint &ep, unsigned timems)

--- a/system/mp/mpcomm.cpp
+++ b/system/mp/mpcomm.cpp
@@ -2287,10 +2287,10 @@ int CMPConnectThread::run()
                 // However, the client-side endpoint cannot be relied upon to be unique, since it may be running on another
                 // private network and therefore multiple clients on different networks connecting to Dali could have the same
                 // client side endpoints. 
-                // To avoid this, always use the server side peer IP and oprt as the mapping from client to MP channel.
+                // To avoid this, always use the server side peer IP and port as the mapping from client to MP channel.
                 // The peer port must be used as well, since the client side port from multiple private networks can be the same.
                 // See corresponding change in CMPPacketReader::notifySelected
-                // NB: if all clients are part of the same network, then this step is strictly unecessary.
+                // NB: if all clients are part of the same network, then this step is strictly unnecessary.
 
                 // Ensure MP connection uses peer endpoint
                 _remoteep.set(peerEp);

--- a/thorlcr/master/thmastermain.cpp
+++ b/thorlcr/master/thmastermain.cpp
@@ -279,7 +279,18 @@ public:
                 PROGLOG("Failed to initialize slaves");
                 return false;
             }
-            Owned<INode> sender = _sender;
+
+            /* NB: in base metal setup, the slaves know which slave number they are in advance, and send their slavenum at registration.
+             * In non attached storage setup, they do not send a slave by default and instead are given a # once all are registered
+             */
+            unsigned slaveNum;
+            msg.read(slaveNum);
+
+            // recv's _sender will be the peer endpoint (with ephemeral port) and potentially from another network
+            // use workers self identified endpoint.
+            // the endpoint's are used by the group processes to identify which rank their own endpoint is within it.
+            Owned<INode> sender = deserializeINode(msg);
+
             if (NotFound != connectedSlaves.find(sender))
             {
                 StringBuffer epStr;
@@ -287,11 +298,6 @@ public:
                 return false;
             }
 
-            /* NB: in base metal setup, the slaves know which slave number they are in advance, and send their slavenum at registration.
-             * In non attached storage setup, they do not send a slave by default and instead are given a # once all are registered
-             */
-            unsigned slaveNum;
-            msg.read(slaveNum);
             if (NotFound == slaveNum)
             {
                 connectedSlaves.append(sender.getLink());

--- a/thorlcr/slave/thslavemain.cpp
+++ b/thorlcr/slave/thslavemain.cpp
@@ -105,6 +105,8 @@ static bool RegisterSelf(SocketEndpoint &masterEp)
         Owned<INode> masterNode = createINode(ep);
         CMessageBuffer msg;
         msg.append(mySlaveNum);
+        // Send myNode which will form part of the process group.
+        queryMyNode()->serialize(msg);
         queryWorldCommunicator().send(msg, masterNode, MPTAG_THORREGISTRATION);
         if (!queryWorldCommunicator().recv(msg, masterNode, MPTAG_THORREGISTRATION))
             return false;


### PR DESCRIPTION
MP clients were self-identifying their endpoints, by serializing them to the MP server. This works fine if both client and server are on the same network, but if clients or servers are on their own private network (clients connecting to a k8s system is a good example), then those private client endpoints are not unique. i.e. 2 clients from different private networks may have identical endpoints and will cause MP clashing and random disconnections.

To avoid this, use the peer endpoint of the connected socket. This means that the MP client connections are now identified and mapped by the peer endpoint of the connected socket.

This also necessitates a few other required changes:

1) Each MP packet also has an endpoint in it, which are encoded in their header. On receipt (via socket notification), change their header to match the peer endpoint.
2) Subscriptions also self-identified, and relied on matching the incoming packets for notification.
Change to ignore the self-identification endpoint, and use the peer endpoint encoded in the message header (sender). 3) The Thor worker nodes rely on being able to identify themselves in the thor process group (formed at registration time), they were relying on the peer sender, which due to the above changes could now be different.
Change to serialize the slaves endpoint to master at registration time and use to build process group.

Signed-off-by: Jake Smith <jake.smith@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
