### PR TITLE
HPCC-28325 Avoid O(N^2) operation optimizing x in <set1> or x in <set2>

### DIFF
--- a/ecl/hql/hqlfold.cpp
+++ b/ecl/hql/hqlfold.cpp
@@ -1893,7 +1893,7 @@ IHqlExpression * combineMask(IHqlExpression * left, IHqlExpression * right)
     return createBoolExpr(no_ne, newTest, ensureExprType(zero, bandType));
 }
 
-bool constantComparison(IHqlExpression * field, IHqlExpression * expr, HqlExprArray & values)
+static bool extractConstantComparison(IHqlExpression * field, IHqlExpression * expr, HqlExprCopyArray & values)
 {
     IHqlExpression * left = expr->queryChild(0);
     IHqlExpression * right = expr->queryChild(1);
@@ -1904,8 +1904,7 @@ bool constantComparison(IHqlExpression * field, IHqlExpression * expr, HqlExprAr
             return false;
         if (!right->queryValue())
             return false;
-        if (values.find(*right) == NotFound)
-            values.append(*LINK(right));
+        values.append(*right);
         return true;
     case no_in:
         {
@@ -1913,17 +1912,47 @@ bool constantComparison(IHqlExpression * field, IHqlExpression * expr, HqlExprAr
                 return false;
             if (right->getOperator() != no_list)
                 return false;
-            ForEachChild(i, right)
-            {
-                IHqlExpression * cur = right->queryChild(i);
-                if (values.find(*cur) == NotFound)
-                    values.append(*LINK(cur));
-            }
+            if (!right->isConstant())
+                return false;
+            unwindChildren(values, right);
             return true;
         }
     }
     return false;
 }
+
+static void removeDuplicatesAndLink(HqlExprArray & result, const HqlExprCopyArray & values)
+{
+    //Assume that items are not duplicated - the memory usage is not significant, reallocation is.
+    result.ensureCapacity(values.ordinality());
+
+    if (values.ordinality() <= 10)
+    {
+        //Special case small lists with a faster O(N^2) algorithm.
+        ForEachItemIn(i, values)
+        {
+            IHqlExpression & cur = values.item(i);
+            if (!result.contains(cur))
+                result.append(OLINK(cur));
+        }
+    }
+    else
+    {
+        //This list can get quite large, so rather than using result.contains(cur), which would be O(N^2)
+        //use the transformextra which is slightly slower, but O(N).
+        TransformMutexBlock lock;
+        ForEachItemIn(i, values)
+        {
+            IHqlExpression & cur = values.item(i);
+            if (!cur.queryTransformExtra())
+            {
+                result.append(OLINK(cur));
+                cur.setTransformExtra(&cur);
+            }
+        }
+    }
+}
+
 
 bool isFilteredWithin(IHqlExpression * expr, IHqlExpression * dataset, HqlExprArray & filters)
 {
@@ -2049,36 +2078,42 @@ IHqlExpression * foldOrExpr(IHqlExpression * expr, bool fold_x_op_not_x)
     }
 
     //optimize x=a|x=b|x=c to x in (a,b,c)
-    HqlExprArray constantValues;
+    HqlExprCopyArray constantValues;
     for (unsigned idx4 = 0; idx4 < transformedArgs.ordinality()-1; idx4++)
     {
         IHqlExpression & cur = transformedArgs.item(idx4);
-        constantValues.kill();
-
-        if (constantComparison(NULL, &cur, constantValues))
+        if (extractConstantComparison(NULL, &cur, constantValues))
         {
-            bool merged = false;
+            UnsignedArray combinedExprIndexes;
             IHqlExpression * compare = cur.queryChild(0);
-            for (unsigned idx5 = idx4+1; idx5 < transformedArgs.ordinality(); )
+            for (unsigned idx5 = idx4+1; idx5 < transformedArgs.ordinality(); idx5++)
             {
                 IHqlExpression & cur2 = transformedArgs.item(idx5);
-                if (constantComparison(compare, &cur2, constantValues))
+                if (extractConstantComparison(compare, &cur2, constantValues))
                 {
-                    merged = true;
-                    transformedArgs.remove(idx5);
+                    //Save the list of expression indexes so they can be removed later
+                    combinedExprIndexes.append(idx5);
                 }
-                else
-                    idx5++;
             }
 
-            if (merged)
+            if (combinedExprIndexes.ordinality())
             {
+                //Avoid deduping and linking the expressions until we know we are going to combine them
+                HqlExprArray linkedValues;
+                removeDuplicatesAndLink(linkedValues, constantValues);
+
                 //MORE: Should promote all items in the list to the same type.
                 IHqlExpression & first = constantValues.item(0);
-                IHqlExpression * list = createValue(no_list, makeSetType(first.getType()), constantValues);
+                IHqlExpression * list = createValue(no_list, makeSetType(first.getType()), linkedValues);
                 OwnedHqlExpr combined = createBoolExpr(no_in, LINK(compare), list);
                 transformedArgs.replace(*combined.getClear(), idx4);
+
+                //Remove the expressions after the new expression has been created, so that linking can be avoided
+                ForEachItemInRev(i, combinedExprIndexes)
+                    transformedArgs.remove(combinedExprIndexes.item(i));
             }
+
+            constantValues.kill();
         }
     }
 


### PR DESCRIPTION
Signed-off-by: Gavin Halliday <gavin.halliday@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [x] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
