### PR TITLE
HPCC-29528 LDAP Connection pool should not retry dead connections

### DIFF
--- a/system/security/LdapSecurity/ldapconnection.cpp
+++ b/system/security/LdapSecurity/ldapconnection.cpp
@@ -889,6 +889,7 @@ private:
     time_t               m_lastaccesstime;
     bool                 m_connected;
     bool                 m_useSSL;
+    StringBuffer         m_connectedHost;
 
 public:
     IMPLEMENT_IINTERFACE
@@ -916,6 +917,7 @@ private:
         if(!ldapserver || *ldapserver == '\0')
             return -1;
 
+        m_connectedHost.clear();
         m_ld = LdapUtils::LdapInit(protocol, ldapserver, m_ldapconfig->getLdapPort(), m_ldapconfig->getLdapSecurePort());
         int rc = LDAP_SUCCESS;
         if(m_ldapconfig->sysuserSpecified())
@@ -927,6 +929,7 @@ private:
         {
             time(&m_lastaccesstime);
             m_connected = true;
+            m_connectedHost.append(ldapserver);
             const char * ldap = NULL;
             switch (m_ldapconfig->getServerType())
             {
@@ -1019,12 +1022,27 @@ public:
 
     virtual bool validate()
     {
+        if(!m_connected)
+            return connect();
+
+        //Ensure we are not using a rejected LDAP AD host
+        StringBuffer hostbuf;
+        m_ldapconfig->getLdapHost(hostbuf);
+        if (strcmp(hostbuf.str(), m_connectedHost.str()))
+        {
+            if (m_ld)//different host, disconnect from previous and try to reconnect to new one
+            {
+                LDAP_UNBIND(m_ld);
+                m_ld = NULL;
+            }
+            m_connected = false;
+            return connect();
+        }
+
         time_t now;
         time(&now);
 
-        if(!m_connected)
-            return connect();
-        else if(now - m_lastaccesstime <= 300)
+        if(now - m_lastaccesstime <= 300)
             return true;
         else
         {


### PR DESCRIPTION
LDAP Connection pool objects should not try reconncting to LDAP AD hosts that have been blacklisted

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
