### PR TITLE
HPCC-28414 Add flexible external ClusterIssuer support (e.g. letsencrypt, zerossl)

### DIFF
--- a/helm/hpcc/templates/_helpers.tpl
+++ b/helm/hpcc/templates/_helpers.tpl
@@ -155,7 +155,7 @@ Returns true if the given certificate issuer is enabled, otherwise false
 {{- $certificates := (.root.Values.certificates | default dict) -}}
 {{- if $certificates.enabled -}}
   {{- $issuers := ($certificates.issuers | default dict) -}}
-  {{- $issuer := get $issuers .issuer -}}
+  {{- $issuer := get $issuers .issuerKeyName -}}
   {{- if $issuer -}}
     {{- (hasKey $issuer "enabled" | ternary $issuer.enabled true) }}
   {{- else -}}
@@ -171,7 +171,7 @@ Returns true if mtls should be enabled, otherwise false
 */}}
 {{- define "hpcc.isMtlsEnabled" -}}
 {{- $security := .root.Values.security | default dict -}}
-{{- if eq (include "hpcc.isIssuerEnabled" (dict "root" .root "issuer" "local")) "true" -}}
+{{- if eq (include "hpcc.isIssuerEnabled" (dict "root" .root "issuerKeyName" "local")) "true" -}}
   {{- (hasKey $security "mtls" | ternary $security.mtls true) -}}
 {{- else -}}
 false
@@ -924,20 +924,20 @@ Generate service entries for TLS
     {{- if and ($externalService) (hasKey .component "certificate") }}
   tls: true
     {{- else }}
-      {{- $externalIssuerName := ternary "remote" "public" (eq "true" ( include "hpcc.usesRemoteClientCertificates" . )) -}}
-      {{- $issuerName := ternary $externalIssuerName "local" $externalService }}
+      {{- $externalIssuerKeyName := ternary "remote" "public" (eq "true" ( include "hpcc.usesRemoteClientCertificates" . )) -}}
+      {{- $issuerKeyName := ternary $externalIssuerKeyName "local" $externalService }}
       {{- $certificates := (.root.Values.certificates | default dict) -}}
       {{- if not $certificates.enabled }}
   tls: false
       {{- else -}}
         {{- $issuers := ($certificates.issuers | default dict) -}}
-        {{- $issuer := get $issuers $issuerName -}}
+        {{- $issuer := get $issuers $issuerKeyName -}}
         {{- if not $issuer }}
   tls: false
         {{- else -}}
           {{- $issuerSpec := ($issuer.spec | default dict) }}
   tls: {{ (hasKey $issuer "enabled" | ternary $issuer.enabled true) }}
-  issuer: {{ $issuerName }}
+  issuer: {{ $issuerKeyName }}
   selfSigned: {{ (hasKey $issuerSpec "selfSigned") }}
   caCert: {{ (not (hasKey $issuerSpec "selfSigned")) }}
         {{- end -}}
@@ -1496,32 +1496,51 @@ NB: if optional 'issuer' passed in use it, otherwise base on visibility and
 use "public" or "local" 
 */}}
 {{- define "hpcc.addCertificate" }}
