### PR TITLE
HPCC-29376 Fix Thor next graph regression

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -14184,7 +14184,7 @@ void executeThorGraph(const char * graphName, IConstWorkUnit &workunit, const IP
 
         // NB: executeGraphOnLingeringThor looks for existing Thor instance that has been used for the same job,
         // and communicates with it directly
-        if (!multiJobLinger && executeGraphOnLingeringThor(workunit, graphName))
+        if (!multiJobLinger && executeGraphOnLingeringThor(workunit, wfid, graphName))
             PROGLOG("Existing lingering Thor handled graph: %s", graphName);
         else
         {
@@ -14495,7 +14495,7 @@ TraceFlags loadTraceFlags(IConstWorkUnit * wu, const std::initializer_list<Trace
 }
 
 #ifdef _CONTAINERIZED
-bool executeGraphOnLingeringThor(IConstWorkUnit &workunit, const char *graphName)
+bool executeGraphOnLingeringThor(IConstWorkUnit &workunit, unsigned wfid, const char *graphName)
 {
     // NB: this routine is not used in a multiJobLinger mode Thor.
 
@@ -14556,7 +14556,7 @@ bool executeGraphOnLingeringThor(IConstWorkUnit &workunit, const char *graphName
 
                 Owned<INode> masterNode = createINode(instanceName);
                 CMessageBuffer msg;
-                VStringBuffer jobStr("%s/%s", workunit.queryWuid(), graphName?graphName:"");
+                VStringBuffer jobStr("%u/%s/%s", wfid, workunit.queryWuid(), graphName?graphName:"");
                 msg.append(jobStr);
                 if (queryWorldCommunicator().sendRecv(msg, masterNode, MPTAG_THOR, 10000))
                 {
@@ -14848,7 +14848,7 @@ bool isActiveK8sService(const char *serviceName)
     throwUnexpected();
 }
 
-bool executeGraphOnLingeringThor(IConstWorkUnit &workunit, const char *graphName)
+bool executeGraphOnLingeringThor(IConstWorkUnit &workunit, unsigned wfid, const char *graphName)
 {
     throwUnexpected();
 }

--- a/common/workunit/workunit.hpp
+++ b/common/workunit/workunit.hpp
@@ -1776,7 +1776,7 @@ enum class KeepK8sJobs { none, podfailures, all };
 extern WORKUNIT_API KeepK8sJobs translateKeepJobs(const char *keepJobs);
 
 extern WORKUNIT_API bool isActiveK8sService(const char *serviceName);
-extern WORKUNIT_API bool executeGraphOnLingeringThor(IConstWorkUnit &workunit, const char *graphName);
+extern WORKUNIT_API bool executeGraphOnLingeringThor(IConstWorkUnit &workunit, unsigned wfid, const char *graphName);
 extern WORKUNIT_API void deleteK8sResource(const char *componentName, const char *job, const char *resource);
 extern WORKUNIT_API void waitK8sJob(const char *componentName, const char *job, unsigned pendingTimeoutSecs, KeepK8sJobs keepJob);
 extern WORKUNIT_API bool applyK8sYaml(const char *componentName, const char *wuid, const char *job, const char *resourceType, const std::list<std::pair<std::string, std::string>> &extraParams, bool optional, bool autoCleanup);

--- a/ecl/eclagent/eclagent.cpp
+++ b/ecl/eclagent/eclagent.cpp
@@ -1963,7 +1963,7 @@ void EclAgent::doProcess()
 
 #ifdef _CONTAINERIZED
     // signal to any lingering Thor's that job is complete and they can quit before timeout.
-    executeGraphOnLingeringThor(*wuRead, nullptr);
+    executeGraphOnLingeringThor(*wuRead, 0, nullptr);
 #endif
 
     DBGLOG("Process complete");

--- a/roxie/ccd/ccdcontext.cpp
+++ b/roxie/ccd/ccdcontext.cpp
@@ -2931,7 +2931,7 @@ public:
         {
 #ifdef _CONTAINERIZED
             // signal to any lingering Thor's that job is complete and they can quit before timeout.
-            executeGraphOnLingeringThor(*workUnit, nullptr);
+            executeGraphOnLingeringThor(*workUnit, 0, nullptr);
 #endif
 
             if (options.failOnLeaks && !failed)


### PR DESCRIPTION
A regression introduced by HPCC-29252 meant each Thor graph after the 1st, failed to run on the same Thor instance, leaving that instance running until the linger period lapsed, and causing a new Thor instance to spin up to service each new graph.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
