### PR TITLE
HPCC-28961 Members of Regression Suite spray class generate and use incorrect temporary logical and physical file paths.

### DIFF
--- a/testing/regress/ecl/filecompcopy.ecl
+++ b/testing/regress/ecl/filecompcopy.ecl
@@ -16,6 +16,8 @@
 ##############################################################################*/
 
 //class=spray
+//nothor
+//nohthor
 
 import $.setup;
 prefix := setup.Files(false, false).QueryFilePrefix;

--- a/testing/regress/ecl/httpcall_jsonpost.ecl
+++ b/testing/regress/ecl/httpcall_jsonpost.ecl
@@ -16,6 +16,9 @@
 ############################################################################## */
 
 //class=spray
+//nothor
+//nohthor
+
 //class=roxieserviceaccess
 //version targetIP='127.0.0.1',goodPort='9876',blacListedPort='9875'
 

--- a/testing/regress/ecl/httpcall_xmlpost.ecl
+++ b/testing/regress/ecl/httpcall_xmlpost.ecl
@@ -16,6 +16,9 @@
 ############################################################################## */
 
 //class=spray
+//nothor
+//nohthor
+
 //class=roxieserviceaccess
 //version targetIP='127.0.0.1',goodPort='9876',blacListedPort='9875'
 

--- a/testing/regress/ecl/key/despray.xml
+++ b/testing/regress/ecl/key/despray.xml
@@ -27,3 +27,6 @@
 <Dataset name='Result 10'>
  <Row><result>Fail</result></Row>
 </Dataset>
+<Dataset name='Result 11'>
+ <Row><result>Pass</result></Row>
+</Dataset>

--- a/testing/regress/ecl/persist_replicate.ecl
+++ b/testing/regress/ecl/persist_replicate.ecl
@@ -16,6 +16,8 @@
 ##############################################################################*/
 
 //class=spray
+//nothor
+//nohthor
 
 import Std.File;
 import $.setup;

--- a/testing/regress/ecl/spray_dir_test.ecl
+++ b/testing/regress/ecl/spray_dir_test.ecl
@@ -15,6 +15,8 @@
     limitations under the License.
 ############################################################################## */
 
+//class=spray
+
 // The aim of this code is to test the wildcard spray from an empty and a not empty directory
 // and test:
 // 1. No failure if empty directory sprayed with wildcard
@@ -28,10 +30,7 @@
 // operation causes a failure.
 // So, to avoid to abort this code is excluded from Thor target
 //nothor
-
 //nohthor
-//class=spray
-
 
 import std.system.thorlib;
 import Std.File AS FileServices;
@@ -40,7 +39,8 @@ import ^ as root;
 engine := thorlib.platform();
 prefix := '~regress::' + engine + '::' + WORKUNIT + '::';
 
-dropzonePath := '/var/lib/HPCCSystems/mydropzone/' : STORED('dropzonePath');
+dropzonePathTemp := '/var/lib/HPCCSystems/mydropzone/' : STORED('dropzonePath');
+dropzonePath := dropzonePathTemp + IF(dropzonePathTemp[LENGTH(dropzonePathTemp)]='/', '', '/');
 
 unsigned VERBOSE := 0;
 

--- a/testing/regress/ecl/spray_expire_test.ecl
+++ b/testing/regress/ecl/spray_expire_test.ecl
@@ -15,9 +15,10 @@
     limitations under the License.
 ############################################################################## */
 
-//nohthor
-
 //class=spray
+//nohthor
+//nothor
+
 //class=copy
 //class=dfuplus
 
@@ -25,7 +26,8 @@ import Std.File AS FileServices;
 import $.setup;
 prefix := setup.Files(false, false).QueryFilePrefix;
 
-dropzonePath := FileServices.GetDefaultDropZone() : STORED('dropzonePath');
+dropzonePathTemp := '/var/lib/HPCCSystems/mydropzone/' : STORED('dropzonePath');
+dropzonePath := dropzonePathTemp + IF(dropzonePathTemp[LENGTH(dropzonePathTemp)]='/', '', '/');
 
 unsigned VERBOSE := 0;
 

