### PR TITLE
HPCC-29379 More cleanup of roxie traceLevel

### DIFF
--- a/roxie/ccd/ccd.hpp
+++ b/roxie/ccd/ccd.hpp
@@ -690,9 +690,9 @@ public:
         blind = _blind;
     }
 
-    void setTraceLevel(unsigned _traceLevel)
+    void setTraceLevel(unsigned _level)
     {
-        ctxTraceLevel = _traceLevel;
+        ctxTraceLevel = _level;
     }
 
     StringBuffer &getStats(StringBuffer &s) const

--- a/roxie/ccd/ccdcontext.cpp
+++ b/roxie/ccd/ccdcontext.cpp
@@ -152,9 +152,6 @@ public:
                 if (callback->wait(5000))
                     break;
             }
-            if (traceLevel > 6)
-                { StringBuffer s; DBGLOG("Processing information from Roxie server in response to %s", newHeader.toString(s).str()); }
-
             MemoryBuffer &serverData = callback->queryData();
             deserialize(serverData);
         }

--- a/roxie/ccd/ccddali.cpp
+++ b/roxie/ccd/ccddali.cpp
@@ -605,7 +605,7 @@ public:
             }
             else // Legacy mode - recently cloned files should have the extra info
             {
-                if (traceLevel > 1)
+                if (doTrace(traceRoxieFiles))
                     DBGLOG("checkClonedFromRemote: Resolving %s in legacy mode", _lfn);
                 Owned<IDistributedFile> cloneFile = resolveLFN(foreignLfn, cacheIt, AccessMode::readRandom, isPrivilegedUser);
                 if (cloneFile)
@@ -620,7 +620,7 @@ public:
         }
         catch (IException *E)
         {
-            if (traceLevel > 3)
+            if (doTrace(traceRoxieFiles))
                 EXCLOG(E);
             E->Release();  // Any failure means act as if no remote info
         }
@@ -643,7 +643,7 @@ public:
             }
             if (cacheIt)
                 cacheDistributedFile(logicalName, dfsFile);
-            if (traceLevel > 1)
+            if (doTrace(traceRoxieFiles))
                 DBGLOG("Dali lookup %s returned %s in %u ms", logicalName, dfsFile != NULL ? "match" : "NO match", msTick()-start);
             return dfsFile.getClear();
         }

--- a/roxie/ccd/ccdfile.cpp
+++ b/roxie/ccd/ccdfile.cpp
@@ -953,7 +953,7 @@ class CRoxieFileCache : implements IRoxieFileCache, implements ICopyFileProgress
                 cidtSleep.wait(cacheReportPeriodSeconds * 1000);
                 if (closing)
                     break;
-                if (traceLevel>8)
+                if (doTrace(traceRoxieFiles, TraceFlags::Max))
                     DBGLOG("Cache info dump");
 
                 // Note - cache info is stored in the DLLSERVER persistent area - which we should perhaps consider renaming
@@ -1943,7 +1943,6 @@ public:
             cacheRootDirectory.append(dllserver_root);
         }
 
-        unsigned cacheWarmTraceLevel = topology->getPropInt("@cacheWarmTraceLevel", traceLevel);
         VStringBuffer cacheFileName("%s/%s/cacheInfo.%d", cacheRootDirectory.str(), roxieName.str(), channel);
         StringBuffer cacheInfo;
         try
