### PR TITLE
HPCC-29189 Check Dropzone Scope Access before spraying/despraying

### DIFF
--- a/esp/services/ws_fs/ws_fsService.cpp
+++ b/esp/services/ws_fs/ws_fsService.cpp
@@ -1997,24 +1997,7 @@ bool CFileSprayEx::onSprayFixed(IEspContext &context, IEspSprayFixed &req, IEspS
         wu->setCommand(DFUcmd_import);
 
         IDFUfileSpec *source = wu->queryUpdateSource();
-        if(srcxml.length() == 0)
-        {
-            RemoteMultiFilename rmfn;
-            SocketEndpoint ep(srcip);
-            if (ep.isNull())
-                throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "SprayFixed to %s: cannot resolve source network IP from %s.", destname, srcip);
-
-            rmfn.setEp(ep);
-            StringBuffer fnamebuf(srcfile);
-            fnamebuf.trim();
-            rmfn.append(fnamebuf.str());    // handles comma separated files
-            source->setMultiFilename(rmfn);
-        }
-        else
-        {
-            srcxml.append('\0');
-            source->setFromXML((const char*)srcxml.toByteArray());
-        }
+        checkDZScopeAccessAndSetSpraySourceDFUFileSpec(context, req.getSourcePlane(), srcip, srcfile, srcxml, source);
 
         IDFUfileSpec *destination = wu->queryUpdateDestination();
         bool nosplit = req.getNosplit();
@@ -2174,24 +2157,7 @@ bool CFileSprayEx::onSprayVariable(IEspContext &context, IEspSprayVariable &req,
         IDFUfileSpec *destination = wu->queryUpdateDestination();
         IDFUoptions *options = wu->queryUpdateOptions();
 
-        if(srcxml.length() == 0)
-        {
-            RemoteMultiFilename rmfn;
-            SocketEndpoint ep(srcip);
-            if (ep.isNull())
-                throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "SprayVariable to %s: cannot resolve source network IP from %s.", destname, srcip);
-
-            rmfn.setEp(ep);
-            StringBuffer fnamebuf(srcfile);
-            fnamebuf.trim();
-            rmfn.append(fnamebuf.str());    // handles comma separated files
-            source->setMultiFilename(rmfn);
-        }
-        else
-        {
-            srcxml.append('\0');
-            source->setFromXML((const char*)srcxml.toByteArray());
-        }
+        checkDZScopeAccessAndSetSpraySourceDFUFileSpec(context, req.getSourcePlane(), srcip, srcfile, srcxml, source);
         source->setMaxRecordSize(req.getSourceMaxRecordSize());
         source->setFormat((DFUfileformat)req.getSourceFormat());
 
@@ -2296,6 +2262,55 @@ bool CFileSprayEx::onSprayVariable(IEspContext &context, IEspSprayVariable &req,
     }
 
     return true;
