### PR TITLE
HPCC-29093 Stop Thor killing slaves of other Thors

### DIFF
--- a/initfiles/bin/init_thorslave.in
+++ b/initfiles/bin/init_thorslave.in
@@ -47,7 +47,9 @@ stop_slaves()
     local isAlive=0
 
     log "Attempting to kill $slavename with SIGTERM"
+    echo $(which pidof)
     slavepids=$(pidof ${slavename})
+    echo "slave pids are: ${slavepids}"
     kill -SIGTERM ${slavepids} > /dev/null 2>&1
     while [[ $isAlive -eq 0 && $timer -gt 0 ]];do
         kill -0 ${slavepids} > /dev/null 2>&1

--- a/initfiles/bin/init_thorslave.in
+++ b/initfiles/bin/init_thorslave.in
@@ -47,9 +47,10 @@ stop_slaves()
     local isAlive=0
 
     log "Attempting to kill $slavename with SIGTERM"
-    killall -SIGTERM $slavename > /dev/null 2>&1
+    slavepids=$(pidof ${slavename})
+    kill -SIGTERM ${slavepids} > /dev/null 2>&1
     while [[ $isAlive -eq 0 && $timer -gt 0 ]];do
-        killall -0 $slavename > /dev/null 2>&1
+        kill -0 ${slavepids} > /dev/null 2>&1
         isAlive=$?
         [[ $isAlive -eq 0 ]] && sleep 0.5
         ((timer--))
@@ -57,7 +58,7 @@ stop_slaves()
 
     if [[ $isAlive -eq 0 ]]; then
         log "Failed to kill slaves with SIGTERM. Sending SIGKILL"
-        killall -SIGKILL $slavename > /dev/null
+        kill -SIGKILL ${slavepids} > /dev/null
     fi
 
     # need regex here to prevent removing other Thor instance pid files

--- a/initfiles/bin/init_thorslave.in
+++ b/initfiles/bin/init_thorslave.in
@@ -47,9 +47,9 @@ stop_slaves()
     local isAlive=0
 
     log "Attempting to kill $slavename with SIGTERM"
-    echo $(which pidof)
+    log $(which pidof)
     slavepids=$(pidof ${slavename})
-    echo "slave pids are: ${slavepids}"
+    log "slave pids are: ${slavepids}"
     kill -SIGTERM ${slavepids} > /dev/null 2>&1
     while [[ $isAlive -eq 0 && $timer -gt 0 ]];do
         kill -0 ${slavepids} > /dev/null 2>&1


### PR DESCRIPTION
Use of killall in init script at start/stop, could match slaves from other slaves on same box, causing other Thor's to die.

killall --exact does not prevent this matching with a long enough common process name (e.g. thorslave_mythor and thorslave_mythor2) Switch to using pidof and kill.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
