### PR TITLE
HPCC-28706 Allow dynamic sizing of compression buffer

### DIFF
--- a/system/jhtree/hlzw.cpp
+++ b/system/jhtree/hlzw.cpp
@@ -155,6 +155,11 @@ unsigned KeyCompressor::writeBlob(const char *data, unsigned datalength)
 }
 
 
+bool KeyCompressor::adjustLimit(size32_t newLimit)
+{
+    return comp && comp->adjustLimit(newLimit);
+}
+
 void KeyCompressor::close()
 { // gets called either when write failed or explicitly by client
     if (comp!=NULL) {

--- a/system/jhtree/hlzw.h
+++ b/system/jhtree/hlzw.h
@@ -24,7 +24,7 @@ typedef unsigned short KEYRECSIZE_T;
 #include "jlzw.hpp"
 #define USE_RANDROWDIFF true
 
-class KeyCompressor 
+class KeyCompressor final
 {
 public:
     KeyCompressor() {}
@@ -33,18 +33,22 @@ public:
     void openBlob(void *blk,int blksize);
     int writekey(offset_t fPtr,const char *key,unsigned datalength, unsigned __int64 sequence);
     unsigned writeBlob(const char *data, unsigned datalength);
-    void *bufptr() { return (comp==NULL)?bufp:comp->bufptr();}
-    int buflen() { return (comp==NULL)?bufl:comp->buflen();}
-    virtual void close();
-    unsigned getCurrentOffset() { return (curOffset+0xf) & 0xfffffff0; }
+    void close();
+    bool adjustLimit(size32_t newLimit);
+
+    unsigned getCurrentOffset() const { return (curOffset+0xf) & 0xfffffff0; }
+    void *bufptr() const { return (comp==NULL)?bufp:comp->bufptr();}
+    int buflen() const { return (comp==NULL)?bufl:comp->buflen();}
+
 protected:
+    ICompressor *comp = nullptr;
+    void *bufp = nullptr;
+    unsigned curOffset = 0;
+    int bufl = 0;
     bool isVariable = false;
     bool isBlob = false;
-    unsigned curOffset = 0;
-    void *bufp = nullptr;
-    int bufl = 0;
+
     void testwrite(const void *p,size32_t s);
-    ICompressor *comp = nullptr;
 };
 
 #endif

--- a/system/jlib/jfcmp.hpp
+++ b/system/jlib/jfcmp.hpp
@@ -42,6 +42,7 @@ protected:
     size32_t outlen = 0;
     size32_t wrmax = 0;
     size32_t dynamicOutSz = 0;
+    size32_t originalMax = 0;
 
     virtual void setinmax() = 0;
     virtual void flushcommitted() = 0;
@@ -74,6 +75,7 @@ public:
         if (max<1024)
             throw MakeStringException(-1,"CFcmpCompressor::open - block size (%d) not large enough", max);
         wrmax = max;
+        originalMax = max;
         if (buf)
         {
             if (bufalloc)

--- a/system/jlib/jio.cpp
+++ b/system/jlib/jio.cpp
@@ -22,7 +22,7 @@
 #include "jfile.hpp"
 #include "jthread.hpp"
 #include "jio.ipp"
-#include "jlzw.ipp"
+#include "jlzw.hpp"
 #include "jmisc.hpp"
 #include <time.h>
 #include <limits.h>

--- a/system/jlib/jlzw.hpp
+++ b/system/jlib/jlzw.hpp
@@ -35,6 +35,8 @@ interface jlib_decl ICompressor : public IInterface
     virtual size32_t buflen()=0;
     virtual void   startblock()=0;                      // row based must call startblock/commitblock
     virtual void   commitblock()=0;
+
+    virtual bool adjustLimit(size32_t newLimit) = 0;    // adjust the maximum size of a fixed size output buffer
 };
 
 interface jlib_decl IExpander : public IInterface

--- a/system/jlib/jlzw.ipp
+++ b/system/jlib/jlzw.ipp
@@ -39,21 +39,22 @@ public:
 };
 
 
-class jlib_decl CLZWCompressor : public ICompressor, public CInterface
+class CLZWCompressor final : public ICompressor, public CInterface
 {
 public:
     IMPLEMENT_IINTERFACE;
 
     CLZWCompressor(bool _supportbigendian);
-    virtual         ~CLZWCompressor();
-    virtual void    open(MemoryBuffer &mb, size32_t initialSize);
-    virtual void    open(void *blk,size32_t blksize);
-    virtual void    close();
-    virtual size32_t    write(const void *buf,size32_t len);
-    virtual void *  bufptr() { return outbuf;}
-    virtual size32_t    buflen() { return outlen;}
-    virtual void    startblock();
-    virtual void    commitblock();
+    virtual ~CLZWCompressor();
+    virtual void open(MemoryBuffer &mb, size32_t initialSize) override;
+    virtual void open(void *blk,size32_t blksize) override;
+    virtual void close() override;
+    virtual size32_t write(const void *buf,size32_t len) override;
+    virtual void * bufptr() override { return outbuf;}
+    virtual size32_t buflen() override { return outlen;}
+    virtual void startblock() override;
+    virtual void commitblock() override;
+    virtual bool adjustLimit(size32_t newLimit) override;
 
 protected:
     void flushbuf();
@@ -64,6 +65,7 @@ protected:
     size32_t inlenblk;
     size32_t outlen;
     size32_t maxlen;
+    size32_t originalMax = 0;
     int curcode;
     size32_t bufalloc;
     void          *outbuf;
@@ -80,7 +82,6 @@ protected:
     unsigned char dictinuse[LZW_HASH_TABLE_SIZE];
     int dictcode[LZW_HASH_TABLE_SIZE];
     bool supportbigendian;
-
 };
 
 


### PR DESCRIPTION
Signed-off-by: Gavin Halliday <gavin.halliday@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [ ] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
