### PR TITLE
HPCC-28386 Various minor improvements to code generation

### DIFF
--- a/ecl/hqlcpp/hqlcpp.cpp
+++ b/ecl/hqlcpp/hqlcpp.cpp
@@ -256,6 +256,7 @@ bool isSimpleTranslatedStringExpr(IHqlExpression * expr)
         case no_variable:
         case no_callback:
         case no_select:
+        case no_quoted:
             return true;
         case no_cast:
         case no_implicitcast:
@@ -287,6 +288,7 @@ bool isSimpleTranslatedExpr(IHqlExpression * expr)
     case type_decimal:
     case type_unicode:
     case type_varunicode:
+    case type_utf8:
         //Less strict rules for strings (and decimal), because string temporaries are more expensive.
         return isSimpleTranslatedStringExpr(expr);
     case type_set:
@@ -791,6 +793,58 @@ IHqlExpression * createTranslated(IHqlExpression * expr, IHqlExpression * length
     return createValue(no_translated, expr->getType(), LINK(expr), LINK(length));
 }
 
+static bool canRemoveCast(IHqlExpression * child, ITypeInfo * type)
+{
+    switch (type->getTypeCode())
+    {
+    case type_string:
+    case type_data:
+    case type_unicode:
+    case type_qstring:
+    case type_utf8:
+        break;
+    default:
+        return false;
+    }
+
+    ITypeInfo * childType = child->queryType()->queryPromotedType();
+    if (type->getStringLen() < childType->getStringLen())
+    {
+        if (child->getOperator() == no_if)
+        {
+            return canRemoveCast(child->queryChild(1), type) && canRemoveCast(child->queryChild(2), type);
+        }
+        return false;
+    }
+    type_t tc = type->getTypeCode();
+    if (tc != childType->getTypeCode())
+    {
+        if (tc == type_string)
+        {
+            if (childType->getTypeCode() != type_varstring)
+                return false;
+            if (type->queryCharset() != childType->queryCharset())
+                return false;
+        }
+        else if (tc == type_unicode)
+        {
+            if (childType->getTypeCode() != type_varunicode)
+                return false;
+            if (type->queryLocale() != childType->queryLocale())
+                return false;
+        }
+        else
+            return false;
+    }
+    else
+    {
+        Owned<ITypeInfo> stretched = getStretchedType(type->getStringLen(), childType);
+        if (stretched != type)
+            return false;
+    }
+    return true;
+}
+
 static IHqlExpression * querySimplifyCompareArgCast(IHqlExpression * expr)
 {
     if (expr->isConstant())
@@ -798,47 +852,9 @@ static IHqlExpression * querySimplifyCompareArgCast(IHqlExpression * expr)
     while ((expr->getOperator() == no_implicitcast) || (expr->getOperator() == no_cast))
     {
         ITypeInfo * type = expr->queryType()->queryPromotedType();
-        switch (type->getTypeCode())
-        {
-        case type_string:
-        case type_data:
-        case type_unicode:
-        case type_qstring:
-        case type_utf8:
-            break;
-        default:
-            return expr;
-        }
         IHqlExpression * child = expr->queryChild(0);
-        ITypeInfo * childType = child->queryType()->queryPromotedType();
-        if (type->getStringLen() < childType->getStringLen())
+        if (!canRemoveCast(child, type))
             break;
-        type_t tc = type->getTypeCode();
-        if (tc != childType->getTypeCode())
-        {
-            if (tc == type_string)
-            {
-                if (childType->getTypeCode() != type_varstring)
-                    break;
-                if (type->queryCharset() != childType->queryCharset())
-                    break;
-            }
-            else if (tc == type_unicode)
-            {
-                if (childType->getTypeCode() != type_varunicode)
-                    break;
-                if (type->queryLocale() != childType->queryLocale())
-                    break;
-            }
-            else
-                break;
-        }
-        else
-        {
-            Owned<ITypeInfo> stretched = getStretchedType(type->getStringLen(), childType);
-            if (stretched != type)
-                break;
-        }
         expr = child;
     }
     return expr;
@@ -847,7 +863,17 @@ static IHqlExpression * querySimplifyCompareArgCast(IHqlExpression * expr)
 
 IHqlExpression * getSimplifyCompareArg(IHqlExpression * expr)
 {
-    IHqlExpression * cast = querySimplifyCompareArgCast(expr);
+    IHqlExpression * cast = expr;
+    for (;;)
+    {
+        cast = querySimplifyCompareArgCast(expr);
+        while (isOpRedundantForCompare(cast))
+            cast = cast->queryChild(0);
+        if (cast == expr)
+            break;
+        expr = cast;
+    }
+
     if (cast->getOperator() != no_substring)
         return LINK(cast);
     if (cast->queryChild(0)->queryType()->getTypeCode() == type_qstring)
@@ -4399,6 +4425,12 @@ void HqlCppTranslator::buildSimpleExpr(BuildCtx & ctx, IHqlExpression * expr, CH
                 break;
             }
         }
+    case no_matchtext:
+    case no_matchunicode:
+    case no_matchutf8:
+        if (!queryRealChild(expr, 0) && ctx.queryMatchExpr(activeValidateMarkerExpr))
+            simple = true;
+        break;
     }
 
     if (simple)
