### PR TITLE
HPCC-29246 Check plane permission when dfu server sprays/desprays file

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -11838,9 +11838,23 @@ SecAccessFlags CDistributedFileDirectory::getFDescPermissions(IFileDescriptor *f
                 for (unsigned k=0;k<localpath.length();k++)
                     if ((localpath.charAt(k)=='?')||(localpath.charAt(k)=='*'))
                         localpath.setCharAt(k,'_');
-                CDfsLogicalFileName dlfn;
-                dlfn.setExternal(rfn.queryEndpoint(),localpath.str());
-                SecAccessFlags perm = getScopePermissions(dlfn.get(),user,auditflags);
+
+                SecAccessFlags perm = SecAccess_None;
+                StringBuffer planeName;
+                fdesc->getPlaneName(planeName);
+                if (!planeName.isEmpty())
+                {
+                    StringBuffer relativePath,dir;
+                    getDropZoneRelativePath(planeName,localpath,relativePath);
+                    splitFilename(relativePath,&dir,&dir,nullptr,nullptr);
+                    perm = getDropZoneScopePermissions(planeName.str(),dir.str(),user,auditflags);
+                }
+                else
+                {
+                    CDfsLogicalFileName dlfn;
+                    dlfn.setExternal(rfn.queryEndpoint(),localpath.str());
+                    perm = getScopePermissions(dlfn.get(),user,auditflags);
+                }
                 if (perm < retPerms) {
                     retPerms = perm;
                     if (retPerms == SecAccess_None)

--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -11840,8 +11840,14 @@ SecAccessFlags CDistributedFileDirectory::getFDescPermissions(IFileDescriptor *f
                         localpath.setCharAt(k,'_');
 
                 SecAccessFlags perm = SecAccess_None;
-                StringBuffer planeName;
+                StringBuffer plane1;
+                fdesc->getClusterGroupName(0, plane1, nullptr);
+                DBGLOG("####getFDescPermissions(): plane1(%s)", plane1.str());
+                IClusterInfo *iClusterInfo = LINK(fdesc->queryClusterNum(i));
+                StringBuffer planeName, planeName1(iClusterInfo->queryGroupName());
+                DBGLOG("####getFDescPermissions(): iClusterInfo->queryGroupName(%s)", planeName1.str());
                 fdesc->getPlaneName(planeName);
+                DBGLOG("####getFDescPermissions(): planeName(%s)", planeName.str());
                 if (!planeName.isEmpty())
                 {
                     StringBuffer relativePath,dir;

--- a/dali/base/dafdesc.cpp
+++ b/dali/base/dafdesc.cpp
@@ -1037,6 +1037,7 @@ class CFileDescriptor:  public CFileDescriptorBase, implements ISuperFileDescrip
     Owned<IStoragePlane> remoteStoragePlane;
     bool setupdone;
     byte version;
+    StringAttr planeName;
 
     IFileDescriptor &querySelf()
     {
@@ -2160,6 +2161,14 @@ public:
     {
         queryProperties().setPropInt("@flags", static_cast<int>(flags));
         fileFlags = flags;
+    }
+    virtual StringBuffer &getPlaneName(StringBuffer &str) override
+    {
+        return str.append(planeName.get());
+    }
+    virtual void setPlaneName(const char *name) override
+    {
+        planeName.set(name);
     }
 };
 

--- a/dali/base/dafdesc.hpp
+++ b/dali/base/dafdesc.hpp
@@ -293,6 +293,8 @@ if endCluster is not called it will assume only one cluster and not replicated
 
     virtual IPropertyTree *queryHistory() = 0;                                       // query file history records
     virtual void setFlags(FileDescriptorFlags flags) = 0;
+    virtual void setPlaneName(const char *name) = 0;
+    virtual StringBuffer &getPlaneName(StringBuffer &ret) = 0;
 };
 
 interface ISuperFileDescriptor: extends IFileDescriptor

--- a/dali/base/dautils.hpp
+++ b/dali/base/dautils.hpp
@@ -546,6 +546,7 @@ extern da_decl IPropertyTree * findDropZonePlane(const char * path, const char *
 extern da_decl bool isHostInPlane(IPropertyTree *plane, const char *host, bool ipMatch);
 extern da_decl bool getPlaneHost(StringBuffer &host, IPropertyTree *plane, unsigned which);
 extern da_decl void getPlaneHosts(StringArray &hosts, IPropertyTree *plane);
+extern da_decl StringBuffer &getDropZoneRelativePath(const char *dropZoneName, const char *dropZonePath, StringBuffer &relativePath);
 extern da_decl void setPageCacheTimeoutMilliSeconds(unsigned timeoutSeconds);
 extern da_decl void setMaxPageCacheItems(unsigned _maxPageCacheItems);
 extern da_decl IRemoteConnection* connectXPathOrFile(const char* path, bool safe, StringBuffer& xpath);

--- a/dali/dfu/dfurun.cpp
+++ b/dali/dfu/dfurun.cpp
@@ -1106,6 +1106,12 @@ public:
             wu->setDebugValue("dfulog", logname.str(), true);
         IConstDFUfileSpec *source = wu->querySource();
         IConstDFUfileSpec *destination = wu->queryDestination();
+        {
+            Owned<IFileDescriptor> fdesc = destination->getFileDescriptor();
+            StringBuffer groupName;
+            fdesc->getClusterGroupName(0, groupName, nullptr);
+            DBGLOG("####runWU(): groupName(%s)", groupName.str());
+        }
         IConstDFUoptions *options = wu->queryOptions();
         Owned<IPropertyTree> opttree = createPTreeFromIPT(options->queryTree());
 

--- a/dali/dfu/dfuwu.hpp
+++ b/dali/dfu/dfuwu.hpp
@@ -257,6 +257,7 @@ interface IConstDFUfileSpec: extends IInterface
     virtual StringBuffer &getRawDirectory(StringBuffer &str) const = 0;
     virtual StringBuffer &getRawFileMask(StringBuffer &str) const = 0;
     virtual bool getRemoteGroupOverride() const = 0;
+    virtual StringBuffer &getPlaneName(StringBuffer &str) const = 0;
 };
 
 interface IDFUfileSpec: extends IConstDFUfileSpec
@@ -290,6 +291,7 @@ interface IDFUfileSpec: extends IConstDFUfileSpec
     virtual IPropertyTree *queryUpdatePartProperties(unsigned partidx) = 0;
     virtual void setRoxiePrefix(const char *val) = 0;   // extra prefix to add to file name
     virtual void setRemoteGroupOverride(bool set) = 0;
+    virtual void setPlaneName(const char *val) = 0;
 };
 
 

--- a/esp/services/ws_fs/ws_fsService.cpp
+++ b/esp/services/ws_fs/ws_fsService.cpp
@@ -1920,7 +1920,8 @@ void CFileSprayEx::readAndCheckSpraySourceReq(MemoryBuffer& srcxml, const char* 
             if (sourceIPReq.isEmpty())
                 throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "Source network IP not specified.");
             Owned<IPropertyTree> plane = getAndValidateDropZone(sourcePath, sourceIPReq);
-            sourcePlaneReq.append(plane->queryProp("@name"));
+            if (plane) //The plane may not be found in bare-metal.
+                sourcePlaneReq.append(plane->queryProp("@name"));
         }
     }
     getStandardPosixPath(sourcePathReq, sourcePath.str());
@@ -2307,6 +2308,7 @@ void CFileSprayEx::checkDZScopeAccessAndSetSpraySourceDFUFileSpec(IEspContext &c
         rmfn.setEp(ep);
         rmfn.append(fnamebuf.str());
         srcDFUfileSpec->setMultiFilename(rmfn);
+        srcDFUfileSpec->setPlaneName(srcPlane);
     }
     else
     {   //this block is copied from the code before PR https://github.com/hpcc-systems/HPCC-Platform/pull/17144.
@@ -2490,6 +2492,7 @@ bool CFileSprayEx::onDespray(IEspContext &context, IEspDespray &req, IEspDespray
             if (umask.length())
                 options->setUMask(umask.str());
             destination->setSingleFilename(rfn);
+            destination->setPlaneName(destPlane);
         }
         else
         {   //Not sure there exists any use case for despraying a file using the dstxml. JIRA-29339 is created to check


### PR DESCRIPTION
1. When spraying/despraying a file, set dropzone plane name in DFUWU and use the name to check the scope permission for the dropzone file.
2. Change the setPlaneExternal() to allow empty path.
3. Fix a bug in CFileSprayEx::readAndCheckSpraySourceReq(): check the plane pointer before using it. The plane may not be found in bare-metal.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
