### PR TITLE
HPCC-29046 Report job timing/transfer rate in FileSpray.GetDFUWorkunits

### DIFF
--- a/esp/scm/ws_fs.ecm
+++ b/esp/scm/ws_fs.ecm
@@ -97,6 +97,8 @@ ESPStruct [nil_remove] DFUWorkunit
     [min_ver("1.14")] int expireDays;
     [min_ver("1.21")] bool PreserveFileParts;
     [min_ver("1.23")] double FileAccessCost;
+    [min_ver("1.25")] int KbPerSecAve;
+    [min_ver("1.25")] int KbPerSec;
 };
 
 ESPStruct [nil_remove] GroupNode
@@ -154,6 +156,8 @@ ESPrequest GetDFUWorkunits
     string ParentWuid;
     string PublisherWuid;
     [min_ver("1.24")] bool includeProgressMessages(false);
+    [min_ver("1.25")] bool includeTimings(false);
+    [min_ver("1.25")] bool includeTransferRate(false);
 };
 
 ESPresponse [encode(0), exceptions_inline]
@@ -698,7 +702,7 @@ ESPresponse [exceptions_inline, nil_remove] GetDFUServerQueuesResponse
 
 ESPservice [
     auth_feature("DEFERRED"),
-    version("1.24"),
+    version("1.25"),
     exceptions_inline("./smc_xslt/exceptions.xslt")] FileSpray
 {
     ESPmethod EchoDateTime(EchoDateTime, EchoDateTimeResponse);

--- a/esp/services/ws_fs/ws_fsService.cpp
+++ b/esp/services/ws_fs/ws_fsService.cpp
@@ -1173,6 +1173,27 @@ bool CFileSprayEx::onGetDFUWorkunits(IEspContext &context, IEspGetDFUWorkunits &
                     prog->formatSummaryMessage(prgmsg.clear());
                     resultWU->setSummaryMessage(prgmsg.str());
                 }
+                if (version >= 1.25)
+                {
+                    if (req.getIncludeTransferRate())
+                    {
+                        resultWU->setKbPerSec(prog->getKbPerSec());
+                        resultWU->setKbPerSecAve(prog->getKbPerSecAve());
+                    }
+                    if (req.getIncludeTimings())
+                    {
+                        CDateTime startAt, stopAt;
+                        prog->getTimeStarted(startAt);
+                        prog->getTimeStopped(stopAt);
+
+                        StringBuffer s;
+                        resultWU->setTimeStarted(startAt.getString(s));
+                        resultWU->setTimeStopped(stopAt.getString(s.clear()));
+                        unsigned secs = prog->getSecsLeft();
+                        if (secs > 0)
+                            resultWU->setSecsLeft(secs);
+                    }
+                }
             }
             result.append(*resultWU.getLink());
             itr->next();


### PR DESCRIPTION
2 options are added into the GetDFUWorkunits request. Inside a GetDFUWorkunits request, if the includeTimings is set to true, report: TimeStarted, TimeStopped, and SecsLeft. If the includeTransferRate is set to true, report: KbPerSec and KbPerSecAve.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
