### PR TITLE
HPCC-28456 Add TxSummary access to ESDL integration scripts

### DIFF
--- a/esp/esdllib/docs/delay.md
+++ b/esp/esdllib/docs/delay.md
@@ -1,0 +1,13 @@
+### delay
+```xml
+    <delay
+        millis="unsigned integer literal"/>
+```
+
+For testing purposes, it can be helpful to have operations with predictable durations. Consider `tx-summary-timer` recording elapsed time. Testing the timer requires waiting for predictable periods of time.
+
+The delay is guaranteed to be at least `millis` milliseonds in duration, as measured in a difference in tick counts. It is not guarantedd to be exactly `millis` milliseonds in duration; no attempt is made to limit the duration.
+
+| Property | Count | Description |
+| :- | :-: | :- |
+| millis | 0..1 | The requested number of milliseconds difference between ending and beginning tick counts.<br/><br/>Default when omitted or empty is *1*. |

--- a/esp/esdllib/docs/getTxSummary.md
+++ b/esp/esdllib/docs/getTxSummary.md
@@ -1,0 +1,43 @@
+#### getTxSummary
+    string getTxSummary()
+    string getTxSummary(style)
+    string getTxSummary(style, level)
+    string getTxSummary(style, level, group)
+
+The transaction summary is a list of significant data points related to a transaction. Upon transaction completion, one or more subsets of this list are converted to text and sent to the ESP's trace log output. `getTxSummary` converts the current contents of the summary to text that can be manipulated by other script components.
+
+| Parameter | Required? | Description |
+| :- | :-: | :- |
+| style | N | Text selector identifying the output text format. May be *text* for legacy text format, or *json* for JSON format.<br/><br/>Default when omitted or empty is *text*. |
+| level | N | Text or numeric filter limiting included summary values based on log level. May be *min* for LogMin, *normal* for LogNormal, *max* for LogMax, or an integer between LogMin (1) and LogMax (10).<br/><br/>Default when omitted or empty is LogMin. |
+| group | N | Text filter limiting included summary values based on target audience. May be *core* for standard platform values. May be *enterprise* for non-standard platform and script-defined values.<br/><br/>Default when omitted or empty is *enterprise*. |
+
+##### Examples
+
+###### Default Summary
+
+This script operation:
+
+```xml
+<es:set-value target="TxSummary" select="getTxSummary()"/>
+```
+
+Yields content similar to this:
+
+```xml
+<TxSummary>activeReqs=1</TxSummary>
+```
+
+###### JSON Summary
+
+Similar to the default summary above, this operation:
+
+```xml
+<es:set-value target="TxSummary" select="getTxSummary('json')"/>
+```
+
+Yields content similar to this:
+
+```xml
+<TxSummary>{"activeReqs": 1}</TxSummary>
+```

