### PR TITLE
HPCC-29160 Fix oversized compressed write

### DIFF
--- a/system/jlib/jlzw.cpp
+++ b/system/jlib/jlzw.cpp
@@ -1973,6 +1973,7 @@ class CCompressedFile : implements ICompressedFileIO, public CInterface
     Owned<ICompressor> compressor;
     Owned<IExpander> expander;
     unsigned compMethod;
+    offset_t lastFlushPos = (offset_t)-1;
 
     unsigned indexNum() { return indexbuf.length()/sizeof(offset_t); }
 
@@ -1999,7 +2000,6 @@ class CCompressedFile : implements ICompressedFileIO, public CInterface
         expsize = (size32_t)(index[b]-curpos);
         return b;
     }
-
 
     void getblock(offset_t pos)
     {
@@ -2035,42 +2035,7 @@ class CCompressedFile : implements ICompressedFileIO, public CInterface
 
     }
 
-    void flush()
-    {   
-        try
-        {
-            curblocknum++;
-            indexbuf.append((unsigned __int64) trailer.expandedSize-overflow.length());
-            offset_t p = ((offset_t)curblocknum)*((offset_t)trailer.blockSize);
-            if (trailer.recordSize==0) {
-                compressor->close();
-                compblklen = compressor->buflen();
-            }
-            if (compblklen) {
-                if (p>trailer.indexPos) { // fill gap
-                    MemoryAttr fill;
-                    size32_t fl = (size32_t)(p-trailer.indexPos);
-                    memset(fill.allocate(fl),0xff,fl);
-                    checkedwrite(trailer.indexPos,fl,fill.get());
-                }
-                checkedwrite(p,compblklen,compblkptr);
-                p += compblklen;
-                compblklen = 0;
-            }
-            trailer.indexPos = p;
-            if (trailer.recordSize==0) {
-                compressor->open(compblkptr, trailer.blockSize);
-            }
-        }
-        catch (IException *e)
-        {
-            writeException = true;
-            EXCLOG(e, "CCompressedFile::flush");
-            throw;
-        }
-    }
-
-    virtual void expand(const void *compbuf,MemoryBuffer &expbuf,size32_t expsize)
+    void expand(const void *compbuf,MemoryBuffer &expbuf,size32_t expsize)
     {
         size32_t rs = trailer.recordSize;
         if (rs) { // diff expand
@@ -2262,14 +2227,7 @@ public:
             }
         }
     }
-
-    virtual offset_t size()                                             
-    { 
-        CriticalBlock block(crit);
-        return trailer.expandedSize;
-    }
-
-    virtual size32_t read(offset_t pos, size32_t len, void * data)          
+    virtual size32_t read(offset_t pos, size32_t len, void * data) override
     {
         CriticalBlock block(crit);
         assertex(mode==ICFread);
@@ -2293,7 +2251,12 @@ public:
         }
         return ret;
     }
-    size32_t write(offset_t pos, size32_t len, const void * data)   
+    virtual offset_t size() override
+    { 
+        CriticalBlock block(crit);
+        return trailer.expandedSize;
+    }
+    virtual size32_t write(offset_t pos, size32_t len, const void * data) override
     {
         CriticalBlock block(crit);
         assertex(mode!=ICFread);
@@ -2313,16 +2276,46 @@ public:
         }
         return ret;
     }
-
-    virtual unsigned __int64 getStatistic(StatisticKind kind)
-    {
-        return fileio->getStatistic(kind);
+    virtual offset_t appendFile(IFile *file,offset_t pos,offset_t len) override { UNIMPLEMENTED; }
+    virtual void setSize(offset_t size) override { UNIMPLEMENTED; }
+    virtual void flush() override
+    {   
+        try
+        {
+            if (lastFlushPos == trailer.expandedSize) // nothing written since last flush. NB: only sequential writes supported
+                return;
+            curblocknum++;
+            indexbuf.append((unsigned __int64) trailer.expandedSize-overflow.length());
+            offset_t p = ((offset_t)curblocknum)*((offset_t)trailer.blockSize);
+            if (trailer.recordSize==0) {
+                compressor->close();
+                compblklen = compressor->buflen();
+            }
+            if (compblklen) {
+                if (p>trailer.indexPos) { // fill gap
+                    MemoryAttr fill;
+                    size32_t fl = (size32_t)(p-trailer.indexPos);
+                    memset(fill.allocate(fl),0xff,fl);
+                    checkedwrite(trailer.indexPos,fl,fill.get());
+                }
+                checkedwrite(p,compblklen,compblkptr);
+                p += compblklen;
+                compblklen = 0;
+            }
+            trailer.indexPos = p;
+            if (trailer.recordSize==0) {
+                compressor->open(compblkptr, trailer.blockSize);
+            }
+            lastFlushPos = trailer.expandedSize;
+        }
+        catch (IException *e)
+        {
+            writeException = true;
+            EXCLOG(e, "CCompressedFile::flush");
+            throw;
+        }
     }
-
-    void setSize(offset_t size) { UNIMPLEMENTED; }
-    offset_t appendFile(IFile *file,offset_t pos,offset_t len) { UNIMPLEMENTED; }
-
-    void close()
+    virtual void close() override
     {
         CriticalBlock block(crit);
         if (mode!=ICFread) {
@@ -2351,33 +2344,37 @@ public:
         curblockpos = 0;
         curblocknum = (unsigned)-1; // relies on wrap
     }
+    virtual unsigned __int64 getStatistic(StatisticKind kind) override
+    {
+        return fileio->getStatistic(kind);
+    }
 
-    unsigned dataCRC()
+// CCompressedFile impl.
+    virtual unsigned dataCRC() override
     {
         if (mode==ICFread)
             return trailer.datacrc;
         return trailer.crc;
     }
-    size32_t recordSize()
+    virtual size32_t recordSize() override
     {
         return trailer.recordSize;
     }
-    size32_t blockSize()
+    virtual size32_t blockSize() override
     {
         return trailer.blockSize;
     }
-    void setBlockSize(size32_t size)
+    virtual void setBlockSize(size32_t size) override
     {
         trailer.blockSize = size;
         compressor->close();
         compressor->open(compblkptr, size);
     }
-    bool readMode()
+    virtual bool readMode() override
     {
         return (mode==ICFread);
     }
-
-    unsigned method()
+    virtual unsigned method() override
     {
         return trailer.method();
     }


### PR DESCRIPTION
The compressed writer can write files larger than necessary, due
to a bug in flush().

flush() ensures all content is committed to disk.
In the case of CCompressedFile it 1st ensures it's on a new block
boundary (1MB), before it flushes unwritten content to disk.
Prior to this change, it also did this when nothing
had been written since the last flush, meaning it would unnecessarily
ensure it was on the next block boundary by back filling the gap
behind it.

The net result on a typical write that called flush before
collecting stats, then again on close() was that it unnecessarily
rounded the last incomplete block (1MB) and committed to disk.

Signed-off-by: Jake Smith <jake.smith@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [ ] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
