### PR TITLE
HPCC-29186 Avoid local ftslave zombies

### DIFF
--- a/common/remote/rmtspawn.cpp
+++ b/common/remote/rmtspawn.cpp
@@ -103,7 +103,7 @@ void getRemoteSpawnSSH(
 }
 
 
-ISocket * spawnRemoteChild(SpawnKind kind, const char * exe, const SocketEndpoint & childEP, unsigned version, const char *logdir, IAbortRequestCallback * abort, const char *extra)
+ISocket *spawnRemoteChild(SpawnKind kind, const char * exe, const SocketEndpoint & childEP, unsigned version, const char *logdir, IAbortRequestCallback * abort, const char *extra, HANDLE *localProcessHandle)
 {
     SocketEndpoint myEP;
     myEP.setLocalHost(0);
@@ -143,7 +143,7 @@ ISocket * spawnRemoteChild(SpawnKind kind, const char * exe, const SocketEndpoin
 
 #ifdef _CONTAINERIZED
     DWORD runcode;
-    if (!invoke_program(cmd.str(), runcode, false))
+    if (!invoke_program(cmd.str(), runcode, false, nullptr, localProcessHandle))
         throw makeStringExceptionV(-1,"Error spawning %s", exe);
 #else
     //Run the program directly if it is being run on the local machine - so ssh doesn't need to be running...
@@ -151,7 +151,7 @@ ISocket * spawnRemoteChild(SpawnKind kind, const char * exe, const SocketEndpoin
     if (childEP.isLocal())
     {
         DWORD runcode;
-        if (!invoke_program(cmd.str(), runcode, false))
+        if (!invoke_program(cmd.str(), runcode, false, nullptr, localProcessHandle))
             throw makeStringExceptionV(-1,"Error spawning %s", exe);
     }
     else

--- a/common/remote/rmtspawn.hpp
+++ b/common/remote/rmtspawn.hpp
@@ -38,7 +38,7 @@ enum SpawnKind
 
 interface IAbortRequestCallback;
 
-extern REMOTE_API ISocket * spawnRemoteChild(SpawnKind kind, const char * exe, const SocketEndpoint & remoteEP, unsigned version, const char *logdir, IAbortRequestCallback * abort = NULL, const char *extra=NULL);
+extern REMOTE_API ISocket *spawnRemoteChild(SpawnKind kind, const char * exe, const SocketEndpoint & remoteEP, unsigned version, const char *logdir, IAbortRequestCallback * abort = nullptr, const char *extra=nullptr, HANDLE *localProcessHandle=nullptr);
 extern REMOTE_API void setRemoteSpawnSSH(
                 const char *identfilename,
                 const char *username, // if NULL then disable SSH

--- a/system/jlib/jmisc.cpp
+++ b/system/jlib/jmisc.cpp
@@ -646,6 +646,21 @@ void close_program(HANDLE handle)
 
 #endif
 
+bool wait_program_timeout(HANDLE handle,DWORD &runcode,unsigned timeoutMs)
+{
+    CTimeMon timer(timeoutMs);
+    while (true)
+    {
+        if (wait_program(handle,runcode,false))
+            break;
+        unsigned remaining;
+        if (timer.timedout(&remaining))
+            return false;
+        MilliSleep(remaining > 1000 ? 1000 : remaining);
+    }
+    return true;
+}
+
 //========================================================================================================================
 
 static bool hadAbortSignal = false;

--- a/system/jlib/jmisc.hpp
+++ b/system/jlib/jmisc.hpp
@@ -78,6 +78,7 @@ jlib_decl StringBuffer& queryCcLogName(const char* wuid, StringBuffer& logname);
 jlib_decl char* readarg(char*& curptr);
 jlib_decl bool invoke_program(const char *command_line, DWORD &runcode, bool wait=true, const char *outfile=NULL, HANDLE *rethandle=NULL, bool throwException = false, bool newProcessGroup = false);
 jlib_decl bool wait_program(HANDLE handle,DWORD &runcode,bool block=true);
+jlib_decl bool wait_program_timeout(HANDLE handle,DWORD &runcode,unsigned timeoutMs);
 jlib_decl bool interrupt_program(HANDLE handle, bool killChildren, int signum=0); // no signum means use default
 jlib_decl bool getHomeDir(StringBuffer & homepath);
 


### PR DESCRIPTION
Wait on local ftslave proceses so they are not left as dangling defunct/zombie child processes.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [ ] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