@@ -1952,7 +1951,7 @@ public:
             {
 #ifndef _WIN32
                 StringBuffer output;
-                VStringBuffer command("ccdcache %s -t %u", cacheFileName.str(), cacheWarmTraceLevel);
+                VStringBuffer command("ccdcache %s -t %u", cacheFileName.str(), doTrace(traceRoxiePrewarm, TraceFlags::Max) ? 2 : (doTrace(traceRoxiePrewarm) ? 1 : 0));
                 unsigned retcode = runExternalCommand(nullptr, output, output, command, nullptr, ".", nullptr);
                 if (output.length())
                 {
@@ -2903,7 +2902,7 @@ public:
                 const char *subname = subNames.item(idx);
                 if (fileMode!=actualMode)
                 {
-                    if (traceLevel>0)
+                    if (traceLevel && traceTranslations)
                         DBGLOG("In query %s: Not translating %s as file type does not match", queryName, subname);
                 }
                 else if (projectedFormatCrc != 0) // projectedFormatCrc is currently 0 for csv/xml which should not create translators.
@@ -2958,7 +2957,7 @@ public:
                         else
                         {
                             translator.setown(createRecordTranslator(projected->queryRecordAccessor(true), actual->queryRecordAccessor(true)));
-                            if (traceLevel>0 && traceTranslations)
+                            if (traceLevel && traceTranslations)
                             {
                                 DBGLOG("In query %s: Record layout translator created for %s", queryName, subname);
                                 translator->describe();

--- a/roxie/ccd/ccdkey.cpp
+++ b/roxie/ccd/ccdkey.cpp
@@ -967,8 +967,6 @@ public:
                         Owned<IFileIO> file = files->getFilePart(idx, base);
                         offset_t size = file->size();
                         baseMap.addFragment(fileEnd, size, idx-1, base, 0);
-                        if (traceLevel > 6)
-                            DBGLOG("File fragment %d size %" I64F "d", idx, size);
                         totalSize += size; // MORE - check for overflow here
                     }
                 }
@@ -989,7 +987,7 @@ public:
                 EXCLOG(MCoperatorError, E);
                 throw E;
             }
-            if (traceLevel > 2)
+            if (doTrace(traceRoxieFiles))
                 DBGLOG("Loading in-memory file, size %" I64F "d", totalSize);
             // MORE - 32-bit systems could wrap here if totalSize > 2^32
             fileEnd = fileStart = (char *) malloc((size_t)totalSize);

--- a/roxie/ccd/ccdlistener.cpp
+++ b/roxie/ccd/ccdlistener.cpp
@@ -53,7 +53,8 @@ static void controlException(StringBuffer &response, IException *E, const IRoxie
     }
     catch(IException *EE)
     {
-        logctx.logOperatorException(EE, __FILE__, __LINE__, "controlException - While reporting exception");
+        if (traceLevel)
+            logctx.logOperatorException(EE, __FILE__, __LINE__, "controlException - While reporting exception");
         EE->Release();
     }
 #ifndef _DEBUG
@@ -633,7 +634,7 @@ public:
         if (sink->getIsSuspended())
         {
             accepted = false;
-            if (traceLevel > 1)
+            if (doTrace(traceRoxieActiveQueries))
                 DBGLOG("Rejecting query since Roxie server pool %d is suspended ", parent->queryPort());
         }
         else
@@ -760,7 +761,7 @@ public:
             }
 #endif /* GLIBC */
             if (traceLevel)
-                traceAffinity(&cpuMask);
+                traceAffinitySettings(&cpuMask);
         }
 #endif
     }
@@ -871,14 +872,14 @@ public:
                         }
                     }
                 }
-                if (traceLevel > 3)
-                    traceAffinity(&threadMask);
+                if (doTrace(traceAffinity))
+                    traceAffinitySettings(&threadMask);
                 pthread_setaffinity_np(GetCurrentThreadId(), sizeof(cpu_set_t), &threadMask);
             }
             else
             {
-                if (traceLevel > 3)
-                    traceAffinity(&cpuMask);
+                if (doTrace(traceAffinity))
+                    traceAffinitySettings(&cpuMask);
                 pthread_setaffinity_np(GetCurrentThreadId(), sizeof(cpu_set_t), &cpuMask);
             }
         }
@@ -903,7 +904,7 @@ protected:
     static unsigned lastCore;
 
 private:
-    static void traceAffinity(cpu_set_t *mask)
+    static void traceAffinitySettings(cpu_set_t *mask)
     {
         StringBuffer trace;
         for (unsigned core = 0; core < CPU_SETSIZE; core++)

--- a/roxie/ccd/ccdprotocol.cpp
+++ b/roxie/ccd/ccdprotocol.cpp
@@ -114,7 +114,7 @@ public:
             }
 #endif /* GLIBC */
             if (traceLevel)
-                traceAffinity(&cpuMask);
+                traceAffinitySettings(&cpuMask);
         }
 #endif
     }
@@ -168,14 +168,14 @@ public:
                         }
                     }
                 }
-                if (traceLevel > 3)
-                    traceAffinity(&threadMask);
+                if (doTrace(traceAffinity))
+                    traceAffinitySettings(&threadMask);
                 pthread_setaffinity_np(GetCurrentThreadId(), sizeof(cpu_set_t), &threadMask);
             }
             else
             {
-                if (traceLevel > 3)
-                    traceAffinity(&cpuMask);
+                if (doTrace(traceAffinity))
+                    traceAffinitySettings(&cpuMask);
                 pthread_setaffinity_np(GetCurrentThreadId(), sizeof(cpu_set_t), &cpuMask);
             }
         }
@@ -195,7 +195,7 @@ protected:
     static unsigned lastCore;
 
 private:
