### PR TITLE
HPCC-28826 cert-manager: add support for secretTemplate

### DIFF
--- a/helm/hpcc/templates/_helpers.tpl
+++ b/helm/hpcc/templates/_helpers.tpl
@@ -1645,11 +1645,16 @@ remote client certificates.
 Adding the following to ESP (Roxie support to be added later)
   remoteClients:
   - name: myRemoteClient
+    organization: myorg #optional
+    secretTemplate:   #optional add annotations to generated secret for tools like kubed config-syncer
+      annotations:
+        kubed.appscode.com/sync: "hpcc=testns"       #sync certificate to matching namespaces
+
 Will generate certificates that can be deployed to the remote client.
 Will cause ESP to require client certificates when a socket connects.
 Will create a TLS based access control list which ESP will check to make sure a connections client certificate is enabled.
 
-Pass in root, client (name), organization (optional), instance (myeclwatch), component (eclwatch), visibility
+Pass in root, client (name), organization (optional), instance (myeclwatch), component (eclwatch), visibility, secretTemplate (optional)
 */}}
 {{- define "hpcc.addClientCertificate" }}
  {{- if (.root.Values.certificates | default dict).enabled -}}
@@ -1670,6 +1675,7 @@ Pass in root, client (name), organization (optional), instance (myeclwatch), com
     {{- $component := .component -}}
     {{- $client := .client -}}
     {{- $organization := .organization -}}
+    {{- $secretTemplate := .secretTemplate -}}
     {{- if not $externalCert -}}
      {{- $_ := fail (printf "Remote certificate defined for non external facing service %s - %s." $component $instance) -}}
     {{- end }}
@@ -1682,6 +1688,10 @@ metadata:
 spec:
   # Secret names are always required.
   secretName: client-{{ $issuerKeyName }}-{{ $component }}-{{ $instance }}-{{ $client }}-tls
+  {{- if $secretTemplate }}
+  secretTemplate:
+{{ toYaml $secretTemplate | indent 4 }}
+  {{- end }}
   duration: 2160h # 90d
   renewBefore: 360h # 15d
   subject:

--- a/helm/hpcc/templates/esp.yaml
+++ b/helm/hpcc/templates/esp.yaml
@@ -204,7 +204,7 @@ kind: ConfigMap
 {{- $instance := .name -}}
 {{- $visibility := .service.visibility -}}
 {{- range $remoteClient := .remoteClients }}
- {{ include "hpcc.addClientCertificate" (dict "root" $ "client" $remoteClient.name "organization" $remoteClient.organization "instance" $instance "component" $application "visibility" $visibility) }}
+ {{ include "hpcc.addClientCertificate" (dict "root" $ "client" $remoteClient.name "organization" $remoteClient.organization "instance" $instance "component" $application "visibility" $visibility "secretTemplate" $remoteClient.secretTemplate) }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/helm/hpcc/values.schema.json
+++ b/helm/hpcc/values.schema.json
@@ -2832,6 +2832,24 @@
           "name": {
             "type": "string",
             "description": "Remote client name"
+          },
+          "organization": {
+            "type": "string",
+            "description": "Remote client organization"
+          },
+          "secretTemplate": {
+            "type": "object",
+            "description": "cert-manager secretTemplate for this remoteClient secret",
+            "properties": {
+              "annotations": {
+                "type": "object",
+                "additionalProperties": { "type": "string" }
+              },
+              "labels": {
+                "type": "object",
+                "additionalProperties": { "type": "string" }
+              }
+            }
           }
         }
       }

--- a/helm/hpcc/values.yaml
+++ b/helm/hpcc/values.yaml
@@ -566,8 +566,12 @@ esp:
 # Add remote clients to generated client certificates and make the ESP require that one of the generated certificates is provided by a client in order to connect
 #   When setting up remote clients make sure that certificates.issuers.remote.enabled is set to true.
 # remoteClients:
-# - name: myclient
-#   organization: mycompany
+# - name: petfoodApplicationProd
+#   organization: petfoodDept
+#   secretTemplate:
+#     annotations:
+#       kubed.appscode.com/sync: "hpccenv=petfoodAppProd" # use kubed config-syncer to replicate certificate to namespace with matching annotation (also supports syncing with separate aks clusters)
+
   service:
     ## port can be used to change the local port used by the pod. If omitted, the default port (8880) is used
     port: 8888
@@ -651,8 +655,6 @@ esp:
   application: sql2ecl
   auth: none
   replicas: 1
-# remoteClients:
-# - name: sqlclient111
   service:
     visibility: local
     servicePort: 8510


### PR DESCRIPTION
Add helm support for cert-manager certificate secretTemplate.

Kubernetes add-ons for doing things like synchronizing secrets/certificates across aks clusters or namespaces require annotations be added to the kubernetes secret resources to control the new behavior.

This can be done through cert-manager using a feature known as the secretTemplate.

Signed-off-by: Anthony Fishbeck <anthony.fishbeck@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
