### PR TITLE
HPCC-28164 Report Queues and Roxie Targets in ws_resources

### DIFF
--- a/common/environment/environment.hpp
+++ b/common/environment/environment.hpp
@@ -66,7 +66,13 @@ enum EnvMachineOS
     MachineOsSize = 4
 };
 
-
+enum RoxieTargetType
+{
+    RTTUnknown = 0,
+    RTTPublished = 1,
+    RTTQueued = 2,
+    RTTBoth = 3
+};
 
 interface IConstComputerTypeInfo : extends IConstEnvBase
 {
@@ -274,7 +280,9 @@ interface IConstWUClusterInfo : extends IInterface
     virtual unsigned getChannelsPerNode() const = 0;
     virtual int getRoxieReplicateOffset() const = 0;
     virtual const char *getAlias() const = 0;
-    virtual bool isQueriesOnly() const = 0;
+    virtual RoxieTargetType getRoxieTargetType() const = 0;
+    virtual bool canPublishQueries() const = 0;
+    virtual bool onlyPublishedQueries() const = 0;
 };
 
 typedef IArrayOf<IConstWUClusterInfo> CConstWUClusterInfoArray;
@@ -300,6 +308,7 @@ extern ENVIRONMENT_API void getRoxieProcessServers(const char *process, SocketEn
 extern ENVIRONMENT_API bool isProcessCluster(const char *remoteDali, const char *process);
 extern ENVIRONMENT_API bool isProcessCluster(const char *process);
 extern ENVIRONMENT_API unsigned getEnvironmentThorClusterNames(StringArray &thorNames, StringArray &groupNames, StringArray &targetNames, StringArray &queueNames);
+extern ENVIRONMENT_API RoxieTargetType readRoxieTargetType(const char *roxieName);
 
 #endif // !_CONTAINERIZED
 

--- a/esp/scm/ws_resources.ecm
+++ b/esp/scm/ws_resources.ecm
@@ -17,6 +17,14 @@
 
 EspInclude(common);
 
+ESPenum HPCCQueueType : string
+{
+    Thor("Thor"),
+    HThor("HThor"),
+    Roxie("Roxie"),
+    All("All")
+};
+
 ESPStruct HPCCService
 {
     string Name;
@@ -88,8 +96,26 @@ ESPresponse [nil_remove, exceptions_inline] WebLinksQueryResponse
     ESParray<ESPstruct ConfiguredWebLink> ConfiguredWebLinks;
 };
 
-ESPservice [auth_feature("ResourceQueryAccess:ACCESS"), version("1.02"), exceptions_inline("./smc_xslt/exceptions.xslt")] WsResources
+ESPStruct [nil_remove] HPCCQueue
 {
+    string Name;
+    ESPenum HPCCQueueType Type;
+};
+
+ESPrequest TargetQueryRequest
+{
+    ESPenum HPCCQueueType Type;
+};
+
+ESPresponse [nil_remove, exceptions_inline] TargetQueryResponse
+{
+    ESParray<ESPstruct HPCCQueue> Queues;
+    ESParray<string> Roxies;
+};
+
+ESPservice [auth_feature("ResourceQueryAccess:ACCESS"), version("1.03"), exceptions_inline("./smc_xslt/exceptions.xslt")] WsResources
+{
+    ESPmethod [auth_feature("ResourceQueryAccess:READ"), min_ver("1.03")] TargetQuery(TargetQueryRequest, TargetQueryResponse);
     ESPmethod [auth_feature("ResourceQueryAccess:READ")] ServiceQuery(ServiceQueryRequest, ServiceQueryResponse);
     ESPmethod [auth_feature("ResourceQueryAccess:READ"), min_ver("1.01")] WebLinksQuery(WebLinksQueryRequest, WebLinksQueryResponse);
 };

--- a/esp/services/ws_packageprocess/ws_packageprocessService.cpp
+++ b/esp/services/ws_packageprocess/ws_packageprocessService.cpp
@@ -1321,11 +1321,7 @@ bool CWsPackageProcessEx::onGetPackageMapSelectOptions(IEspContext &context, IEs
             ForEachItemIn(c, clusters)
             {
                 IConstWUClusterInfo &cluster = clusters.item(c);
-#ifndef _CONTAINERIZED
-                if (cluster.getPlatform() == RoxieCluster)
-#else
-                if ((cluster.getPlatform() == RoxieCluster) && cluster.isQueriesOnly())
-#endif
+                if ((cluster.getPlatform() == RoxieCluster) && cluster.canPublishQueries())
                 {
                     SCMStringBuffer str;
                     Owned<IEspTargetData> target = createTargetData();

--- a/esp/services/ws_resources/ws_resourcesService.hpp
+++ b/esp/services/ws_resources/ws_resourcesService.hpp
@@ -37,6 +37,7 @@ public:
     virtual ~CWsResourcesEx() {};
     virtual void init(IPropertyTree* cfg, const char* process, const char* service) override {};
 
+    virtual bool onTargetQuery(IEspContext& context, IEspTargetQueryRequest& req, IEspTargetQueryResponse& resp) override;
     virtual bool onServiceQuery(IEspContext& context, IEspServiceQueryRequest& req, IEspServiceQueryResponse& resp) override;
     virtual bool onWebLinksQuery(IEspContext& context, IEspWebLinksQueryRequest& req, IEspWebLinksQueryResponse& resp) override;
 };

--- a/esp/services/ws_smc/ws_smcService.cpp
+++ b/esp/services/ws_smc/ws_smcService.cpp
@@ -283,7 +283,7 @@ void CActivityInfo::readTargetClusterInfo(CConstWUClusterInfoArray& clusters, IP
     ForEachItemIn(c, clusters)
     {
         IConstWUClusterInfo &cluster = clusters.item(c);
-        if (cluster.isQueriesOnly()) //"publish-only" roxie queues not in SDS /JobQueues.
+        if (cluster.onlyPublishedQueries()) //"publish-only" roxie not in SDS /JobQueues.
             continue;
 
         Owned<CWsSMCTargetCluster> targetCluster = new CWsSMCTargetCluster();

--- a/esp/smc/SMCLib/TpContainer.cpp
+++ b/esp/smc/SMCLib/TpContainer.cpp
@@ -490,12 +490,12 @@ class CContainerWUClusterInfo : public CSimpleInterfaceOf<IConstWUClusterInfo>
     ClusterType platform;
     unsigned clusterWidth;
     StringArray thorProcesses;
-    bool queriesOnly = false;
+    RoxieTargetType roxieTargetType = RTTQueued;
 
 public:
     CContainerWUClusterInfo(const char* _name, const char* type, const char* _ldapUser,
         unsigned _clusterWidth, bool _queriesOnly)
-        : name(_name), ldapUser(_ldapUser), clusterWidth(_clusterWidth), queriesOnly(_queriesOnly)
+        : name(_name), ldapUser(_ldapUser), clusterWidth(_clusterWidth)
     {
         StringBuffer queue;
         if (strieq(type, "thor"))
@@ -508,6 +508,8 @@ public:
         {
             agentQueue.set(getClusterEclAgentQueueName(queue.clear(), name));
             platform = RoxieCluster;
+            if (_queriesOnly)
+                roxieTargetType = RTTPublished;
         }
         else
         {
@@ -550,9 +552,17 @@ public:
     {
         return false;
     }
-    virtual bool isQueriesOnly() const override
+    virtual RoxieTargetType getRoxieTargetType() const override
     {
-        return queriesOnly;
+        return roxieTargetType;
+    }
+    virtual bool canPublishQueries() const override
+    {
+        return roxieTargetType & RTTPublished;
+    }
+    virtual bool onlyPublishedQueries() const override
+    {
+        return roxieTargetType == RTTPublished;
     }
     virtual IStringVal& getScope(IStringVal& str) const override
     {

--- a/esp/smc/SMCLib/TpWrapper.hpp
+++ b/esp/smc/SMCLib/TpWrapper.hpp
@@ -126,7 +126,6 @@ using std::string;
 
 #define SDS_LOCK_TIMEOUT 30000
 
-
 class TPWRAPPER_API CTpWrapper : public CInterface  
 {
     
@@ -143,6 +142,9 @@ private:
         bool slaveNode, IArrayOf<IEspTpMachine>& machineList);
     void appendThorMachineList(double clientVersion, IConstEnvironment* constEnv, INode& node, const char* clusterName,
          const char* machineType, unsigned& processNumber, unsigned channels, const char* directory, IArrayOf<IEspTpMachine>& machineList);
+    void getRoxieServices(IPropertyTree* environmentRoot, const char* serviceName, IArrayOf<IConstHPCCService>& services);
+    void getRoxieService(IPropertyTree* clusterTree, IArrayOf<IConstHPCCService>& services);
+    void getESPServices(IPropertyTree* environmentRoot, const char* serviceType, const char* serviceName, IArrayOf<IConstHPCCService>& services);
 
 #ifndef _CONTAINERIZED
     IPropertyTree* getEnvironment(const char* xpath);

--- a/initfiles/componentfiles/configxml/@temp/esp_service_WsSMC.xsl
+++ b/initfiles/componentfiles/configxml/@temp/esp_service_WsSMC.xsl
@@ -145,6 +145,10 @@ This is required by its binding with ESP service '<xsl:value-of select="$espServ
             <xsl:with-param name="bindingNode" select="$bindingNode"/>
             <xsl:with-param name="authNode" select="$authNode"/>
         </xsl:apply-templates>
+        <xsl:apply-templates select="." mode="ws_resources">
+            <xsl:with-param name="bindingNode" select="$bindingNode"/>
+            <xsl:with-param name="authNode" select="$authNode"/>
+        </xsl:apply-templates>
     </xsl:template>
 
     <!-- WS-SMC -->
@@ -794,6 +798,32 @@ This is required by its binding with ESP service '<xsl:value-of select="$espServ
                 <xsl:with-param name="bindingNode" select="$bindingNode"/>
                 <xsl:with-param name="authMethod" select="$authNode/@method"/>
                 <xsl:with-param name="service" select="'ws_dfsservice'"/>
+            </xsl:call-template>
+        </EspBinding>
+    </xsl:template>
+
+    <!-- ws_resources -->
+    <xsl:template match="EspService" mode="ws_resources">
+        <xsl:param name="bindingNode"/>
+        <xsl:param name="authNode"/>
+
+        <xsl:variable name="serviceType" select="'ws_resources'"/>
+        <xsl:variable name="serviceName" select="concat($serviceType, '_', @name, '_', $process)"/>
+        <xsl:variable name="bindName" select="concat($serviceType, '_', $bindingNode/@name, '_', $process)"/>
+        <xsl:variable name="bindType" select="'ws_resourcesSoapBinding'"/>
+        <xsl:variable name="servicePlugin">
+            <xsl:call-template name="defineServicePlugin">
+                <xsl:with-param name="plugin" select="'ws_resources'"/>
+            </xsl:call-template>
+        </xsl:variable>
+        <EspService name="{$serviceName}" type="{$serviceType}" plugin="{$servicePlugin}">
+        </EspService>
+        <EspBinding name="{$bindName}" service="{$serviceName}" protocol="{$bindingNode/@protocol}" type="{$bindType}"
+            plugin="{$servicePlugin}" netAddress="0.0.0.0" port="{$bindingNode/@port}">
+            <xsl:call-template name="bindAuthentication">
+                <xsl:with-param name="bindingNode" select="$bindingNode"/>
+                <xsl:with-param name="authMethod" select="$authNode/@method"/>
+                <xsl:with-param name="service" select="'ws_resources'"/>
             </xsl:call-template>
         </EspBinding>
     </xsl:template>


### PR DESCRIPTION
1. Add new method TargetQuery to the ESP WsResources service. The
method is used to report the information about HPCC Queues and the
names of the roxies which do not listen to port zero.
2. CTpWrapper::getServices() is revised to read the roxie services
and esp services in bare metal environment. The ESP deployment script 
for bare metal environment is revised to load the WsResources into bare 
metal ESP. With those changes, the information about those services is 
reported in WsResources.ServiceQuery method.

Signed-off-by: wangkx <kevin.wang@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
