### PR TITLE
HPCC-28968 Expose internal HPCC settings as environment variables

### DIFF
--- a/.github/workflows/build-vcpkg.yml
+++ b/.github/workflows/build-vcpkg.yml
@@ -336,6 +336,16 @@ jobs:
           cmake -S ./HPCC-Platform -B ./build ${{ matrix.cmake_config_options }}
           cmake --build ./build ${{ matrix.cmake_build_options }}
 
+      - name: WinTest
+        if: ${{ matrix.os == "windows-2022" && contains(matrix.event_name, github.event_name) && needs.preamble.outputs.platform }}
+        shell: bash
+        run: |
+          find ./build -name 'eclcc'
+          echo "OUTPUT(1);" > test.ecl
+          cat ./test.ecl
+          ./build/Release/bin/eclcc -g ./test.ecl
+          ./a.out
+
       - name: Upload error logs
         if: ${{ failure() || cancelled() }}
         uses: actions/upload-artifact@v3

--- a/helm/hpcc/templates/_helpers.tpl
+++ b/helm/hpcc/templates/_helpers.tpl
@@ -190,6 +190,7 @@ Pass in root as .
 {{- $certificates := (.Values.certificates | default dict) -}}
 {{- $issuers := ($certificates.issuers | default dict) -}}
 {{- $security := .Values.security | default dict -}}
+deploymentName: {{ (include "hpcc.fullname" (dict "root" $)) }}
 mtls: {{ (include "hpcc.isMtlsEnabled" (dict "root" $)) }}
 imageVersion: {{ .Values.global.image.version | default .Chart.Version }}
 singleNode: {{ .Values.global.singleNode | default false }}

--- a/system/jlib/jptree.cpp
+++ b/system/jlib/jptree.cpp
@@ -19,6 +19,7 @@
 #include <unordered_set>
 #include <string>
 #include <tuple>
+#include <algorithm>
 
 #include "platform.h"
 #include "jarray.hpp"
@@ -8711,15 +8712,45 @@ class CConfigUpdater : public CInterface
     CriticalSection notifyFuncCS;
     unsigned notifyFuncId = 0;
     std::unordered_map<unsigned, ConfigUpdateFunc> notifyConfigUpdates;
+    std::vector<unsigned> pendingInitializeFuncIds;
 
 public:
-    CConfigUpdater(const char *_absoluteConfigFilename, IPropertyTree *_componentDefault, const char * * argv, const char * _componentTag, const char * _envPrefix, const char *_legacyFilename, IPropertyTree * (_mapper)(IPropertyTree *), const char *_altNameAttribute)
-        : absoluteConfigFilename(_absoluteConfigFilename), componentDefault(_componentDefault), componentTag(_componentTag), envPrefix(_envPrefix), legacyFilename(_legacyFilename), mapper(_mapper), altNameAttribute(_altNameAttribute)
+    CConfigUpdater()
     {
+    }
+    bool isInitialized() const
+    {
+        return args.ordinality(); // NB: null terminated, so always >=1 if initialized
+    }
+    void init(const char *_absoluteConfigFilename, IPropertyTree *_componentDefault, const char * * argv, const char * _componentTag, const char * _envPrefix, const char *_legacyFilename, IPropertyTree * (_mapper)(IPropertyTree *), const char *_altNameAttribute)
+    {
+        dbgassertex(!isInitialized());
+        absoluteConfigFilename.set(_absoluteConfigFilename);
+        componentDefault.set(_componentDefault);
+        componentTag.set(_componentTag);
+        envPrefix.set(_envPrefix);
+        legacyFilename.set(_legacyFilename);
+        mapper = _mapper;
+        altNameAttribute.set(_altNameAttribute);
         while (const char *arg = *argv++)
             args.append(arg);
         args.append(nullptr);
 
+        while (pendingInitializeFuncIds.size())
+        {
+            unsigned notifyFuncId = pendingInitializeFuncIds.back();
+            pendingInitializeFuncIds.pop_back();
+            ConfigUpdateFunc notifyFunc = notifyConfigUpdates[notifyFuncId];
+            notifyFunc(getComponentConfigSP(), getGlobalConfigSP());
+        }
+    }
+    bool startMonitoring()
+    {
+#if !defined(__linux__) // file moinitoring only supported in Linux (because createFileEventWatcher only implemented in Linux at the moment)
+        return false;
+#endif
+        if (0 == absoluteConfigFilename.length() || (nullptr != fileWatcher.get()))
+            return false;
         auto updateFunc = [&](const char *filename, FileWatchEvents events)
         {
             bool changed = containsFileWatchEvents(events, FileWatchEvents::closedWrite) && streq(filename, configFilename);
@@ -8751,18 +8782,15 @@ public:
                 absoluteConfigFilename.set(std::get<0>(result).c_str());
             }
         };
