### PR TITLE
HPCC-29670 Fix broken file spray (no DZRestriction) and refactoring

### DIFF
--- a/dali/base/dautils.cpp
+++ b/dali/base/dautils.cpp
@@ -161,6 +161,11 @@ IPropertyTree * findDropZonePlane(const char * path, const char * host, bool ipM
     return findPlane("lz", path, host, ipMatch, mustMatch);
 }
 
+bool isPathInPlane(IPropertyTree *plane, const char *path)
+{
+    return isEmptyString(path) || startsWith(path, plane->queryProp("@prefix"));
+}
+
 extern da_decl const char *queryDfsXmlBranchName(DfsXmlBranchKind kind)
 {
     switch (kind) {

--- a/dali/base/dautils.hpp
+++ b/dali/base/dautils.hpp
@@ -548,6 +548,7 @@ extern da_decl bool validateDropZone(IPropertyTree *plane, const char *path, con
 extern da_decl bool isHostInPlane(IPropertyTree *plane, const char *host, bool ipMatch);
 extern da_decl bool getPlaneHost(StringBuffer &host, IPropertyTree *plane, unsigned which);
 extern da_decl void getPlaneHosts(StringArray &hosts, IPropertyTree *plane);
+extern da_decl bool isPathInPlane(IPropertyTree *plane, const char *path);
 extern da_decl void setPageCacheTimeoutMilliSeconds(unsigned timeoutSeconds);
 extern da_decl void setMaxPageCacheItems(unsigned _maxPageCacheItems);
 extern da_decl IRemoteConnection* connectXPathOrFile(const char* path, bool safe, StringBuffer& xpath);

--- a/esp/services/ws_fs/ws_fsService.hpp
+++ b/esp/services/ws_fs/ws_fsService.hpp
@@ -66,15 +66,15 @@ public:
 
 class CFileSprayEx : public CFileSpray
 {
-    void readAndCheckSpraySourceReq(MemoryBuffer& srcxml, const char* srcIP, const char* srcPath, const char* srcplane,
+    void readAndCheckSpraySourceReq(IEspContext& context, const char* srcIP, const char* srcPath, const char* srcplane,
         StringBuffer& sourcePlaneReq, StringBuffer& sourceIPReq, StringBuffer& sourcePathReq);
     void getServersInDropZone(const char* dropZoneName, IArrayOf<IConstTpDropZone>& dropZoneList,
         bool isECLWatchVisibleOnly, StringArray& serverList);
     IPropertyTree* getAndValidateDropZone(const char * path, const char * host);
     IEspDFUWorkunit* createDFUWUFromSashaListResult(const char* result);
     void setDFUCommand(const char* commandStr, IEspDFUWorkunit* dfuWU);
-    void checkDZScopeAccessAndSetSpraySourceDFUFileSpec(IEspContext& context, const char* srcPlane, const char * srcHost,
-        const char* srcFile, MemoryBuffer& srcXML, IDFUfileSpec* srcDFUfileSpec);
+    void setSpraySourceDFUFileSpec(IEspContext& context, const char * srcHost,
+        const char* srcFile, const MemoryBuffer& srcXML, IDFUfileSpec* srcDFUfileSpec);
 
 public:
     virtual void init(IPropertyTree *cfg, const char *process, const char *service);

--- a/esp/smc/SMCLib/TpCommon.cpp
+++ b/esp/smc/SMCLib/TpCommon.cpp
@@ -119,29 +119,29 @@ extern TPWRAPPER_API bool matchNetAddressRequest(const char* netAddressReg, bool
     return streq(netAddressReg, tpMachine.getConfigNetaddress());
 }
 
-extern TPWRAPPER_API bool validateDropZoneHostAndPath(const char* dropZoneName, const char* hostToCheck, const char* pathToCheck)
+extern TPWRAPPER_API StringBuffer &findDropZonePlaneName(const char* host, const char* path, StringBuffer& planeName)
 {
-    //Both hostToCheck and pathToCheck should not be empty. For backward compatibility, the dropZoneName may be empty.
-    if (isEmptyString(hostToCheck))
-        throw makeStringException(ECLWATCH_INVALID_INPUT, "Host not defined.");
-    if (isEmptyString(pathToCheck))
-        throw makeStringException(ECLWATCH_INVALID_INPUT, "Path not defined.");
-
-    if (containsRelPaths(pathToCheck)) //Detect a path like: /home/lexis/runtime/var/lib/HPCCSystems/mydropzone/../../../
-        throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "Invalid path %s", pathToCheck);
-
-    StringBuffer path(pathToCheck);
-    addPathSepChar(path);
-    if (isEmptyString(dropZoneName))
+    //Call findDropZonePlane() to resolve plane by hostname. Shouldn't resolve plane
+    //by hostname in containerized but kept for backward compatibility for now.
+    Owned<IPropertyTree> plane = findDropZonePlane(path, host, true, false);
+    if (plane)
+        planeName.append(plane->queryProp("@name"));
+    else
     {
-        Owned<IPropertyTree> plane = findDropZonePlane(path, hostToCheck, isIPAddress(hostToCheck), false);
-        return nullptr != plane;
+        Owned<IException> e = makeStringExceptionV(ECLWATCH_INVALID_INPUT, "DropZone not found for host '%s' path '%s'.", host, path);
+#ifndef _CONTAINERIZED
+        // In bare-metal, if environment.conf is configured with useDropZoneRestriction=false, issue warning only
+        Owned<IEnvironmentFactory> factory = getEnvironmentFactory(true);
+        Owned<IConstEnvironment> env = factory->openEnvironment();
+        if (!env->isDropZoneRestrictionEnabled())
+        {
+            WARNLOG(e);
+            return planeName; // NB: not filled
+        }
+#endif
+        throw e.getClear();
     }
-
-    Owned<IPropertyTree> plane = getDropZonePlane(dropZoneName);
-    if (nullptr == plane)
-        return false;
-    return validateDropZone(plane, path, hostToCheck, isIPAddress(hostToCheck));
+    return planeName;
 }
 
 static SecAccessFlags getDropZoneScopePermissions(IEspContext& context, const IPropertyTree* dropZone, const char* dropZonePath)
@@ -167,31 +167,40 @@ static SecAccessFlags getDropZoneScopePermissions(IEspContext& context, const IP
     return queryDistributedFileDirectory().getDropZoneScopePermissions(name, dropZonePath, userDesc);
 }
 
-extern TPWRAPPER_API SecAccessFlags getDZPathScopePermissions(IEspContext& context, const char* dropZoneName, const char* dropZonePath, const char* dropZoneHost)
+extern TPWRAPPER_API SecAccessFlags getDZPathScopePermissions(IEspContext& context, const char* dropZoneName, const char* dropZonePath)
 {
     if (isEmptyString(dropZonePath))
         throw makeStringException(ECLWATCH_INVALID_CLUSTER_NAME, "getDZPathScopePermissions(): DropZone path must be specified.");
 
-    Owned<IPropertyTree> dropZone;
-    if (isEmptyString(dropZoneName))
-        dropZone.setown(findDropZonePlane(dropZonePath, dropZoneHost, true, true));
-    else
-    {
-        dropZone.setown(getDropZonePlane(dropZoneName));
-        if (!dropZone)
-            throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "getDZPathScopePermissions(): DropZone %s not found.", dropZoneName);
-    }
+    Owned<IPropertyTree> dropZone = getDropZonePlane(dropZoneName);
+    if (!dropZone)
+        throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "getDZPathScopePermissions(): DropZone %s not found.", dropZoneName);
 
     return getDropZoneScopePermissions(context, dropZone, dropZonePath);
 }
 
-extern TPWRAPPER_API SecAccessFlags getDZFileScopePermissions(IEspContext& context, const char* dropZoneName, const char* dropZonePath,
-    const char* dropZoneHost)
+extern TPWRAPPER_API void checkDZPathScopePermissions(IEspContext& context, const char* dropZoneName, const char* dropZonePath, SecAccessFlags accessReq)
+{
+    SecAccessFlags access = getDZPathScopePermissions(context, dropZoneName, dropZonePath);
+    if (access < accessReq)
+        throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "Access DropZone Scope %s %s not allowed for user %s (permission:%s). %s Access Required.",
+            dropZoneName, dropZonePath, context.queryUserId(), getSecAccessFlagName(access), getSecAccessFlagName(accessReq));
+}
+
+extern TPWRAPPER_API SecAccessFlags getDZFileScopePermissions(IEspContext& context, const char* dropZoneName, const char* dropZoneFilePath)
 {
     StringBuffer dir, fileName;
-    splitFilename(dropZonePath, &dir, &dir, nullptr, nullptr);
-    dropZonePath = dir.str();
-    return getDZPathScopePermissions(context, dropZoneName, dropZonePath, dropZoneHost);
+    splitFilename(dropZoneFilePath, &dir, &dir, nullptr, nullptr);
+    dropZoneFilePath = dir.str();
+    return getDZPathScopePermissions(context, dropZoneName, dropZoneFilePath);
+}
+
+extern TPWRAPPER_API void checkDZFileScopePermissions(IEspContext& context, const char* dropZoneName, const char* dropZoneFilePath, SecAccessFlags accessReq)
+{
+    SecAccessFlags access = getDZFileScopePermissions(context, dropZoneName, dropZoneFilePath);
+    if (access < accessReq)
+        throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "Access DropZone Scope %s for file %s not allowed for user %s (permission:%s). %s Access Required.",
+            dropZoneName, dropZoneFilePath, context.queryUserId(), getSecAccessFlagName(access), getSecAccessFlagName(accessReq));
 }
 
 extern TPWRAPPER_API void validateDropZoneAccess(IEspContext& context, const char* targetDZNameOrHost, const char* hostReq, SecAccessFlags permissionReq,
@@ -209,9 +218,35 @@ extern TPWRAPPER_API void validateDropZoneAccess(IEspContext& context, const cha
             throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "Host %s is not valid DropZone plane %s", hostReq, targetDZNameOrHost);
     }
     const char *dropZoneName = dropZone->queryProp("@name");