--- a/esp/esdllib/docs/tx-summary-timer.md
+++ b/esp/esdllib/docs/tx-summary-timer.md
@@ -1,0 +1,48 @@
+
+### tx-summary-timer
+```xml
+    <tx-summary-timer
+        core_group="Boolean literal"
+        level="enumerated text or numeric literal"
+        mode="enumerated text literal"
+        name="text literal"
+        optional="Boolean literal"
+        trace="text literal">
+      <!-- operations to be timed -->
+    </tx-summary-timer>
+```
+
+The transaction summary is a list of significant data points related to a transaction. Upon transaction completion, one or more subsets of this list converted to text and sent to the ESP's trace log output. `tx-summary-timer` adds or updates a named value in the summary list with the total processing time, measured in milliseconds, of its child operations.
+
+With respect to the summary, this operation is concerned only with the creation of summary data. With this in mind, summary data points may be one of two types:
+
+- A *scalar* data point is a single, one-off, value with no inherent meaning to the ESP. Scalar values may be created depending on the `mode` property.
+- A *timer* data point is a single value understood by the ESP to be a number that may be incremented after its insertion. Timer values may be created and/or updated depending on the `mode` propeerty.
+
+| Property | Count | Description |
+| :- | :-: | :- |
+| core_group | 0..1 | Flag indicating whether the entry should (*true*) or should not (*false*) be included in output produced for the core audience. All entries are included in output for the enterprise audience.<br/><br/>Default when omitted or empty is *false*. |
+| level | 0..1 | Minimum ESP log level at which the entry is included in log output. May be `min` (1), `normal` (5), `max` (10), or an integer between 1 and 10.<br/><br/>Default when omitted or empty is *1*. |
+| mode | 0..1 | Choice of how to add the value to trace output. May be `append` (add a new scalar value to the end of the list), `set` (replace an existing scalar value or add a new scalar value to the end of the list), or `accumulate` (increment an existing timer value or add a new timer value to the end).<br/><br/>Default when omiited or empty is *append*. |
+| name | 1..1 | Unique value label of the form `text ( '.' text )*`, where no `text` component may be empty.<br/><br/>The dotted name notation has special meaning in JSON formatted summary output. Each name segment preceding a dot represents the name of a JSON object nested within the summary object; multiple such segments result in multiple levels of embedded objects. |
+| optional | 0..1 | Flag indicating whether script syntax errors are fatal (*false*) or merely generate warnings (*true*).<br/><br/>Defaults to *false*. |
+| trace | 0..1 | Label used in trace log output messages.<br/><br/>Default when omitted or empty is the element name. |
+
+Success is not guaranteed. Failure will produce warnings in trace output and script processing will continue. Script authors are responsible for resolving reported warnings. Reasons for failure are:
+
+- Use of a malformed name;
+- Appending a scalar with a name in use;
+- Setting a scalar with a name in use as a timer;
+- Accumulating a timer with a name in use as a scalar.
+
+Avoid the following usage:
+```xml
+<tx-summary-timer name="my timer">
+    <!-- some operations -->
+    <tx-summary-timer name="my timer">
+        <!-- some operations -->
+    </tx-summary-timer>
+    <!-- some operations -->
+</tx-summary-timer>
+```
+The presumed intention of such markup is to time the execution of the outer operation, including the inner operation. The effect of this markup is to update the timer twice, once with the the duration of the inner operation and again with the duration of the outer operation (which already includes the inner operation's duration).

--- a/esp/esdllib/docs/tx-summary-value.md
+++ b/esp/esdllib/docs/tx-summary-value.md
@@ -1,0 +1,37 @@
+
+### tx-summary-value
+```xml
+    <tx-summary-value
+        core_group="Boolean literal"
+        level="enumerated text or numeric literal"
+        mode="enumerated text literal"
+        name="text literal"
+        optional="Boolean literal"
+        select="XPath evaluable to text"
+        trace="text literal"
+        type="enumerated text literal"/>
+```
+
+The transaction summary is a list of significant data points related to a transaction. Upon transaction completion, one or more subsets of this list are converted to text and sent to the ESP's trace log output. `tx-summary-value` adds or updates a named value in the summary list with the result of evaluating the `value` XPath.
+
+With respect to the summary, this operation is concerned only with the creation of summary data. With this in mind, summary data points may be one of two types:
+
+- A *scalar* data point is a single, one-off, value with no inherent meaning to the ESP. All values created are scalars.
+- A *timer* data point is a single value understood by the ESP to be a number that may be incremented after its insertion. No timer values are created or updated.
+
+| Property | Count | Description |
+| :- | :-: | :- |
+| core_group | 0..1 | Flag indicating whether the entry should (*true*) or should not (*false*) be included in output produced for the core audience. All entries are included in output for the enterprise audience.<br/><br/>Default when omitted or empty is *false*. |
+| level | 0..1 | Minimum ESP log level at which the entry is included in log output. May be `min` (1), `normal` (5), `max` (10), or an integer between 1 and 10.<br/><br/>Default when omitted or empty is *1*. |
+| mode | 0..1 | Choice of how to add the value to trace output. May be `append` (add a new scalar value to the end of the list) or `set` (replace an existing scalar value or add a new scalar value to the end of the list).<br/><br/>Default when omiited or empty is *append*. |
+| name | 1..1 | Unique value label of the form `text ( '.' text )*`, where no `text` component may be empty.<br/><br/>The dotted name notation has special meaning in JSON formatted summary output. Each name segment preceding a dot represents the name of a JSON object nested within the summary object; multiple such segments result in multiple levels of embedded objects. |
+| optional | 0..1 | Flag indicating whether script syntax errors are fatal (*false*) or merely generate warnings (*true*).<br/><br/>Defaults when omitted or empty is *false*. |
+| select | 1..1 | XPath expression that evaluates to the scalar value to be recorded. |
+| trace | 0..1 | Label used in trace log output messages.<br/><br/>Default when omitted or empty is the element name. |
+| type | 0..1 | Choice of how to interpret the evaluated `select` expression. May be *text* if the value should be used as-is. May be *signed* if the value should be handled as a signed integer, up to 64 bits. May be *unsigned* if the value should be handled as an unsigned integer, up to 64 bits. May be *decimal* if the value should be handled as a non-integral number.<br/><br/>Default when omitted or empty is *text*. The default can handle all numeric values, but numbers will be presented as strings in JSON output. The default must be overridden when JSON output requires typed numeric values. |
+
+Success is not guaranteed. Failure will produce warnings in trace output and script processing will continue. Script authors are responsible for resolving reported warnings. Reasons for failure are:
+
+- Use of a malformed name;
+- Appending a scalar with a name in use;
+- Setting a scalar with a name in use as a timer.

--- a/esp/esdllib/esdl_script.cpp
+++ b/esp/esdllib/esdl_script.cpp
@@ -25,6 +25,7 @@
 #include "rtlformat.hpp"
 #include "jsecrets.hpp"
 #include "esdl_script.hpp"
+#include "txsummary.hpp"
 
 #include <fxpp/FragmentedXmlPullParser.hpp>
 using namespace xpp;
@@ -2339,6 +2340,316 @@ public:
     }
 };
 
