### PR TITLE
Revert "HPCC-28553 Check dropzone scope access in ESP FileSpray"

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -1136,7 +1136,6 @@ public:
     SecAccessFlags getFilePermissions(const char *lname,IUserDescriptor *user,unsigned auditflags);
     SecAccessFlags getNodePermissions(const IpAddress &ip,IUserDescriptor *user,unsigned auditflags);
     SecAccessFlags getFDescPermissions(IFileDescriptor *,IUserDescriptor *user,unsigned auditflags=0);
-    SecAccessFlags getDropZoneScopePermissions(const char *dropZoneName,const char *dropZonePath,IUserDescriptor *user,unsigned auditflags=0);
     void setDefaultUser(IUserDescriptor *user);
     IUserDescriptor* queryDefaultUser();
 
@@ -11786,15 +11785,6 @@ SecAccessFlags CDistributedFileDirectory::getFDescPermissions(IFileDescriptor *f
         }
     }
     return retPerms;
-}
-
-SecAccessFlags CDistributedFileDirectory::getDropZoneScopePermissions(const char *dropZoneName,const char *dropZonePath,IUserDescriptor *user,unsigned auditflags)
-{
-    CDfsLogicalFileName dlfn;
-    dlfn.setPlaneExternal(dropZoneName,dropZonePath);
-    StringBuffer scopes;
-    dlfn.getScopes(scopes);
-    return getScopePermissions(scopes,user,auditflags);
 }
 
 void CDistributedFileDirectory::setDefaultUser(IUserDescriptor *user)

--- a/dali/base/dadfs.hpp
+++ b/dali/base/dadfs.hpp
@@ -646,7 +646,6 @@ interface IDistributedFileDirectory: extends IInterface
     virtual IUserDescriptor* queryDefaultUser()=0;
     virtual SecAccessFlags getNodePermissions(const IpAddress &ip,IUserDescriptor *user,unsigned auditflags=0)=0;
     virtual SecAccessFlags getFDescPermissions(IFileDescriptor *,IUserDescriptor *user,unsigned auditflags=0)=0;
-    virtual SecAccessFlags getDropZoneScopePermissions(const char *dropZoneName,const char *dropZonePath,IUserDescriptor *user,unsigned auditflags=0)=0;
 
     virtual DistributedFileCompareResult fileCompare(const char *lfn1,const char *lfn2,DistributedFileCompareMode mode,StringBuffer &errstr,IUserDescriptor *user)=0;
     virtual bool filePhysicalVerify(const char *lfn1,IUserDescriptor *user,bool includecrc,StringBuffer &errstr)=0;

--- a/dali/base/dautils.cpp
+++ b/dali/base/dautils.cpp
@@ -46,20 +46,18 @@
 #define SDS_CONNECT_TIMEOUT  (1000*60*60*2)     // better than infinite
 #define MIN_REDIRECTION_LOAD_INTERVAL 1000
 
