### PR TITLE
HPCC-28819 Fix use_method_name logic for esdl cli

### DIFF
--- a/testing/esp/esdlcmd/esdlcmd-test.py
+++ b/testing/esp/esdlcmd/esdlcmd-test.py
@@ -378,6 +378,18 @@ def main():
         TestCaseXSD(run_settings, 'wsexctest3-xsd-no-exc', 'xsd', 'ws_exc_test_3.ecm', 'WsExcTest3',
                     xsl_base_path, ['--no-exceptions-inline']),
 
+        # use_method_name tests
+
+        # Shows how the name of the method is used as the xsd:element name for the request structure.
+        # One element is created for each method that shares a request structure. Enabled when the
+        # use_method_name option is present on the EsdlService definition.
+        TestCaseXSD(run_settings, 'use-method-name', 'wsdl', 'ws_usemethodname.ecm', 'WsUseMethodName',
+                    xsl_base_path),
+
+        # Shows how the request structure name is used as the xsd:element name for the request structure.
+        # A single element is created for each request structure defined. This is default behavior.
+        TestCaseXSD(run_settings, 'use-request-name', 'wsdl', 'ws_userequestname.ecm', 'WsUseRequestName',
+                    xsl_base_path),
     ]
 
     for case in test_cases:

--- a/testing/esp/esdlcmd/inputs/ws_usemethodname.ecm
+++ b/testing/esp/esdlcmd/inputs/ws_usemethodname.ecm
@@ -1,0 +1,33 @@
+ESPrequest FooRequest
+{
+  string Bar;
+  string Baz;
+};
+
+ESPresponse FooResponse
+{
+  int Bingo;
+};
+
+ESPrequest FruitRequest
+{
+  string Flavor;
+  string Color;
+};
+
+ESPresponse FruitResponse
+{
+  int Eat;
+};
+
+ESPresponse OrangeResponse
+{
+  bool Peels;
+};
+
+ESPservice[version("1"), use_method_name] WsUseMethodName
+{
+  ESPmethod Unique(FooRequest, FooResponse);
+  ESPmethod Apple(FruitRequest, FruitResponse);
+  ESPmethod Orange(FruitRequest, OrangeResponse);
+};

--- a/testing/esp/esdlcmd/inputs/ws_userequestname.ecm
+++ b/testing/esp/esdlcmd/inputs/ws_userequestname.ecm
@@ -1,0 +1,33 @@
+ESPrequest FooRequest
+{
+  string Bar;
+  string Baz;
+};
+
+ESPresponse FooResponse
+{
+  int Bingo;
+};
+
+ESPrequest FruitRequest
+{
+  string Flavor;
+  string Color;
+};
+
+ESPresponse FruitResponse
+{
+  int Eat;
+};
+
+ESPresponse OrangeResponse
+{
+  bool Peels;
+};
+
+ESPservice[version("1")] WsUseRequestName
+{
+  ESPmethod Unique(FooRequest, FooResponse);
+  ESPmethod Apple(FruitRequest, FruitResponse);
+  ESPmethod Orange(FruitRequest, OrangeResponse);
+};