-    static void traceAffinity(cpu_set_t *mask)
+    static void traceAffinitySettings(cpu_set_t *mask)
     {
         StringBuffer trace;
         for (unsigned core = 0; core < CPU_SETSIZE; core++)
@@ -295,7 +295,7 @@ public:
         {
             ssock.setown(secureContext->createSecureSocket(base));
             int loglevel = SSLogMin;
-            if (traceLevel > 2)
+            if (doTrace(traceRoxieSockets))
                 loglevel = SSLogMax;
             int status = ssock->secure_accept(loglevel);
             if (status < 0)
@@ -1731,7 +1731,7 @@ readAnother:
                 client->querySocket()->getPeerAddress(peer);
                 if (!client->readBlocktms(rawText.clear(), readWait, &httpHelper, continuationNeeded, isStatus, global->maxBlockSize))
                 {
-                    if (traceLevel > 8)
+                    if (doTrace(traceRoxieSockets, TraceFlags::Max))
                     {
                         StringBuffer b;
                         DBGLOG("No data reading query from socket");
@@ -1765,7 +1765,7 @@ readAnother:
                         break;
                 }
             }
-            if (traceLevel > 0 && !expectedError)
+            if (doTrace(traceRoxieSockets) && !expectedError)
             {
                 StringBuffer b;
                 IERRLOG("Error reading query from socket: %s", E->errorMessage(b).str());

--- a/roxie/ccd/ccdqueue.cpp
+++ b/roxie/ccd/ccdqueue.cpp
@@ -1018,7 +1018,7 @@ void sendUnloadMessage(hash64_t hash, const char *id, const IRoxieContextLogger 
     mb.append(sizeof(RoxiePacketHeader), &header);
     mb.append((char) LOGGING_FLAGSPRESENT);
     mb.append(id);
-    if (traceLevel > 1)
+    if (doTrace(traceRoxiePackets))
         DBGLOG("UNLOAD sent for query %s", id);
     Owned<IRoxieQueryPacket> packet = createRoxiePacket(mb);
     ROQ->sendPacket(packet, logctx);
@@ -1254,7 +1254,7 @@ public:
         }
         if (found)
         {
-            if (traceLevel > 0)
+            if (traceLevel)
             {
                 StringBuffer xx;
                 AgentContextLogger l(x);
@@ -1270,7 +1270,7 @@ public:
         {
             available.signal();
             noteQueued();
-            if (traceLevel > 10)
+            if (doTrace(traceIBYTI, TraceFlags::Max))
             {
                 AgentContextLogger l(x);
                 StringBuffer xx; 
@@ -2024,8 +2024,8 @@ protected:
             CallbackEntry &c = callbacks.item(idx);
             if (c.matches(header, lfn))
             {
-                if (traceLevel > 10)
-                    DBGLOG("callback return matched a waiting query"); 
+                if (doTrace(traceRoxieFiles, TraceFlags::Max))
+                    DBGLOG("File callback return matched a waiting query"); 
                 c.doFileCallback(len, data, header.retries==QUERY_ABORTED);
             }
         }
@@ -2615,7 +2615,7 @@ public:
         }
         if (!checkRank)
         {
-            if (traceLevel > 8)
+            if (doTrace(traceRoxiePackets))
                 DBGLOG("discarding data for aborted query");
             ROQ->abortCompleted(header);
         }
@@ -3486,7 +3486,7 @@ public:
                 Owned<IMessageResult> mr = mc->getNextResult(5000, anyActivity);
                 if (mr)
                 {
-                    if (traceLevel > 4)
+                    if (doTrace(traceRoxiePackets))
                         DBGLOG("Discarding unwanted message");
                     unsigned headerLen;
                     const RoxiePacketHeader &header = *(const RoxiePacketHeader *) mr->getMessageHeader(headerLen);

--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -2510,16 +2510,12 @@ public:
         {
             if (preload && !paused && noThread)
             {
-                if (traceLevel > 4)
-                    DBGLOG("Preload fetching first %d records", preload);
                 if (groupAtOnce)
                     pullGroups(preload);
                 else
                     pullRecords(preload);
                 if (eof)
                 {
-                    if (traceLevel > 4)
-                        DBGLOG("No need to start puller after preload");
                     helper->processDone();
                 }
             }

--- a/roxie/ccd/ccdstate.cpp
+++ b/roxie/ccd/ccdstate.cpp
@@ -400,7 +400,7 @@ static Owned<KeptLowerCaseAtomTable> daliMisses;
 static void noteDaliMiss(const char *filename)
 {
     CriticalBlock b(daliMissesCrit);
-    if (traceLevel > 9)
+    if (doTrace(traceRoxieFiles, TraceFlags::Max))
         DBGLOG("noteDaliMiss %s", filename);
     daliMisses->addAtom(filename);
 }
@@ -461,7 +461,7 @@ protected:
         unsigned hash = hashcz((const unsigned char *) fileName, 0x811C9DC5);
         CriticalBlock b(daliLookupCrits[hash % NUM_DALI_CRITS]);
         // MORE - look at alwaysCreate... This may be useful to implement earlier locking semantics.
-        if (traceLevel > 9)
+        if (doTrace(traceRoxieFiles, TraceFlags::Max))
             DBGLOG("resolveLFNusingDaliOrLocal %s %d %d %x %d", fileName, useCache, cacheResult, (unsigned)accessMode, alwaysCreate);
         IResolvedFile* result = NULL;
         if (useCache)
@@ -520,7 +520,7 @@ protected:
         }
         if (cacheResult)
         {
-            if (traceLevel > 9)
+            if (doTrace(traceRoxieFiles, TraceFlags::Max))
                 DBGLOG("resolveLFNusingDaliOrLocal %s - cache add %d", fileName, result != NULL);
             if (result)
                 daliFiles.addCache(fileName, result);
@@ -3067,7 +3067,7 @@ extern void loadPlugins()
     DBGLOG("Preloading plugins from %s", pluginDirectory.str());
     if (pluginDirectory.length())
     {
-        plugins = new SafePluginMap(&PluginCtx, traceLevel >= 1);
+        plugins = new SafePluginMap(&PluginCtx, traceLevel);
         if (topology->hasProp("preload"))
         {
             Owned<IPropertyTreeIterator> preloads = topology->getElements("preload");

--- a/roxie/udplib/udptopo.cpp
+++ b/roxie/udplib/udptopo.cpp
@@ -53,7 +53,7 @@ void ChannelInfo::noteChannelsSick(unsigned primarySubChannel) const
         unsigned newDelay = currentDelay[subChannel] / 2;
         if (newDelay < minIbytiDelay)
             newDelay = minIbytiDelay;
-        if (doTrace(traceIBYTIfails))
+        if (doTrace(traceIBYTI))
             DBGLOG("IBYTI delay for subchannel %d is now %d", subChannel, newDelay);
         currentDelay[subChannel] = newDelay;
         subChannel++;
@@ -64,7 +64,7 @@ void ChannelInfo::noteChannelsSick(unsigned primarySubChannel) const
 
 void ChannelInfo::noteChannelHealthy(unsigned subChannel) const
 {
-    if (doTrace(traceIBYTIfails) && currentDelay[subChannel] != initIbytiDelay)
+    if (doTrace(traceIBYTI) && currentDelay[subChannel] != initIbytiDelay)
         DBGLOG("Resetting IBYTI delay for subchannel %d to %d", subChannel, initIbytiDelay);
     currentDelay[subChannel] = initIbytiDelay;
 }

--- a/system/jlib/jtrace.hpp
+++ b/system/jlib/jtrace.hpp
@@ -80,11 +80,13 @@ constexpr TraceFlags traceSubscriptions = TraceFlags::flag4;
 constexpr TraceFlags traceRoxieFiles = TraceFlags::flag5;
 constexpr TraceFlags traceRoxieActiveQueries = TraceFlags::flag6;
 constexpr TraceFlags traceRoxiePackets = TraceFlags::flag7;
-constexpr TraceFlags traceIBYTIfails = TraceFlags::flag8;
+constexpr TraceFlags traceIBYTI = TraceFlags::flag8;
 constexpr TraceFlags traceRoxiePings = TraceFlags::flag9;
 constexpr TraceFlags traceLimitExceeded = TraceFlags::flag10;
 constexpr TraceFlags traceRoxiePrewarm = TraceFlags::flag11;
 constexpr TraceFlags traceMissingOptFiles = TraceFlags::flag12;
+constexpr TraceFlags traceAffinity = TraceFlags::flag13;
+constexpr TraceFlags traceRoxieSockets = TraceFlags::flag14;
 
 
 //========================================================================================= 
@@ -103,11 +105,13 @@ constexpr std::initializer_list<TraceOption> roxieTraceOptions
     TRACEOPT(traceRoxieFiles),
     TRACEOPT(traceRoxieActiveQueries),
     TRACEOPT(traceRoxiePackets),
-    TRACEOPT(traceIBYTIfails),
+    TRACEOPT(traceIBYTI),
     TRACEOPT(traceRoxiePings),
     TRACEOPT(traceLimitExceeded),
     TRACEOPT(traceRoxiePrewarm),
-    TRACEOPT(traceMissingOptFiles)
+    TRACEOPT(traceMissingOptFiles),
+    TRACEOPT(traceAffinity),
+    TRACEOPT(traceRoxieSockets)
 };
 
 interface IPropertyTree;


### PR DESCRIPTION
Change traceLevels greater than 1 to use doTrace.
Cleanup some weird use of traceLevel with cache prewarm.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [ ] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
