### PR TITLE
HPCC-29053 Add --init-publisher-wuid option to ecl command line

### DIFF
--- a/ecl/ecl-bundle/CMakeLists.txt
+++ b/ecl/ecl-bundle/CMakeLists.txt
@@ -30,6 +30,7 @@ include(${HPCC_SOURCE_DIR}/esp/scm/smcscm.cmake)
 set (    SRCS
          ${ESPSCM_GENERATED_DIR}/common_esp.cpp
          ${ESPSCM_GENERATED_DIR}/ws_smc_esp.cpp
+         ${ESPSCM_GENERATED_DIR}/ws_fs_esp.cpp
          ecl-bundle.cpp
          ${HPCC_SOURCE_DIR}/ecl/eclcmd/eclcmd_shell.cpp
          ${HPCC_SOURCE_DIR}/ecl/eclcmd/eclcmd_common.hpp
@@ -54,9 +55,10 @@ include_directories (
          ${HPCC_SOURCE_DIR}/ecl/eclcmd
          ${HPCC_SOURCE_DIR}/ecl/eclcc
          ${HPCC_SOURCE_DIR}/common/thorhelper
+         ${ESPSCM_GENERATED_DIR}
     )
 
-ADD_DEFINITIONS( -D_CONSOLE -DWSSMC_API_LOCAL )
+ADD_DEFINITIONS( -D_CONSOLE -DWSSMC_API_LOCAL -DFileSpray_API_LOCAL )
 
 HPCC_ADD_EXECUTABLE ( ecl-bundle ${SRCS} )
 install ( TARGETS ecl-bundle RUNTIME DESTINATION ${EXEC_DIR} )

--- a/ecl/ecl-package/CMakeLists.txt
+++ b/ecl/ecl-package/CMakeLists.txt
@@ -30,6 +30,7 @@ include(${HPCC_SOURCE_DIR}/esp/scm/espscm.cmake)
 set (    SRCS
          ${ESPSCM_GENERATED_DIR}/common_esp.cpp
          ${ESPSCM_GENERATED_DIR}/ws_packageprocess_esp.cpp
+         ${ESPSCM_GENERATED_DIR}/ws_fs_esp.cpp
          ecl-package.cpp
          ${HPCC_SOURCE_DIR}/ecl/eclcmd/eclcmd_shell.cpp
          ${HPCC_SOURCE_DIR}/ecl/eclcmd/eclcmd_common.hpp
@@ -53,9 +54,10 @@ include_directories (
          ${HPCC_SOURCE_DIR}/ecl/eclcmd
          ${HPCC_SOURCE_DIR}/ecl/eclcc
          ${HPCC_SOURCE_DIR}/common/thorhelper
+         ${ESPSCM_GENERATED_DIR}
     )
 
-ADD_DEFINITIONS( -D_CONSOLE -DWsPackageProcess_API_LOCAL )
+ADD_DEFINITIONS( -D_CONSOLE -DWsPackageProcess_API_LOCAL -DFileSpray_API_LOCAL )
 
 HPCC_ADD_EXECUTABLE ( ecl-packagemap ${SRCS} )
 

--- a/ecl/ecl-package/ecl-package.cpp
+++ b/ecl/ecl-package/ecl-package.cpp
@@ -533,6 +533,8 @@ public:
             usage();
             return false;
         }
+        if (!dfuOptions.finalizeOptions(*this, globals))
+            return false;
         StringBuffer err;
         if (optFileName.isEmpty())
             err.append("\n ... Missing package file name\n");
@@ -563,7 +565,12 @@ public:
         StringBuffer pkgInfo;
         pkgInfo.loadFile(optFileName);
 
-        fprintf(stdout, "\n ... adding package map %s\n\n", optFileName.str());
+        if (dfuOptions.optOnlyCopyFiles)
+            fprintf(stdout, "\n ... copying files for package map %s\n\n", optFileName.str());
+        else if (dfuOptions.optStopIfFilesCopied)
+            fprintf(stdout, "\n ... copying files for, OR adding package map %s\n\n", optFileName.str());
+        else
+            fprintf(stdout, "\n ... adding package map %s\n\n", optFileName.str());
 
         Owned<IClientAddPackageRequest> request = packageProcessClient->createAddPackageRequest();
         setRpcOptions(request->rpc());
@@ -712,6 +719,8 @@ public:
             usage();
             return false;
         }