--- a/testing/regress/ecl/spray_header_test.ecl
+++ b/testing/regress/ecl/spray_header_test.ecl
@@ -15,9 +15,9 @@
     limitations under the License.
 ############################################################################## */
 
-//nohthor
-
 //class=spray
+//nohthor
+//nothor
 
 //version isTerminated=false
 //version isTerminated=true
@@ -28,7 +28,8 @@ import ^ as root;
 
 
 isTerminated := #IFDEFINED(root.isTerminated, false);
-dropzonePath := '/var/lib/HPCCSystems/mydropzone/' : STORED('dropzonePath');
+dropzonePathTemp := '/var/lib/HPCCSystems/mydropzone/' : STORED('dropzonePath');
+dropzonePath := dropzonePathTemp + IF(dropzonePathTemp[LENGTH(dropzonePathTemp)]='/', '', '/');
 prefix := setup.Files(false, false).QueryFilePrefix;
 
 unsigned VERBOSE := 0;
@@ -48,14 +49,14 @@ header := DATASET([{'Id', 'Field1', 'Field2', 'Field3', 'Field4'}], Layout);
     // Create a one record CSV logical file with terminator a the end
     setupFile := output(header, , sprayPrepFileName, CSV, OVERWRITE);
 
-    desprayOutFileName := dropzonePath + prefix + 'spray_input_terminated';
+    desprayOutFileName := dropzonePath + WORKUNIT + '-spray_input_terminated';
     sprayOutFileName := prefix + 'spray_test_terminated';
 #else
     sprayPrepFileName := prefix + 'spray_prep_not_terminated';
     // Create a one record CSV logical file without terminator a the end
     setupFile := output(header, , sprayPrepFileName, CSV(TERMINATOR('')), OVERWRITE);
 
-    desprayOutFileName := dropzonePath + prefix + 'spray_input_not_terminated';
+    desprayOutFileName := dropzonePath + WORKUNIT + '-spray_input_not_terminated';
     sprayOutFileName := prefix + 'spray_test_not_terminated';
 #end
 

--- a/testing/regress/ecl/spray_queue_test.ecl
+++ b/testing/regress/ecl/spray_queue_test.ecl
@@ -15,8 +15,9 @@
     limitations under the License.
 ############################################################################## */
 
-//nothor
 //class=spray
+//nothor
+//nohthor
 
 import std.system.thorlib;
 import Std.File AS FileServices;

--- a/testing/regress/ecl/spray_replicate_test.ecl
+++ b/testing/regress/ecl/spray_replicate_test.ecl
@@ -15,14 +15,15 @@
     limitations under the License.
 ############################################################################## */
 
-//noHThor
-
 //class=spray
+//noHThor
+//noThor
 
 import std.system.thorlib;
 import Std.File AS FileServices;
 
-dropzonePath := '/var/lib/HPCCSystems/mydropzone/' : STORED('dropzonePath');
+dropzonePathTemp := '/var/lib/HPCCSystems/mydropzone/' : STORED('dropzonePath');
+dropzonePath := dropzonePathTemp + IF(dropzonePathTemp[LENGTH(dropzonePathTemp)]='/', '', '/');
 espIpPort := 'http://127.0.0.1:8010/FileSpray' : STORED('espIpPort');
 engine := thorlib.platform();
 prefix := '~regress::' + engine + '::' + WORKUNIT + '::';

--- a/testing/regress/ecl/spray_test.ecl
+++ b/testing/regress/ecl/spray_test.ecl
@@ -15,9 +15,9 @@
     limitations under the License.
 ############################################################################## */
 
-//nohthor
-
 //class=spray
+//nohthor
+//nothor
 
 //version sprayFixed=true
 //version sprayFixed=false,sprayEmpty=false
@@ -34,7 +34,8 @@ prefix := setup.Files(false, false).QueryFilePrefix;
 boolean sprayFixed := #IFDEFINED(root.sprayFixed, true);
 boolean sprayEmpty := #IFDEFINED(root.sprayEmpty, false);
 