-    SecAccessFlags permission = getDZFileScopePermissions(context, dropZoneName, fileNameWithRelPath, hostReq);
+    SecAccessFlags permission = getDZFileScopePermissions(context, dropZoneName, fileNameWithRelPath);
     if (permission < permissionReq)
         throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "Access DropZone Scope %s %s not allowed for user %s (permission:%s). %s Access Required.",
             dropZoneName, fileNameWithRelPath, context.queryUserId(), getSecAccessFlagName(permission), getSecAccessFlagName(permissionReq));
     dlfn.setPlaneExternal(dropZoneName, fileNameWithRelPath);
 }
+
+extern TPWRAPPER_API void checkDropZoneInput(IEspContext& context, StringBuffer& dropZoneName, const char* host, const char* path)
+{
+    if (dropZoneName.isEmpty())
+        findDropZonePlaneName(host, path, dropZoneName);
+    if (!dropZoneName.isEmpty()) // must be true, unless bare-metal and isDropZoneRestrictionEnabled()==false
+    {
+        Owned<IPropertyTree> dropZone = getDropZonePlane(dropZoneName);
+        if (!dropZone)
+            throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "Unknown landing zone: %s", dropZoneName.str());
+        if (isContainerized() && strsame("localhost", host)) //ECLWatch may send "localhost" for dropzones without hosts.
+            host = nullptr;
+        else if (!isEmptyString(host) && !isHostInPlane(dropZone, host, false))
+            throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "Host '%s' is not valid for dropzone '%s'", host, dropZoneName.str());
+        if (!isPathInPlane(dropZone, path))
+            throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "Path '%s' is not valid for dropzone '%s'", path, dropZoneName.str());
+    }
+}
+
+extern TPWRAPPER_API void checkDropZoneInputAndAccess(IEspContext& context, StringBuffer& dropZoneName, const char* host, const char* path, SecAccessFlags accessReq)
+{
+    checkDropZoneInput(context, dropZoneName, host, path);
+    if (!dropZoneName.isEmpty()) // must be true, unless bare-metal and isDropZoneRestrictionEnabled()==false
+        checkDZPathScopePermissions(context, dropZoneName, path, accessReq);
+}
+