-{{- if (.root.Values.certificates | default dict).enabled -}}
-{{- $externalCert := or (and (hasKey . "external") .external) (ne (include "hpcc.isVisibilityPublic" .) "") -}}
-{{- $externalIssuerName := ternary "remote" "public" (eq "true" ( include "hpcc.usesRemoteClientCertificates" . )) -}}
-{{- $issuerName := .issuer | default (ternary $externalIssuerName "local" $externalCert) -}}
-{{- if eq (include "hpcc.isIssuerEnabled" (dict "root" .root "issuer" $issuerName)) "true" -}}
-{{- $issuer := get .root.Values.certificates.issuers $issuerName -}}
-{{- if $issuer -}}
-{{- $namespace := .root.Release.Namespace -}}
-{{- $service := (.service | default dict) -}}
-{{- $domain := ( $service.domain | default $issuer.domain | default $namespace | default "default" ) -}}
-{{- $name := .name }}
-
+ {{- if (.root.Values.certificates | default dict).enabled -}}
+  {{- $externalCert := or (and (hasKey . "external") .external) (ne (include "hpcc.isVisibilityPublic" .) "") -}}
+  {{- $externalIssuerKeyName := ternary "remote" "public" (eq "true" ( include "hpcc.usesRemoteClientCertificates" . )) -}}
+  {{- $issuerKeyName := .issuerKeyName | default (ternary $externalIssuerKeyName "local" $externalCert) -}}
+  {{- if eq (include "hpcc.isIssuerEnabled" (dict "root" .root "issuerKeyName" $issuerKeyName)) "true" -}}
+   {{- $issuer := get .root.Values.certificates.issuers $issuerKeyName -}}
+   {{- if $issuer -}}
+    {{- $namespace := .root.Release.Namespace -}}
+    {{- $clientUsage := (hasKey $issuer "clientUsage" | ternary $issuer.clientUsage (ne "public" $issuerKeyName)) -}}
+    {{- $spiffe := (hasKey $issuer "spiffe" | ternary $issuer.spiffe (ne "public" $issuerKeyName)) }}
+    {{- $service := (.service | default dict) -}}
+    {{- $wildcard := (hasKey $issuer "wildcard" | ternary $issuer.wildcard false) -}}
+    {{- /* Having a service specific domain overrules wildcard. We can consider wildcard at the service level later */ -}}
+    {{- if and $wildcard (not $service.domain) -}}
+     {{- /* Issuer wildcard certifiacte should already be generated */ -}}
+     {{- if ne $issuerKeyName "public" -}}
+      {{- $_ := fail (printf "Issuer %s - wildcard currently only supported for public issuer." $issuerKeyName) -}}
+     {{- end -}}
+     {{- if not $issuer.domain -}}
+      {{- $_ := fail (printf "Issuer %s - setting wildcard requires configuring a domain." $issuerKeyName) -}}
+     {{- end }}
+     {{- if $spiffe -}}
+      {{- $_ := fail (printf "Issuer %s - setting wildcard not supported with spiffe setting enabled." $issuerKeyName) -}}
+     {{- end }}
+     {{- if $clientUsage -}}
+      {{- $_ := fail (printf "Issuer %s - setting wildcard not supported with clientUsage setting enabled." $issuerKeyName) -}}
+     {{- end }}
+    {{- else -}}
+     {{- $domain := ( $service.domain | default $issuer.domain | default $namespace | default "default" ) -}}
+     {{- $name := .name -}}
+     # spiffe and clientUsage default is off for public issuer to simplify use of letsencrypt, etc.
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: {{ .component }}-{{ $issuerName }}-{{ $name }}-cert
+  name: {{ .component }}-{{ $issuerKeyName }}-{{ $name }}-cert
   namespace: {{ $namespace }}
 spec:
   # Secret names are always required.
-  secretName: {{ .component }}-{{ $issuerName }}-{{ $name }}-tls
+  secretName: {{ .component }}-{{ $issuerKeyName }}-{{ $name }}-tls
   duration: 2160h # 90d
   renewBefore: 360h # 15d
   subject:
     organizations:
     - HPCC Systems
-  commonName: {{ trunc 64 (printf "%s.%s" $name $domain) }}
+  commonName: {{ (trunc 64 (printf "%s.%s" $name $domain)) | quote }}
   isCA: false
   privateKey:
     algorithm: RSA
@@ -1529,30 +1548,34 @@ spec:
     size: 2048
   usages:
     - server auth
+     {{- if $clientUsage }}
     - client auth
+     {{- end }}
   dnsNames:
- {{- /* if servicename is passed we simply create a service entry of that name */ -}}
- {{- if .servicename }}
+     {{- /* if servicename is passed we simply create a service entry of that name */ -}}
+     {{- if .servicename }}
   - {{ .servicename }}.{{ $domain }}
- {{- /* if service parameter is passed in we are using the component config as a service config entry */ -}}
- {{- else if .service -}}
-   {{- $public := and (hasKey .service "visibility") (not (eq .service.visibility "cluster")) -}}
-   {{- if eq $public $externalCert }}
+      {{- /* if service parameter is passed in we are using the component config as a service config entry */ -}}
+     {{- else if .service -}}
+      {{- $public := and (hasKey .service "visibility") (not (eq .service.visibility "cluster")) -}}
+      {{- if eq $public $externalCert }}
   - {{ $name }}.{{ $domain }}
-   {{- end }}
- {{- /* if services parameter is passed the component has an array of services to configure */ -}}
- {{- else if .services -}}
-  {{- range $service := .services }}
-   {{- $external := and (hasKey $service "external") $service.external -}}
-   {{- if eq $external $externalCert }}
+      {{- end }}
+     {{- /* if services parameter is passed the component has an array of services to configure */ -}}
+     {{- else if .services -}}
+      {{- range $service := .services }}
+       {{- $external := and (hasKey $service "external") $service.external -}}
+       {{- if eq $external $externalCert }}
   - {{ $service.name }}.{{ $domain }}
-   {{- end }}
-  {{- end }}
- {{- else if not $externalCert }}
+       {{- end }}
+      {{- end }}
+     {{- else if not $externalCert }}
   - "{{ $name }}.{{ $domain }}"
- {{- end }}
+     {{- end }}
+     {{- if $spiffe }}
   uris:
   - spiffe://hpcc.{{ $domain }}/{{ .component }}/{{ $name }}
+     {{- end }}
   # Issuer references are always required.
   issuerRef:
     name: {{ $issuer.name }}