-dropzonePath := FileServices.GetDefaultDropZone() +'/' : STORED('dropzonePath');
+dropzonePathTemp := '/var/lib/HPCCSystems/mydropzone/' : STORED('dropzonePath');
+dropzonePath := dropzonePathTemp + IF(dropzonePathTemp[LENGTH(dropzonePathTemp)]='/', '', '/');
 
 unsigned VERBOSE := 0;
 

--- a/testing/regress/ecl/spray_test_json.ecl
+++ b/testing/regress/ecl/spray_test_json.ecl
@@ -15,9 +15,9 @@
     limitations under the License.
 ############################################################################## */
 
-
-//nohthor
 //class=spray
+//nohthor
+//nothor
 
 #onwarning(10138, ignore);
 
@@ -35,7 +35,8 @@ isSmallFile := #IFDEFINED(root.isSmallFile, true);
 
 isUnBallanced := #IFDEFINED(root.isUnBallanced, false);
 
-dropzonePath := FileServices.GetDefaultDropZone() +'/' : STORED('dropzonePath');
+dropzonePathTemp := '/var/lib/HPCCSystems/mydropzone/' : STORED('dropzonePath');
+dropzonePath := dropzonePathTemp + IF(dropzonePathTemp[LENGTH(dropzonePathTemp)]='/', '', '/');
 engine := thorlib.platform() : stored('thor');
 prefix := setup.Files(false, false).FilePrefix + '-' + WORKUNIT;
 nodes := thorlib.nodes();

--- a/testing/regress/ecl/spray_test_xml.ecl
+++ b/testing/regress/ecl/spray_test_xml.ecl
@@ -15,10 +15,10 @@
     limitations under the License.
 ############################################################################## */
 
-//nohthor
-//noroxie
-
 //class=spray
+//nohthor
+//nothor
+
 
 //version xml_header='none',xml_footer='none'
 //version xml_header='none',xml_footer='short'
@@ -36,7 +36,8 @@ import ^ as root;
 
 prefix := setup.Files(false, false).QueryFilePrefix;
 
-dropzonePath := '/var/lib/HPCCSystems/mydropzone/' : STORED('dropzonePath');
+dropzonePathTemp := '/var/lib/HPCCSystems/mydropzone/' : STORED('dropzonePath');
+dropzonePath := dropzonePathTemp + IF(dropzonePathTemp[LENGTH(dropzonePathTemp)]='/', '', '/');
 
 espUrl := FileServices.GetEspURL() + '/FileSpray';
 
@@ -77,7 +78,7 @@ allPeople := DATASET([ {'foo', 10, 1},
             ,Layout_Person);
 
 setupXmlPrepFileName := prefix + 'original_xml';
-desprayXmlOutFileName := dropzonePath + prefix + '-desprayed_xml';
+desprayXmlOutFileName := dropzonePath + WORKUNIT + '-desprayed_xml';
 sprayXmlTargetFileName := prefix + 'sprayed_xml';
 dsSetup := DISTRIBUTE(allPeople);
 

--- a/testing/regress/ecl/supercopy.ecl
+++ b/testing/regress/ecl/supercopy.ecl
@@ -16,10 +16,11 @@
 ############################################################################## */
 
 #onwarning(4523, ignore);
-
-//nothor
-//class=superfile
 //class=spray
+//nothor
+//nohthor
+
+//class=superfile
 //class=copy
 
 import std.system.thorlib;


### PR DESCRIPTION
Fix despray path generation for:
- despray.ecl
- spray_header_test.ecl
- spray_test_json.ecl
- spray_test_xml.ecl

The despray.ecl extended with test to despray into a (Drop Zone) relative path.

Except the split_test.ecl all Spray class member exclude from Hthor and Thor engines.

The split_test.ecl run only on Thor.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [ ] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [x] This change fixes the problem, not just the symptom
  - [x] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [x] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->
Tested manually on local VM.
<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
