### PR TITLE
HPCC-29372 Unable to insert folders ECLIDE

### DIFF
--- a/esp/services/ws_access/ws_accessService.cpp
+++ b/esp/services/ws_access/ws_accessService.cpp
@@ -2075,44 +2075,24 @@ bool Cws_accessEx::onResourceDelete(IEspContext &context, IEspResourceDeleteRequ
             resp.setPrefix(req.getPrefix());
         }
         SecResourceType rtype = str2type(basednReq->getRtype());
-        Owned<IMultiException> me = MakeMultiException("onResourceDelete");
-        try
+
+        for(unsigned i = 0; i < names.length(); i++)
         {
-            for(unsigned i = 0; i < names.length(); i++)
-            {
-                const char* name = names.item(i);
+            const char* name = names.item(i);
 
-                if(name == NULL || *name == '\0')
-                    continue;
+            if(name == NULL || *name == '\0')
+                continue;
 
-                StringBuffer namebuf(name);
-                if(rtype == RT_MODULE && stricmp(name, "repository") != 0 && Utils::strncasecmp(name, "repository.", 11) != 0)
-                    namebuf.insert(0, "repository.");
+            StringBuffer namebuf(name);
+            if(rtype == RT_MODULE && stricmp(name, "repository") != 0 && Utils::strncasecmp(name, "repository.", 11) != 0)
+                namebuf.insert(0, "repository.");
 
-                const char* prefix = req.getPrefix();
-                if(prefix && *prefix)
-                    namebuf.insert(0, prefix);
+            const char* prefix = req.getPrefix();
+            if(prefix && *prefix)
+                namebuf.insert(0, prefix);
 
-                try
-                {
-                    secmgr->deleteResource(rtype, namebuf.str(), basednReq->getBasedn(), context.querySecureContext());
-                }
-                catch(IException* e)
-                {
-                    me->append(*e);
-                }
-            }
+            secmgr->deleteResource(rtype, namebuf.str(), basednReq->getBasedn(), context.querySecureContext());
         }
-
-        catch(...)
-        {
-            resp.setRetcode(-1);
-            resp.setRetmsg("Unknown error");
-            return false;
-        }
-
-        if(me->ordinality())
-            throw me.getLink();
 
         resp.setRetcode(0);
     }

--- a/system/security/LdapSecurity/ldapconnection.cpp
+++ b/system/security/LdapSecurity/ldapconnection.cpp
@@ -4568,9 +4568,8 @@ public:
 
         if ( rc != LDAP_SUCCESS )
         {
-            throw MakeStringException(-1, "Error deleting %s: %s", dn.str(), ldap_err2string(rc));
+            DBGLOG("error deleting %s: %s", dn.str(), ldap_err2string(rc));
         }
-        
     }
 
     virtual void renameResource(SecResourceType rtype, const char* oldname, const char* newname, const char* basedn)


### PR DESCRIPTION
A previous fix https://github.com/hpcc-systems/HPCC-Platform/pull/16719 introduced this problem, where deleteResource() used to just log errors, but with the above fix it now throws.  The correct behavior is to not throw, same as the other similar resource management interfaces.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