+        fileWatcher.setown(createFileEventWatcher(updateFunc));
 
-        if (absoluteConfigFilename.length())
-        {
-            fileWatcher.setown(createFileEventWatcher(updateFunc));
-
-            // watch the path, not the filename, because the filename might not be seen if directories are moved, softlinks are changed..
-            StringBuffer path, filename;
-            splitFilename(absoluteConfigFilename, nullptr, &path, &filename, &filename);
-            configFilename.set(filename);
-            fileWatcher->add(path, FileWatchEvents::anyChange);
-            fileWatcher->start();
-        }
+        // watch the path, not the filename, because the filename might not be seen if directories are moved, softlinks are changed..
+        StringBuffer path, filename;
+        splitFilename(absoluteConfigFilename, nullptr, &path, &filename, &filename);
+        configFilename.set(filename);
+        fileWatcher->add(path, FileWatchEvents::anyChange);
+        fileWatcher->start();
+        return true;
     }
     void executeCallbacks(IPropertyTree *oldComponentConfiguration, IPropertyTree *oldGlobalConfiguration)
     {
@@ -8779,23 +8807,46 @@ public:
             }
         }
     }
-    unsigned addNotifyFunc(ConfigUpdateFunc notifyFunc)
+    unsigned addNotifyFunc(ConfigUpdateFunc notifyFunc, bool callWhenInstalled)
     {
         CriticalBlock b(notifyFuncCS);
         notifyFuncId++;
         notifyConfigUpdates[notifyFuncId] = notifyFunc;
+        if (callWhenInstalled)
+        {
+            if (isInitialized())
+                notifyFunc(getComponentConfigSP(), getGlobalConfigSP());
+            else
+            {
+                // If the configuration is not yet be loaded, track notify callbacks that
+                // want to be initialized on install, and call during CConfigUpdater::init.
+                pendingInitializeFuncIds.push_back(notifyFuncId);
+            }
+        }
         return notifyFuncId;
     }
     bool removeNotifyFunc(unsigned funcId)
     {
         CriticalBlock b(notifyFuncCS);
-        return notifyConfigUpdates.erase(funcId) > 0;
+        auto it = notifyConfigUpdates.find(funcId);
+        if (it == notifyConfigUpdates.end())
+            return false;
+
+        ConfigUpdateFunc notifyFunc = it->second;
+        notifyConfigUpdates.erase(it);
+        if (!isInitialized())
+        {
+           auto it = std::remove(pendingInitializeFuncIds.begin(), pendingInitializeFuncIds.end(), funcId);
+           pendingInitializeFuncIds.erase(it, pendingInitializeFuncIds.end());
+        }
+        return true;
     }
 };
 
 static CConfigUpdater *configFileUpdater = nullptr;
-MODULE_INIT(INIT_PRIORITY_STANDARD)
+MODULE_INIT(INIT_PRIORITY_JPTREE)
 {
+    configFileUpdater = new CConfigUpdater();
     return true;
 }
 
@@ -8804,37 +8855,31 @@ MODULE_EXIT()
     ::Release(configFileUpdater);
 }
 
-unsigned installConfigUpdateHook(ConfigUpdateFunc notifyFunc)
+unsigned installConfigUpdateHook(ConfigUpdateFunc notifyFunc, bool callWhenInstalled)
 {
-    if (!configFileUpdater)
-        WARNLOG("installConfigUpdateHook(): configuration updater not installed");
-    else
-        return configFileUpdater->addNotifyFunc(notifyFunc);
-    return 0;
+    if (!configFileUpdater) // NB: installConfigUpdateHook should always be called after configFlieUpdater is initialized
+        return 0;
+    return configFileUpdater->addNotifyFunc(notifyFunc, callWhenInstalled);
 }
 
 void removeConfigUpdateHook(unsigned notifyFuncId)
 {
     if (0 == notifyFuncId)
         return;
-    if (!configFileUpdater)
-    {
-        WARNLOG("removeConfigUpdateHook(): configuration updater not installed");
+    if (!configFileUpdater) // NB: removeConfigUpdateHook should always be called after configFlieUpdater is initialized
         return;
-    }
     if (!configFileUpdater->removeNotifyFunc(notifyFuncId))
         WARNLOG("removeConfigUpdateHook(): notifyFuncId %u not installed", notifyFuncId);
 }
 
 void executeConfigUpdaterCallbacks()
 {
-    if (!configFileUpdater)
-        WARNLOG("executeConfigUpdaterCallbacks(): configuration updater not installed");
-    else
-        configFileUpdater->executeCallbacks(componentConfiguration.getLink(), globalConfiguration.getLink());
+    if (!configFileUpdater) // NB: executeConfigUpdaterCallbacks should always be called after configFlieUpdater is initialized
+        return;
+    configFileUpdater->executeCallbacks(componentConfiguration.getLink(), globalConfiguration.getLink());
 }
 #else
