### PR TITLE
HPCC-27065 Add helm options to change default plane for index builds

### DIFF
--- a/dali/base/dafdesc.cpp
+++ b/dali/base/dafdesc.cpp
@@ -3659,6 +3659,20 @@ bool getDefaultSpillPlane(StringBuffer &ret)
 #endif
 }
 
+bool getDefaultIndexBuildStoragePlane(StringBuffer &ret)
+{
+#ifdef _CONTAINERIZED
+    if (getComponentConfigSP()->getProp("@indexBuildPlane", ret))
+        return true;
+    else if (getGlobalConfigSP()->getProp("storage/@indexBuildPlane", ret))
+        return true;
+    else
+        return getDefaultStoragePlane(ret);
+#else
+    return false;
+#endif
+}
+
 //---------------------------------------------------------------------------------------------------------------------
 
 static bool isAccessible(const IPropertyTree * xml)

--- a/dali/base/dafdesc.hpp
+++ b/dali/base/dafdesc.hpp
@@ -403,6 +403,7 @@ extern da_decl bool setReplicateDir(const char *name,StringBuffer &out, bool isr
 extern da_decl void initializeStorageGroups(bool createPlanesFromGroups);
 extern da_decl bool getDefaultStoragePlane(StringBuffer &ret);
 extern da_decl bool getDefaultSpillPlane(StringBuffer &ret);
+extern da_decl bool getDefaultIndexBuildStoragePlane(StringBuffer &ret);
 extern da_decl IStoragePlane * getDataStoragePlane(const char * name, bool required);
 extern da_decl IStoragePlane * getRemoteStoragePlane(const char * name, bool required);
 extern da_decl IStoragePlane * createStoragePlane(IPropertyTree *meta);

--- a/ecl/hthor/hthor.cpp
+++ b/ecl/hthor/hthor.cpp
@@ -351,11 +351,14 @@ private:
     }
 };
 
-ClusterWriteHandler *createClusterWriteHandler(IAgentContext &agent, IHThorIndexWriteArg *iwHelper, IHThorDiskWriteArg *dwHelper, const char * lfn, StringAttr &fn, bool extend)
+ClusterWriteHandler *createClusterWriteHandler(IAgentContext &agent, IHThorIndexWriteArg *iwHelper, IHThorDiskWriteArg *dwHelper, const char * lfn, StringAttr &fn, bool extend, bool isIndex)
 {
     //In the containerized system, the default data plane for this component is in the configuration
     StringBuffer defaultCluster;
-    getDefaultStoragePlane(defaultCluster);
+    if (isIndex)
+        getDefaultIndexBuildStoragePlane(defaultCluster);
+    else
+        getDefaultStoragePlane(defaultCluster);
     Owned<CHThorClusterWriteHandler> clusterHandler;
     unsigned clusterIdx = 0;
     while(true)
@@ -536,7 +539,7 @@ void CHThorDiskWriteActivity::resolve()
                 throw MakeStringException(99, "Could not resolve DFS Logical file %s", lfn.str());
             }
 
-            clusterHandler.setown(createClusterWriteHandler(agent, NULL, &helper, dfsLogicalName.get(), filename, extend));
+            clusterHandler.setown(createClusterWriteHandler(agent, NULL, &helper, dfsLogicalName.get(), filename, extend, false));
         }
     }
     else
@@ -1117,7 +1120,7 @@ CHThorIndexWriteActivity::CHThorIndexWriteActivity(IAgentContext &_agent, unsign
                 throw MakeStringException(99, "Cannot write %s, file already exists (missing OVERWRITE attribute?)", lfn.str());
         }
     }
-    clusterHandler.setown(createClusterWriteHandler(agent, &helper, NULL, lfn, filename, false));
+    clusterHandler.setown(createClusterWriteHandler(agent, &helper, NULL, lfn, filename, false, true));
     sizeLimit = agent.queryWorkUnit()->getDebugValueInt64("hthorDiskWriteSizeLimit", defaultHThorDiskWriteSizeLimit);
     defaultNoSeek = agent.queryWorkUnit()->getDebugValueBool("noSeekBuildIndex", isContainerized());
 }

--- a/helm/hpcc/templates/_warnings.tpl
+++ b/helm/hpcc/templates/_warnings.tpl
@@ -33,6 +33,9 @@ Pass in dict with root and warnings
  {{- end -}}
  {{- /* Gather a list of ephemeral and persistant planes */ -}}
  {{- $storage := (.root.Values.storage | default dict) -}}
+ {{- if hasKey $storage "indexBuildPlane" -}}
+  {{- include "hpcc.checkPlaneExists" (dict "root" .root "planeName" $storage.indexBuildPlane "contextPrefix" "indexBuildPlane: ") -}}
+ {{- end -}}
  {{- $match := dict "ephemeral" (list) "persistant" (list) -}}
  {{- $planes := ($storage.planes | default list) -}}
  {{- $searchLabels := list "data" "dali" "sasha" "dll" "lz" -}}

--- a/helm/hpcc/values.schema.json
+++ b/helm/hpcc/values.schema.json
@@ -34,6 +34,10 @@
         },
         "remote": {
           "$ref": "#/definitions/remoteStorage"
+        },
+        "indexBuildPlane": {
+          "type": "string",
+          "description": "Default plane for index builds"
         }
       },
       "additionalProperties": false