@@ -1560,10 +1583,11 @@ spec:
     kind: {{ $issuer.kind }}
     group: cert-manager.io
 ---
-{{- end }}
-{{- end }}
-{{- end }}
-{{- end }}
+    {{- end -}}
+   {{- end -}}
+  {{- end -}}
+ {{- end -}}
+{{- end -}}
 
 {{/*
 Builds the commonName for a client certificate.  Used in creation of both certificate and access control list.
@@ -1572,18 +1596,18 @@ Builds the commonName for a client certificate.  Used in creation of both certif
 {{- define "hpcc.getClientCommonName" -}}
  {{- if (.root.Values.certificates | default dict).enabled -}}
   {{- $externalCert := or (and (hasKey . "external") .external) (ne (include "hpcc.isVisibilityPublic" .) "") -}}
-  {{- $issuerName := .issuer | default (ternary "remote" "local" $externalCert) -}}
-  {{- if ne (include "hpcc.isIssuerEnabled" (dict "root" .root "issuer" $issuerName)) "true" -}}
-   {{- $_ := fail (printf "Issuer '%s' for client certificates not enabled." $issuerName) -}}
+  {{- $issuerKeyName := .issuerKeyName | default (ternary "remote" "local" $externalCert) -}}
+  {{- if ne (include "hpcc.isIssuerEnabled" (dict "root" .root "issuerKeyName" $issuerKeyName)) "true" -}}
+   {{- $_ := fail (printf "Issuer '%s' for client certificates not enabled." $issuerKeyName) -}}
   {{- else -}}
-   {{- $issuer := get .root.Values.certificates.issuers $issuerName -}}
+   {{- $issuer := get .root.Values.certificates.issuers $issuerKeyName -}}
    {{- if not $issuer -}}
-    {{- $_ := fail (printf "Issuer '%s' for client certificates not found." $issuerName) -}}
+    {{- $_ := fail (printf "Issuer '%s' for client certificates not found." $issuerKeyName) -}}
    {{- else -}}
     {{- $namespace := .root.Release.Namespace -}}
     {{- $service := (.service | default dict) -}}
     {{- $domain := ( $service.domain | default $issuer.domain | default $namespace | default "default" ) -}}
-    {{- trunc 64 (printf "%s@%s.%s" .client .instance $domain) }}
+    {{- (trunc 64 (printf "%s@%s.%s" .client .instance $domain)) -}}
    {{- end -}}
   {{- end -}}
  {{- end -}}
@@ -1594,16 +1618,16 @@ Turns an array of remoteClients into a | delimited string to be used for the tru
   Pass in root, remoteClients, instance (myeclwatch), component (eclwatch), visibility
 */}}
 {{- define "hpcc.getTrustedPeerString" -}}
- {{- if not .remoteClients -}}
+ {{- if not (hasKey . "remoteClients") -}}
   anyone
  {{- else -}}
   {{/* Turn remoteClients array into one single array element which is a | delimited string */}}
   {{- $instance := .instance -}}
   {{- $component := .component -}}
   {{- $visibility := .visibility -}}
-  {{- $root := .root }}
+  {{- $root := .root -}}
   {{- range $remoteClient := .remoteClients -}}
-   {{- include "hpcc.getClientCommonName" (dict "root" $root "client" $remoteClient.name "instance" $instance "component" $component "visibility" $visibility) -}}|
+   {{- include "hpcc.getClientCommonName" (dict "root" $root "client" $remoteClient.name "instance" $instance "component" $component "visibility" $visibility "issuerKeyName" "remote") -}}|
   {{- end -}}
  {{- end -}}
 {{- end }}
@@ -1623,14 +1647,14 @@ Pass in root, client (name), organization (optional), instance (myeclwatch), com
 {{- define "hpcc.addClientCertificate" }}
  {{- if (.root.Values.certificates | default dict).enabled -}}
   {{- $externalCert := or (and (hasKey . "external") .external) (ne (include "hpcc.isVisibilityPublic" .) "") -}}
-  {{- $issuerName := .issuer | default (ternary "remote" "local" $externalCert) -}}
-  {{- if eq (include "hpcc.isIssuerEnabled" (dict "root" .root "issuer" $issuerName)) "true" -}}
-   {{- $issuer := get .root.Values.certificates.issuers $issuerName -}}
+  {{- $issuerKeyName := .issuerKeyName | default (ternary "remote" "local" $externalCert) -}}
+  {{- if eq (include "hpcc.isIssuerEnabled" (dict "root" .root "issuerKeyName" $issuerKeyName)) "true" -}}
+   {{- $issuer := get .root.Values.certificates.issuers $issuerKeyName -}}
    {{- if not $issuer -}}
-    {{- $_ := fail (printf "Issuer %s for client certificates not found." $issuerName) -}}
+    {{- $_ := fail (printf "Issuer %s for client certificates not found." $issuerKeyName) -}}
    {{- else -}}
     {{- if not $issuer.enabled -}}