+        if (!dfuOptions.finalizeOptions(*this, globals))
+            return false;
         StringBuffer err;
         if (optSrcPath.isEmpty())
             err.append("\n ... Missing path to source packagemap\n");
@@ -730,7 +739,12 @@ public:
     {
         Owned<IClientWsPackageProcess> packageProcessClient = createCmdClient(WsPackageProcess, *this);
 
-        fprintf(stdout, "\n ... copy package map %s to %s\n\n", optSrcPath.str(), optTarget.str());
+        if (dfuOptions.optOnlyCopyFiles)
+            fprintf(stdout, "\n ... copying files, in preparation for copying package map %s to %s\n\n", optSrcPath.str(), optTarget.str());
+        else if (dfuOptions.optStopIfFilesCopied)
+            fprintf(stdout, "\n ... copying files for, OR copying package map %s to %s\n\n", optSrcPath.str(), optTarget.str());
+        else
+            fprintf(stdout, "\n ... copying package map %s to %s\n\n", optSrcPath.str(), optTarget.str());
 
         Owned<IClientCopyPackageMapRequest> request = packageProcessClient->createCopyPackageMapRequest();
         setRpcOptions(request->rpc());
@@ -1279,6 +1293,8 @@ public:
             usage();
             return false;
         }
+        if (!dfuOptions.finalizeOptions(*this, globals))
+            return false;
         StringBuffer err;
         if (optFileName.isEmpty())
             err.append("\n ... Missing package file name\n");
@@ -1308,7 +1324,12 @@ public:
         StringBuffer content;
         content.loadFile(optFileName);
 
-        fprintf(stdout, "\n ... adding packagemap %s part %s from file %s\n\n", optPMID.get(), optPartName.get(), optFileName.get());
+        if (dfuOptions.optOnlyCopyFiles)
+            fprintf(stdout, "\n ... copying files for packagemap %s part %s from file %s\n\n", optPMID.get(), optPartName.get(), optFileName.get());
+        else if (dfuOptions.optStopIfFilesCopied)
+            fprintf(stdout, "\n ... copying files for, OR adding packagemap %s part %s from file %s\n\n", optPMID.get(), optPartName.get(), optFileName.get());
+        else
+            fprintf(stdout, "\n ... adding packagemap %s part %s from file %s\n\n", optPMID.get(), optPartName.get(), optFileName.get());
 
         Owned<IClientAddPartToPackageMapRequest> request = packageProcessClient->createAddPartToPackageMapRequest();
         setRpcOptions(request->rpc());

