### PR TITLE
HPCC-28754 Allow engines to specify their preferred read planes.

### DIFF
--- a/dali/base/dadfs.hpp
+++ b/dali/base/dadfs.hpp
@@ -887,4 +887,6 @@ extern da_decl double calcFileAccessCost(const char * cluster, __int64 numDiskWr
 constexpr bool defaultPrivilegedUser = true;
 constexpr bool defaultNonPrivilegedUser = false;
 
+extern da_decl void configurePreferredPlanes();
+
 #endif

--- a/dali/base/dafdesc.cpp
+++ b/dali/base/dafdesc.cpp
@@ -2150,6 +2150,12 @@ public:
     {
         UNIMPLEMENTED_X("querySubFiles called from CFileDescriptor!");
     }
+
+    virtual void setFlags(FileDescriptorFlags flags) override
+    {
+        queryProperties().setPropInt("@flags", static_cast<int>(flags));
+        fileFlags = flags;
+    }
 };
 
 class CSuperFileDescriptor:  public CFileDescriptor

--- a/dali/base/dafdesc.hpp
+++ b/dali/base/dafdesc.hpp
@@ -292,6 +292,7 @@ if endCluster is not called it will assume only one cluster and not replicated
     virtual void ensureReplicate() = 0;                                             // make sure a file can be replicated
 
     virtual IPropertyTree *queryHistory() = 0;                                       // query file history records
+    virtual void setFlags(FileDescriptorFlags flags) = 0;
 };
 
 interface ISuperFileDescriptor: extends IFileDescriptor

--- a/ecl/eclagent/eclagent.cpp
+++ b/ecl/eclagent/eclagent.cpp
@@ -575,7 +575,7 @@ EclAgent::EclAgent(IConstWorkUnit *wu, const char *_wuid, bool _checkVersion, bo
             abortmonitor->setGuillotineCost(money2cost_type(guillotineCost));
         }
     }
-
+    configurePreferredPlanes();
 }
 
 EclAgent::~EclAgent()

--- a/helm/hpcc/values.schema.json
+++ b/helm/hpcc/values.schema.json
@@ -1430,6 +1430,9 @@
         },
         "egress": {
           "$ref" : "#/definitions/egress"
+        },
+        "preferredDataReadPlanes": {
+          "$ref" : "#/definitions/preferredDataReadPlanes"
         }
       }
     },
@@ -2094,6 +2097,9 @@
         },
         "egress": {
           "$ref" : "#/definitions/egress"
+        },
+        "preferredDataReadPlanes": {
+          "$ref" : "#/definitions/preferredDataReadPlanes"
         }
       }
     },
@@ -2302,6 +2308,9 @@
         },
         "egress": {
           "$ref" : "#/definitions/egress"
+        },
+        "preferredDataReadPlanes": {
+          "$ref" : "#/definitions/preferredDataReadPlanes"
         }
       }
     },
@@ -2864,6 +2873,11 @@
           }
         }
       }
+    },
+    "preferredDataReadPlanes": {
+      "description": "A list of planes that will take precedence to read from if logical files reside on mutiple planes",
+      "type": "array",
+      "items": { "type": "string" }
     }
   }
 }

--- a/roxie/ccd/ccdmain.cpp
+++ b/roxie/ccd/ccdmain.cpp
@@ -1323,6 +1323,7 @@ int CCD_API roxie_main(int argc, const char *argv[], const char * defaultYaml)
         initializeTopology(topoValues, myRoles);
         writeSentinelFile(sentinelFile);
 #endif
+        configurePreferredPlanes();
         createDelayedReleaser();
         CCycleTimer loadPackageTimer;
         globalPackageSetManager = createRoxiePackageSetManager(standAloneDll.getClear());

--- a/thorlcr/master/thmastermain.cpp
+++ b/thorlcr/master/thmastermain.cpp
@@ -1079,6 +1079,8 @@ int main( int argc, const char *argv[]  )
             if (pinterval)
                 startPerformanceMonitor(pinterval, PerfMonStandard, nullptr);
 #endif
+            configurePreferredPlanes();
+
             // NB: workunit/graphName only set in one-shot mode (if isCloud())
             thorMain(logHandler, workunit, graphName);
             LOG(MCauditInfo, ",Progress,Thor,Terminate,%s,%s,%s",thorname,nodeGroup.str(),queueName.str());

--- a/thorlcr/mfilemanager/thmfilemanager.cpp
+++ b/thorlcr/mfilemanager/thmfilemanager.cpp
@@ -542,7 +542,7 @@ public:
             desc->setDefaultDir(dir.str());
 
             if (job.getOptBool("subDirPerFilePart", dirPerPart) && total>1)
-                desc->queryProperties().setPropInt("@flags", static_cast<int>(FileDescriptorFlags::dirperpart));
+                desc->setFlags(FileDescriptorFlags::dirperpart);
 
             StringBuffer partmask;
             getPartMask(partmask,logicalName,total);


### PR DESCRIPTION
Add a hthor/roxie/thor option that can list the preferred planes to be used to read files from.
For files that reside on multiple planes, this will cause the engines to prefer the copy on one of these planes vs the default (1st) plane for those files.

Signed-off-by: Jake Smith <jake.smith@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [x] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
