### PR TITLE
HPCC-29189 Check Dropzone scope access before spraying/despraying

### DIFF
--- a/esp/services/ws_fileio/ws_fileioservice.hpp
+++ b/esp/services/ws_fileio/ws_fileioservice.hpp
@@ -45,10 +45,6 @@ public:
     virtual bool onCreateFile(IEspContext &context, IEspCreateFileRequest &req, IEspCreateFileResponse &resp);
     virtual bool onWriteFileData(IEspContext &context,  IEspWriteFileDataRequest &req,  IEspWriteFileDataResponse &resp);
     virtual bool onReadFileData(IEspContext &context,     IEspReadFileDataRequest &req,   IEspReadFileDataResponse &resp);
-
-protected:
-    void validateDropZoneAccess(IEspContext &context, const char *targetDZNameOrHost, const char *hostReq,
-        SecAccessFlags permissionReq, const char *fileNameWithRelPath, CDfsLogicalFileName &dlfn);
 };
 
 #endif //_ESPWIZ_WsFileIO_HPP__

--- a/esp/services/ws_fs/ws_fsBinding.cpp
+++ b/esp/services/ws_fs/ws_fsBinding.cpp
@@ -400,7 +400,7 @@ int CFileSpraySoapBindingEx::downloadFile(IEspContext &context, CHttpRequest* re
         request->getParameter("Name", nameStr);
         request->getParameter("DropZoneName", dropZoneName);
 
-        SecAccessFlags permission = getDropZoneScopePermissions(context, dropZoneName, pathStr, netAddressStr);
+        SecAccessFlags permission = getDZPathScopePermissions(context, dropZoneName, pathStr, netAddressStr);
         if (permission < SecAccess_Read)
             throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "Access DropZone Scope %s %s %s not allowed for user %s (permission:%s). Read Access Required.",
                 dropZoneName.str(), netAddressStr.str(), pathStr.str(), context.queryUserId(), getSecAccessFlagName(permission));
@@ -490,7 +490,7 @@ int CFileSpraySoapBindingEx::onStartUpload(IEspContext& ctx, CHttpRequest* reque
     request->getParameter("DropZoneName", dropZoneName);
     if (!validateDropZonePath(nullptr, netAddress, path)) //The path should be the absolute path for the dropzone.
         throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "Invalid Landing Zone path %s", path.str());
-    SecAccessFlags permission = getDropZoneScopePermissions(ctx, dropZoneName, path, netAddress);
+    SecAccessFlags permission = getDZPathScopePermissions(ctx, dropZoneName, path, netAddress);
     if (permission < SecAccess_Full)
         throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "Access DropZone Scope %s %s %s not allowed for user %s (permission:%s). Full Access Required.",
             dropZoneName.str(), netAddress.str(), path.str(), ctx.queryUserId(), getSecAccessFlagName(permission));

--- a/esp/services/ws_fs/ws_fsService.hpp
+++ b/esp/services/ws_fs/ws_fsService.hpp
@@ -67,12 +67,14 @@ public:
 class CFileSprayEx : public CFileSpray
 {
     void readAndCheckSpraySourceReq(MemoryBuffer& srcxml, const char* srcIP, const char* srcPath, const char* srcplane,
-        StringBuffer& sourceIPReq, StringBuffer& sourcePathReq);
+        StringBuffer& sourcePlaneReq, StringBuffer& sourceIPReq, StringBuffer& sourcePathReq);
     void getServersInDropZone(const char* dropZoneName, IArrayOf<IConstTpDropZone>& dropZoneList,
         bool isECLWatchVisibleOnly, StringArray& serverList);
     IPropertyTree* getAndValidateDropZone(const char * path, const char * host);
     IEspDFUWorkunit* createDFUWUFromSashaListResult(const char* result);
     void setDFUCommand(const char* commandStr, IEspDFUWorkunit* dfuWU);
+    void checkDZScopeAccessAndSetSpraySourceDFUFileSpec(IEspContext& context, const char* srcPlane, const char * srcHost,
+        const char* srcFile, MemoryBuffer& srcXML, IDFUfileSpec* srcDFUfileSpec);
 
 public:
     virtual void init(IPropertyTree *cfg, const char *process, const char *service);

--- a/esp/smc/SMCLib/TpCommon.cpp
+++ b/esp/smc/SMCLib/TpCommon.cpp
@@ -156,27 +156,15 @@ extern TPWRAPPER_API bool validateDropZonePath(const char* dropZoneName, const c
     return false;
 }
 
-extern TPWRAPPER_API SecAccessFlags getDropZoneScopePermissions(IEspContext& context, const char* dropZoneName, const char* dropZonePath, const char* dropZoneHost)
+static SecAccessFlags getDropZoneScopePermissions(IEspContext& context, const IPropertyTree* dropZone, const char* dropZonePath)
 {
     if (isEmptyString(dropZonePath))
         throw makeStringException(ECLWATCH_INVALID_CLUSTER_NAME, "getDropZoneScopePermissions(): DropZone path must be specified.");
 
-    Owned<IPropertyTree> plane;
-    if (isEmptyString(dropZoneName))
-    {
-        plane.setown(findDropZonePlane(dropZonePath, dropZoneHost, true, true));
-        dropZoneName = plane->queryProp("@name");
-    }
-    else
-    {
-        plane.setown(getDropZonePlane(dropZoneName));
-        if (!plane)
-            throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "getDropZoneScopePermissions(): DropZone %s not found.", dropZoneName);
-    }
-
     //If the dropZonePath is an absolute path, change it to a relative path.
     StringBuffer s;