-unsigned installConfigUpdateHook(ConfigUpdateFunc notifyFunc)
+unsigned installConfigUpdateHook(ConfigUpdateFunc notifyFunc, bool callWhenInstalled)
 {
     return 0;
 }
@@ -8865,9 +8910,7 @@ void CConfigUpdateHook::installOnce(ConfigUpdateFunc callbackFunc, bool callWhen
         id = configCBId.load(std::memory_order_acquire);
         if ((unsigned)-1 == id)
         {
-            if (callWhenInstalled)
-                callbackFunc(getComponentConfigSP(), getGlobalConfigSP());
-            id = installConfigUpdateHook(callbackFunc);
+            id = installConfigUpdateHook(callbackFunc, callWhenInstalled);
             configCBId.store(id, std::memory_order_release);
         }
     }
@@ -9021,8 +9064,10 @@ static std::tuple<std::string, IPropertyTree *, IPropertyTree *> doLoadConfigura
 
 jlib_decl IPropertyTree * loadConfiguration(IPropertyTree *componentDefault, const char * * argv, const char * componentTag, const char * envPrefix, const char * legacyFilename, IPropertyTree * (mapper)(IPropertyTree *), const char *altNameAttribute, bool monitor)
 {
-    if (componentConfiguration)
+    assertex(configFileUpdater); // NB: loadConfiguration should always be called after configFlieUpdater is initialized
+    if (configFileUpdater->isInitialized())
         throw makeStringExceptionV(99, "Configuration for component %s has already been initialised", componentTag);
+
     auto result = doLoadConfiguration(componentDefault, argv, componentTag, envPrefix, legacyFilename, mapper, altNameAttribute);
 
     componentConfiguration.setown(std::get<1>(result));
@@ -9037,16 +9082,15 @@ jlib_decl IPropertyTree * loadConfiguration(IPropertyTree *componentDefault, con
      * on-demand, which means this mechanism is sufficient to cover most cases.
      * 
      * In bare-metal the monitoring mechanism will similarly spot any legacy config file changes, e.g.
-     * that would be refreshed by during a 'service hpcc-init setup'.
+     * that would be refreshed during a 'service hpcc-init setup'.
      * Some bare-metal code relies on directly interrogating the environment, for those situations, there is
      * also a default triggering mechanism (see executeConfigUpdaterCallbacks in daclient.cpp) that will cause any
      * installed config hooks to be called when an environment change is detected e.g when pushed to Dali)
      */
 
-#if defined(__linux__)
+    configFileUpdater->init(std::get<0>(result).c_str(), componentDefault, argv, componentTag, envPrefix, legacyFilename, mapper, altNameAttribute);
     if (monitor)
-        configFileUpdater = new CConfigUpdater(std::get<0>(result).c_str(), componentDefault, argv, componentTag, envPrefix, legacyFilename, mapper, altNameAttribute);
-#endif
+        configFileUpdater->startMonitoring();
     return componentConfiguration.getLink();
 }
 

--- a/system/jlib/jptree.hpp
+++ b/system/jlib/jptree.hpp
@@ -331,7 +331,7 @@ jlib_decl const char * queryComponentName();
 
 // ConfigUpdateFunc calls are made in a mutex, but after new confis are swapped in
 typedef std::function<void (const IPropertyTree *oldComponentConfiguration, const IPropertyTree *oldGlobalConfiguration)> ConfigUpdateFunc;
-jlib_decl unsigned installConfigUpdateHook(ConfigUpdateFunc notifyFunc);
+jlib_decl unsigned installConfigUpdateHook(ConfigUpdateFunc notifyFunc, bool callWhenInstalled);
 jlib_decl void removeConfigUpdateHook(unsigned notifyFuncId);
 jlib_decl void executeConfigUpdaterCallbacks();
 


### PR DESCRIPTION
In particular the deployment name, such that ECL can use it with getEnv("HPCC_DEPLOYMENT")

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