--- a/testing/esp/esdlcmd/key/wsusemethodname.wsdl
+++ b/testing/esp/esdlcmd/key/wsusemethodname.wsdl
@@ -1,0 +1,183 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:tns="urn:hpccsystems:ws:wsusemethodname@ver=1" targetNamespace="urn:hpccsystems:ws:wsusemethodname@ver=1">
+  <wsdl:types>
+    <xsd:schema elementFormDefault="qualified" targetNamespace="urn:hpccsystems:ws:wsusemethodname@ver=1">
+      <xsd:element name="string" nillable="true" type="xsd:string"/>
+      <xsd:complexType name="EspException">
+        <xsd:all>
+          <xsd:element name="Code" type="xsd:string" minOccurs="0"/>
+          <xsd:element name="Audience" type="xsd:string" minOccurs="0"/>
+          <xsd:element name="Source" type="xsd:string" minOccurs="0"/>
+          <xsd:element name="Message" type="xsd:string" minOccurs="0"/>
+        </xsd:all>
+      </xsd:complexType>
+      <xsd:complexType name="ArrayOfEspException">
+        <xsd:sequence>
+          <xsd:element name="Source" type="xsd:string" minOccurs="0"/>
+          <xsd:element name="Exception" type="tns:EspException" minOccurs="0" maxOccurs="unbounded"/>
+        </xsd:sequence>
+      </xsd:complexType>
+      <xsd:element name="Exceptions" type="tns:ArrayOfEspException"/>
+      <xsd:element name="Apple">
+        <xsd:complexType>
+          <xsd:all>
+            <xsd:element minOccurs="0" name="Flavor" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="Color" type="xsd:string"/>
+          </xsd:all>
+        </xsd:complexType>
+      </xsd:element>
+      <xsd:element name="Orange">
+        <xsd:complexType>
+          <xsd:all>
+            <xsd:element minOccurs="0" name="Flavor" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="Color" type="xsd:string"/>
+          </xsd:all>
+        </xsd:complexType>
+      </xsd:element>
+      <xsd:element name="Ping">
+        <xsd:complexType>
+          <xsd:all/>
+        </xsd:complexType>
+      </xsd:element>
+      <xsd:element name="Unique">
+        <xsd:complexType>
+          <xsd:all>
+            <xsd:element minOccurs="0" name="Bar" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="Baz" type="xsd:string"/>
+          </xsd:all>
+        </xsd:complexType>
+      </xsd:element>
+      <xsd:element name="FruitResponse">
+        <xsd:complexType>
+          <xsd:all>
+            <xsd:element minOccurs="0" name="Eat" type="xsd:int"/>
+          </xsd:all>
+        </xsd:complexType>
+      </xsd:element>
+      <xsd:element name="OrangeResponse">
+        <xsd:complexType>
+          <xsd:all>
+            <xsd:element minOccurs="0" name="Peels" type="xsd:boolean"/>
+          </xsd:all>
+        </xsd:complexType>
+      </xsd:element>
+      <xsd:element name="WsUseMethodNamePingResponse">
+        <xsd:complexType>
+          <xsd:all/>
+        </xsd:complexType>
+      </xsd:element>
+      <xsd:element name="FooResponse">
+        <xsd:complexType>
+          <xsd:all>
+            <xsd:element minOccurs="0" name="Bingo" type="xsd:int"/>
+          </xsd:all>
+        </xsd:complexType>
+      </xsd:element>
+    </xsd:schema>
+  </wsdl:types>
+  <wsdl:message name="EspSoapFault">
+    <wsdl:part name="parameters" element="tns:Exceptions"/>
+  </wsdl:message>
+  <wsdl:message name="AppleSoapIn">
+    <wsdl:part name="parameters" element="tns:Apple"/>
+  </wsdl:message>
+  <wsdl:message name="AppleSoapOut">
+    <wsdl:part name="parameters" element="tns:FruitResponse"/>
+  </wsdl:message>
+  <wsdl:message name="OrangeSoapIn">
+    <wsdl:part name="parameters" element="tns:Orange"/>
+  </wsdl:message>
+  <wsdl:message name="OrangeSoapOut">
+    <wsdl:part name="parameters" element="tns:OrangeResponse"/>
+  </wsdl:message>
+  <wsdl:message name="PingSoapIn">
+    <wsdl:part name="parameters" element="tns:Ping"/>
+  </wsdl:message>
+  <wsdl:message name="PingSoapOut">
+    <wsdl:part name="parameters" element="tns:WsUseMethodNamePingResponse"/>
+  </wsdl:message>
+  <wsdl:message name="UniqueSoapIn">
+    <wsdl:part name="parameters" element="tns:Unique"/>
+  </wsdl:message>
+  <wsdl:message name="UniqueSoapOut">
+    <wsdl:part name="parameters" element="tns:FooResponse"/>
+  </wsdl:message>
+  <wsdl:portType name="WsUseMethodNameServiceSoap">
+    <wsdl:operation name="Apple">
+      <wsdl:input message="tns:AppleSoapIn"/>
+      <wsdl:output message="tns:AppleSoapOut"/>
+      <wsdl:fault name="excfault" message="tns:EspSoapFault"/>
+    </wsdl:operation>
+    <wsdl:operation name="Orange">
+      <wsdl:input message="tns:OrangeSoapIn"/>
+      <wsdl:output message="tns:OrangeSoapOut"/>
+      <wsdl:fault name="excfault" message="tns:EspSoapFault"/>
+    </wsdl:operation>
+    <wsdl:operation name="Ping">
+      <wsdl:input message="tns:PingSoapIn"/>
+      <wsdl:output message="tns:PingSoapOut"/>
+      <wsdl:fault name="excfault" message="tns:EspSoapFault"/>
+    </wsdl:operation>
+    <wsdl:operation name="Unique">
+      <wsdl:input message="tns:UniqueSoapIn"/>
+      <wsdl:output message="tns:UniqueSoapOut"/>
+      <wsdl:fault name="excfault" message="tns:EspSoapFault"/>
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="WsUseMethodNameServiceSoap" type="tns:WsUseMethodNameServiceSoap">
+    <soap:binding transport="http://schemas.xmlsoap.org/soap/http" style="document"/>
+    <wsdl:operation name="Apple">
+      <soap:operation style="document" soapAction="WsUseMethodName/Apple?ver_=1.000000"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+      <wsdl:fault name="excfault">
+        <soap:fault name="excfault" use="literal"/>
+      </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="Orange">
+      <soap:operation style="document" soapAction="WsUseMethodName/Orange?ver_=1.000000"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+      <wsdl:fault name="excfault">
+        <soap:fault name="excfault" use="literal"/>
+      </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="Ping">
+      <soap:operation style="document" soapAction="WsUseMethodName/Ping?ver_=1.000000"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+      <wsdl:fault name="excfault">
+        <soap:fault name="excfault" use="literal"/>
+      </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="Unique">
+      <soap:operation style="document" soapAction="WsUseMethodName/Unique?ver_=1.000000"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+      <wsdl:fault name="excfault">
+        <soap:fault name="excfault" use="literal"/>
+      </wsdl:fault>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="WsUseMethodName">
+    <wsdl:port name="WsUseMethodNameServiceSoap" binding="tns:WsUseMethodNameServiceSoap">
+      <soap:address location="localhost"/>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>