--- a/esp/smc/SMCLib/TpWrapper.hpp
+++ b/esp/smc/SMCLib/TpWrapper.hpp
@@ -239,10 +239,14 @@ extern TPWRAPPER_API StringArray & getRoxieDirectAccessPlanes(StringArray & plan
 extern TPWRAPPER_API bool validateDataPlaneName(const char *remoteDali, const char * name);
 extern TPWRAPPER_API bool matchNetAddressRequest(const char* netAddressReg, bool ipReq, IConstTpMachine& tpMachine);
 
-extern TPWRAPPER_API bool validateDropZoneHostAndPath(const char* dropZoneName, const char* hostToCheck, const char* pathToCheck);
-extern TPWRAPPER_API SecAccessFlags getDZPathScopePermissions(IEspContext& context, const char* dropZoneName, const char* dropZonePath, const char* dropZoneHost);
-extern TPWRAPPER_API SecAccessFlags getDZFileScopePermissions(IEspContext& context, const char* dropZoneName, const char* dropZonePath, const char* dropZoneHost);
+extern TPWRAPPER_API StringBuffer &findDropZonePlaneName(const char* host, const char* path, StringBuffer& planeName);
+extern TPWRAPPER_API SecAccessFlags getDZPathScopePermissions(IEspContext& context, const char* dropZoneName, const char* dropZonePath);
+extern TPWRAPPER_API void checkDZPathScopePermissions(IEspContext& context, const char* dropZoneName, const char* dropZonePath, SecAccessFlags accessReq);
+extern TPWRAPPER_API SecAccessFlags getDZFileScopePermissions(IEspContext& context, const char* dropZoneName, const char* dropZoneFilePath);
+extern TPWRAPPER_API void checkDZFileScopePermissions(IEspContext& context, const char* dropZoneName, const char* dropZoneFilePath, SecAccessFlags accessReq);
 extern TPWRAPPER_API void validateDropZoneAccess(IEspContext& context, const char* targetDZNameOrHost, const char* hostReq, SecAccessFlags permissionReq,
     const char* fileNameWithRelPath, CDfsLogicalFileName& dlfn);
+extern TPWRAPPER_API void checkDropZoneInput(IEspContext& context, StringBuffer& dropZoneName, const char* host, const char* path);
+extern TPWRAPPER_API void checkDropZoneInputAndAccess(IEspContext& context, StringBuffer& dropZoneName, const char* host, const char* path, SecAccessFlags accessReq);
 
 #endif //_ESPWIZ_TpWrapper_HPP__


### PR DESCRIPTION
This PR is a copy of the original branch for https://github.com/hpcc-systems/HPCC-Platform/pull/17378. To minimize the changes for 9.0.x, the latest branch for that PR only contains the fix for the crash when file spray with DropZoneRestriction disabled. This PR replaces that PR for master.

1. When spraying a file with no DropZoneRestriction, the getAndValidateDropZone() may not return a dropzone plane. The readAndCheckSpraySourceReq() should validate the return and read the plane name if there is the return.
2. In the checkDZScopeAccessAndSetSpraySourceDFUFileSpec(), validate DZPathScopePermissions only if the dropzone plane name is found in the readAndCheckSpraySourceReq().
3. Create throwOrLogDropZoneLookUpError(): if not bare metal or DropZoneRestriction enabled, throw an exception; otherwise, log the error.
4. Create findDropZonePlaneName(): if a plane name is not found based on dropzone host and path, call throwOrLogDropZoneLookUpError().
5. In ESP FileSpray service, call the findDropZonePlaneName() to find a dropzone plane name. Validate DZPathScopePermissions only if the plane name is found.
6. In getDZPathScopePermissions(), if a dropzone plane is not found based on dropzone host and path, call throwOrLogDropZoneLookUpError().

Revise based on review:
1. Remove the host from the getDZPathScopePermissions() and the getDZFileScopePermissions().
2. Move the findDropZonePlaneName() so that it can be called from both ws_fsService.cpp and ws_fsBinding.cpp.
3. Add checkDZPathScopePermissions() and checkDZFileScopePermissions().

Revise based on review:
1. Add isPathInPlane().
2. Remove the validateDropZonePath() and change related code.
3. Move the code from the throwOrLogDropZoneLookUpError() to the findDropZonePlaneName().
4. Several small changes.

Revise based on review:
1. Change the isPathInPlane() to return true for empty path.
2. Move the checkDropZoneInputAndAccess() to SMCLib.
3. Revise it so that it can be used by ws_fsService.cpp.
4. Revise the onFileList() to use checkDropZoneInputAndAccess().
5. Call checkDropZoneInputAndAccess() from OnFileList and onDeleteDropZoneFiles.
6. Call checkDropZoneInput() from OnDespray.

Revise based on review:
1. Do not check 'localhost' if containerized
2. Revise readAndCheckSpraySourceReq() for spray to use checkDropZoneInput(), including: move the scope access check from checkDZScopeAccessAndSetSpraySourceDFUFileSpec()
to readAndCheckSpraySourceReq() and rename
checkDZScopeAccessAndSetSpraySourceDFUFileSpec()
to setSpraySourceDFUFileSpec().
3. Remove the #include "dautils.hpp" from ws_Binding.cpp since the checkDropZoneInputAndAccess() has been moved to SMCLib.
4. Clean the code for the XML MemoryBuffer cast.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