-static IPropertyTree *getPlaneHostGroup(IPropertyTree *plane)
-{
-    if (plane->hasProp("@hostGroup"))
-        return getHostGroup(plane->queryProp("@hostGroup"), true);
-    else if (plane->hasProp("hosts"))
-        return LINK(plane); // plane itself holds 'hosts'
-    return nullptr;
-}
 
 bool isHostInPlane(IPropertyTree *plane, const char *host, bool ipMatch)
 {
-    Owned<IPropertyTree> planeGroup = getPlaneHostGroup(plane);
-    if (!planeGroup)
-        return false;
+    Owned<IPropertyTree> planeGroup;
+    if (plane->hasProp("@hostGroup"))
+        planeGroup.setown(getHostGroup(plane->queryProp("@hostGroup"), true));
+    else
+    {
+        if (!plane->hasProp("hosts"))
+            return false;
+        planeGroup.set(plane); // plane itself holds 'hosts'
+    }
     Owned<IPropertyTreeIterator> hostsIter = planeGroup->getElements("hosts");
     SocketEndpoint hostEp;
     if (ipMatch)
@@ -81,8 +79,12 @@ bool isHostInPlane(IPropertyTree *plane, const char *host, bool ipMatch)
 
 bool getPlaneHost(StringBuffer &host, IPropertyTree *plane, unsigned which)
 {
-    Owned<IPropertyTree> hostGroup = getPlaneHostGroup(plane);
-    if (!hostGroup)
+    Owned<IPropertyTree> hostGroup;
+    if (plane->hasProp("@hostGroup"))
+        hostGroup.setown(getHostGroup(plane->queryProp("@hostGroup"), true));
+    else if (plane->hasProp("hosts"))
+        hostGroup.set(plane); // the plane holds the "hosts"
+    else
         return false;
 
     if (which >= hostGroup->getCount("hosts"))
@@ -90,17 +92,6 @@ bool getPlaneHost(StringBuffer &host, IPropertyTree *plane, unsigned which)
     VStringBuffer xpath("hosts[%u]", which+1); // which is 0 based
     host.append(hostGroup->queryProp(xpath));
     return true;
-}
-
-void getPlaneHosts(StringArray &hosts, IPropertyTree *plane)
-{
-    Owned<IPropertyTree> hostGroup = getPlaneHostGroup(plane);
-    if (hostGroup)
-    {
-        Owned<IPropertyTreeIterator> hostsIter = hostGroup->getElements("hosts");
-        ForEach (*hostsIter)
-            hosts.append(hostsIter->query().queryProp(nullptr));
-    }
 }
 
 constexpr const char * lz_plane_path = "storage/planes[@category='lz']";

--- a/dali/base/dautils.hpp
+++ b/dali/base/dautils.hpp
@@ -545,7 +545,6 @@ extern da_decl IPropertyTree * getDropZonePlane(const char * name);
 extern da_decl IPropertyTree * findDropZonePlane(const char * path, const char * host, bool ipMatch);
 extern da_decl bool isHostInPlane(IPropertyTree *plane, const char *host, bool ipMatch);
 extern da_decl bool getPlaneHost(StringBuffer &host, IPropertyTree *plane, unsigned which);
-extern da_decl void getPlaneHosts(StringArray &hosts, IPropertyTree *plane);
 extern da_decl void setPageCacheTimeoutMilliSeconds(unsigned timeoutSeconds);
 extern da_decl void setMaxPageCacheItems(unsigned _maxPageCacheItems);
 extern da_decl IRemoteConnection* connectXPathOrFile(const char* path, bool safe, StringBuffer& xpath);

--- a/esp/scm/ws_fs.ecm
+++ b/esp/scm/ws_fs.ecm
@@ -534,7 +534,6 @@ ESPresponse [exceptions_inline] DFUWUFileResponse
 
 ESPrequest FileListRequest
 {
-    [min_ver("1.24")] string DropZoneName;
     string Netaddr;
     string Path;
     string Mask;
@@ -697,7 +696,7 @@ ESPresponse [exceptions_inline, nil_remove] GetDFUServerQueuesResponse
 
 ESPservice [
     auth_feature("DEFERRED"),
-    version("1.24"),
+    version("1.23"),
     exceptions_inline("./smc_xslt/exceptions.xslt")] FileSpray
 {
     ESPmethod EchoDateTime(EchoDateTime, EchoDateTimeResponse);

--- a/esp/services/ws_fs/ws_fsBinding.cpp
+++ b/esp/services/ws_fs/ws_fsBinding.cpp
@@ -393,17 +393,12 @@ int CFileSpraySoapBindingEx::downloadFile(IEspContext &context, CHttpRequest* re
         if (!context.validateFeatureAccess(FILE_SPRAY_URL, SecAccess_Full, false))
             throw MakeStringException(ECLWATCH_FILE_SPRAY_ACCESS_DENIED, "Failed to download file. Permission denied.");
 
-        StringBuffer netAddressStr, osStr, pathStr, nameStr, dropZoneName;
+        StringBuffer netAddressStr, osStr, pathStr, nameStr;
         request->getParameter("NetAddress", netAddressStr);
         request->getParameter("OS", osStr);
         request->getParameter("Path", pathStr);
         request->getParameter("Name", nameStr);
-        request->getParameter("DropZoneName", dropZoneName);
 
-        SecAccessFlags permission = getDropZoneScopePermissions(context, dropZoneName, pathStr, netAddressStr);
-        if (permission < SecAccess_Read)
-            throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "Access DropZone Scope %s %s %s not allowed for user %s (permission:%s). Read Access Required.",
-                dropZoneName.str(), netAddressStr.str(), pathStr.str(), context.queryUserId(), getSecAccessFlagName(permission));
 #if 0
         StringArray files;
         IProperties* params = request->queryParameters();
@@ -484,16 +479,11 @@ int CFileSpraySoapBindingEx::downloadFile(IEspContext &context, CHttpRequest* re
 
 int CFileSpraySoapBindingEx::onStartUpload(IEspContext& ctx, CHttpRequest* request, CHttpResponse* response, const char* serv, const char* method)
 {
-    StringBuffer netAddress, path, dropZoneName;
+    StringBuffer netAddress, path;
     request->getParameter("NetAddress", netAddress);
     request->getParameter("Path", path);
-    request->getParameter("DropZoneName", dropZoneName);
     if (!validateDropZonePath(nullptr, netAddress, path)) //The path should be the absolute path for the dropzone.
         throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "Invalid Landing Zone path %s", path.str());
-    SecAccessFlags permission = getDropZoneScopePermissions(ctx, dropZoneName, path, netAddress);
-    if (permission < SecAccess_Full)
-        throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "Access DropZone Scope %s %s %s not allowed for user %s (permission:%s). Full Access Required.",
-            dropZoneName.str(), netAddress.str(), path.str(), ctx.queryUserId(), getSecAccessFlagName(permission));
 
     return EspHttpBinding::onStartUpload(ctx, request, response, serv, method);
 }

--- a/esp/services/ws_fs/ws_fsService.cpp
+++ b/esp/services/ws_fs/ws_fsService.cpp
@@ -2338,6 +2338,100 @@ void CFileSprayEx::getDropZoneInfoByDestPlane(double clientVersion, const char* 
     getDropZoneHost(destPlane, dropZone, hostip);
 }
 
+void CFileSprayEx::getDropZoneInfoByIP(double clientVersion, const char* ip, const char* destFileIn, StringBuffer& destFileOut, StringBuffer& umask)
+{
+#ifndef _CONTAINERIZED
+    if (destFileIn && *destFileIn)
+        destFileOut.set(destFileIn);
+
+    if (!ip || !*ip)
+        throw MakeStringExceptionDirect(ECLWATCH_INVALID_IP, "Network address must be specified for a drop zone!");
+
+    Owned<IEnvironmentFactory> factory = getEnvironmentFactory(true);
+    Owned<IConstEnvironment> constEnv = factory->openEnvironment();
+
+    StringBuffer destFile;
+    if (isAbsolutePath(destFileIn))
+    {
+        destFile.set(destFileIn);
+        Owned<IConstDropZoneInfo> dropZone = constEnv->getDropZoneByAddressPath(ip, destFile.str());
+        if (!dropZone)
+        {
+            if (constEnv->isDropZoneRestrictionEnabled())
+                throw MakeStringException(ECLWATCH_DROP_ZONE_NOT_FOUND, "No drop zone configured for '%s' and '%s'. Check your system drop zone configuration.", ip, destFile.str());
+            else
+            {
+                LOG(MCdebugInfo, unknownJob, "No drop zone configured for '%s' and '%s'. Check your system drop zone configuration.", ip, destFile.str());
+                return;
+            }
+        }
+
+
+        SCMStringBuffer directory, maskBuf;
+        dropZone->getDirectory(directory);
+        destFileOut.set(destFile.str());
+        dropZone->getUMask(maskBuf);
+        if (maskBuf.length())
+            umask.set(maskBuf.str());
+
+        return;
+    }
+
+    Owned<IConstDropZoneInfoIterator> dropZoneItr = constEnv->getDropZoneIteratorByAddress(ip);
+    if (dropZoneItr->count() < 1)
+    {
+        if (constEnv->isDropZoneRestrictionEnabled())
+            throw MakeStringException(ECLWATCH_DROP_ZONE_NOT_FOUND, "Drop zone not found for network address '%s'. Check your system drop zone configuration.", ip);
+        else
+        {
+            LOG(MCdebugInfo, unknownJob, "Drop zone not found for network address '%s'. Check your system drop zone configuration.", ip);
+            return;
+        }
+    }
+
+    bool dzFound = false;
+    ForEach(*dropZoneItr)
+    {
+        IConstDropZoneInfo& dropZoneInfo = dropZoneItr->query();
+
+        SCMStringBuffer dropZoneDirectory, dropZoneUMask;
+        dropZoneInfo.getDirectory(dropZoneDirectory);
+        dropZoneInfo.getUMask(dropZoneUMask);
+        if (!dropZoneDirectory.length())
+            continue;
+
+        if (!dzFound)
+        {
+            dzFound = true;
+            destFileOut.set(dropZoneDirectory.str());
+            addPathSepChar(destFileOut);
+            destFileOut.append(destFileIn);
+            if (dropZoneUMask.length())
+                umask.set(dropZoneUMask.str());
+        }
+        else
+        {
+            if (constEnv->isDropZoneRestrictionEnabled())
+                throw MakeStringException(ECLWATCH_INVALID_INPUT, "> 1 drop zones found for network address '%s'.", ip);
+            else
+            {
+                LOG(MCdebugInfo, unknownJob, "> 1 drop zones found for network address '%s'.", ip);
+                return;
+            }
+        }
+    }
+    if (!dzFound)
+    {
+        if (constEnv->isDropZoneRestrictionEnabled())
+            throw MakeStringException(ECLWATCH_DROP_ZONE_NOT_FOUND, "No valid drop zone found for network address '%s'. Check your system drop zone configuration.", ip);
+        else
+            LOG(MCdebugInfo, unknownJob, "No valid drop zone found for network address '%s'. Check your system drop zone configuration.", ip);
+    }
+#else
+    throw makeStringException(-1, "Internal error: CFileSprayEx::getDropZoneInfoByIP should not be called in containerized environment");
+#endif
+}
+
 static StringBuffer & expandLogicalAsPhysical(StringBuffer & target, const char * name, const char * separator)
 {
     const char * cur = name;
@@ -2378,17 +2472,30 @@ bool CFileSprayEx::onDespray(IEspContext &context, IEspDespray &req, IEspDespray
         MemoryBuffer& dstxml = (MemoryBuffer&)req.getDstxml();
         if(dstxml.length() == 0)
         {
+#ifdef _CONTAINERIZED
             if (isEmptyString(destPlane))
                 destPlane = req.getDestGroup();  // allow eclwatch to continue providing storage plane as 'destgroup' field
             if (isEmptyString(destPlane))
             {
                 if (destip.isEmpty())
-                    throw makeStringException(ECLWATCH_INVALID_INPUT, "Neither destination storage plane or destination IP specified.");
-                Owned<IPropertyTree> plane = findDropZonePlane(destPath, destip, true);
-                if (!plane)
-                    throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "DropZone Plane not found for host %s path %s.", destip.str(), destPath.str());
-                destPlane = plane->queryProp("@name");
+                    throw MakeStringException(ECLWATCH_INVALID_INPUT, "Neither destination storage plane or destination IP specified.");
+                Owned<IPropertyTreeIterator> planesIter = getDropZonePlanesIterator();
+                ForEach(*planesIter)
+                {
+                    IPropertyTree &lzPlane = planesIter->query();
+                    if (isHostInPlane(&lzPlane, destip, true))
+                    {
+                        destPlane = lzPlane.queryProp("@name");
+                        break;
+                    }
+                }
+                if (isEmptyString(destPlane))
+                    throw makeStringException(ECLWATCH_INVALID_INPUT, "Destination IP does not match a hosts based storage plane.");
             }
+#else
+            if (isEmptyString(destPlane) && destip.isEmpty())
+                throw MakeStringException(ECLWATCH_INVALID_INPUT, "Destination network IP/storage plane not specified.");
+#endif
 
             //If the destination filename is not provided, calculate a relative filename from the logical filename
             if(!destfile || !*destfile)
@@ -2419,7 +2526,10 @@ bool CFileSprayEx::onDespray(IEspContext &context, IEspDespray &req, IEspDespray
         if(dstxml.length() == 0)
         {
             StringBuffer destfileWithPath, umask;
-            getDropZoneInfoByDestPlane(version, destPlane, destfile, destfileWithPath, umask, destip);
+            if (!isEmptyString(destPlane))
+                getDropZoneInfoByDestPlane(version, destPlane, destfile, destfileWithPath, umask, destip);
+            else
+                getDropZoneInfoByIP(version, destip, destfile, destfileWithPath, umask);
 
             RemoteFilename rfn;
             SocketEndpoint ep(destip.str());
@@ -2812,10 +2922,9 @@ bool CFileSprayEx::onFileList(IEspContext &context, IEspFileListRequest &req, IE
             throw MakeStringException(ECLWATCH_INVALID_INPUT, "Path not specified.");
 
         double version = context.getClientVersion();
-        const char* dropZoneName = req.getDropZoneName();
         const char* netaddr = req.getNetaddr();
-        if (isEmptyString(dropZoneName) && isEmptyString(netaddr))
-            throw makeStringException(ECLWATCH_INVALID_INPUT, "DropZoneName or Netaddr must be specified.");
+        if (!netaddr || !*netaddr)
+            throw MakeStringException(ECLWATCH_INVALID_INPUT, "Network address not specified.");
         const char* fileNameMask = req.getMask();
         bool directoryOnly = req.getDirectoryOnly();
         PROGLOG("FileList:  Netaddr %s, Path %s", netaddr, path);
@@ -2837,36 +2946,55 @@ bool CFileSprayEx::onFileList(IEspContext &context, IEspFileListRequest &req, IE
                 throw MakeStringException(ECLWATCH_ACCESS_TO_FILE_DENIED, "Only cfg or log file allowed.");
         }
 
-        if (isEmptyString(dropZoneName))
-            dropZoneName = findDropZonePlaneName(sPath, netaddr);
-        SecAccessFlags permission = getDropZoneScopePermissions(context, dropZoneName, sPath, nullptr);
-        if (permission < SecAccess_Read)
-            throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "Access DropZone Scope %s %s not allowed for user %s (permission:%s). Read Access Required.",
-                dropZoneName, sPath.str(), context.queryUserId(), getSecAccessFlagName(permission));
+        if (!validateDropZonePath(nullptr, netaddr, sPath) && !validateConfigurationDirectory(nullptr, "log", nullptr, nullptr, sPath)) //The path should be the absolute path for the dropzone or log file.
+            throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "Invalid file path %s", sPath.str());
 
-        StringArray hosts;
-        if (isEmptyString(netaddr))
-        {
-            Owned<IPropertyTree> dropZone = getDropZonePlane(dropZoneName);
-            if (!dropZone)
-                throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "Unknown landing zone: %s", dropZoneName);
-            getPlaneHosts(hosts, dropZone);
-            if (!hosts.ordinality())
-                hosts.append("localhost");
-        }
-        else
-            hosts.append(netaddr);
+        RemoteFilename rfn;
+        SocketEndpoint ep;
+#ifdef MACHINE_IP
+        ep.set(MACHINE_IP);
+#else
+        ep.set(netaddr);
+        if (ep.isNull())
+            throw MakeStringException(ECLWATCH_INVALID_INPUT, "FileList: cannot resolve network IP from %s.", netaddr);
+#endif
+        rfn.setPath(ep, sPath.str());
+        Owned<IFile> f = createIFile(rfn);
+        if (f->isDirectory()!=fileBool::foundYes)
+            throw MakeStringException(ECLWATCH_INVALID_DIRECTORY, "%s is not a directory.", path);
 
-        IArrayOf<IConstPhysicalFileStruct>& files = resp.getFiles();
-        ForEachItemIn(i, hosts)
+        IArrayOf<IEspPhysicalFileStruct> files;
+        Owned<IDirectoryIterator> di = f->directoryFiles(NULL, false, true);
+        if(di.get() != NULL)
         {
-            const char* host = hosts.item(i);
-            if (validateDropZonePath(nullptr, host, sPath))
-                getDropZoneFiles(context, dropZoneName, host, sPath, fileNameMask, directoryOnly, files);
+            ForEach(*di)
+            {
+                StringBuffer fname;
+                di->getName(fname);
+
+                if (fname.length() == 0 || (directoryOnly && !di->isDir()) || (!di->isDir() && !isEmptyString(fileNameMask) && !WildMatch(fname.str(), fileNameMask, true)))
+                    continue;
+
+                Owned<IEspPhysicalFileStruct> onefile = createPhysicalFileStruct();
+
+                onefile->setName(fname.str());
+                onefile->setIsDir(di->isDir());
+                onefile->setFilesize(di->getFileSize());
+                CDateTime modtime;
+                StringBuffer timestr;
+                di->getModifiedTime(modtime);
+                unsigned y,m,d,h,min,sec,nsec;
+                modtime.getDate(y,m,d,true);
+                modtime.getTime(h,min,sec,nsec,true);
+                timestr.appendf("%04d-%02d-%02d %02d:%02d:%02d", y,m,d,h,min,sec);
+                onefile->setModifiedtime(timestr.str());
+                files.append(*onefile.getLink());
+            }
         }
 
         sPath.replace('\\', '/');//XSLT cannot handle backslashes
         resp.setPath(sPath);
+        resp.setFiles(files);
         resp.setNetaddr(netaddr);
         if (osStr && *osStr)
         {
@@ -2921,15 +3049,22 @@ bool CFileSprayEx::checkDropZoneIPAndPath(double clientVersion, const char* drop
     return false;
 }
 
-void CFileSprayEx::addDropZoneFile(IEspContext& context, IDirectoryIterator* di, const char* name, const char* path, const char* server, IArrayOf<IConstPhysicalFileStruct>& files)
+void CFileSprayEx::addDropZoneFile(IEspContext& context, IDirectoryIterator* di, const char* name, const char pathSep, const char* server, IArrayOf<IEspPhysicalFileStruct>& files)
 {
-    double version = context.getClientVersion();
-
     Owned<IEspPhysicalFileStruct> aFile = createPhysicalFileStruct();
 
-    aFile->setName(name);
-    if (!isEmptyString(path))
-        aFile->setPath(path);
+    const char* pName = strrchr(name, pathSep);
+    if (!pName)
+        aFile->setName(name);
+    else
+    {
+        StringBuffer sPath;
+        sPath.append(pName - name, name);
+        aFile->setPath(sPath.str());
+
+        pName++; //skip the PathSepChar
+        aFile->setName(pName);
+    }
 
     aFile->setIsDir(di->isDir());
     CDateTime modtime;
@@ -2941,50 +3076,34 @@ void CFileSprayEx::addDropZoneFile(IEspContext& context, IDirectoryIterator* di,
     timestr.appendf("%04d-%02d-%02d %02d:%02d:%02d", y,m,d,h,min,sec);
     aFile->setModifiedtime(timestr.str());
     aFile->setFilesize(di->getFileSize());
-    if (version >= 1.23)
-        aFile->setServer(server);
+    aFile->setServer(server);
     files.append(*aFile.getLink());
 }
 
-bool CFileSprayEx::searchDropZoneFiles(IEspContext& context, const char* dropZoneName, const char* server,
-    const char* dir, const char* relDir, const char* nameFilter, IArrayOf<IConstPhysicalFileStruct>& files, unsigned& filesFound)
+void CFileSprayEx::searchDropZoneFiles(IEspContext& context, const char* server, const char* dir, const char* nameFilter, IArrayOf<IEspPhysicalFileStruct>& files, unsigned& filesFound)
 {
-    if (getDropZoneScopePermissions(context, dropZoneName, dir, server) < SecAccess_Read)
-        return false;
-
     RemoteFilename rfn;
     SocketEndpoint ep(server);
     rfn.setPath(ep, dir);
     Owned<IFile> f = createIFile(rfn);
     if(f->isDirectory()!=fileBool::foundYes)
-        throw makeStringExceptionV(ECLWATCH_INVALID_DIRECTORY, "%s is not a directory.", dir);
+        throw MakeStringException(ECLWATCH_INVALID_DIRECTORY, "%s is not a directory.", dir);
 
-    Owned<IDirectoryIterator> di = f->directoryFiles(nullptr, false, true);
+    const char pathSep = getPathSepChar(dir);
+    Owned<IDirectoryIterator> di = f->directoryFiles(nameFilter, true, true);
     ForEach(*di)
     {
         StringBuffer fname;
         di->getName(fname);
-
-        if (di->isDir())
-        {
-            StringBuffer fullPath(dir), relPath(relDir);
-            addPathSepChar(fullPath).append(fname);
-            if (!relPath.isEmpty())
-                addPathSepChar(relPath);
-            relPath.append(fname);
-            if (!searchDropZoneFiles(context, dropZoneName, server, fullPath, relPath, nameFilter, files, filesFound))
-                continue;
-        }
-        if (!isEmptyString(nameFilter) && !WildMatch(fname, nameFilter, false))
+        if (!fname.length())
             continue;
-
-        addDropZoneFile(context, di, fname.str(), relDir, server, files);
 
         filesFound++;
         if (filesFound > dropZoneFileSearchMaxFiles)
             break;
+
+        addDropZoneFile(context, di, fname.str(), pathSep, server, files);
     }
-    return true;
 }
 
 bool CFileSprayEx::onDropZoneFileSearch(IEspContext &context, IEspDropZoneFileSearchRequest &req, IEspDropZoneFileSearchResponse &resp)
@@ -3018,7 +3137,7 @@ bool CFileSprayEx::onDropZoneFileSearch(IEspContext &context, IEspDropZoneFileSe
         double version = context.getClientVersion();
         bool serverFound = false;
         unsigned filesFound = 0;
-        IArrayOf<IConstPhysicalFileStruct> &files = resp.getFiles();
+        IArrayOf<IEspPhysicalFileStruct> files;
         bool isIPAddressReq = isIPAddress(dropZoneServerReq);
         IArrayOf<IConstTpDropZone> allTpDropZones;
         CTpWrapper tpWrapper;
@@ -3038,7 +3157,7 @@ bool CFileSprayEx::onDropZoneFileSearch(IEspContext &context, IEspDropZoneFileSe
                 IConstTpMachine& tpMachine = tpMachines.item(ii);
                 if (isEmptyString(dropZoneServerReq) || matchNetAddressRequest(dropZoneServerReq, isIPAddressReq, tpMachine))
                 {
-                    searchDropZoneFiles(context, dropZoneName, tpMachine.getNetaddress(), dropZone.getPath(), nullptr, nameFilter, files, filesFound);
+                    searchDropZoneFiles(context, tpMachine.getNetaddress(), dropZone.getPath(), nameFilter, files, filesFound);
                     serverFound = true;
                 }
             }
@@ -3051,6 +3170,7 @@ bool CFileSprayEx::onDropZoneFileSearch(IEspContext &context, IEspDropZoneFileSe
             VStringBuffer msg("More than %u files are found. Only %u files are returned.", dropZoneFileSearchMaxFiles, dropZoneFileSearchMaxFiles);
             resp.setWarning(msg.str());
         }
+        resp.setFiles(files);
     }
     catch(IException* e)
     {
@@ -3151,33 +3271,62 @@ bool CFileSprayEx::onOpenSave(IEspContext &context, IEspOpenSaveRequest &req, IE
     return true;
 }
 
-void CFileSprayEx::getDropZoneFiles(IEspContext &context, const char *dropZoneName, const char *host, const char *path, const char *fileNameMask, bool directoryOnly, IArrayOf<IConstPhysicalFileStruct> &files)
+bool CFileSprayEx::getDropZoneFiles(IEspContext &context, const char* dropZone, const char* netaddr, const char* path,
+                                    IEspDropZoneFilesRequest &req, IEspDropZoneFilesResponse &resp)
 {
-    SocketEndpoint ep(host);
+    if (!checkDropZoneIPAndPath(context.getClientVersion(), dropZone, netaddr, path))
+        throw MakeStringException(ECLWATCH_DROP_ZONE_NOT_FOUND, "Dropzone is not found in the environment settings.");
+
+    bool directoryOnly = req.getDirectoryOnly();
+
     RemoteFilename rfn;
+    SocketEndpoint ep;
+#ifdef MACHINE_IP
+    ep.set(MACHINE_IP);
+#else
+    ep.set(netaddr);
+    if (ep.isNull())
+        throw MakeStringException(ECLWATCH_INVALID_INPUT, "CFileSprayEx::getDropZoneFiles: cannot resolve network IP from %s.", netaddr);
+#endif
+
     rfn.setPath(ep, path);
     Owned<IFile> f = createIFile(rfn);
-    if (f->isDirectory()!=fileBool::foundYes)
-        throw makeStringExceptionV(ECLWATCH_INVALID_DIRECTORY, "%s is not a directory.", path);
+    if(f->isDirectory()!=fileBool::foundYes)
+        throw MakeStringException(ECLWATCH_INVALID_DIRECTORY, "%s is not a directory.", path);
 
-    Owned<IDirectoryIterator> di = f->directoryFiles(nullptr, false, true);
-    ForEach(*di)
+    IArrayOf<IEspPhysicalFileStruct> files;
+    Owned<IDirectoryIterator> di = f->directoryFiles(NULL, false, true);
+    if(di.get() != NULL)
     {
-        StringBuffer fileName;
-        di->getName(fileName);
-
-        if ((directoryOnly && !di->isDir()) || (!di->isDir() && !isEmptyString(fileNameMask) && !WildMatch(fileName.str(), fileNameMask, true)))
-            continue;
-
-        if (di->isDir())
+        ForEach(*di)
         {
-            VStringBuffer fullPath("%s%s", path, fileName.str());
-            if (getDropZoneScopePermissions(context, dropZoneName, fullPath, nullptr) < SecAccess_Read)
-                continue;
-        }
+            StringBuffer fname;
+            di->getName(fname);
 
-        addDropZoneFile(context, di, fileName, path, host, files);
+            if (fname.length() == 0 || (directoryOnly && !di->isDir()))
+                continue;
+
+            Owned<IEspPhysicalFileStruct> onefile = createPhysicalFileStruct();
+
+            onefile->setName(fname.str());
+            onefile->setIsDir(di->isDir());
+            onefile->setFilesize(di->getFileSize());
+            CDateTime modtime;
+            StringBuffer timestr;
+            di->getModifiedTime(modtime);
+            unsigned y,m,d,h,min,sec,nsec;
+            modtime.getDate(y,m,d,true);
+            modtime.getTime(h,min,sec,nsec,true);
+            timestr.appendf("%04d-%02d-%02d %02d:%02d:%02d", y,m,d,h,min,sec);
+            onefile->setModifiedtime(timestr.str());
+            onefile->setServer(netaddr);
+            files.append(*onefile.getLink());
+        }
     }
+
+    resp.setFiles(files);
+
+    return true;
 }
 
 void CFileSprayEx::getServersInDropZone(const char *dropZoneName, IArrayOf<IConstTpDropZone> &dropZoneList, bool isECLWatchVisibleOnly, StringArray &serverList)
@@ -3277,19 +3426,8 @@ bool CFileSprayEx::onDropZoneFiles(IEspContext &context, IEspDropZoneFilesReques
         }
         addPathSepChar(directoryStr);
 
-        if (isEmptyString(dzName))
-            dzName = findDropZonePlaneName(directoryStr, netAddress);
-        if (getDropZoneScopePermissions(context, dzName, directoryStr, nullptr) < SecAccess_Read)
-            return false;
-
-        bool directoryOnly = req.getDirectoryOnly();
-        IArrayOf<IConstPhysicalFileStruct> &files = resp.getFiles();
         if (!isEmptyString(netAddress))
-        {
-            if (!checkDropZoneIPAndPath(context.getClientVersion(), dzName, netAddress, directoryStr))
-                throw makeStringException(ECLWATCH_DROP_ZONE_NOT_FOUND, "Dropzone is not found in the environment settings.");
-            getDropZoneFiles(context, dzName, netAddress, directoryStr, nullptr, directoryOnly, files);
-        }
+            getDropZoneFiles(context, dzName, netAddress, directoryStr, req, resp);
         else
         {
             //Find out all DropZone servers inside the DropZone.
@@ -3299,11 +3437,7 @@ bool CFileSprayEx::onDropZoneFiles(IEspContext &context, IEspDropZoneFilesReques
                 return true;
 
             ForEachItemIn(itr, servers)
-            {
-                const char* host = servers.item(itr);
-                if (checkDropZoneIPAndPath(context.getClientVersion(), dzName, host, directoryStr))
-                    getDropZoneFiles(context, dzName, host, directoryStr, nullptr, directoryOnly, files);
-            }
+                getDropZoneFiles(context, dzName, servers.item(itr), directoryStr, req, resp);
         }
 
         resp.setDropZoneName(dzName);
@@ -3346,8 +3480,6 @@ bool CFileSprayEx::onDeleteDropZoneFiles(IEspContext &context, IEspDeleteDropZon
 
         if (!checkDropZoneIPAndPath(version, dzName, netAddress, path.str()))
             throw MakeStringException(ECLWATCH_DROP_ZONE_NOT_FOUND, "Dropzone is not found in the environment settings.");
-
-        checkDropZoneFileScopeAccess(context, dzName, netAddress, path, files, SecAccess_Full);
 
         RemoteFilename rfn;
         SocketEndpoint ep(netAddress);
@@ -3410,76 +3542,6 @@ bool CFileSprayEx::onDeleteDropZoneFiles(IEspContext &context, IEspDeleteDropZon
     }
 
     return true;
-}
-
-void CFileSprayEx::checkDropZoneFileScopeAccess(IEspContext &context, const char *dropZoneName, const char *netAddress,
-    const char *dropZonePath, const StringArray &dropZoneFiles, SecAccessFlags accessReq)
-{
-    const char *accessReqName = getSecAccessFlagName(accessReq);
-    if (isEmptyString(dropZoneName))
-        dropZoneName = findDropZonePlaneName(dropZonePath, netAddress);
-    SecAccessFlags permission = getDropZoneScopePermissions(context, dropZoneName, dropZonePath, nullptr);
-    if (permission < accessReq)
-        throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "Access DropZone Scope %s %s not allowed for user %s (permission:%s). %s Permission Required.",
-            dropZoneName, dropZonePath, accessReqName, context.queryUserId(), getSecAccessFlagName(permission));
-
-    RemoteFilename rfn;
-    SocketEndpoint ep(netAddress);
-    rfn.setIp(ep);
-
-    StringBuffer errorMessage;
-    MapStringTo<bool> uniquePath;
-    const char pathSep = getPathSepChar(dropZonePath);
-    ForEachItemIn(i, dropZoneFiles)
-    {
-        const char *fileNameWithPath = dropZoneFiles.item(i);
-        if (isEmptyString(fileNameWithPath))
-            continue;
-
-        StringBuffer fileToDelete(dropZonePath);
-        addPathSepChar(fileToDelete).append(fileNameWithPath);
-
-        StringBuffer pathToCheck;
-        rfn.setRemotePath(fileToDelete.str());
-        Owned<IFile> rFile = createIFile(rfn);
-        if (rFile->isDirectory() == fileBool::foundYes)
-            pathToCheck.append(fileNameWithPath);
-        else
-        {
-            splitDirTail(fileNameWithPath, pathToCheck);
-            if (pathToCheck.isEmpty())
-                continue;
-        }
-
-        //a subfolder or a file under a subfolder. Check whether accessing the subfolder is allowed.
-        bool *found = uniquePath.getValue(pathToCheck.str());
-        if (found)
-        {
-            if (!*found) //found a path denied
-                errorMessage.append("; ").append(fileNameWithPath);
-            continue;
-        }
-
-        StringBuffer fullPath(dropZonePath);
-        addPathSepChar(fullPath).append(pathToCheck);
-        SecAccessFlags permission = getDropZoneScopePermissions(context, dropZoneName, fullPath, nullptr);
-        if (permission < accessReq)
-        {
-            uniquePath.setValue(pathToCheck.str(), false); //add a path denied
-            if (errorMessage.isEmpty())
-                errorMessage.setf("User %s (permission:%s): failed to access the DropZone Scopes for the following file(s). %s Permission Required. %s",
-                   context.queryUserId(), getSecAccessFlagName(permission), accessReqName, fileNameWithPath);
-            else
-                errorMessage.append("; ").append(fileNameWithPath);
-        }
-        else
-        {
-            uniquePath.setValue(pathToCheck.str(), true); //add a path allowed
-        }
-    }
-
-    if (!errorMessage.isEmpty())
-        throw makeStringException(ECLWATCH_INVALID_INPUT, errorMessage.str());
 }
 
 void CFileSprayEx::appendGroupNode(IArrayOf<IEspGroupNode>& groupNodes, const char* nodeName, const char* clusterType,

--- a/esp/services/ws_fs/ws_fsService.hpp
+++ b/esp/services/ws_fs/ws_fsService.hpp
@@ -143,20 +143,19 @@ protected:
     void getInfoFromSasha(IEspContext &context, const char *sashaServer, const char* wuid, IEspDFUWorkunit *info);
     bool getArchivedWUInfo(IEspContext &context, IEspGetDFUWorkunit &req, IEspGetDFUWorkunitResponse &resp);
     bool GetArchivedDFUWorkunits(IEspContext &context, IEspGetDFUWorkunits &req, IEspGetDFUWorkunitsResponse &resp);
-    void getDropZoneFiles(IEspContext &context, const char *dropZoneName, const char *host, const char *path, const char *fileNameMask, bool directoryOnly, IArrayOf<IConstPhysicalFileStruct> &files);
+    bool getDropZoneFiles(IEspContext &context, const char* dropZone, const char* netaddr, const char* path, IEspDropZoneFilesRequest &req, IEspDropZoneFilesResponse &resp);
     bool ParseLogicalPath(const char * pLogicalPath, StringBuffer &title);
     bool ParseLogicalPath(const char * pLogicalPath, const char *group, const char* cluster, StringBuffer &folder, StringBuffer &title, StringBuffer &defaultFolder, StringBuffer &defaultReplicateFolder);
     StringBuffer& getAcceptLanguage(IEspContext& context, StringBuffer& acceptLanguage);
     void appendGroupNode(IArrayOf<IEspGroupNode>& groupNodes, const char* nodeName, const char* clusterType, bool replicateOutputs);
     bool getOneDFUWorkunit(IEspContext& context, const char* wuid, IEspGetDFUWorkunitsResponse& resp);
+    void getDropZoneInfoByIP(double clientVersion, const char* destIP, const char* destFile, StringBuffer& path, StringBuffer& mask);
     void getDropZoneInfoByDestPlane(double clientVersion, const char* destGroup, const char* destFileIn, StringBuffer& destFileOut, StringBuffer& umask, StringBuffer & hostip);
     bool checkDropZoneIPAndPath(double clientVersion, const char* dropZone, const char* netAddr, const char* path);
-    void addDropZoneFile(IEspContext& context, IDirectoryIterator* di, const char* name, const char* path, const char* server, IArrayOf<IConstPhysicalFileStruct>&files);
-    bool searchDropZoneFiles(IEspContext& context, const char* dropZone, const char* server, const char* dir, const char* relDir, const char* nameFilter, IArrayOf<IConstPhysicalFileStruct>& files, unsigned& filesFound);
+    void addDropZoneFile(IEspContext& context, IDirectoryIterator* di, const char* name, const char pathSep, const char* server, IArrayOf<IEspPhysicalFileStruct>&files);
+    void searchDropZoneFiles(IEspContext& context, const char* server, const char* dir, const char* nameFilter, IArrayOf<IEspPhysicalFileStruct>& files, unsigned& filesFound);
     void setDFUServerQueueReq(const char* dfuServerQueue, IDFUWorkUnit* wu);
     void setUserAuth(IEspContext &context, IDFUWorkUnit* wu);
-    void checkDropZoneFileScopeAccess(IEspContext &context, const char *dropZoneName, const char *netAddress,
-        const char *dropZonePath, const StringArray &dropZoneFiles, SecAccessFlags accessReq);
 };
 
 #endif //_ESPWIZ_FileSpray_HPP__

--- a/esp/smc/SMCLib/TpCommon.cpp
+++ b/esp/smc/SMCLib/TpCommon.cpp
@@ -156,22 +156,3 @@ extern TPWRAPPER_API bool validateDropZonePath(const char* dropZoneName, const c
     return false;
 }
 
-extern TPWRAPPER_API const char* findDropZonePlaneName(const char* dropZonePath, const char* dropZoneHost)
-{
-    Owned<IPropertyTree> plane = findDropZonePlane(dropZonePath, dropZoneHost, true);
-    if (!plane)
-        throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "findDropZonePlaneName(): DropZone not found for Host %s and Path %s.", dropZoneHost, dropZonePath);
-    return plane->queryProp("@name");
-}
-
-extern TPWRAPPER_API SecAccessFlags getDropZoneScopePermissions(IEspContext& context, const char* dropZoneName, const char* dropZonePath, const char* dropZoneHost)
-{
-    if (isEmptyString(dropZonePath))
-        throw makeStringException(ECLWATCH_INVALID_CLUSTER_NAME, "getDropZoneScopePermissions(): DropZone path must be specified.");
-    if (isEmptyString(dropZoneName))
-        dropZoneName = findDropZonePlaneName(dropZonePath, dropZoneHost);
-
-    Owned<IUserDescriptor> userDesc = createUserDescriptor();
-    userDesc->set(context.queryUserId(), context.queryPassword(), context.querySignature());
-    return queryDistributedFileDirectory().getDropZoneScopePermissions(dropZoneName, dropZonePath, userDesc);
-}

--- a/esp/smc/SMCLib/TpWrapper.hpp
+++ b/esp/smc/SMCLib/TpWrapper.hpp
@@ -229,8 +229,6 @@ extern TPWRAPPER_API bool validateDataPlaneName(const char *remoteDali, const ch
 extern TPWRAPPER_API bool matchNetAddressRequest(const char* netAddressReg, bool ipReq, IConstTpMachine& tpMachine);
 
 extern TPWRAPPER_API bool validateDropZonePath(const char* dropZoneName, const char* netAddr, const char* pathToCheck);
-extern TPWRAPPER_API const char* findDropZonePlaneName(const char* dropZonePath, const char* dropZoneHost);
-extern TPWRAPPER_API SecAccessFlags getDropZoneScopePermissions(IEspContext& context, const char * dropZoneName, const char * dropZonePath, const char * dropZoneHost);
 
 #endif //_ESPWIZ_TpWrapper_HPP__
 


### PR DESCRIPTION
This reverts commit 4fc65dedfcacbde22ea192e614d78c4008b64e8b.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