--- a/ecl/eclcmd/CMakeLists.txt
+++ b/ecl/eclcmd/CMakeLists.txt
@@ -38,6 +38,7 @@ set (    SRCS
          ${ESPSCM_GENERATED_DIR}/ws_workunits_esp.cpp
          ${ESPSCM_GENERATED_DIR}/ws_codesign_esp.cpp
          ${ESPSCM_GENERATED_DIR}/ws_logaccess_esp.cpp
+         ${ESPSCM_GENERATED_DIR}/ws_fs_esp.cpp
          eclcmd.hpp
          ecl.cpp
          eclcmd_common.hpp
@@ -72,9 +73,10 @@ include_directories (
          ./../../system/jlib
          ./../../system/xmllib
          ${HPCC_SOURCE_DIR}/common/thorhelper
+         ${ESPSCM_GENERATED_DIR}
     )
 
-ADD_DEFINITIONS( -D_CONSOLE -DWSWU_API_LOCAL -Dws_codesign_API_LOCAL -Dws_logaccess_API_LOCAL )
+ADD_DEFINITIONS( -D_CONSOLE -DWSWU_API_LOCAL -Dws_codesign_API_LOCAL -Dws_logaccess_API_LOCAL -DFileSpray_API_LOCAL )
 
 
 HPCC_ADD_EXECUTABLE ( ecl ${SRCS} )

--- a/ecl/eclcmd/eclcmd_core.cpp
+++ b/ecl/eclcmd/eclcmd_core.cpp
@@ -396,6 +396,8 @@ public:
     {
         if (!EclCmdWithEclTarget::finalizeOptions(globals))
             return false;
+        if (!dfuOptions.finalizeOptions(*this, globals))
+            return false;
         if (!activateSet)
         {
             bool activate;

--- a/ecl/eclcmd/queries/CMakeLists.txt
+++ b/ecl/eclcmd/queries/CMakeLists.txt
@@ -23,6 +23,7 @@ set (    SRCS
          ${ESPSCM_GENERATED_DIR}/ws_workunits_queryset_req_resp_esp.cpp
          ${ESPSCM_GENERATED_DIR}/ws_workunits_esp.cpp
          ${ESPSCM_GENERATED_DIR}/ws_logaccess_esp.cpp
+         ${ESPSCM_GENERATED_DIR}/ws_fs_esp.cpp
          ecl-queries.cpp
          ../eclcmd_shell.cpp
          ../eclcmd_common.hpp
@@ -46,9 +47,10 @@ include_directories (
          ${HPCC_SOURCE_DIR}/ecl/eclcmd
          ${HPCC_SOURCE_DIR}/ecl/eclcc
          ${HPCC_SOURCE_DIR}/common/thorhelper
+         ${ESPSCM_GENERATED_DIR}
     )
 
-ADD_DEFINITIONS( -D_CONSOLE -DWSWU_API_LOCAL -Dws_logaccess_API_LOCAL )
+ADD_DEFINITIONS( -D_CONSOLE -DWSWU_API_LOCAL -Dws_logaccess_API_LOCAL -DFileSpray_API_LOCAL )
 
 HPCC_ADD_EXECUTABLE ( ecl-queries ${SRCS} )
 add_dependencies ( ecl-queries espscm)

--- a/ecl/eclcmd/queries/ecl-queries.cpp
+++ b/ecl/eclcmd/queries/ecl-queries.cpp
@@ -527,6 +527,8 @@ public:
     {
         if (!EclCmdCommon::finalizeOptions(globals))
             return false;
+        if (!dfuOptions.finalizeOptions(*this, globals))
+            return false;
         if (optSourceQueryPath.isEmpty() && optTargetCluster.isEmpty())
         {
             fputs("source and target must both be specified.\n", stderr);
@@ -763,6 +765,8 @@ public:
     virtual bool finalizeOptions(IProperties *globals)
     {
         if (!EclCmdCommon::finalizeOptions(globals))
+            return false;
+        if (!dfuOptions.finalizeOptions(*this, globals))
             return false;
         if (optSourceQuerySet.isEmpty() || optDestQuerySet.isEmpty())
         {
@@ -1119,6 +1123,8 @@ public:
     virtual bool finalizeOptions(IProperties *globals)
     {
         if (!EclCmdCommon::finalizeOptions(globals))
+            return false;
+        if (!dfuOptions.finalizeOptions(*this, globals))
             return false;
         if (optTarget.isEmpty())
         {
@@ -1503,6 +1509,8 @@ public:
     }
     virtual bool finalizeOptions(IProperties *globals)
     {
+        if (!dfuOptions.finalizeOptions(*this, globals))
+            return false;
         if (!EclCmdCommon::finalizeOptions(globals))
             return false;
         if (optFilename.isEmpty() || optDestQuerySet.isEmpty())

--- a/ecl/eclcmd/roxie/CMakeLists.txt
+++ b/ecl/eclcmd/roxie/CMakeLists.txt
@@ -21,6 +21,7 @@ set (    SRCS
          ${ESPSCM_GENERATED_DIR}/ws_dfu_common_esp.cpp
          ${ESPSCM_GENERATED_DIR}/ws_dfuXref_esp.cpp
          ${ESPSCM_GENERATED_DIR}/ws_dfu_esp.cpp
+         ${ESPSCM_GENERATED_DIR}/ws_fs_esp.cpp
          ecl-roxie.cpp
          ../eclcmd_shell.cpp
          ../eclcmd_common.hpp
@@ -44,9 +45,10 @@ include_directories (
          ${HPCC_SOURCE_DIR}/ecl/eclcmd
          ${HPCC_SOURCE_DIR}/ecl/eclcc
          ${HPCC_SOURCE_DIR}/common/thorhelper
+         ${ESPSCM_GENERATED_DIR}
     )
 
-ADD_DEFINITIONS( -D_CONSOLE -DWSSMC_API_LOCAL -DWSDFU_API_LOCAL -DWSDFUXREF_API_LOCAL )
+ADD_DEFINITIONS( -D_CONSOLE -DWSSMC_API_LOCAL -DWSDFU_API_LOCAL -DWSDFUXREF_API_LOCAL -DFileSpray_API_LOCAL )
 
 HPCC_ADD_EXECUTABLE ( ecl-roxie ${SRCS} )
 add_dependencies ( ecl-roxie espscm )

--- a/esp/scm/ws_fs.ecm
+++ b/esp/scm/ws_fs.ecm
@@ -223,6 +223,18 @@ CreateDFUWorkunitResponse
     ESPstruct DFUWorkunit result;
 };
 
+ESPrequest CreateDFUPublisherWorkunit
+{
+    string DFUServerQueue;
+};
+
+ESPresponse [exceptions_inline]
+
+CreateDFUPublisherWorkunitResponse
+{
+    ESPstruct DFUWorkunit result;
+};
+
 ESPrequest UpdateDFUWorkunit
 {
     ESPstruct DFUWorkunit wu;
@@ -708,6 +720,7 @@ ESPservice [
     ESPmethod [resp_xsl_default("/esp/xslt/dfu_progress.xslt")] GetDFUProgress(ProgressRequest, ProgressResponse);
 
     ESPmethod [resp_xsl_default("/esp/xslt/dfu_wuid.xslt")] CreateDFUWorkunit(CreateDFUWorkunit, CreateDFUWorkunitResponse);
+    ESPmethod CreateDFUPublisherWorkunit(CreateDFUPublisherWorkunit, CreateDFUPublisherWorkunitResponse);
     ESPmethod [resp_xsl_default("/esp/xslt/dfu_wuid.xslt")] UpdateDFUWorkunit(UpdateDFUWorkunit, UpdateDFUWorkunitResponse);
     ESPmethod DeleteDFUWorkunit(DeleteDFUWorkunit, DeleteDFUWorkunitResponse);
     ESPmethod DeleteDFUWorkunits(DeleteDFUWorkunits, DeleteDFUWorkunitsResponse);

--- a/esp/scm/ws_packageprocess.ecm
+++ b/esp/scm/ws_packageprocess.ecm
@@ -48,6 +48,7 @@ ESPrequest AddPackageRequest
     [min_ver("1.05")] bool DfuOverwrite(false);
     [min_ver("1.05")] bool OnlyCopyFiles(false); //Copies the files needed for the command but doesn't actually complete the command
     [min_ver("1.05")] bool StopIfFilesCopied(false); //Command only completes if no files need copying.  User can run again after DFU Publisher Workunit completes.
+    [min_ver("1.06")] string DfuPublisherWuid; //Wuid can be preallocated and then passed in here to use.  Will be created if empty
 };
 
 
@@ -82,6 +83,7 @@ ESPrequest CopyPackageMapRequest
     [min_ver("1.05")] bool DfuOverwrite(false);
     [min_ver("1.05")] bool OnlyCopyFiles(false); //Copies the files needed for the command but doesn't actually complete the command
     [min_ver("1.05")] bool StopIfFilesCopied(false); //Command only completes if no files need copying.  User can run again after DFU Publisher Workunit completes.
+    [min_ver("1.06")] string DfuPublisherWuid; //Wuid can be preallocated and then passed in here to use.  Will be created if empty
 };
 
 ESPresponse [exceptions_inline] CopyPackageMapResponse
@@ -315,6 +317,7 @@ ESPrequest AddPartToPackageMapRequest
     [min_ver("1.05")] bool DfuOverwrite(false);
     [min_ver("1.05")] bool OnlyCopyFiles(false); //Copies the files needed for the command but doesn't actually complete the command
     [min_ver("1.05")] bool StopIfFilesCopied(false); //Command only completes if no files need copying.  User can run again after DFU Publisher Workunit completes.
+    [min_ver("1.06")] string DfuPublisherWuid; //Wuid can be preallocated and then passed in here to use.  Will be created if empty
 };
 
 ESPresponse [exceptions_inline] AddPartToPackageMapResponse
@@ -352,7 +355,7 @@ ESPresponse [exceptions_inline] GetPartFromPackageMapResponse
     string Content;
 };
 
-ESPservice [auth_feature("NONE"), version("1.05"), default_client_version("1.05"), exceptions_inline("./smc_xslt/exceptions.xslt")] WsPackageProcess
+ESPservice [auth_feature("NONE"), version("1.06"), default_client_version("1.06"), exceptions_inline("./smc_xslt/exceptions.xslt")] WsPackageProcess
 {
     ESPmethod Echo(EchoRequest, EchoResponse);
     ESPmethod [auth_feature("PackageMapAccess:WRITE")] AddPackage(AddPackageRequest, AddPackageResponse);

--- a/esp/scm/ws_workunits_queryset_req_resp.ecm
+++ b/esp/scm/ws_workunits_queryset_req_resp.ecm
@@ -54,6 +54,7 @@ ESPrequest [nil_remove] WURecreateQueryRequest
     [min_ver("1.89")] bool DfuOverwrite(false);
     [min_ver("1.89")] bool OnlyCopyFiles(false); //Copies the files needed for the command but doesn't actually complete the command
     [min_ver("1.89")] bool StopIfFilesCopied(false); //Command only completes if no files need copying.  User can run again after DFU Publisher Workunit completes.
+    [min_ver("1.95")] string DfuPublisherWuid; //Wuid can be preallocated and then passed in here to use.  Will be created if empty
 };
 
 ESPresponse [exceptions_inline, nil_remove] WURecreateQueryResponse
@@ -139,6 +140,7 @@ ESPrequest [nil_remove] WUPublishWorkunitRequest
     [min_ver("1.89")] bool DfuOverwrite(false);
     [min_ver("1.89")] bool OnlyCopyFiles(false); //Copies the files needed for the command but doesn't actually complete the command
     [min_ver("1.89")] bool StopIfFilesCopied(false); //Command only completes if no files need copying.  User can run again after DFU Publisher Workunit completes.
+    [min_ver("1.95")] string DfuPublisherWuid; //Wuid can be preallocated and then passed in here to use.  Will be created if empty
 };
 
 ESPresponse [exceptions_inline] WUPublishWorkunitResponse
@@ -388,6 +390,7 @@ ESPrequest WUQuerysetImportRequest
     [min_ver("1.89")] bool DfuOverwrite(false);
     [min_ver("1.89")] bool OnlyCopyFiles(false); //Copies the files needed for the command but doesn't actually complete the command
     [min_ver("1.89")] bool StopIfFilesCopied(false); //Command only completes if no files need copying.  User can run again after DFU Publisher Workunit completes.
+    [min_ver("1.95")] string DfuPublisherWuid; //Wuid can be preallocated and then passed in here to use.  Will be created if empty
 };
 
 ESPresponse [exceptions_inline] WUQuerysetImportResponse
@@ -474,6 +477,7 @@ ESPrequest [nil_remove] WUQuerySetCopyQueryRequest
     [min_ver("1.89")] bool DfuOverwrite(false);
     [min_ver("1.89")] bool OnlyCopyFiles(false); //Copies the files needed for the command but doesn't actually complete the command
     [min_ver("1.89")] bool StopIfFilesCopied(false); //Command only completes if no files need copying.  User can run again after DFU Publisher Workunit completes.
+    [min_ver("1.95")] string DfuPublisherWuid; //Wuid can be preallocated and then passed in here to use.  Will be created if empty
 };
 
 ESPresponse [exceptions_inline] WUQuerySetCopyQueryResponse
@@ -508,6 +512,7 @@ ESPrequest [nil_remove] WUCopyQuerySetRequest
     [min_ver("1.89")] bool DfuOverwrite(false);
     [min_ver("1.89")] bool OnlyCopyFiles(false); //Copies the files needed for the command but doesn't actually complete the command
     [min_ver("1.89")] bool StopIfFilesCopied(false); //Command only completes if no files need copying.  User can run again after DFU Publisher Workunit completes.
+    [min_ver("1.95")] string DfuPublisherWuid; //Wuid can be preallocated and then passed in here to use.  Will be created if empty
 };
 
 ESPresponse [exceptions_inline] WUCopyQuerySetResponse

--- a/esp/scm/ws_workunits_req_resp.ecm
+++ b/esp/scm/ws_workunits_req_resp.ecm
@@ -1081,6 +1081,7 @@ ESPrequest [nil_remove] WUEclDefinitionActionRequest
     string DfuQueue;
     bool OnlyCopyFiles(false); //Copies the files needed for the command but doesn't actually complete the command
     bool StopIfFilesCopied(false); //Command only completes if no files need copying.  User can run again after DFU Publisher Workunit completes.
+    [min_ver("1.95")] string DfuPublisherWuid; //Wuid can be preallocated and then passed in here to use.  Will be created if empty
 };
 
 ESPresponse [exceptions_inline] WUEclDefinitionActionResponse

--- a/esp/services/ws_fs/ws_fsService.cpp
+++ b/esp/services/ws_fs/ws_fsService.cpp
@@ -1509,6 +1509,29 @@ bool CFileSprayEx::onCreateDFUWorkunit(IEspContext &context, IEspCreateDFUWorkun
     return true;
 }
 
+bool CFileSprayEx::onCreateDFUPublisherWorkunit(IEspContext &context, IEspCreateDFUPublisherWorkunit &req, IEspCreateDFUPublisherWorkunitResponse &resp)
+{
+    try
+    {
+        context.ensureFeatureAccess(DFU_WU_URL, SecAccess_Write, ECLWATCH_DFU_WU_ACCESS_DENIED, "Failed to create DFU Publisher workunit. Permission denied.");
+
+        Owned<IDFUWorkUnitFactory> factory = getDFUWorkUnitFactory();
+        Owned<IDFUWorkUnit> wu = factory->createPublisherWorkUnit();
+        setDFUServerQueueReq(req.getDFUServerQueue(), wu);
+        setUserAuth(context, wu);
+        wu->commit();
+        const char * d = wu->queryId();
+        IEspDFUWorkunit &result = resp.updateResult();
+        DeepAssign(context, wu, result);
+    }
+    catch(IException* e)
+    {
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
+    }
+
+    return true;
+}
+
 bool CFileSprayEx::onUpdateDFUWorkunit(IEspContext &context, IEspUpdateDFUWorkunit &req, IEspUpdateDFUWorkunitResponse &resp)
 {
     try

--- a/esp/services/ws_fs/ws_fsService.hpp
+++ b/esp/services/ws_fs/ws_fsService.hpp
@@ -108,6 +108,7 @@ public:
     virtual bool onGetDFUWorkunits(IEspContext &context, IEspGetDFUWorkunits &req, IEspGetDFUWorkunitsResponse &resp);
     virtual bool onGetDFUWorkunit(IEspContext &context, IEspGetDFUWorkunit &req, IEspGetDFUWorkunitResponse &resp);
     virtual bool onCreateDFUWorkunit(IEspContext &context, IEspCreateDFUWorkunit &req, IEspCreateDFUWorkunitResponse &resp);
+    virtual bool onCreateDFUPublisherWorkunit(IEspContext &context, IEspCreateDFUPublisherWorkunit &req, IEspCreateDFUPublisherWorkunitResponse &resp);
     virtual bool onUpdateDFUWorkunit(IEspContext &context, IEspUpdateDFUWorkunit &req, IEspUpdateDFUWorkunitResponse &resp);
     virtual bool onDeleteDFUWorkunits(IEspContext &context, IEspDeleteDFUWorkunits &req, IEspDeleteDFUWorkunitsResponse &resp);
     virtual bool onDeleteDFUWorkunit(IEspContext &context, IEspDeleteDFUWorkunit &req, IEspDeleteDFUWorkunitResponse &resp);

--- a/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
+++ b/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
@@ -974,7 +974,7 @@ bool CWsWorkunitsEx::onWUPublishWorkunit(IEspContext &context, IEspWUPublishWork
     if (req.getDfuOverwrite())
         updateFlags |= DFU_UPDATEF_OVERWRITE;
 
-    StringBuffer publisherWuid;
+    StringBuffer publisherWuid(req.getDfuPublisherWuid());
     if (!req.getDontCopyFiles())
     {
         QueryFileCopier cpr(target);
@@ -2126,7 +2126,7 @@ bool CWsWorkunitsEx::onWURecreateQuery(IEspContext &context, IEspWURecreateQuery
 
         if (req.getRepublish())
         {
-            StringBuffer publisherWuid;
+            StringBuffer publisherWuid(req.getDfuPublisherWuid());
             if (!req.getDontCopyFiles())
             {
                 StringBuffer daliIP;
@@ -3287,6 +3287,7 @@ public:
     StringArray existingQueryIds;
     StringArray copiedQueryIds;
     StringArray missingWuids;
+    StringBuffer dfu_jobname;
     StringAttr dfu_queue;
 };
 
@@ -3313,7 +3314,7 @@ bool CWsWorkunitsEx::onWUCopyQuerySet(IEspContext &context, IEspWUCopyQuerySetRe
     cloner.setQueryDirectory(queryDirectory);
 
     SCMStringBuffer process;
-    StringBuffer publisherWuid;
+    StringBuffer publisherWuid(req.getDfuPublisherWuid());
     if (req.getCopyFiles())
     {
         Owned <IConstWUClusterInfo> clusterInfo = getWUClusterInfoByName(target);
@@ -3332,7 +3333,10 @@ bool CWsWorkunitsEx::onWUCopyQuerySet(IEspContext &context, IEspWUCopyQuerySetRe
             if (req.getAppendCluster())
                 updateFlags |= DALI_UPDATEF_APPEND_CLUSTER;
             if (req.getDfuCopyFiles())
+            {
                 updateFlags |= DFU_UPDATEF_COPY;
+                cloner.dfu_jobname.append("copy queryset ").append(srcTarget);
+            }
             if (req.getDfuOverwrite())
                 updateFlags |= DFU_UPDATEF_OVERWRITE;
             cloner.dfu_queue.set(req.getDfuQueue());
@@ -3429,7 +3433,7 @@ bool CWsWorkunitsEx::onWUQuerysetCopyQuery(IEspContext &context, IEspWUQuerySetC
     Owned<IWorkUnitFactory> factory = getWorkUnitFactory(context.querySecManager(), context.queryUser());
     Owned<IConstWorkUnit> cw = factory->openWorkUnit(wuid.str());
 
-    StringBuffer publisherWuid;
+    StringBuffer publisherWuid(req.getDfuPublisherWuid());
     if (!req.getDontCopyFiles())
     {
         StringBuffer daliIP;
@@ -3457,6 +3461,7 @@ bool CWsWorkunitsEx::onWUQuerysetCopyQuery(IEspContext &context, IEspWUQuerySetC
         cpr.srcCluster.set(srcCluster);
         cpr.queryname.set(targetQueryName);
         cpr.dfu_queue.set(req.getDfuQueue());
+
         cpr.copy(publisherWuid, cw, updateFlags);
 
         if (req.getIncludeFileErrors())
@@ -3571,7 +3576,7 @@ bool CWsWorkunitsEx::onWUQuerysetImport(IEspContext &context, IEspWUQuerysetImpo
         else
             cloner.cloneAllLocal(activate, req.getQueryMask());
 
-        StringBuffer publisherWuid;
+        StringBuffer publisherWuid(req.getDfuPublisherWuid());
         cloner.cloneFiles(publisherWuid);
         if (req.getIncludeFileErrors())
             cloner.gatherFileErrors(resp.getFileErrors());

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -5528,6 +5528,7 @@ void CWsWorkunitsEx::publishEclDefinition(IEspContext &context, const char *targ
     publishReq->setDfuCopyFiles(req.getDfuCopyFiles());
     publishReq->setDfuOverwrite(req.getDfuOverwrite());
     publishReq->setDfuQueue(req.getDfuQueue());
+    publishReq->setDfuPublisherWuid(req.getDfuPublisherWuid());
 
     publishReq->setAllowForeignFiles(req.getAllowForeign());
     publishReq->setUpdateDfs(req.getUpdateDfs());


### PR DESCRIPTION
Add --init-publisher-wuid option wherever the cli supports --dfu-copy.  --init-publisher-wuid will preallocate the publisher wuid and display it on the command line before running the rest of the command.  This will allow the user to track the progress even if the cli interface gets disconnected from the server before the command completes.

This commit also improves the setting of the Publisher Workunit job name making it easier to find and understand the context of publisher workunits.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [x] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [x] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [x] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