+/**
+ * @brief Helper structure used by both tx-summary-value and tx-summary-timer.
+ *
+ * There is common data used by both operations. Because one operation is childless and the other
+ * allows children, they cannot have a common base class. Instead each contains an instance of this
+ * structure to provide common handling of the common data.
+ */
+struct TxSummaryCoreInfo
+{
+    StringAttr m_name;
+    unsigned   m_level = LogMin;
+    unsigned   m_groups = TXSUMMARY_GRP_ENTERPRISE;
+
+    TxSummaryCoreInfo(StartTag& stag, const char* tagname, const char* traceName, bool ignoreCodingErrors)
+    {
+        m_name.set(stag.getValue("name"));
+        if (m_name.isEmpty())
+            esdlOperationError(ESDL_SCRIPT_MissingOperationAttr, tagname, "without name", traceName, !ignoreCodingErrors);
+        const char* level = stag.getValue("level");
+        if (!isEmptyString(level))
+        {
+            if (strieq(level, "min"))
+                m_level = LogMin;
+            else if (strieq(level, "normal"))
+                m_level = LogNormal;
+            else if (strieq(level, "max"))
+                m_level = LogMax;
+            else if (TokenDeserializer().deserialize(level, m_level) != Deserialization_SUCCESS || m_level < LogMin || m_level > LogMax)
+                esdlOperationError(ESDL_SCRIPT_InvalidOperationAttr, tagname, "invalid level", traceName, !ignoreCodingErrors);
+        }
+        const char* coreGroup = stag.getValue("core_group");
+        if (!isEmptyString(coreGroup) && strToBool(coreGroup))
+            m_groups |= TXSUMMARY_GRP_CORE;
+    }
+};
+
+static TokenDeserializer s_deserializer;
+
+class CEsdlTransformOperationTxSummaryValue : public CEsdlTransformOperationWithoutChildren
+{
+protected:
+    enum Type { Text, Signed, Unsigned, Decimal };
+    enum Mode { Append, Set };
+    TxSummaryCoreInfo     m_info;
+    Owned<ICompiledXpath> m_value;
+    Type                  m_type = Text;
+    Mode                  m_mode = Append;
+
+public:
+    CEsdlTransformOperationTxSummaryValue(IXmlPullParser& xpp, StartTag& stag, const StringBuffer& prefix)
+        : CEsdlTransformOperationWithoutChildren(xpp, stag, prefix)
+        , m_info(stag, m_tagname, m_traceName, m_ignoreCodingErrors)
+    {
+        m_value.setown(compileOptionalXpath(stag.getValue("select")));
+        if (!m_value)
+            esdlOperationError(ESDL_SCRIPT_MissingOperationAttr, m_tagname, "without select", m_traceName, !m_ignoreCodingErrors);
+        const char* type = stag.getValue("type");
+        if (!isEmptyString(type))
+        {
+            if (strieq(type, "signed"))
+                m_type = Signed;
+            else if (strieq(type, "unsigned"))
+                m_type = Unsigned;
+            else if (strieq(type, "decimal"))
+                m_type = Decimal;
+            else if (!strieq(type, "text"))
+                esdlOperationError(ESDL_SCRIPT_InvalidOperationAttr, m_tagname, "invalid type", m_traceName, !m_ignoreCodingErrors);
+        }
+        const char* mode = stag.getValue("mode");
+        if (!isEmptyString(mode))
+        {
+            if (strieq(mode, "set"))
+                m_mode = Set;
+            else if (!strieq(mode, "append"))
+                esdlOperationError(ESDL_SCRIPT_InvalidOperationAttr, m_tagname, VStringBuffer("invalid mode '%s'", mode), m_traceName, !m_ignoreCodingErrors);
+        }
+    }
+
+    virtual ~CEsdlTransformOperationTxSummaryValue()
+    {
+    }
+
+    void injectText(const char* value, CTxSummary* txSummary) const
+    {
+        switch (m_mode)
+        {
+        case Append:
+            if (!txSummary->append(m_info.m_name, value, m_info.m_level, m_info.m_groups))
+                UWARNLOG("script operation %s did not append '%s=%s' [text]; name is malformed or is in use", m_tagname.str(), m_info.m_name.str(), value);
+            break;
+        case Set:
+            if (!txSummary->set(m_info.m_name, value, m_info.m_level, m_info.m_groups))
+                UWARNLOG("script operation %s did not set '%s=%s' [text]; name is malformed or identifies a cumulative timer", m_tagname.str(), m_info.m_name.str(), value);
+            break;
+        default:
+            break;
+        }
+    }
+    void injectSigned(const char* rawValue, CTxSummary* txSummary) const
+    {
+        signed long long sll;
+        if (s_deserializer.deserialize(rawValue, sll) == Deserialization_SUCCESS)
+        {
+            switch (m_mode)
+            {
+            case Append:
+                if (!txSummary->append(m_info.m_name, sll, m_info.m_level, m_info.m_groups))
+                    UWARNLOG("script operation %s did not append '%s=%s' [signed]; name is malformed or is in use", m_tagname.str(), m_info.m_name.str(), rawValue);
+                break;
+            case Set:
+                if (!txSummary->set(m_info.m_name, sll, m_info.m_level, m_info.m_groups))
+                    UWARNLOG("script operation %s did not set '%s=%s' [signed]; name is malformed or identifies a cumulative timer", m_tagname.str(), m_info.m_name.str(), rawValue);
+                break;
+            default:
+                break;
+            }
+        }
+        else
+            UWARNLOG("script operation %s did not set '%s=%s'; not a signed integer", m_tagname.str(), m_info.m_name.str(), rawValue);
+    }
+    void injectUnsigned(const char* rawValue, CTxSummary* txSummary) const
+    {
+        unsigned long long ull;
+        if (s_deserializer.deserialize(rawValue, ull) == Deserialization_SUCCESS)
+        {
+            switch (m_mode)
+            {
+            case Append:
+                if (!txSummary->append(m_info.m_name, ull, m_info.m_level, m_info.m_groups))
+                    UWARNLOG("script operation %s did not append '%s=%s' [unsigned]; name is malformed or is in use", m_tagname.str(), m_info.m_name.str(), rawValue);
+                break;
+            case Set:
+                if (!txSummary->set(m_info.m_name, ull, m_info.m_level, m_info.m_groups))
+                    UWARNLOG("script operation %s did not set '%s=%s' [unsigned]; name is malformed or identifies a cumulative timer", m_tagname.str(), m_info.m_name.str(), rawValue);
+                break;
+            default:
+                break;
+            }
+        }
+        else
+            UWARNLOG("script operation %s did not set '%s=%s'; not an unsigned integer", m_tagname.str(), m_info.m_name.str(), rawValue);
+    }
+    void injectDecimal(const char* rawValue, CTxSummary* txSummary) const
+    {
+        double d;
+        if (s_deserializer.deserialize(rawValue, d) == Deserialization_SUCCESS)
+        {
+            switch (m_mode)
+            {
+            case Append:
+                if (!txSummary->append(m_info.m_name, d, m_info.m_level, m_info.m_groups))
+                    UWARNLOG("script operation %s did not append '%s=%s' [decimal]; name is malformed or is in use", m_tagname.str(), m_info.m_name.str(), rawValue);
+                break;
+            case Set:
+                if (!txSummary->set(m_info.m_name, d, m_info.m_level, m_info.m_groups))
+                    UWARNLOG("script operation %s did not set '%s=%s' [decimal]; name is malformed or identifies a cumulative timer", m_tagname.str(), m_info.m_name.str(), rawValue);
+                break;
+            default:
+                break;
+            }
+        }
+        else
+            UWARNLOG("script operation %s did not set '%s=%s'; not decimal", m_tagname.str(), m_info.m_name.str(), rawValue);
+    }
+    void injectValue(const char* rawValue, CTxSummary* txSummary)
+    {
+        switch (m_type)
+        {
+        case Text:
+            injectText(rawValue, txSummary);
+            break;
+        case Signed:
+            injectSigned(rawValue, txSummary);
+            break;
+        case Unsigned:
+            injectUnsigned(rawValue, txSummary);
+            break;
+        case Decimal:
+            injectDecimal(rawValue, txSummary);
+            break;
+        default:
+            break;
+        }
+    }
+    virtual bool exec(CriticalSection* crit, IInterface* preparedForAsync, IEsdlScriptContext* scriptContext, IXpathContext* targetContext, IXpathContext* sourceContext) override
+    {
+        IEspContext* espCtx = scriptContext->queryEspContext();
+        CTxSummary* txSummary = (espCtx ? espCtx->queryTxSummary() : nullptr);
+        if (!txSummary)
+            return true;
+        OptionalCriticalBlock block(crit);
+
+        if (m_value)
+        {
+            StringBuffer value;
+            sourceContext->evaluateAsString(m_value, value);
+            injectValue(value, txSummary);
+        }
+        return true;
+    }
+
+    virtual void toDBGLog () override
+    {
+    #if defined(_DEBUG)
+        DBGLOG(">%s> %s(%s)", m_traceName.str(), m_tagname.str(), m_info.m_name.str());
+    #endif
+    }
+};
+
+class CEsdlTransformOperationTxSummaryTimer : public CEsdlTransformOperationWithChildren
+{
+protected:
+    enum Mode { Append, Set, Accumulate };
+    TxSummaryCoreInfo m_info;
+    Mode              m_mode = Append;
+
+public:
+    CEsdlTransformOperationTxSummaryTimer(IXmlPullParser& xpp, StartTag& stag, const StringBuffer& prefix, IEsdlFunctionRegister* functionRegister)
+        : CEsdlTransformOperationWithChildren(xpp, stag, prefix, true, functionRegister, nullptr)
+        , m_info(stag, m_tagname, m_traceName, m_ignoreCodingErrors)
+    {
+        const char* mode = stag.getValue("mode");
+        if (!isEmptyString(mode))
+        {
+            if (strieq(mode, "set"))
+                m_mode = Set;
+            else if (strieq(mode, "accumulate"))
+                m_mode = Accumulate;
+            else if (!strieq(mode, "append"))
+                esdlOperationError(ESDL_SCRIPT_InvalidOperationAttr, m_tagname, VStringBuffer("invalid mode '%s'", mode), m_traceName, !m_ignoreCodingErrors);
+        }
+    }
+
+    virtual ~CEsdlTransformOperationTxSummaryTimer()
+    {
+    }
+
+    virtual bool exec(CriticalSection* crit, IInterface* preparedForAsync, IEsdlScriptContext* scriptContext, IXpathContext* targetContext, IXpathContext* sourceContext) override
+    {
+        IEspContext* espCtx = scriptContext->queryEspContext();
+        CTxSummary* txSummary = (espCtx ? espCtx->queryTxSummary() : nullptr);
+        if (!txSummary)
+            return true;
+        StringBuffer value;
+        OptionalCriticalBlock block(crit);
+        CTimeMon timer;
+        processChildren(scriptContext, targetContext, sourceContext);
+        unsigned delta = timer.elapsed();
+        switch (m_mode)
+        {
+        case Append:
+            if (!txSummary->append(m_info.m_name, delta, m_info.m_level, m_info.m_groups))
+                UWARNLOG("script operation %s did not append '%s=%u'; name is malformed or is in use", m_tagname.str(), m_info.m_name.str(), delta);
+            break;
+        case Set:
+            if (!txSummary->set(m_info.m_name, delta, m_info.m_level, m_info.m_groups))
+                UWARNLOG("script operation %s did not set '%s=%u'; name is malformed or identifies a cumulative timer", m_tagname.str(), m_info.m_name.str(), delta);
+            break;
+        case Accumulate:
+            if (!txSummary->updateTimer(m_info.m_name, delta, m_info.m_level, m_info.m_groups))
+                UWARNLOG("script operation %s did not add %ums to cumulative timer '%s'; name is malformed or identifies a scalar value", m_tagname.str(), delta,  m_info.m_name.str());
+            break;
+        default:
+            break;
+        }
+        return true;
+    }
+
+    virtual void toDBGLog () override
+    {
+    #if defined(_DEBUG)
+        DBGLOG(">>>%s> %s %s >>>>", m_traceName.str(), m_tagname.str(), m_info.m_name.str());
+        CEsdlTransformOperationWithChildren::toDBGLog();
+        DBGLOG (">>>>>>>>>>> %s >>>>>>>>>>", m_tagname.str());
+    #endif
+    }
+};
+
+class CEsdlTransformOperationDelay : public CEsdlTransformOperationWithoutChildren
+{
+protected:
+    unsigned m_millis = 1;
+public:
+    CEsdlTransformOperationDelay(IXmlPullParser& xpp, StartTag& stag, const StringBuffer& prefix)
+        : CEsdlTransformOperationWithoutChildren(xpp, stag, prefix)
+    {
+        const char* millis = stag.getValue("millis");
+        if (!isEmptyString(millis) && s_deserializer.deserialize(millis, m_millis) != Deserialization_SUCCESS)
+            esdlOperationError(ESDL_SCRIPT_InvalidOperationAttr, m_tagname, "invalid millis", m_traceName, !m_ignoreCodingErrors);
+    }
+
+    virtual ~CEsdlTransformOperationDelay()
+    {
+    }
+
+    virtual bool exec(CriticalSection* crit, IInterface* preparedForAsync, IEsdlScriptContext* scriptContext, IXpathContext* targetContext, IXpathContext* sourceContext) override
+    {
+        OptionalCriticalBlock block(crit);
+        MilliSleep(m_millis);
+        return true;
+    }
+
+    virtual void toDBGLog () override
+    {
+    #if defined(_DEBUG)
+        DBGLOG(">%s> %s", m_traceName.str(), m_tagname.str());
+    #endif
+    }
+};
+
 IEsdlTransformOperation *createEsdlTransformOperation(IXmlPullParser &xpp, const StringBuffer &prefix, bool withVariables, bool ignoreCodingErrors, IEsdlFunctionRegister *functionRegister, bool canDeclareFunctions)
 {
     StartTag stag;
@@ -2418,6 +2729,12 @@ IEsdlTransformOperation *createEsdlTransformOperation(IXmlPullParser &xpp, const
         return new CEsdlTransformOperationSynchronize(xpp, stag, prefix, functionRegister);
     if (streq(op, "script"))
         return new CEsdlTransformOperationScript(xpp, stag, prefix, functionRegister);
+    if (streq(op, "tx-summary-value"))
+        return new CEsdlTransformOperationTxSummaryValue(xpp, stag, prefix);
+    if (streq(op, "tx-summary-timer"))
+        return new CEsdlTransformOperationTxSummaryTimer(xpp, stag, prefix, functionRegister);
+    if (streq(op, "delay"))
+        return new CEsdlTransformOperationDelay(xpp, stag, prefix);
     return nullptr;
 }
 

--- a/testing/unittests/txSummarytests.cpp
+++ b/testing/unittests/txSummarytests.cpp
@@ -101,7 +101,7 @@ public:
     void testTypes()
     {
         VStringBuffer resultJSON("{\"emptystr\":\"\",\"nullstr\":\"\",\"int\":%i,\"uint\":%u,\"uint64\":%" I64F "u,\"querytimer\":42,\"updatetimernew\":23,\"bool\":1}", INT_MAX, UINT_MAX, ULLONG_MAX );
-        VStringBuffer resultText("emptystr;nullstr;int=%i;uint=%u;uint64=%" I64F "u;querytimer=42ms;updatetimernew=23ms;bool=1;", INT_MAX, UINT_MAX, ULLONG_MAX );
+        VStringBuffer resultText("emptystr;nullstr;int=%i;uint=%u;uint64=%" I64F "u;querytimer=42;updatetimernew=23;bool=1;", INT_MAX, UINT_MAX, ULLONG_MAX );
         const char* testName="testTypes";
         Owned<CTxSummary> tx = new CTxSummary();
 
@@ -124,6 +124,11 @@ public:
 
         // Cumulative Timer
         CumulativeTimer* t = tx->queryTimer("querytimer", LogMin, TXSUMMARY_GRP_ENTERPRISE);
+        if (!t)
+        {
+            fprintf(stdout, "\nTest (testTypes): expected cumulative time 'querytimer'\n");
+            CPPUNIT_ASSERT(false);
+        }
         t->add(23);
         tx->updateTimer("querytimer", 19, LogMin, TXSUMMARY_GRP_ENTERPRISE);
         tx->updateTimer("updatetimernew", 23, LogMin, TXSUMMARY_GRP_ENTERPRISE);
@@ -188,17 +193,7 @@ public:
         if(result)
             throw MakeStringException(100, "Failed Test (%s) - allowed malformed key with empty path part: (bread..baker)", testName);
 
-        CumulativeTimer* timer = nullptr;
-        try
-        {
-            // expected exception thrown because "app" is not a timer
-            timer = tx->queryTimer("app", LogMin, TXSUMMARY_GRP_ENTERPRISE);
-        }
-        catch(IException* e)
-        {
-            e->Release();
-        }
-
+        CumulativeTimer* timer = tx->queryTimer("app", LogMin, TXSUMMARY_GRP_ENTERPRISE);
         if(timer)
             throw MakeStringException(100, "Failed Test (%s) - string entry mistaken for CumulativeTimer", testName);
     }
@@ -266,10 +261,10 @@ public:
         constexpr const char* resultOps1JsonMin = R"!!({"dev-str":"q","dev-int":1,"dev-uint":2,"dev-uint64":3,"dev-timer":19,"dev-bool":0})!!";
         constexpr const char* resultOps2JsonMax = R"!!({"ops-str":"q","ops-int":1,"ops-uint":2,"ops-uint64":3,"ops-timer":23,"ops-bool":0,"max-only":1})!!";
         constexpr const char* resultOps2JsonMin = R"!!({"ops-str":"q","ops-int":1,"ops-uint":2,"ops-uint64":3,"ops-timer":23,"ops-bool":0})!!";
-        constexpr const char* resultOps1TextMax = R"!!(dev-str=q;dev-int=1;dev-uint=2;dev-uint64=3;dev-timer=19ms;dev-bool=0;max-only=1;)!!";
-        constexpr const char* resultOps1TextMin = R"!!(dev-str=q;dev-int=1;dev-uint=2;dev-uint64=3;dev-timer=19ms;dev-bool=0;)!!";
-        constexpr const char* resultOps2TextMax = R"!!(ops-str=q;ops-int=1;ops-uint=2;ops-uint64=3;ops-timer=23ms;ops-bool=0;max-only=1;)!!";
-        constexpr const char* resultOps2TextMin = R"!!(ops-str=q;ops-int=1;ops-uint=2;ops-uint64=3;ops-timer=23ms;ops-bool=0;)!!";
+        constexpr const char* resultOps1TextMax = R"!!(dev-str=q;dev-int=1;dev-uint=2;dev-uint64=3;dev-timer=19;dev-bool=0;max-only=1;)!!";
+        constexpr const char* resultOps1TextMin = R"!!(dev-str=q;dev-int=1;dev-uint=2;dev-uint64=3;dev-timer=19;dev-bool=0;)!!";
+        constexpr const char* resultOps2TextMax = R"!!(ops-str=q;ops-int=1;ops-uint=2;ops-uint64=3;ops-timer=23;ops-bool=0;max-only=1;)!!";
+        constexpr const char* resultOps2TextMin = R"!!(ops-str=q;ops-int=1;ops-uint=2;ops-uint64=3;ops-timer=23;ops-bool=0;)!!";
         const char* testName="testFilter";
 
         Owned<CTxSummary> tx = new CTxSummary();
@@ -295,6 +290,11 @@ public:
         // Cumulative Timer
         // create with a call to query, then update
         CumulativeTimer* t = tx->queryTimer("dev-timer", LogMin, TXSUMMARY_GRP_CORE);
+        if (!t)
+        {
+            fprintf(stdout, "\nTest (testFilter): expected cumulative time 'dev-timer'\n");
+            CPPUNIT_ASSERT(false);
+        }
         tx->updateTimer("dev-timer", 19, LogMin, TXSUMMARY_GRP_CORE);
         // create with a call to update
         tx->updateTimer("ops-timer", 23, LogMin, TXSUMMARY_GRP_ENTERPRISE);


### PR DESCRIPTION
- Add operation tx-summary-value to add values to the summary.
- Add operation tx-summary-timer to add elapsed times to the summary.
- Add extension function getTxSummary to read current summary content.
- Add operation delay to faciliate testing of tx-summary-timer.
- Update cumulative timer logic regarding exceptions and value output.

Signed-off-by: Tim Klemm <tim.klemm@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