-    const char* prefix = plane->queryProp("@prefix");
+    const char* prefix = dropZone->queryProp("@prefix");
+    const char* name = dropZone->queryProp("@name");
     if (hasPrefix(dropZonePath, prefix, true))
     {
         const char* p = dropZonePath + strlen(prefix);
@@ -188,5 +176,54 @@ extern TPWRAPPER_API SecAccessFlags getDropZoneScopePermissions(IEspContext& con
 
     Owned<IUserDescriptor> userDesc = createUserDescriptor();
     userDesc->set(context.queryUserId(), context.queryPassword(), context.querySignature());
-    return queryDistributedFileDirectory().getDropZoneScopePermissions(dropZoneName, dropZonePath, userDesc);
+    return queryDistributedFileDirectory().getDropZoneScopePermissions(name, dropZonePath, userDesc);
+}
+
+extern TPWRAPPER_API SecAccessFlags getDZPathScopePermissions(IEspContext& context, const char* dropZoneName, const char* dropZonePath, const char* dropZoneHost)
+{
+    if (isEmptyString(dropZonePath))
+        throw makeStringException(ECLWATCH_INVALID_CLUSTER_NAME, "getDZPathScopePermissions(): DropZone path must be specified.");
+
+    Owned<IPropertyTree> dropZone;
+    if (isEmptyString(dropZoneName))
+        dropZone.setown(findDropZonePlane(dropZonePath, dropZoneHost, true, true));
+    else
+    {
+        dropZone.setown(getDropZonePlane(dropZoneName));
+        if (!dropZone)
+            throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "getDZPathScopePermissions(): DropZone %s not found.", dropZoneName);
+    }
+
+    return getDropZoneScopePermissions(context, dropZone, dropZonePath);
+}
+
+extern TPWRAPPER_API SecAccessFlags getDZFileScopePermissions(IEspContext& context, const char* dropZoneName, const char* dropZonePath,
+    const char* dropZoneHost)
+{
+    StringBuffer dir, fileName;
+    splitFilename(dropZonePath, &dir, &dir, nullptr, nullptr);
+    dropZonePath = dir.str();
+    return getDZPathScopePermissions(context, dropZoneName, dropZonePath, dropZoneHost);
+}
+
+extern TPWRAPPER_API void validateDropZoneAccess(IEspContext& context, const char* targetDZNameOrHost, const char* hostReq, SecAccessFlags permissionReq,
+    const char* fileNameWithRelPath, CDfsLogicalFileName& dlfn)
+{
+    if (containsRelPaths(fileNameWithRelPath)) //Detect a path like: a/../../../f
+        throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "Invalid file path %s", fileNameWithRelPath);
+
+    Owned<IPropertyTree> dropZone = getDropZonePlane(targetDZNameOrHost);
+    if (!dropZone) //The targetDZNameOrHost could be a dropzone host.
+        dropZone.setown(findDropZonePlane(nullptr, targetDZNameOrHost, true, true));
+    else if (!isEmptyString(hostReq))
+    {
+        if (!isHostInPlane(dropZone, hostReq, true))
+            throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "Host %s is not valid DropZone plane %s", hostReq, targetDZNameOrHost);
+    }
+    const char *dropZoneName = dropZone->queryProp("@name");
+    SecAccessFlags permission = getDZFileScopePermissions(context, dropZoneName, fileNameWithRelPath, hostReq);
+    if (permission < permissionReq)
+        throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "Access DropZone Scope %s %s not allowed for user %s (permission:%s). %s Access Required.",
+            dropZoneName, fileNameWithRelPath, context.queryUserId(), getSecAccessFlagName(permission), getSecAccessFlagName(permissionReq));
+    dlfn.setPlaneExternal(dropZoneName, fileNameWithRelPath);
 }

--- a/esp/smc/SMCLib/TpWrapper.hpp
+++ b/esp/smc/SMCLib/TpWrapper.hpp
@@ -231,7 +231,10 @@ extern TPWRAPPER_API bool validateDataPlaneName(const char *remoteDali, const ch
 extern TPWRAPPER_API bool matchNetAddressRequest(const char* netAddressReg, bool ipReq, IConstTpMachine& tpMachine);
 
 extern TPWRAPPER_API bool validateDropZonePath(const char* dropZoneName, const char* netAddr, const char* pathToCheck);
-extern TPWRAPPER_API SecAccessFlags getDropZoneScopePermissions(IEspContext& context, const char * dropZoneName, const char * dropZonePath, const char * dropZoneHost);
+extern TPWRAPPER_API SecAccessFlags getDZPathScopePermissions(IEspContext& context, const char* dropZoneName, const char* dropZonePath, const char* dropZoneHost);
+extern TPWRAPPER_API SecAccessFlags getDZFileScopePermissions(IEspContext& context, const char* dropZoneName, const char* dropZonePath, const char* dropZoneHost);
+extern TPWRAPPER_API void validateDropZoneAccess(IEspContext& context, const char* targetDZNameOrHost, const char* hostReq, SecAccessFlags permissionReq,
+    const char* fileNameWithRelPath, CDfsLogicalFileName& dlfn);
 
 #endif //_ESPWIZ_TpWrapper_HPP__
 


### PR DESCRIPTION
Before spraying a file from a dropzone, we need to check whether the user has the permission to access the dropzone file or not. Similar permission check has to be done before despraying a file to a dropzone.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