+}
+
+void CFileSprayEx::checkDZScopeAccessAndSetSpraySourceDFUFileSpec(IEspContext &context, const char *srcPlane, const char *srcHost,
+    const char *srcFile, MemoryBuffer &srcXML, IDFUfileSpec *srcDFUfileSpec)
+{
+    if(srcXML.length() == 0)
+    {
+        SecAccessFlags permission = getDropZoneScopePermissions(context, srcPlane, srcFile, srcHost);
+        if (permission < SecAccess_Read)
+            throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "Access DropZone Scope %s %s not allowed for user %s (permission:%s). Read Access Required.",
+                isEmptyString(srcPlane) ? srcHost : srcPlane, srcFile, context.queryUserId(), getSecAccessFlagName(permission));
+
+        RemoteMultiFilename rmfn;
+        SocketEndpoint ep(srcHost);
+        if (ep.isNull())
+            throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "Cannot resolve source network IP from %s.", srcHost);
+
+        rmfn.setEp(ep);
+        StringBuffer fnamebuf(srcFile);
+        fnamebuf.trim();
+        rmfn.append(fnamebuf.str());    // handles comma separated files
+        srcDFUfileSpec->setMultiFilename(rmfn);
+    }
+    else
+    {
+        srcXML.append('\0');
+        srcDFUfileSpec->setFromXML((const char*)srcXML.toByteArray());
+
+        //Should the srcPlane is read from the fileSpec (add to the srcXML and set by the srcXML)?
+        validateDropZoneScopePermissionsByDFUFileSpec(context, srcPlane, srcDFUfileSpec, SecAccess_Read);
+    }
+}
+
+void CFileSprayEx::validateDropZoneScopePermissionsByDFUFileSpec(IEspContext &context, const char *dropZoneName, IDFUfileSpec *fileSpec, SecAccessFlags permissionReq)
+{
+    StringBuffer host, path;
+    RemoteFilename rfn;
+    fileSpec->getPartFilename(0, 0, rfn);
+    rfn.getLocalPath(path);
+
+    if (isEmptyString(dropZoneName))
+        rfn.queryEndpoint().getIpText(host);
+
+    SecAccessFlags permission = getDropZoneScopePermissions(context, dropZoneName, path, host);
+    if (permission < permissionReq)
+        throw makeStringExceptionV(ECLWATCH_INVALID_INPUT,
+            "Access DropZone Scope %s %s not allowed for user %s (permission:%s). %s Access Required.",
+            isEmptyString(dropZoneName) ? host.str() : dropZoneName, path.str(), context.queryUserId(),
+            getSecAccessFlagName(permission), getSecAccessFlagName(permissionReq));
 }
 
 bool CFileSprayEx::onReplicate(IEspContext &context, IEspReplicate &req, IEspReplicateResponse &resp)
@@ -2450,6 +2465,11 @@ bool CFileSprayEx::onDespray(IEspContext &context, IEspDespray &req, IEspDespray
             if (!isEmptyString(destPlane))
                 getDropZoneInfoByDestPlane(version, destPlane, destfile, destfileWithPath, umask, destip);
 
+            SecAccessFlags permission = getDropZoneScopePermissions(context, destPlane, destfileWithPath, destip);
+            if (permission < SecAccess_Write)
+                throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "Access DropZone Scope %s %s not allowed for user %s (permission:%s). Write Access Required.",
+                    isEmptyString(destPlane) ? destip : destPlane, destfileWithPath.str(), context.queryUserId(), getSecAccessFlagName(permission));
+
             RemoteFilename rfn;
             SocketEndpoint ep(destip.str());
             if (ep.isNull())
@@ -2468,6 +2488,7 @@ bool CFileSprayEx::onDespray(IEspContext &context, IEspDespray &req, IEspDespray
         {
             dstxml.append('\0');
             destination->setFromXML((const char*)dstxml.toByteArray());
+            validateDropZoneScopePermissionsByDFUFileSpec(context, destPlane, destination, SecAccess_Write);
         }
         destination->setTitle(srcTitle.str());
 

--- a/esp/services/ws_fs/ws_fsService.hpp
+++ b/esp/services/ws_fs/ws_fsService.hpp
@@ -71,6 +71,10 @@ class CFileSprayEx : public CFileSpray
     void getServersInDropZone(const char* dropZoneName, IArrayOf<IConstTpDropZone>& dropZoneList,
         bool isECLWatchVisibleOnly, StringArray& serverList);
     IPropertyTree* getAndValidateDropZone(const char * path, const char * host);
+    void checkDZScopeAccessAndSetSpraySourceDFUFileSpec(IEspContext& context, const char* srcPlane, const char * srcHost,
+        const char* srcFile, MemoryBuffer& srcXML, IDFUfileSpec* srcDFUfileSpec);
+    void validateDropZoneScopePermissionsByDFUFileSpec(IEspContext& context, const char* dropZoneName, IDFUfileSpec* fileSpec,
+        SecAccessFlags permissionReq);
 
 public:
     virtual void init(IPropertyTree *cfg, const char *process, const char *service);


### PR DESCRIPTION
Before spraying a file from a dropzone, we need to check whether the user has the permission to access the dropzone file or not. Similar permission check has to be done before despraying a file to a dropzone.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
