### PR TITLE
HPCC-28912 Enable required values in ESDL script param operation

### DIFF
--- a/esp/esdllib/esdl_script.cpp
+++ b/esp/esdllib/esdl_script.cpp
@@ -1206,10 +1206,20 @@ public:
 
 class CEsdlTransformOperationParameter : public CEsdlTransformOperationVariable
 {
+private:
+    Owned<ICompiledXpath> m_failureCode;
+    Owned<ICompiledXpath> m_failureMsg;
 public:
     CEsdlTransformOperationParameter(IXmlPullParser &xpp, StartTag &stag, const StringBuffer &prefix, IEsdlFunctionRegister *functionRegister)
         : CEsdlTransformOperationVariable(xpp, stag, prefix, functionRegister)
     {
+        if (!m_select)
+        {
+            m_failureCode.setown(compileOptionalXpath(stag.getValue("failure_code")));
+            m_failureMsg.setown(compileOptionalXpath(stag.getValue("failure_message")));
+            if (m_failureCode && !m_failureMsg)
+                recordError(ESDL_SCRIPT_MissingOperationAttr, "failure_code without failure_message");
+        }
     }
 
     virtual ~CEsdlTransformOperationParameter()
@@ -1222,6 +1232,13 @@ public:
 
         if (m_select)
             return sourceContext->declareCompiledParameter(m_name, m_select);
+        if (m_failureMsg && !sourceContext->checkParameterName(m_name))
+        {
+            StringBuffer msg;
+            int code = (m_failureCode ? (int)sourceContext->evaluateAsNumber(m_failureCode) : ESDL_SCRIPT_Error);
+            sourceContext->evaluateAsString(m_failureMsg, msg);
+            throw makeStringExceptionV(code, "%s", msg.str());
+        }
         return sourceContext->declareParameter(m_name, "");
     }
 };
@@ -3150,13 +3167,8 @@ void processServiceAndMethodTransforms(IEsdlScriptContext * scriptCtx, std::init
     }
     else
     {
-        // enable transforms to distinguish secure versus insecure requests
-        sourceContext->addInputValue("espTransactionID", "");
-        sourceContext->addInputValue("espUserName", "");
-        sourceContext->addInputValue("espUserRealm", "");
-        sourceContext->addInputValue("espUserPeer", "");
-        sourceContext->addInputValue("espUserStatus", "");
-        sourceContext->addInputValue("espUserStatusString", "");
+        // Input values do not default to empty when added. They default to empty when
+        // imported as parameters. Setting empty here serves no purpose.
     }
 
     StringBuffer defaultTarget; //This default gives us backward compatibility with only being able to write to the actual request

--- a/system/xmllib/libxml_xpathprocessor.cpp
+++ b/system/xmllib/libxml_xpathprocessor.cpp
@@ -1134,6 +1134,15 @@ public:
         return addStringVariable(name, value, getCurrentScope());
     }
 
+    virtual bool checkParameterName(const char * name) override
+    {
+        if (hasVariable(name, nullptr, getCurrentScope()))
+            return true;
+        if (findInput(name))
+            return true;
+        return false;
+    }
+
     virtual bool addXpathVariable(const char * name, const char * xpath) override
     {
         return addXpathVariable(name, xpath, nullptr);

--- a/system/xmllib/xpathprocessor.hpp
+++ b/system/xmllib/xpathprocessor.hpp
@@ -55,6 +55,7 @@ interface XMLLIB_API IXpathContext : public IInterface
     virtual const char * getVariable(const char * name, StringBuffer & variable) = 0;
     virtual bool addInputXpath(const char * name, const char * xpath) = 0; //values should be declared as parameters before use, "strict parameter mode" requires it
     virtual bool addInputValue(const char * name, const char * value) = 0; //values should be declared as parameters before use, "strict parameter mode" requires it
+    virtual bool checkParameterName(const char * name) = 0;
     virtual bool declareParameter(const char * name, const char *value) = 0;
     virtual bool declareCompiledParameter(const char * name, ICompiledXpath * compiled) = 0;
     virtual void declareRemainingInputs() = 0;


### PR DESCRIPTION
Throw exception from the param operation when the named input is not defined, the operation's select property is omitted, and the failure_message is present. Backward compatibility is maintained.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
