### PR TITLE
HPCC-29479 Support flexible secure user name comparison rules

### DIFF
--- a/system/security/LdapSecurity/ldapsecurity.ipp
+++ b/system/security/LdapSecurity/ldapsecurity.ipp
@@ -156,6 +156,7 @@ public:
     IPropertyTree* getDataElement(const char* xpath = ".") const override { return nullptr; }
     IPropertyTreeIterator* getDataElements(const char* xpath = ".") const override { return nullptr; }
     bool setData(IPropertyTree* data) override { return false; }
+    virtual bool isCanonicalMatch(const char* name) const override { return (name && strieq(m_name.str(), name)); }
 
 //interface ISecCredentials
     bool setPassword(const char * pw);

--- a/system/security/shared/SecureUser.hpp
+++ b/system/security/shared/SecureUser.hpp
@@ -328,6 +328,11 @@ public:
     {
         return false;
     }
+
+    virtual bool isCanonicalMatch(const char* name) const override
+    {
+        return (name && strieq(m_name.str(), name));
+    }
 };
 
 #endif // SECUREUSER_INCL

--- a/system/security/shared/seclib.hpp
+++ b/system/security/shared/seclib.hpp
@@ -272,7 +272,8 @@ static const SecFeatureBit SUF_Clone                       = 0x0800000000;
 static const SecFeatureBit SUF_GetDataElement              = 0x1000000000;
 static const SecFeatureBit SUF_GetDataElements             = 0x2000000000;
 static const SecFeatureBit SUF_SetData                     = 0x4000000000;
-static const SecFeatureSet SUF_ALL_FEATURES                = 0x7FFFFFFFFF; // update to include all added feature bits
+static const SecFeatureBit SUF_IsCanonicalMatch            = 0x8000000000;
+static const SecFeatureSet SUF_ALL_FEATURES                = 0xFFFFFFFFFF; // update to include all added feature bits
 
 class CDateTime;
 interface IPropertyIterator;
@@ -318,6 +319,17 @@ interface ISecUser : implements ISecObject
     virtual IPropertyTree* getDataElement(const char* xpath = ".") const = 0;
     virtual IPropertyTreeIterator* getDataElements(const char* xpath = ".") const = 0;
     virtual bool setData(IPropertyTree* data) = 0;
+    /**
+     * @brief Determine if the input value is equivalent to an instance's name.
+     *
+     * Most user names are case-insensitive. Instead of the ESP assuming this is true for all
+     * names when matching names, each implementation can enforce its own comparison rules.
+     *
+     * @param name potential alternate acceptable name for the instance
+     * @return true the input value and instance name are interchangeable 
+     * @return false the input value and instance name are not interchangeable
+     */
+    virtual bool isCanonicalMatch(const char* name) const = 0;
 };
 
 


### PR DESCRIPTION
Enable secure user name matching based on security-manager defined rules. Define the default rule to be a case-insensitive comparison, while allowing individual security managers to customize behavior by manipulating the user objects they construct.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