-     {{- $_ := fail (printf "Issuer %s for client certificates not enabled." $issuerName) -}}
+     {{- $_ := fail (printf "Issuer %s for client certificates not enabled." $issuerKeyName) -}}
     {{- end }}
     {{- $namespace := .root.Release.Namespace -}}
     {{- $service := (.service | default dict) -}}
@@ -1646,11 +1670,11 @@ Pass in root, client (name), organization (optional), instance (myeclwatch), com
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: client-{{ $issuerName }}-{{ $component }}-{{ $instance }}-{{ $client }}-cert
+  name: client-{{ $issuerKeyName }}-{{ $component }}-{{ $instance }}-{{ $client }}-cert
   namespace: {{ $namespace }}
 spec:
   # Secret names are always required.
-  secretName: client-{{ $issuerName }}-{{ $component }}-{{ $instance }}-{{ $client }}-tls
+  secretName: client-{{ $issuerKeyName }}-{{ $component }}-{{ $instance }}-{{ $client }}-tls
   duration: 2160h # 90d
   renewBefore: 360h # 15d
   subject:
@@ -1660,7 +1684,7 @@ spec:
     {{- else }}
     - HPCC Client
     {{- end }}
-  commonName: {{ include "hpcc.getClientCommonName" . }}
+  commonName: {{ (include "hpcc.getClientCommonName" .) | quote }}
   isCA: false
   privateKey:
     algorithm: RSA
@@ -1688,7 +1712,7 @@ Key is in pem format and the private key would need to be extracted.
 */}}
 {{- define "hpcc.addUDPCertificate" }}
 {{- if (.root.Values.certificates | default dict).enabled -}}
-{{- if eq (include "hpcc.isIssuerEnabled" (dict "root" .root "issuer" "local")) "true" -}}
+{{- if eq (include "hpcc.isIssuerEnabled" (dict "root" .root "issuerKeyName" "local")) "true" -}}
 {{- $issuer := .root.Values.certificates.issuers.local -}}
 {{- $namespace := .root.Release.Namespace -}}
 {{- $name := .name -}}
@@ -1737,22 +1761,33 @@ NB: if optional 'issuer' passed in use it, otherwise base on visibility and
 use "public" or "local" 
 */}}
 {{- define "hpcc.addCertificateVolumeMount" -}}
-{{- $externalCert := or (and (hasKey . "external") .external) (ne (include "hpcc.isVisibilityPublic" .) "") -}}
-{{- $externalIssuerName := ternary "remote" "public" (eq "true" ( include "hpcc.usesRemoteClientCertificates" . )) -}}
-{{- $issuerName := .issuer | default (ternary $externalIssuerName "local" $externalCert) -}}
-{{- /*
+ {{- $externalCert := or (and (hasKey . "external") .external) (ne (include "hpcc.isVisibilityPublic" .) "") -}}
+ {{- $externalIssuerKeyName := ternary "remote" "public" (eq "true" ( include "hpcc.usesRemoteClientCertificates" . )) -}}
+ {{- $issuerKeyName := .issuerKeyName | default (ternary $externalIssuerKeyName "local" $externalCert) -}}
+ {{- /*
     A .certificate parameter means the user explicitly configured a certificate to use
     otherwise check if certificate generation is enabled
-*/ -}}
-{{- if .certificate -}}
-- name: certificate-{{ .component }}-{{ $issuerName }}-{{ .name }}
-  mountPath: /opt/HPCCSystems/secrets/certificates/{{ $issuerName }}
-{{- else if (.root.Values.certificates | default dict).enabled -}}
-{{- if eq (include "hpcc.isIssuerEnabled" (dict "root" .root "issuer" $issuerName)) "true" -}}
-- name: certificate-{{ .component }}-{{ $issuerName }}-{{ .name }}
-  mountPath: /opt/HPCCSystems/secrets/certificates/{{ $issuerName }}
-{{- end }}
-{{- end -}}
+ */ -}}
+ {{- if .certificate -}}
+- name: certificate-{{ .component }}-{{ $issuerKeyName }}-{{ .name }}
+  mountPath: /opt/HPCCSystems/secrets/certificates/{{ $issuerKeyName }}
+ {{- else if (.root.Values.certificates | default dict).enabled -}}
+  {{- if eq (include "hpcc.isIssuerEnabled" (dict "root" .root "issuerKeyName" $issuerKeyName)) "true" -}}
+   {{- $issuer := get .root.Values.certificates.issuers $issuerKeyName -}}
+   {{- if not $issuer -}}
+    {{- $_ := fail (printf "Issuer %s for certificate not found." $issuerKeyName) -}}
+   {{- else -}}
+    {{- $wildcard := (hasKey $issuer "wildcard" | ternary $issuer.wildcard false) }}
+    {{- if $wildcard }}
+- name: certificate-{{ $issuerKeyName }}-wild
+  mountPath: /opt/HPCCSystems/secrets/certificates/{{ $issuerKeyName }}
+    {{- else }}
+- name: certificate-{{ .component }}-{{ $issuerKeyName }}-{{ .name }}
+  mountPath: /opt/HPCCSystems/secrets/certificates/{{ $issuerKeyName }}
+    {{- end }}
+   {{- end }}
+  {{- end -}}
+ {{- end -}}
 {{- end -}}
 
 {{/*
@@ -1761,24 +1796,36 @@ NB: if optional 'issuer' passed in use it, otherwise base on visibility and
 use "public" or "local" 
 */}}
 {{- define "hpcc.addCertificateVolume" -}}
