### PR TITLE
HPCC-29074 Add HTTPCALL support for application/x-www-form-urlencoded

### DIFF
--- a/ecl/hql/hqlatoms.cpp
+++ b/ecl/hql/hqlatoms.cpp
@@ -196,6 +196,7 @@ IAtom * flagAtom;
 IAtom * flagsAtom;
 IAtom * flatAtom;
 IAtom * foldAtom;
+IAtom * formEncodedAtom;
 IAtom * formatAtom;
 IAtom * forwardAtom;
 IAtom * fullonlyAtom;
@@ -675,6 +676,7 @@ MODULE_INIT(INIT_PRIORITY_HQLATOM)
     MAKEATOM(flat);
     MAKEATOM(fold);
     MAKEATOM(format);
+    MAKEATOM(formEncoded);
     MAKEATOM(forward);
     fullonlyAtom = createLowerCaseAtom("full only");        // different to get the ECL regeneration correct..
     fullouterAtom = createLowerCaseAtom("full outer");

--- a/ecl/hql/hqlatoms.hpp
+++ b/ecl/hql/hqlatoms.hpp
@@ -200,6 +200,7 @@ extern HQL_API IAtom * flagAtom;
 extern HQL_API IAtom * flagsAtom;
 extern HQL_API IAtom * flatAtom;
 extern HQL_API IAtom * foldAtom;
+extern HQL_API IAtom * formEncodedAtom;
 extern HQL_API IAtom * formatAtom;
 extern HQL_API IAtom * forwardAtom;
 extern HQL_API IAtom * fullonlyAtom;