@@ -1415,6 +1419,10 @@
           "description": "The default storage plane to write data files to",
           "type": "string"
         },
+        "indexBuildPlane": {
+          "description": "The default storage plane to write index files to",
+          "type": "string"
+        },
         "annotations": {
           "type": "object",
           "additionalProperties": { "type": "string" }
@@ -1492,6 +1500,10 @@
         },
         "spillPlane": {
           "description": "The storage plane to write spill files to",
+          "type": "string"
+        },
+        "indexBuildPlane": {
+          "description": "The default storage plane to write index files to",
           "type": "string"
         },
         "resources": {
@@ -2275,6 +2287,10 @@
         },
         "spillPlane": {
           "description": "The storage plane to write spill files to",
+          "type": "string"
+        },
+        "indexBuildPlane": {
+          "description": "The default storage plane to write index files to",
           "type": "string"
         },
         "annotations": {

--- a/roxie/ccd/ccd.hpp
+++ b/roxie/ccd/ccd.hpp
@@ -368,6 +368,7 @@ extern StringBuffer fileNameServiceDali;
 extern StringBuffer roxieName;
 #ifdef _CONTAINERIZED
 extern StringBuffer defaultPlane;
+extern StringBuffer defaultIndexBuildPlane;
 #endif
 extern bool trapTooManyActiveQueries;
 extern unsigned maxEmptyLoopIterations;

--- a/roxie/ccd/ccdfile.cpp
+++ b/roxie/ccd/ccdfile.cpp
@@ -2137,7 +2137,7 @@ static bool getDirectAccessStoragePlanes(StringArray &planes)
 ILazyFileIO *createPhysicalFile(const char *id, IPartDescriptor *pdesc, IPartDescriptor *remotePDesc, RoxieFileType fileType, int numParts, bool startCopy, unsigned channel)
 {
 #ifdef _CONTAINERIZED
-    const char *myCluster = defaultPlane.str();
+    const char *myCluster = (ROXIE_KEY == fileType) ? defaultIndexBuildPlane.str() : defaultPlane.str();
 #else
     const char *myCluster = roxieName.str();
 #endif

--- a/roxie/ccd/ccdmain.cpp
+++ b/roxie/ccd/ccdmain.cpp
@@ -185,6 +185,7 @@ StringBuffer fileNameServiceDali;
 StringBuffer roxieName;
 #ifdef _CONTAINERIZED
 StringBuffer defaultPlane;
+StringBuffer defaultIndexBuildPlane;
 #endif
 bool trapTooManyActiveQueries;
 unsigned maxEmptyLoopIterations;
@@ -735,6 +736,7 @@ int CCD_API roxie_main(int argc, const char *argv[], const char * defaultYaml)
             setStatisticsComponentName(SCTroxie, "roxie", true);
 #ifdef _CONTAINERIZED
         getDefaultStoragePlane(defaultPlane);
+        getDefaultIndexBuildStoragePlane(defaultIndexBuildPlane);
 #endif
         installDefaultFileHooks(topology);
 

--- a/thorlcr/activities/indexwrite/thindexwrite.cpp
+++ b/thorlcr/activities/indexwrite/thindexwrite.cpp
@@ -101,7 +101,7 @@ public:
         if (idx == 0)
         {
             StringBuffer defaultCluster;
-            if (getDefaultStoragePlane(defaultCluster))
+            if (getDefaultIndexBuildStoragePlane(defaultCluster))
                 clusters.append(defaultCluster);
         }
 

--- a/thorlcr/activities/keydiff/thkeydiff.cpp
+++ b/thorlcr/activities/keydiff/thkeydiff.cpp
@@ -81,7 +81,7 @@ public:
             throw MakeActivityException(this, 0, "Unsupported: keydiff(%s, %s) - Cannot diff a key that's wider(%d) than the target cluster size(%d)", originalIndexFile->queryLogicalName(), newIndexFile->queryLogicalName(), width, container.queryJob().querySlaves());
 
         StringBuffer defaultCluster;
-        if (getDefaultStoragePlane(defaultCluster))
+        if (getDefaultIndexBuildStoragePlane(defaultCluster))
             clusters.append(defaultCluster);
         IArrayOf<IGroup> groups;
         fillClusterArray(container.queryJob(), outputName, clusters, groups);

--- a/thorlcr/activities/keypatch/thkeypatch.cpp
+++ b/thorlcr/activities/keypatch/thkeypatch.cpp
@@ -82,7 +82,7 @@ public:
             throw MakeActivityException(this, 0, "Unsupported: keypatch(%s, %s) - Cannot patch a key that's wider(%d) than the target cluster size(%d)", originalIndexFile->queryLogicalName(), patchFile->queryLogicalName(), width, container.queryJob().querySlaves());
 
         StringBuffer defaultCluster;
-        if (getDefaultStoragePlane(defaultCluster))
+        if (getDefaultIndexBuildStoragePlane(defaultCluster))
             clusters.append(defaultCluster);
         IArrayOf<IGroup> groups;
         fillClusterArray(container.queryJob(), outputName, clusters, groups);


### PR DESCRIPTION
Setting "indexBuildPlane" at a global level (under storage:) or at a per component level, will instruct the engines to use this plane in preference to the default data plane for index builds.

Signed-off-by: Jake Smith <jake.smith@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