-{{- $externalCert := or (and (hasKey . "external") .external) (ne (include "hpcc.isVisibilityPublic" .) "") -}}
-{{- $externalIssuerName := ternary "remote" "public" (eq "true" ( include "hpcc.usesRemoteClientCertificates" . )) -}}
-{{- $issuerName := .issuer | default (ternary $externalIssuerName "local" $externalCert) -}}
-{{- /*
-    A .certificate parameter means the user explicitly configured a certificate to use
-    otherwise check if certificate generation is enabled
-*/ -}}
-{{- if .certificate -}}
-- name: certificate-{{ .component }}-{{ $issuerName }}-{{ .name }}
+ {{- $externalCert := or (and (hasKey . "external") .external) (ne (include "hpcc.isVisibilityPublic" .) "") -}}
+ {{- $externalIssuerKeyName := ternary "remote" "public" (eq "true" ( include "hpcc.usesRemoteClientCertificates" . )) -}}
+ {{- $issuerKeyName := .issuerKeyName | default (ternary $externalIssuerKeyName "local" $externalCert) -}}
+ {{- /*
+     A .certificate parameter means the user explicitly configured a certificate to use
+     otherwise check if certificate generation is enabled
+ */ -}}
+ {{- if .certificate -}}
+- name: certificate-{{ .component }}-{{ $issuerKeyName }}-{{ .name }}
   secret:
     secretName: {{ .certificate }}
-{{- else if (.root.Values.certificates | default dict).enabled -}}
-{{- if eq (include "hpcc.isIssuerEnabled" (dict "root" .root "issuer" $issuerName)) "true" -}}
-- name: certificate-{{ .component }}-{{ $issuerName }}-{{ .name }}
+ {{- else if (.root.Values.certificates | default dict).enabled -}}
+  {{- if eq (include "hpcc.isIssuerEnabled" (dict "root" .root "issuerKeyName" $issuerKeyName)) "true" -}}
+   {{- $issuer := get .root.Values.certificates.issuers $issuerKeyName -}}
+   {{- if not $issuer -}}
+    {{- $_ := fail (printf "Issuer %s for certificate not found." $issuerKeyName) -}}
+   {{- else -}}
+    {{- $wildcard := (hasKey $issuer "wildcard" | ternary $issuer.wildcard false) }}
+    {{- if $wildcard }}
+- name: certificate-{{ $issuerKeyName }}-wild
   secret:
-    secretName: {{ .component }}-{{ $issuerName }}-{{ .name }}-tls
-{{- end -}}
-{{- end -}}
+    secretName: {{ $issuerKeyName }}-wild-tls
+    {{- else }}
+- name: certificate-{{ .component }}-{{ $issuerKeyName }}-{{ .name }}
+  secret:
+    secretName: {{ .component }}-{{ $issuerKeyName }}-{{ .name }}-tls
+    {{- end -}}
+   {{- end -}}
+  {{- end -}}
+ {{- end -}}
 {{- end -}}
 
 {{/*
@@ -1786,7 +1833,7 @@ Add the certificate volume mount for a roxie udp key
 */}}
 {{- define "hpcc.addUDPCertificateVolumeMount" }}
 {{- if (.root.Values.certificates | default dict).enabled -}}
-{{- if eq (include "hpcc.isIssuerEnabled" (dict "root" .root "issuer" "local")) "true" -}}
+{{- if eq (include "hpcc.isIssuerEnabled" (dict "root" .root "issuerKeyName" "local")) "true" -}}
 - name: certificate-{{ .component }}-udp-{{ .name }}
   mountPath: /opt/HPCCSystems/secrets/certificates/udp
 {{- end -}}
@@ -1798,7 +1845,7 @@ Add a secret volume for a roxie udp key
 */}}
 {{- define "hpcc.addUDPCertificateVolume" }}
 {{- if (.root.Values.certificates | default dict).enabled -}}