--- a/ecl/hql/hqlgram.y
+++ b/ecl/hql/hqlgram.y
@@ -228,6 +228,7 @@ static void eclsyntaxerror(HqlGram * parser, const char * s, short yystate, int 
   FIRST
   TOK_FIXED
   FLAT
+  FORMENCODED
   FORMAT_ATTR
   FORWARD
   FROM
@@ -3791,6 +3792,16 @@ soapFlag
                             HqlExprArray args;
                             $3.unwindCommaList(args);
                             $$.setExpr(createExprAttribute(xmlAtom, args), $1);
+                        }
+    | FORMENCODED       {
+                            $$.setExpr(createAttribute(formEncodedAtom));
+                            $$.setPosition($1);
+                        }
+    | FORMENCODED '(' expression ')'
+                        {
+                            parser->normalizeExpression($3, type_string, true);
+                            $$.setExpr(createExprAttribute(formEncodedAtom, $3.getExpr()));
+                            $$.setPosition($1);
                         }
     | JSON_TOKEN        {
                             $$.setExpr(createAttribute(jsonAtom));

--- a/ecl/hql/hqlgram2.cpp
+++ b/ecl/hql/hqlgram2.cpp
@@ -7732,7 +7732,7 @@ inline bool hasHttpMarkupFlag(IHqlExpression *flags)
 {
     if (!flags)
         return false;
-    return (queryAttributeInList(jsonAtom, flags)!=nullptr || queryAttributeInList(xmlAtom, flags)!=nullptr);
+    return (queryAttributeInList(jsonAtom, flags)!=nullptr || queryAttributeInList(xmlAtom, flags)!=nullptr || queryAttributeInList(formEncodedAtom, flags)!=nullptr);
 }
 
 IHqlExpression * HqlGram::processHttpMarkupFlag(__int64 op)
@@ -11519,6 +11519,7 @@ static void getTokenText(StringBuffer & msg, int token)
     case TOK_FIXED: msg.append("FIXED"); break;
     case FLAT: msg.append("FLAT"); break;
     case FORMAT_ATTR: msg.append("FORMAT"); break;
+    case FORMENCODED: msg.append("FORMENCODED"); break;
     case FORWARD: msg.append("FORWARD"); break;
     case FROM: msg.append("FROM"); break;
     case FROMUNICODE: msg.append("FROMUNICODE"); break;

--- a/ecl/hql/hqllex.l
+++ b/ecl/hql/hqllex.l
@@ -751,6 +751,7 @@ FILTERED            { RETURNSYM(FILTERED); }
 FIRST               { RETURNSYM(FIRST); }
 FIXED               { RETURNSYM(TOK_FIXED); }
 FLAT                { RETURNSYM(FLAT); }
+FORMENCODED         { RETURNSYM(FORMENCODED); }             // Dynamically enabled based on the context
 FORMAT              { RETURNSYM(FORMAT_ATTR); }             // Dynamically enabled based on the context
 FORWARD             { RETURNSYM(FORWARD); }
 FROM                { RETURNSYM(FROM); }

--- a/ecl/hql/reservedwords.cpp
+++ b/ecl/hql/reservedwords.cpp
@@ -433,6 +433,7 @@ static const char * eclReserved14[] = { //Attribute functions (some might actual
     "default",
     "escape",
     "format",
+    "formencoded",
     "global",
     "groupby",
     "guard",

--- a/ecl/hqlcpp/hqlcerrors.hpp
+++ b/ecl/hqlcpp/hqlcerrors.hpp
@@ -228,6 +228,7 @@
 #define HQLERR_OutputLimitMaxExceeded           4216
 #define HQLERR_OutputLimitFutureMaxExceeded     4217
 #define HQLERR_UnsupportedReturnType            4218
+#define HQLERR_UnsupportedFormEncNotation       4219
 
 //Warnings....
 #define HQLWRN_PersistDataNotLikely             4500
@@ -540,6 +541,7 @@
 #define HQLERR_OutputLimitMaxExceeded_Text      "Dali result outputs are restricted to an absolute maximum of %u MB (%u MB specified by option). A huge dali result usually indicates the ECL needs altering."
 #define HQLERR_OutputLimitFutureMaxExceeded_Text "In the next platform version dali result outputs will be restricted to an absolute maximum of %u MB (%u MB specified by option). A huge dali result usually indicates the ECL needs altering."
 #define HQLERR_UnsupportedReturnType_Text       "Function returning type %s is not currently supported"
+#define HQLERR_UnsupportedFormEncNotation_Text  "x-www-form-urlencoded parameter notation format %s is not currently supported"
 
 //Warnings.
 #define HQLWRN_CannotRecreateDistribution_Text  "Cannot recreate the distribution for a persistent dataset"

--- a/initfiles/examples/http/eclwatch_service_query.ecl
+++ b/initfiles/examples/http/eclwatch_service_query.ecl
@@ -1,0 +1,61 @@
+ServiceQueryRequest := RECORD
+  string Type { XPATH('Type') } := 'EclWatch';
+  string Name { XPATH('Name') } := '';
+END;
+
+HpccServiceRecord := RECORD
+  string Name { XPATH('Name') };
+  string Type { XPATH('Type') };
+  integer2 Port { XPATH('Port') };
+  boolean TLSSecure { XPATH('TLSSecure') };
+END;
+
+
+ServiceQueryResponse := RECORD
+    dataset(HpccServiceRecord) services { XPATH('Services/Service') };
+END;
+
+
+
+// Get the list of EclWatch services by calling WsResources/ServiceQueryCall using several different protocols.
+//
+//
+
+
+//---------------- HTTP --------------------------------
+
+//Using an HTTP GET URL that returns JSON content:
+
+OUTPUT(HTTPCALL('http://.:8010/WsResources/ServiceQuery.json?Type=EclWatch','GET', 'application/json', ServiceQueryResponse, XPATH('/ServiceQueryResponse'), LOG('http get json')), NAMED('http_get_json'));
+
+//Using a HTTP GET URL that returns XML content:
+
+OUTPUT(HTTPCALL('http://.:8010/WsResources/ServiceQuery.xml?Type=EclWatch','GET', 'text/xml', ServiceQueryResponse, XPATH('/ServiceQueryResponse'), LOG('http get xml')), NAMED('http_get_xml'));
+
+//Using a JSON post
+
+OUTPUT(HTTPCALL('http://.:8010/WsResources','ServiceQueryRequest', ServiceQueryRequest, ServiceQueryResponse, JSON, XPATH('ServiceQueryResponse'), LOG('http post json')), NAMED('http_post_json'));
+
+
+
+//Using a form url encoded post
+//
+// Note: for nested content the following mapping / notation will be used:
+// FORMENCODED('dot') ==> a[1].b[2].c=123
+// FORMENCODED('bracket') ==> a[1][b][2][c]=123
+// FORMENCODED('esp') ==> a.1.b.2.c=123
+//
+
+
+OUTPUT(HTTPCALL('http://.:8010/WsResources/ServiceQuery','', ServiceQueryRequest, ServiceQueryResponse, FORMENCODED('esp'), XPATH('ServiceQueryResponse'), LOG('form encoded post json')), NAMED('form_post'));
+
+
+//---------------- SOAP --------------------------------
+
+//Using SOAP LITERAL:
+
+OUTPUT(SOAPCALL('http://.:8010/WsResources','ServiceQueryRequest', ServiceQueryRequest, ServiceQueryResponse, LITERAL, XPATH('ServiceQueryResponse'), LOG('soap literal')), NAMED('soap_literal'));
+
+//Using ESP specific SOAP
+
+OUTPUT(SOAPCALL('http://.:8010/WsResources','ServiceQuery', ServiceQueryRequest, ServiceQueryResponse, XPATH('ServiceQueryResponse'), LOG('soap esp')), NAMED('soap_esp'));

--- a/initfiles/examples/http/oauth_token.ecl
+++ b/initfiles/examples/http/oauth_token.ecl
@@ -1,0 +1,19 @@
+OauthTokenRequest := RECORD
+  string client_id {xpath('client_id')} := 'acmepaymentscorp-3rCEQzwEHMT9PPvuXcClpe3v';
+  string client_secret {xpath('client_secret')} := '<client_token>';
+  string code {xpath('code')} := '<code>';
+  string redirect_uri {xpath('redirect_uri')} := 'http://example.com:9900/ui/apps/acmepaymentscorp/resources/console/global/oauthclientredirect.html?dynamic=true';
+  string grant_type {xpath('grant_type')} := 'authorization_code';
+  string scope {xpath('scope')} := 'Scope1';
+END;
+
+
+OauthTokenResponse := RECORD
+  string access_token;
+  string id_token;
+  string refresh_token;
+  string token_type;
+  integer2 expires_in;
+END;
+
+output(HTTPCALL('https://ocidservice.authexample.io:443/oauth2/token','', OauthTokenRequest, OauthTokenResponse, FORMENCODED('dot')));

--- a/initfiles/examples/http/oauth_token_output.xml
+++ b/initfiles/examples/http/oauth_token_output.xml
@@ -1,0 +1,11 @@
+<Result>
+    <Dataset name='Result 1'>
+        <Row>
+            <access_token>SlAV32hkKG</access_token>
+            <id_token>eyJhbGciOiJSUzI1NiIsImtpZCI6IjFlOWdkazcifQ.ewogImlzcyI6ICJodHRwOi8vc2VydmVyLmV4YW1wbGUuY29tIiwKICJzdWIiOiAiMjQ4Mjg5NzYxMDAxIiwKICJhdWQiOiAiczZCaGRSa3F0MyIsCiAibm9uY2UiOiAibi0wUzZfV3pBMk1qIiwKICJleHAiOiAxMzExMjgxOTcwLAogImlhdCI6IDEzMTEyODA5NzAKfQ.ggW8hZ1EuVLuxNuuIJKX_V8a_OMXzR0EHR9R6jgdqrOOF4daGU96Sr_P6qJp6IcmD3HP99Obi1PRs-cwh3LO-p146waJ8IhehcwL7F09JdijmBqkvPeB2T9CJNqeGpe-gccMg4vfKjkM8FcGvnzZUN4_KSP0aAp1tOJ1zZwgjxqGByKHiOtX7TpdQyHE5lcMiKPXfEIQILVq0pc_E2DzL7emopWoaoZTF_m0_N0YzFC6g6EJbOEoRoSK5hoDalrcvRYLSrQAZZKflyuVCyixEoV9GfNQC3_osjzw2PAithfubEEBLuVVk4XUVrWOLrLl0nx7RkKU8NXNHq-rvKMzqg</id_token>
+            <refresh_token>8xLOxBtZp8</refresh_token>
+            <token_type>Bearer</token_type>
+            <expires_in>3600</expires_in>
+        </Row>
+    </Dataset>
+</Result>

--- a/initfiles/examples/http/oauth_token_resp.txt
+++ b/initfiles/examples/http/oauth_token_resp.txt
@@ -1,0 +1,10 @@
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "access_token": "SlAV32hkKG",
+  "token_type": "Bearer",
+  "refresh_token": "8xLOxBtZp8",
+  "expires_in": 3600,
+  "id_token": "eyJhbGciOiJSUzI1NiIsImtpZCI6IjFlOWdkazcifQ.ewogImlzcyI6ICJodHRwOi8vc2VydmVyLmV4YW1wbGUuY29tIiwKICJzdWIiOiAiMjQ4Mjg5NzYxMDAxIiwKICJhdWQiOiAiczZCaGRSa3F0MyIsCiAibm9uY2UiOiAibi0wUzZfV3pBMk1qIiwKICJleHAiOiAxMzExMjgxOTcwLAogImlhdCI6IDEzMTEyODA5NzAKfQ.ggW8hZ1EuVLuxNuuIJKX_V8a_OMXzR0EHR9R6jgdqrOOF4daGU96Sr_P6qJp6IcmD3HP99Obi1PRs-cwh3LO-p146waJ8IhehcwL7F09JdijmBqkvPeB2T9CJNqeGpe-gccMg4vfKjkM8FcGvnzZUN4_KSP0aAp1tOJ1zZwgjxqGByKHiOtX7TpdQyHE5lcMiKPXfEIQILVq0pc_E2DzL7emopWoaoZTF_m0_N0YzFC6g6EJbOEoRoSK5hoDalrcvRYLSrQAZZKflyuVCyixEoV9GfNQC3_osjzw2PAithfubEEBLuVVk4XUVrWOLrLl0nx7RkKU8NXNHq-rvKMzqg"
+}

--- a/rtl/include/eclhelper.hpp
+++ b/rtl/include/eclhelper.hpp
@@ -613,7 +613,9 @@ enum
     XWFopt          = 0x0002,
     XWFnoindent     = 0x0004,
     XWFexpandempty  = 0x0008,
-    XWFonlyindentroot = 0x0010 //JSON only for now.  only indent and add newline at root level.  Useful for writing out individual rows in ECL ouptut
+    XWFonlyindentroot = 0x0010, //JSON only for now.  only indent and add newline at root level.  Useful for writing out individual rows in ECL output
+    XWFbracketformenc = 0x0020,  //form encoding has a couple different styles: bracket, dot, and our hpcc proprietary format
+    XWFhpccformenc = 0x0040
 };
 
 
