### PR TITLE
HPCC-28516 Report no Log Access Plug-in when accessing workunit log

### DIFF
--- a/esp/bindings/http/platform/httptransport.cpp
+++ b/esp/bindings/http/platform/httptransport.cpp
@@ -2942,3 +2942,33 @@ bool CHttpResponse::checkPersistentEligible()
 
     return CHttpMessage::checkPersistentEligible();
 }
+
+void CHttpResponse::setErrorMessageContent(const char* message, ESPSerializationFormat format)
+{
+    StringBuffer resp;
+    switch (format)
+    {
+    case ESPSerializationJSON:
+        appendJSONStringValue(resp.append("{"), "Error", message, true);
+        resp.append("}");
+        break;
+    case ESPSerializationXML:
+        encodeXML(message, resp.append("<Error>"));
+        resp.append("</Error>");
+        break;
+    default:
+        resp.append("Error: ").append(message);
+        break;
+    }
+    setContent(resp);
+}
+
+void CHttpResponse::setLogAccessErrorMessageContent(const char* message, LogAccessLogFormat format)
+{
+    if (format == LOGACCESS_LOGFORMAT_json)
+        setErrorMessageContent(message, ESPSerializationJSON);
+    else if (format == LOGACCESS_LOGFORMAT_xml)
+        setErrorMessageContent(message, ESPSerializationXML);
+    else
+        setErrorMessageContent(message, ESPSerializationANY);
+}

--- a/esp/bindings/http/platform/httptransport.ipp
+++ b/esp/bindings/http/platform/httptransport.ipp
@@ -410,6 +410,8 @@ public:
     virtual bool httpContentFromFile(const char *filepath);
     virtual bool handleExceptions(IXslProcessor *xslp, IMultiException *me, const char *serv, const char *meth, const char *errorXslt);
     virtual void handleExceptions(IXslProcessor *xslp, IMultiException *me, const char *serv, const char *meth, const char *errorXslt, bool logHandleExceptions);
+    virtual void setErrorMessageContent(const char* message, ESPSerializationFormat format);
+    virtual void setLogAccessErrorMessageContent(const char* message, LogAccessLogFormat format);
 
     virtual void redirect(CHttpRequest &req, const char *url)
     {

--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -25,7 +25,7 @@ EspInclude(ws_workunits_queryset_req_resp);
 
 ESPservice [
     auth_feature("DEFERRED"), //This declares that the method logic handles feature level authorization
-    version("1.95"), default_client_version("1.95"), cache_group("ESPWsWUs"),
+    version("1.96"), default_client_version("1.96"), cache_group("ESPWsWUs"),
     noforms,exceptions_inline("./smc_xslt/exceptions.xslt"),use_method_name] WsWorkunits
 {
     ESPmethod [cache_seconds(60), resp_xsl_default("/esp/xslt/workunits.xslt")]     WUQuery(WUQueryRequest, WUQueryResponse);

--- a/esp/scm/ws_workunits_req_resp.ecm
+++ b/esp/scm/ws_workunits_req_resp.ecm
@@ -904,6 +904,7 @@ ESPresponse [exceptions_inline] WUGetZAPInfoResponse
     string Archive;
     [min_ver("1.73")] string EmailTo;
     [min_ver("1.73")] string EmailFrom;
+    [min_ver("1.96")] string Message;
 };
 
 ESPrequest [nil_remove] WUCreateZAPInfoRequest

--- a/esp/services/ws_workunits/ws_workunitsHelpers.cpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.cpp
@@ -326,7 +326,14 @@ void WsWuInfo::sendImportedWorkunitComponentLog(const char* logFile, CHttpRespon
 void WsWuInfo::sendWorkunitComponentLogs(IEspContext* context, CHttpResponse* response, WUComponentLogOptions& options)
 {
     if (!queryRemoteLogAccessor())
-        throw makeStringException(ECLWATCH_LOGACCESS_UNAVAILABLE, "WsWuInfo: Remote Log Access plug-in not available!");
+    {
+        //Called from CWsWorkunitsSoapBindingEx::onGetInstantQuery() where an exception has to be added to
+        //the response directly ('throw makeStringException()' not work).
+        response->setLogAccessErrorMessageContent("WsWuInfo: Remote Log Access plug-in not available!", options.logFormat);
+        response->setStatus(HTTP_STATUS_OK);
+        response->send();
+        return;
+    }
 
     setLogTimeRange(options.logFetchOptions, options.wuLogSearchTimeBuffSecs);
     options.logFetchOptions.setFilter(getJobIDLogAccessFilter(wuid));

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -4970,6 +4970,8 @@ bool CWsWorkunitsEx::onWUGetZAPInfo(IEspContext &context, IEspWUGetZAPInfoReques
             ipaddr.getIpText(EspIP);
             resp.setESPIPAddress(EspIP.str());
         }
+        if ((version >= 1.96) && !queryRemoteLogAccessor())
+            resp.setMessage("Warning: may not be able to include log file because Remote Log Access plug-in is not available!");
 
         //Get Archive
         Owned<IConstWUQuery> query = cw->getQuery();


### PR DESCRIPTION
When Log Access plug-in not available, send a warning for: 1. ZAP Report dialog; 2. log display request.

Signed-off-by: wangkx <kevin.wang@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
