### PR TITLE
HPCC-28887 Add limit option to dfuplus status for publisher workunits

### DIFF
--- a/dali/dfuplus/dfuplus.cpp
+++ b/dali/dfuplus/dfuplus.cpp
@@ -1523,8 +1523,9 @@ int CDfuPlusHelper::status()
     const char* wuid = globals->queryProp("wuid");
     if(!wuid || !*wuid)
         throw MakeStringException(-1, "wuid not specified");
+    int limit = globals->getPropInt("limit");
     if (isDfuPublisherWuid(wuid))
-        return reportDfuPublisherStatus(wuid);
+        return reportDfuPublisherStatus(wuid, limit);
     return reportDfuWorkunitStatus(wuid);
 }
 
@@ -1587,11 +1588,12 @@ int CDfuPlusHelper::reportDfuWorkunitStatus(const char *wuid)
     return reportDfuWorkunitStatus(resp->getResult(), false);
 }
 
-int CDfuPlusHelper::reportDfuPublisherStatus(const char *wuid)
+int CDfuPlusHelper::reportDfuPublisherStatus(const char *wuid, int limit)
 {
     Owned<IClientGetDFUWorkunits> req = sprayclient->createGetDFUWorkunitsRequest();
     setMtlsSecret(req->rpc());
     req->setPublisherWuid(wuid);
+    req->setPageSize((limit > 0) ? limit : 1000);
 
     Owned<IClientGetDFUWorkunitsResponse> resp = sprayclient->GetDFUWorkunits(req);
     if (outputServiceCallExceptions(resp.get()))

--- a/dali/dfuplus/dfuplus.hpp
+++ b/dali/dfuplus/dfuplus.hpp
@@ -92,8 +92,7 @@ private:
 
     int reportDfuWorkunitStatus(IConstDFUWorkunit & dfuwu, bool jobinfo);
     int reportDfuWorkunitStatus(const char *wuid);
-    int reportDfuPublisherStatus(IConstDFUWorkunit & dfuwu);
-    int reportDfuPublisherStatus(const char *wuid);
+    int reportDfuPublisherStatus(const char *wuid, int limit);
 
     Owned<IProperties> globals;
     Owned<IClientFileSpray> sprayclient;

--- a/dali/dfuplus/main.cpp
+++ b/dali/dfuplus/main.cpp
@@ -168,6 +168,8 @@ void handleSyntax()
     out.append("        srcpassword=<password-for-source-dali>\n");
     out.append("    status options:\n");
     out.append("        wuid=<dfu-workunit-id>\n");
+    out.append("        limit=<limit> -- For publisher wuids, maximum number of child workunits\n");
+    out.append("                         to list, default is 1000.\n");
     out.append("    abort options:\n");
     out.append("        wuid=<dfu-workunit-id>\n");
     out.append("    resubmit options:\n");


### PR DESCRIPTION
Add a limit=<limit> option to the cli dfuplus status command. When checking the status of DFU publisher workunits, limit controls the max number of child workunits to list the status for.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [x] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [x] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [ ] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