@@ -2226,7 +2228,8 @@ enum
     SOAPFnoroot         = 0x004000,
     SOAPFjson           = 0x008000,
     SOAPFxml            = 0x010000,
-    SOAPFlogusertail    = 0x020000
+    SOAPFlogusertail    = 0x020000,
+    SOAPFformEncoded    = 0x040000
 };
 
 struct IHThorWebServiceCallActionArg : public IHThorArg

--- a/system/jlib/jstring.cpp
+++ b/system/jlib/jstring.cpp
@@ -1537,7 +1537,7 @@ StringBuffer &  StringBuffer::appendhex(unsigned char c, char lower)
     return *this;
 }
 
-void appendURL(StringBuffer *dest, const char *src, size32_t len, char lower)
+void appendURL(StringBuffer *dest, const char *src, size32_t len, char lower, bool keepUnderscore)
 {
   if (len == (size32_t)-1)
     len = (size32_t)strlen(src);
@@ -1547,6 +1547,8 @@ void appendURL(StringBuffer *dest, const char *src, size32_t len, char lower)
     unsigned char c = (unsigned char) *src;
     if (c == ' ')
       dest->append('+');
+    else if (c == '_' && keepUnderscore)
+      dest->append(c);
     else if ((c & 0x80) || !isalnum(*src))
     {
       dest->append('%');

--- a/system/jlib/jstring.hpp
+++ b/system/jlib/jstring.hpp
@@ -383,7 +383,7 @@ interface IEntityHelper
     virtual bool find(const char *entity, StringBuffer &value) = 0;
 };
 
-void jlib_decl appendURL(StringBuffer *dest, const char *src, size32_t len = -1, char lower=FALSE);
+void jlib_decl appendURL(StringBuffer *dest, const char *src, size32_t len = -1, char lower=FALSE, bool keepUnderscore=false);
 extern jlib_decl StringBuffer &appendDecodedURL(StringBuffer &out, const char *url);
 extern jlib_decl StringBuffer &appendDecodedURL(StringBuffer &s, size_t len, const char *url);
 extern jlib_decl StringBuffer & appendStringAsCPP(StringBuffer &out, unsigned len, const char * src, bool addBreak);


### PR DESCRIPTION
Some services, like the OICD service oauth/token for example, only support being called using HTTP FORM URL ENCODED POST (application/x-www-form-urlencoded).

Note: when nested content is needed you can specify one of the following notations:

 FORMENCODED('dot')     ==> a[1].b[2].c=123
 FORMENCODED('bracket') ==> a[1][b][2][c]=123
 FORMENCODED('esp')     ==> a.1.b.2.c=123

For example usage see initfiles/examples/http.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [x] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [ ] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [x] Send notifications about my Pull Request position in Smoketest queue.
- [x] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