--- a/testing/esp/esdlcmd/key/wsuserequestname.wsdl
+++ b/testing/esp/esdlcmd/key/wsuserequestname.wsdl
@@ -1,0 +1,175 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:tns="urn:hpccsystems:ws:wsuserequestname@ver=1" targetNamespace="urn:hpccsystems:ws:wsuserequestname@ver=1">
+  <wsdl:types>
+    <xsd:schema elementFormDefault="qualified" targetNamespace="urn:hpccsystems:ws:wsuserequestname@ver=1">
+      <xsd:element name="string" nillable="true" type="xsd:string"/>
+      <xsd:complexType name="EspException">
+        <xsd:all>
+          <xsd:element name="Code" type="xsd:string" minOccurs="0"/>
+          <xsd:element name="Audience" type="xsd:string" minOccurs="0"/>
+          <xsd:element name="Source" type="xsd:string" minOccurs="0"/>
+          <xsd:element name="Message" type="xsd:string" minOccurs="0"/>
+        </xsd:all>
+      </xsd:complexType>
+      <xsd:complexType name="ArrayOfEspException">
+        <xsd:sequence>
+          <xsd:element name="Source" type="xsd:string" minOccurs="0"/>
+          <xsd:element name="Exception" type="tns:EspException" minOccurs="0" maxOccurs="unbounded"/>
+        </xsd:sequence>
+      </xsd:complexType>
+      <xsd:element name="Exceptions" type="tns:ArrayOfEspException"/>
+      <xsd:element name="FruitRequest">
+        <xsd:complexType>
+          <xsd:all>
+            <xsd:element minOccurs="0" name="Flavor" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="Color" type="xsd:string"/>
+          </xsd:all>
+        </xsd:complexType>
+      </xsd:element>
+      <xsd:element name="WsUseRequestNamePingRequest">
+        <xsd:complexType>
+          <xsd:all/>
+        </xsd:complexType>
+      </xsd:element>
+      <xsd:element name="FooRequest">
+        <xsd:complexType>
+          <xsd:all>
+            <xsd:element minOccurs="0" name="Bar" type="xsd:string"/>
+            <xsd:element minOccurs="0" name="Baz" type="xsd:string"/>
+          </xsd:all>
+        </xsd:complexType>
+      </xsd:element>
+      <xsd:element name="FruitResponse">
+        <xsd:complexType>
+          <xsd:all>
+            <xsd:element minOccurs="0" name="Eat" type="xsd:int"/>
+          </xsd:all>
+        </xsd:complexType>
+      </xsd:element>
+      <xsd:element name="OrangeResponse">
+        <xsd:complexType>
+          <xsd:all>
+            <xsd:element minOccurs="0" name="Peels" type="xsd:boolean"/>
+          </xsd:all>
+        </xsd:complexType>
+      </xsd:element>
+      <xsd:element name="WsUseRequestNamePingResponse">
+        <xsd:complexType>
+          <xsd:all/>
+        </xsd:complexType>
+      </xsd:element>
+      <xsd:element name="FooResponse">
+        <xsd:complexType>
+          <xsd:all>
+            <xsd:element minOccurs="0" name="Bingo" type="xsd:int"/>
+          </xsd:all>
+        </xsd:complexType>
+      </xsd:element>
+    </xsd:schema>
+  </wsdl:types>
+  <wsdl:message name="EspSoapFault">
+    <wsdl:part name="parameters" element="tns:Exceptions"/>
+  </wsdl:message>
+  <wsdl:message name="AppleSoapIn">
+    <wsdl:part name="parameters" element="tns:FruitRequest"/>
+  </wsdl:message>
+  <wsdl:message name="AppleSoapOut">
+    <wsdl:part name="parameters" element="tns:FruitResponse"/>
+  </wsdl:message>
+  <wsdl:message name="OrangeSoapIn">
+    <wsdl:part name="parameters" element="tns:FruitRequest"/>
+  </wsdl:message>
+  <wsdl:message name="OrangeSoapOut">
+    <wsdl:part name="parameters" element="tns:OrangeResponse"/>
+  </wsdl:message>
+  <wsdl:message name="PingSoapIn">
+    <wsdl:part name="parameters" element="tns:WsUseRequestNamePingRequest"/>
+  </wsdl:message>
+  <wsdl:message name="PingSoapOut">
+    <wsdl:part name="parameters" element="tns:WsUseRequestNamePingResponse"/>
+  </wsdl:message>
+  <wsdl:message name="UniqueSoapIn">
+    <wsdl:part name="parameters" element="tns:FooRequest"/>
+  </wsdl:message>
+  <wsdl:message name="UniqueSoapOut">
+    <wsdl:part name="parameters" element="tns:FooResponse"/>
+  </wsdl:message>
+  <wsdl:portType name="WsUseRequestNameServiceSoap">
+    <wsdl:operation name="Apple">
+      <wsdl:input message="tns:AppleSoapIn"/>
+      <wsdl:output message="tns:AppleSoapOut"/>
+      <wsdl:fault name="excfault" message="tns:EspSoapFault"/>
+    </wsdl:operation>
+    <wsdl:operation name="Orange">
+      <wsdl:input message="tns:OrangeSoapIn"/>
+      <wsdl:output message="tns:OrangeSoapOut"/>
+      <wsdl:fault name="excfault" message="tns:EspSoapFault"/>
+    </wsdl:operation>
+    <wsdl:operation name="Ping">
+      <wsdl:input message="tns:PingSoapIn"/>
+      <wsdl:output message="tns:PingSoapOut"/>
+      <wsdl:fault name="excfault" message="tns:EspSoapFault"/>
+    </wsdl:operation>
+    <wsdl:operation name="Unique">
+      <wsdl:input message="tns:UniqueSoapIn"/>
+      <wsdl:output message="tns:UniqueSoapOut"/>
+      <wsdl:fault name="excfault" message="tns:EspSoapFault"/>
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="WsUseRequestNameServiceSoap" type="tns:WsUseRequestNameServiceSoap">
+    <soap:binding transport="http://schemas.xmlsoap.org/soap/http" style="document"/>
+    <wsdl:operation name="Apple">
+      <soap:operation style="document" soapAction="WsUseRequestName/Apple?ver_=1.000000"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+      <wsdl:fault name="excfault">
+        <soap:fault name="excfault" use="literal"/>
+      </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="Orange">
+      <soap:operation style="document" soapAction="WsUseRequestName/Orange?ver_=1.000000"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+      <wsdl:fault name="excfault">
+        <soap:fault name="excfault" use="literal"/>
+      </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="Ping">
+      <soap:operation style="document" soapAction="WsUseRequestName/Ping?ver_=1.000000"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+      <wsdl:fault name="excfault">
+        <soap:fault name="excfault" use="literal"/>
+      </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="Unique">
+      <soap:operation style="document" soapAction="WsUseRequestName/Unique?ver_=1.000000"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+      <wsdl:fault name="excfault">
+        <soap:fault name="excfault" use="literal"/>
+      </wsdl:fault>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="WsUseRequestName">
+    <wsdl:port name="WsUseRequestNameServiceSoap" binding="tns:WsUseRequestNameServiceSoap">
+      <soap:address location="localhost"/>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>


### PR DESCRIPTION
Ensure that when use_method_name is set for an EsdlService that the wsdl sets the wsdl:message/wsdl:part/@element name for each "SoapIn" message is set to the name of the method. Generate one xsd:element corresponding to each method using a given request structure, and set that element's name attribute to the name of the method that uses it.

Signed-off-by: Terrence Asselin <terrence.asselin@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [x] I have added tests to cover my changes.
  - [x] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [x] Scalability
  - [x] Performance
  - [x] Security
  - [x] Thread-safety
  - [x] Cloud-compatibility
  - [x] Premature optimization
  - [x] Existing deployed queries will not be broken
  - [x] This change fixes the problem, not just the symptom
  - [x] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [x] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->
Created two test cases in the esdlcmd regression script. Also manually inspected the results of applying this updated transform to the WsWorkunits ecm file and spot checked several methods to ensure their wsdl entries were correct. Valgrind and memory tests were not required as this was a change to an xslt that would not result in any leaks that aren't already present in the libxslt.
<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