-{{- if eq (include "hpcc.isIssuerEnabled" (dict "root" .root "issuer" "local")) "true" -}}
+{{- if eq (include "hpcc.isIssuerEnabled" (dict "root" .root "issuerKeyName" "local")) "true" -}}
 - name: certificate-{{ .component }}-udp-{{ .name }}
   secret:
     secretName: {{ .component }}-udp-{{ .name }}-dtls

--- a/helm/hpcc/templates/dafilesrv.yaml
+++ b/helm/hpcc/templates/dafilesrv.yaml
@@ -27,12 +27,12 @@ data:
 {{- $_ := set $commonCtx "certificatesEnabled" (($.Values.certificates | default dict).enabled) -}}
 {{- if $commonCtx.certificatesEnabled -}}
  {{- $externalCert := ne (include "hpcc.isVisibilityPublic" $commonCtx) "" -}}
- {{- $issuerName := ternary "public" "local" $externalCert -}}
- {{- $issuer := get $.Values.certificates.issuers $issuerName -}}
+ {{- $issuerKeyName := ternary "public" "local" $externalCert -}}
+ {{- $issuer := get $.Values.certificates.issuers $issuerKeyName -}}
  {{- if $issuer }}
   {{- $_ := set $commonCtx "exposure" (ternary "public" "local" $externalCert) -}}
  {{ else }}
-  {{- $_ := fail (printf "dafilesrv - unable to locate issuer '%s'" $issuerName) -}}
+  {{- $_ := fail (printf "dafilesrv - unable to locate issuer '%s'" $issuerKeyName) -}}
  {{ end }}
 {{ end }}
 {{- $configSHA := include "hpcc.getConfigSHA" ($commonCtx | merge (dict "configMapHelper" "hpcc.dafilesrvConfigMap" "component" "dafilesrv" "excludeKeys" "global")) }}

--- a/helm/hpcc/templates/esp.yaml
+++ b/helm/hpcc/templates/esp.yaml
@@ -38,23 +38,23 @@ data:
 {{- include "hpcc.generateMetricsConfig" . | indent 6 }}
 {{- if and .root.Values.certificates .root.Values.certificates.enabled }}
  {{- $externalCert := (ne (include "hpcc.isVisibilityPublic" (dict "root" .root "visibility" .me.service.visibility)) "") -}}
- {{- $externalIssuerName := ternary "remote" "public" (eq "true" ( include "hpcc.usesRemoteClientCertificates" .me )) -}}
- {{- $issuerName := ternary $externalIssuerName "local" $externalCert -}}
+ {{- $externalIssuerKeyName := ternary "remote" "public" (eq "true" ( include "hpcc.usesRemoteClientCertificates" .me )) -}}
+ {{- $issuerKeyName := ternary $externalIssuerKeyName "local" $externalCert -}}
  {{- if not (hasKey .me "tls" )}}
-      tls: {{ include "hpcc.isIssuerEnabled" (dict "root" .root "issuer" $issuerName) }}
+      tls: {{ include "hpcc.isIssuerEnabled" (dict "root" .root "issuerKeyName" $issuerKeyName) }}
  {{- end }}
       tls_config:
  {{- if $externalCert }}
-        certificate: /opt/HPCCSystems/secrets/certificates/{{ $issuerName }}/tls.crt
-        privatekey: /opt/HPCCSystems/secrets/certificates/{{ $issuerName }}/tls.key
+        certificate: /opt/HPCCSystems/secrets/certificates/{{ $issuerKeyName }}/tls.crt
+        privatekey: /opt/HPCCSystems/secrets/certificates/{{ $issuerKeyName }}/tls.key
    {{- if (hasKey .me "remoteClients" )}}
         verify:
           enable: true
           address_match: false
           accept_selfsigned: false
-          trusted_peers: [ {{ include "hpcc.getTrustedPeerString" (dict "root" .root "remoteClients" .me.remoteClients "instance" .me.name "component" .me.application "visibility" .me.service.visibility) }} ]
+          trusted_peers: [ {{ include "hpcc.getTrustedPeerString" (dict "root" .root "remoteClients" .me.remoteClients "instance" .me.name "component" .me.application "visibility" .me.service.visibility) | quote }} ]
           ca_certificates:
-            path: /opt/HPCCSystems/secrets/certificates/{{ $issuerName }}/ca.crt
+            path: /opt/HPCCSystems/secrets/certificates/{{ $issuerKeyName }}/ca.crt
    {{- end }}
  {{- else }}
         certificate: /opt/HPCCSystems/secrets/certificates/local/tls.crt
@@ -97,7 +97,7 @@ data:
 {{- else -}}
  {{- $_ := set $commonCtx "externalCert" false -}}
 {{- end -}}