@@ -6765,6 +6797,54 @@ void HqlCppTranslator::doBuildExprCast(BuildCtx & ctx, IHqlExpression * expr, CH
             }
             break;
         }
+    }
+
+    if (expr->isPure() && ctx.getMatchExpr(expr, tgt))
+        return;
+
+    //A few casts have to go via an intermediate type.  Special case them here to make it more likely that the arguments
+    //will be commoned up.  since (cast)translated will not match (cast)original
+    ITypeInfo * argType = arg->queryType();
+    Owned<ITypeInfo> intermediateType;
+    switch (exprType->getTypeCode())
+    {
+    case type_swapint:
+        {
+            if (exprType == argType)
+                break;
+            if (argType->getTypeCode() != type_int)
+                intermediateType.setown(makeIntType(exprType->getSize(), exprType->isSigned()));
+            break;
+        }
+        case type_int:
+        {
+            switch (argType->getTypeCode())
+            {
+            case type_qstring:
+                //Even better would be to implement qString->int function
+                intermediateType.setown(makeStringType(argType->getStringLen(), NULL, NULL));
+                break;
+            }
+            break;
+        }
+        case type_real:
+        {
+            switch (argType->getTypeCode())
+            {
+            case type_swapint:
+                intermediateType.setown(makeIntType(argType->getSize(), argType->isSigned()));
+                break;
+            }
+            break;
+        }
+    }
+
+    if (intermediateType)
+    {
+        OwnedHqlExpr intermediate = createValue(no_implicitcast, intermediateType.getClear(), LINK(arg));
+        OwnedHqlExpr recast = createValue(no_implicitcast, LINK(exprType), intermediate.getClear());
+        buildExpr(ctx, recast, tgt);
+        return;
     }
 
     CHqlBoundExpr pure;

--- a/ecl/hqlcpp/hqlcppcase.cpp
+++ b/ecl/hqlcpp/hqlcppcase.cpp
@@ -794,7 +794,10 @@ void HqlCppCaseInfo::buildGeneralAssign(BuildCtx & ctx, IExprProcessor & target)
     Owned<BuildCtx> subctx = new BuildCtx(ctx);
     CHqlBoundExpr pureCond;
     if (cond.get())
-        translator.buildCachedExpr(*subctx, cond, pureCond);
+    {
+        OwnedHqlExpr simpleCond = complexCompare ? getSimplifyCompareArg(cond) : LINK(cond);
+        translator.buildCachedExpr(*subctx, simpleCond, pureCond);
+    }
     
     OwnedHqlExpr testMore;
 


### PR DESCRIPTION
Signed-off-by: Gavin Halliday <gavin.halliday@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [x] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