-{{- $signingEnabled := eq (include "hpcc.isIssuerEnabled" (dict "root" $ "issuer" "signing")) "true" -}}
+{{- $signingEnabled := eq (include "hpcc.isIssuerEnabled" (dict "root" $ "issuerKeyName" "signing")) "true" -}}
 {{- $generateSigningCert := and ($signingEnabled) (eq $application "eclwatch") -}}
 {{- $signingCertGenerator := and ($signingEnabled) (has $application (list "eclwatch" "eclservices")) | ternary "eclwatch" "" -}}
 apiVersion: apps/v1
@@ -162,7 +162,7 @@ spec:
  {{- include "hpcc.addCertificateVolumeMount" (dict "root" $ "component" $application "name" .name "external" false) | nindent 8 }}
 {{- end }}
 {{- if $signingCertGenerator }}
- {{- include "hpcc.addCertificateVolumeMount" (dict "root" $ "component" $signingCertGenerator "name" "global" "issuer" "signing") | nindent 8 }}
+ {{- include "hpcc.addCertificateVolumeMount" (dict "root" $ "component" $signingCertGenerator "name" "global" "issuerKeyName" "signing") | nindent 8 }}
 {{- end }}
       volumes:
 {{ include "hpcc.addConfigMapVolume" . | indent 6 }}
@@ -173,7 +173,7 @@ spec:
  {{- include "hpcc.addCertificateVolume" (dict "root" $ "component" $application "name" .name "external" false) | nindent 6 }}
 {{- end }}
 {{- if $signingCertGenerator }}
- {{- include "hpcc.addCertificateVolume" (dict "root" $ "component" $signingCertGenerator "name" "global" "issuer" "signing") | nindent 6 }}
+ {{- include "hpcc.addCertificateVolume" (dict "root" $ "component" $signingCertGenerator "name" "global" "issuerKeyName" "signing") | nindent 6 }}
 {{- end }}
 ---
 kind: ConfigMap
@@ -198,7 +198,7 @@ kind: ConfigMap
  {{- include "hpcc.addCertificate" (dict "root" $ "name" .name "service" .service "component" $application "external" false) }}
 {{- end }}
 {{- if $generateSigningCert }}
- {{- include "hpcc.addCertificate" (dict "root" $ "name" "global" "component" $application "issuer" "signing") }}
+ {{- include "hpcc.addCertificate" (dict "root" $ "name" "global" "component" $application "issuerKeyName" "signing") }}
 {{- end }}
 
 {{- $instance := .name -}}

--- a/helm/hpcc/templates/issuers.yaml
+++ b/helm/hpcc/templates/issuers.yaml
@@ -21,10 +21,80 @@
 ##############################################################################
 
 */}}
-{{- define "hpcc.issuers" -}}
-{{- if (hasKey .me "spec") -}} {{- /* no spec means we are referencing an external issuer and don't need to instantiate our own */ -}}
-{{- $issuerEnabled := (hasKey .me "enabled" | ternary .me.enabled true) -}}
-{{- if $issuerEnabled }}
+
+{{/*
+Use cert-manager to create a public certificate and private key for use with TLS
+There are separate certificate issuers for local and public certificates
+by default public certificates are self-signed and local certificates are signed
+by our own certificate authority.  A CA certificate is also provided to the pod
+so that we can recognize the signature of our own CA.
+NB: if optional 'issuer' passed in use it, otherwise base on visibility and
+use "public" or "local"
+*/}}
+
+
+{{/*
+Some issuers, such as letsencrypt, have limitations on the number of resources that can
+be created. When using wildcards we can share a common certificate across all users
+of that issuer.
+
+This is initially intended for non-prod use of letsencrypt for our public issuer.
+All public services should use the same cert, greatly minimizing the letsencrypt
+resources except in prod.
+*/}}
+{{- define "hpcc.addWildIssuerCertificate" -}}
+ {{- $namespace := .root.Release.Namespace -}}
+ {{- $issuerKeyName := .issuerKeyName -}}
+ {{- $issuer := .me -}}
+ {{- if $issuer.wildcard -}}
+  {{- if ne $issuerKeyName "public" -}}
+   {{- $_ := fail (printf "Issuer %s - wildcard currently only supported for public issuer." $issuerKeyName) -}}
+  {{- end -}}
+  {{- if not $issuer.domain -}}
+   {{- $_ := fail (printf "Issuer %s - setting wildcard requires configuring a domain." $issuerKeyName) -}}
+  {{- end }}
+  {{- $spiffe := (hasKey $issuer "spiffe" | ternary $issuer.spiffe (ne "public" $issuerKeyName)) }}
+  {{- if $spiffe -}}
+   {{- $_ := fail (printf "Issuer %s - setting wildcard not supported with spiffe setting enabled." $issuerKeyName) -}}
+  {{- end }}
+  {{- $clientUsage := (hasKey $issuer "clientUsage" | ternary $issuer.clientUsage (ne "public" $issuerKeyName)) -}}
+  {{- if $clientUsage -}}
+   {{- $_ := fail (printf "Issuer %s - setting wildcard not supported with clientUsage setting enabled." $issuerKeyName) -}}
+  {{- end }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ $issuerKeyName }}-wild-cert
+  namespace: {{ $namespace }}
+spec:
+  secretName: {{ $issuerKeyName }}-wild-tls
+  duration: 2160h # 90d
+  renewBefore: 360h # 15d
+  subject:
+    organizations:
+    - HPCC Systems
+  commonName: {{ (printf "*.%s" $issuer.domain) | trunc 64 | quote }}
+  isCA: false
+  privateKey:
+    algorithm: RSA
+    encoding: PKCS1
+    size: 2048
+  usages:
+    - server auth
+  dnsNames:
+  - {{ (printf "*.%s" $issuer.domain) | quote }}
+  issuerRef:
+    name: {{ $issuer.name }}
+    kind: {{ $issuer.kind }}
+    group: cert-manager.io
+---
+ {{- end -}}
+{{- end -}}
+
+{{- define "hpcc.addIssuer" -}}
+ {{- $issuerEnabled := (hasKey .me "enabled" | ternary .me.enabled true) -}}
+ {{- if $issuerEnabled }}
+  {{- if (hasKey .me "spec") -}} {{- /* no spec means we are referencing an external issuer and don't need to instantiate our own */ -}}
 apiVersion: cert-manager.io/v1
 kind: {{ .me.kind | default "Issuer" }}
 metadata:
@@ -32,20 +102,21 @@ metadata:
   namespace: {{ .root.Release.Namespace | default "default" }}
    {{- if .me.spec }}
 spec:
-  {{- if not .root.Values.global.noResourceValidation -}}
-  {{- if .me.spec.ca }}
-   {{- if .me.spec.ca.secretName }}
-    {{- if not (lookup "v1" "Secret" .root.Release.Namespace .me.spec.ca.secretName) }}
-      {{- $_ := fail (printf "\n\nUsing a local certificate authority requires a CA certificate stored in the secret named '%s'. To disable mTLS security set \"certificates.enabled=false\". To bypass this validation check set \"global.noResourceValidation=true\". \n" .me.spec.ca.secretName ) -}}
+    {{- if not .root.Values.global.noResourceValidation -}}
+     {{- if .me.spec.ca }}
+      {{- if .me.spec.ca.secretName }}
+       {{- if not (lookup "v1" "Secret" .root.Release.Namespace .me.spec.ca.secretName) }}
+        {{- $_ := fail (printf "\n\nUsing a local certificate authority requires a CA certificate stored in the secret named '%s'. To disable mTLS security set \"certificates.enabled=false\". To bypass this validation check set \"global.noResourceValidation=true\". \n" .me.spec.ca.secretName ) -}}
+       {{- end }}
+      {{- end }}
+     {{- end }}
     {{- end }}
+{{ toYaml .me.spec | indent 2 }}
+---
    {{- end }}
   {{- end }}
-  {{- end }}
-{{ toYaml .me.spec | indent 2 }}
-
+  {{ include "hpcc.addWildIssuerCertificate" (dict "root" .root "issuerKeyName" .issuerKeyName "me" .me ) }}
  {{- end }}
-{{- end }}
-{{- end }}
 {{- end }}
 
 {{- template "hpcc.ensureNoResourceValidationFlag" ( dict "root" $ ) }}
@@ -58,8 +129,7 @@ spec:
    {{- end -}}
   {{- end -}}
   {{- range $k, $v := .Values.certificates.issuers }}
-{{- include "hpcc.issuers" (dict "root" $ "me" $v ) }}
----
+{{- include "hpcc.addIssuer" (dict "root" $ "issuerKeyName" $k "me" $v ) }}
   {{- end }}
  {{- end }}
 {{- end }}


### PR DESCRIPTION
Add some flexibility for pointing to external cert-manager ClusterIssuers.  Will allow us to point to existing issuers to generate our public certificates.  Only public certificates currently supported because of limitations on adding our own fields for MTLS features between HPCC components.

Flexibility needed because of constraints on some issuers.  Letsencrypt for example limits how many certificates a domain can create.

Added a wildcard option which will use wild card certificates instead of individual certificates.  This is not ideal, but is a workaround for limits of letsencrypt.

For external issuers the spec field should be set to null to be sure and wipeout any default values.


Example helm values:

```
certificates:
  enabled: true
  issuers:
    public:
      domain: myexample.azure.hpccsystems.io
      kind: ClusterIssuer
      name: letsencrypt
      wildcard: true
      spec: null
```

or

```
certificates:
  enabled: true
  issuers:
    public:
      domain: myexample.azure.hpccsystems.io
      kind: ClusterIssuer
      name: zerossl
      spec: null
```

Signed-off-by: Anthony Fishbeck <anthony.fishbeck@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
