### PR TITLE
HPCC-29549 Handle fully qualified path when validating DZ scope access

### DIFF
--- a/dali/base/dautils.cpp
+++ b/dali/base/dautils.cpp
@@ -156,6 +156,11 @@ IPropertyTree * findDropZonePlane(const char * path, const char * host, bool ipM
     return findPlane("lz", path, host, ipMatch, mustMatch);
 }
 
+bool isPathInPlane(IPropertyTree *plane, const char *path)
+{
+    return isEmptyString(path) || startsWith(path, plane->queryProp("@prefix"));
+}
+
 extern da_decl const char *queryDfsXmlBranchName(DfsXmlBranchKind kind)
 {
     switch (kind) {

--- a/dali/base/dautils.hpp
+++ b/dali/base/dautils.hpp
@@ -547,6 +547,7 @@ extern da_decl IPropertyTree * findDropZonePlane(const char * path, const char *
 extern da_decl bool isHostInPlane(IPropertyTree *plane, const char *host, bool ipMatch);
 extern da_decl bool getPlaneHost(StringBuffer &host, IPropertyTree *plane, unsigned which);
 extern da_decl void getPlaneHosts(StringArray &hosts, IPropertyTree *plane);
+extern da_decl bool isPathInPlane(IPropertyTree *plane, const char *path);
 extern da_decl void setPageCacheTimeoutMilliSeconds(unsigned timeoutSeconds);
 extern da_decl void setMaxPageCacheItems(unsigned _maxPageCacheItems);
 extern da_decl IRemoteConnection* connectXPathOrFile(const char* path, bool safe, StringBuffer& xpath);

--- a/esp/services/ws_fs/ws_fsService.cpp
+++ b/esp/services/ws_fs/ws_fsService.cpp
@@ -1871,6 +1871,8 @@ bool CFileSprayEx::onGetDFUExceptions(IEspContext &context, IEspGetDFUExceptions
 
 static StringBuffer &getDropZoneHost(const char *planeName, IPropertyTree *plane, StringBuffer &host)
 {
+    if (isContainerized() && strsame("localhost", host.str())) //ECLWatch may send "localhost" for dropzones without hosts.
+        host.clear();
     if (!host.isEmpty())
     {
         if (!isHostInPlane(plane, host, true))
@@ -1904,7 +1906,20 @@ IPropertyTree *CFileSprayEx::getAndValidateDropZone(const char *path, const char
     return nullptr;
 }
 
-void CFileSprayEx::readAndCheckSpraySourceReq(MemoryBuffer& srcxml, const char* srcIP, const char* srcPath, const char* srcPlane,
+static bool parseUNCPath(const char* sprayPath, StringBuffer& localPath, StringBuffer& hostInPath)
+{
+    if (!isPathSepChar(sprayPath[0]) || (sprayPath[0] != sprayPath[1]))
+        return false;
+
+    splitUNCFilename(sprayPath, &hostInPath, &localPath, &localPath, &localPath);
+    hostInPath.remove(0, 2); //Skip the leading "//"
+    if (hostInPath.isEmpty())
+        throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "Invalid SourcePath %s.", sprayPath);
+
+    return true;
+}
+
+void CFileSprayEx::readAndCheckSpraySourceReq(IEspContext& context, MemoryBuffer& srcxml, const char* srcIP, const char* srcPath, const char* srcPlane,
     StringBuffer& sourcePlaneReq, StringBuffer& sourceIPReq, StringBuffer& sourcePathReq)
 {
     StringBuffer sourcePath(srcPath);
@@ -1916,38 +1931,107 @@ void CFileSprayEx::readAndCheckSpraySourceReq(MemoryBuffer& srcxml, const char* 
         if (containsRelPaths(sourcePath)) //Detect a path like: a/../../../f
             throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "Invalid path %s", sourcePath.str());
 
-        if (!isEmptyString(srcPlane))
+        Owned<IPropertyTree> dropZone;
+        sourceIPReq.set(srcIP).trim();
+        sourcePlaneReq.set(srcPlane).trim();
+
+        // establish dropzone if possible
+        if (!sourcePlaneReq.isEmpty())
         {
-            Owned<IPropertyTree> dropZone = getDropZonePlane(srcPlane);
+            dropZone.setown(getDropZonePlane(sourcePlaneReq));
             if (!dropZone)
-                throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "Unknown landing zone: %s", srcPlane);
-            const char * dropZonePlanePath = dropZone->queryProp("@prefix");
-            if (isAbsolutePath(sourcePath))
-            {
-                if (!startsWith(sourcePath, dropZonePlanePath))
-                    throw makeStringException(ECLWATCH_INVALID_INPUT, "Invalid source path");
-            }
-            else
-            {
-                StringBuffer s(sourcePath);
-                sourcePath.set(dropZonePlanePath);
-                addNonEmptyPathSepChar(sourcePath);
-                sourcePath.append(s);
-            }
-            getDropZoneHost(srcPlane, dropZone, sourceIPReq);
-            sourcePlaneReq.append(srcPlane);
+                throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "Unknown landing zone: %s", sourcePlaneReq.str());
+            if (!sourceIPReq.isEmpty() && !isHostInPlane(dropZone, sourceIPReq, true))
+                throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "SourceIP '%s' is not defined within the dropzone %s.", sourceIPReq.str(), dropZone->queryProp("@name"));
         }
         else
         {
-            sourceIPReq.set(srcIP).trim();
             if (sourceIPReq.isEmpty())
                 throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "Source network IP not specified.");
-            Owned<IPropertyTree> plane = getAndValidateDropZone(sourcePath, sourceIPReq);
-            if (plane)
-                sourcePlaneReq.append(plane->queryProp("@name"));
+            dropZone.setown(findDropZonePlane(nullptr, sourceIPReq, true, isContainerized()));
+            if (dropZone)
+                sourcePlaneReq.append(dropZone->queryProp("@name"));
+            // else - only possible if bare-metal and isDropZoneRestrictionEnabled()==false
         }
+
+        SocketEndpoint sourceHostEp(sourceIPReq);
+
+        //Validate dropzone scope access for every files from the sourcePathReq.
+        //Correct relative path and save into the sourcePathReq.
+        getStandardPosixPath(sourcePathReq, sourcePath.str());
+        StringArray files;
+        files.appendList(sourcePathReq, ","); // handles comma separated files
+        sourcePathReq.clear();
+        ForEachItemIn(i, files)
+        {
+            const char* file = files.item(i);
+            if (isEmptyString(file))
+                continue;
+
+            //Parse the file to find/validate possible host/ip and local path.
+            //Validate file path.
+            StringBuffer hostInPath, localPath, absPath;
+            const char* path = nullptr;
+            if (parseUNCPath(file, localPath, hostInPath))
+            {
+                SocketEndpoint hostInPathEp(hostInPath);
+                if (!sourceIPReq.isEmpty() && !sourceHostEp.ipequals(hostInPathEp))
+                    throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "The host '%s' defined in the SourcePath '%s' does not match with the host '%s' defined in SourceIP.", hostInPath.str(), file, sourceIPReq.str());
+                if (dropZone)
+                {
+                    // don't re-check if sourceIPReq specified and therefore already checked valid previously.
+                    if (sourceIPReq.isEmpty())
+                    {
+                        if (!isHostInPlane(dropZone, hostInPath, true))
+                           throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "Host '%s' in '%s' is not defined within the dropzone %s.", hostInPath.str(), file, dropZone->queryProp("@name"));
+                    }
+                    if (!isPathInPlane(dropZone, localPath))
+                        throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "Path '%s' in '%s' is not valid for dropzone '%s'", localPath.str(), file, dropZone->queryProp("@name"));
+                }
+                // else implies bare-metal+restrictions off - sourceIPReq cannot be empty, if no dropzone.
+
+                path = localPath.str();
+            }
+            else
+            {
+                path = file;
+                if (isAbsolutePath(path))
+                {
+                    if (dropZone && !isPathInPlane(dropZone, path))
+                        throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "Path '%s' is not valid for dropzone '%s'", path, sourcePlaneReq.str());
+                }
+                else
+                {
+                    if (dropZone) // force paths to absolute, for LDAP checking below
+                    {
+                        absPath.set(dropZone->queryProp("@prefix"));
+                        addNonEmptyPathSepChar(absPath);
+                        absPath.append(path);
+                        path = absPath.str();
+                    }
+                }
+            }
+
+            if (dropZone)
+            {
+                //Based on the tests, the dfuserver only supports the wildcard inside the file name, like '/path/f*'.
+                //The dfuserver throws an error if the wildcard is inside the path, like /p*ath/file.
+                SecAccessFlags permission = getDZFileScopePermissions(context, sourcePlaneReq, path, nullptr);
+                if (permission < SecAccess_Read)
+                    throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "Access DropZone Scope %s %s not allowed for user %s (permission:%s). Read Access Required.",
+                        sourcePlaneReq.str(), path, context.queryUserId(), getSecAccessFlagName(permission));
+            }
+
+            if (!sourcePathReq.isEmpty())
+                sourcePathReq.append(",");
+            if (!hostInPath.isEmpty())
+                sourcePathReq.append("//").append(hostInPath);
+            sourcePathReq.append(path);
+        }
+        // fill in sourceIPReq based on dropzone if not provided
+        if (dropZone && sourceIPReq.isEmpty())
+            getDropZoneHost(sourcePlaneReq, dropZone, sourceIPReq);
     }
-    getStandardPosixPath(sourcePathReq, sourcePath.str());
 }
 
 static void checkValidDfuQueue(const char * dfuQueue)
@@ -1993,7 +2077,7 @@ bool CFileSprayEx::onSprayFixed(IEspContext &context, IEspSprayFixed &req, IEspS
 
         MemoryBuffer& srcxml = (MemoryBuffer&)req.getSrcxml();
         StringBuffer sourcePlaneReq, sourceIPReq, sourcePathReq;
-        readAndCheckSpraySourceReq(srcxml, req.getSourceIP(), req.getSourcePath(), req.getSourcePlane(), sourcePlaneReq, sourceIPReq, sourcePathReq);
+        readAndCheckSpraySourceReq(context, srcxml, req.getSourceIP(), req.getSourcePath(), req.getSourcePlane(), sourcePlaneReq, sourceIPReq, sourcePathReq);
         const char* srcfile = sourcePathReq.str();
         const char* destname = req.getDestLogicalName();
         if(isEmptyString(destname))
@@ -2032,7 +2116,7 @@ bool CFileSprayEx::onSprayFixed(IEspContext &context, IEspSprayFixed &req, IEspS
         wu->setCommand(DFUcmd_import);
 
         IDFUfileSpec *source = wu->queryUpdateSource();
-        checkDZScopeAccessAndSetSpraySourceDFUFileSpec(context, sourcePlaneReq, sourceIPReq, srcfile, srcxml, source);
+        setSpraySourceDFUFileSpec(context, sourcePlaneReq, sourceIPReq, srcfile, srcxml, source);
 
         IDFUfileSpec *destination = wu->queryUpdateDestination();
         bool nosplit = req.getNosplit();
@@ -2158,7 +2242,7 @@ bool CFileSprayEx::onSprayVariable(IEspContext &context, IEspSprayVariable &req,
 
         MemoryBuffer& srcxml = (MemoryBuffer&)req.getSrcxml();
         StringBuffer sourcePlaneReq, sourceIPReq, sourcePathReq;
-        readAndCheckSpraySourceReq(srcxml, req.getSourceIP(), req.getSourcePath(), req.getSourcePlane(), sourcePlaneReq, sourceIPReq, sourcePathReq);
+        readAndCheckSpraySourceReq(context, srcxml, req.getSourceIP(), req.getSourcePath(), req.getSourcePlane(), sourcePlaneReq, sourceIPReq, sourcePathReq);
         const char* srcfile = sourcePathReq.str();
         const char* destname = req.getDestLogicalName();
         if(isEmptyString(destname))
@@ -2191,7 +2275,7 @@ bool CFileSprayEx::onSprayVariable(IEspContext &context, IEspSprayVariable &req,
         IDFUfileSpec *destination = wu->queryUpdateDestination();
         IDFUoptions *options = wu->queryUpdateOptions();
 
-        checkDZScopeAccessAndSetSpraySourceDFUFileSpec(context, sourcePlaneReq, sourceIPReq, srcfile, srcxml, source);
+        setSpraySourceDFUFileSpec(context, sourcePlaneReq, sourceIPReq, srcfile, srcxml, source);
         source->setMaxRecordSize(req.getSourceMaxRecordSize());
         source->setFormat((DFUfileformat)req.getSourceFormat());
 
@@ -2298,43 +2382,19 @@ bool CFileSprayEx::onSprayVariable(IEspContext &context, IEspSprayVariable &req,
     return true;
 }
 
-void CFileSprayEx::checkDZScopeAccessAndSetSpraySourceDFUFileSpec(IEspContext &context, const char *srcPlane, const char *srcHost,
+void CFileSprayEx::setSpraySourceDFUFileSpec(IEspContext &context, const char *srcPlane, const char *srcHost,
     const char *srcFile, MemoryBuffer &srcXML, IDFUfileSpec *srcDFUfileSpec)
 {
     if(srcXML.length() == 0)
     {
         //The srcHost is validated in readAndCheckSpraySourceReq().
-        //If the srcPlane is found by readAndCheckSpraySourceReq(), the DZFileScopePermissions
-        //should be validated for every files in srcFile.
-        StringBuffer fnamebuf(srcFile);
-        fnamebuf.trim();
-        if (!isEmptyString(srcPlane))  // must be true, unless bare-metal and isDropZoneRestrictionEnabled()==false
-        {
-            StringArray files;
-            files.appendList(fnamebuf, ","); // handles comma separated files
-            ForEachItemIn(i, files)
-            {
-                const char *file = files.item(i);
-                if (isEmptyString(file))
-                    continue;
-
-                //Based on the tests, the dfuserver only supports the wildcard inside the file name, like '/path/f*'.
-                //The dfuserver throws an error if the wildcard is inside the path, like /p*ath/file.
-
-                SecAccessFlags permission = getDZFileScopePermissions(context, srcPlane, file, srcHost);
-                if (permission < SecAccess_Read)
-                    throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "Access DropZone Scope %s %s not allowed for user %s (permission:%s). Read Access Required.",
-                        srcPlane, file, context.queryUserId(), getSecAccessFlagName(permission));
-            }
-        }
-
         SocketEndpoint ep(srcHost);
         if (ep.isNull())
             throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "Cannot resolve source network IP from %s.", srcHost);
 
         RemoteMultiFilename rmfn;
         rmfn.setEp(ep);
-        rmfn.append(fnamebuf.str());
+        rmfn.append(srcFile);
         srcDFUfileSpec->setMultiFilename(rmfn);
     }
     else

--- a/esp/services/ws_fs/ws_fsService.cpp
+++ b/esp/services/ws_fs/ws_fsService.cpp
@@ -1871,8 +1871,6 @@ bool CFileSprayEx::onGetDFUExceptions(IEspContext &context, IEspGetDFUExceptions
 
 static StringBuffer &getDropZoneHost(const char *planeName, IPropertyTree *plane, StringBuffer &host)
 {
-    if (isContainerized() && strsame("localhost", host.str())) //ECLWatch may send "localhost" for dropzones without hosts.
-        host.clear();
     if (!host.isEmpty())
     {
         if (!isHostInPlane(plane, host, true))

--- a/esp/services/ws_fs/ws_fsService.hpp
+++ b/esp/services/ws_fs/ws_fsService.hpp
@@ -66,14 +66,14 @@ public:
 
 class CFileSprayEx : public CFileSpray
 {
-    void readAndCheckSpraySourceReq(MemoryBuffer& srcxml, const char* srcIP, const char* srcPath, const char* srcplane,
+    void readAndCheckSpraySourceReq(IEspContext& context, MemoryBuffer& srcxml, const char* srcIP, const char* srcPath, const char* srcplane,
         StringBuffer& sourcePlaneReq, StringBuffer& sourceIPReq, StringBuffer& sourcePathReq);
     void getServersInDropZone(const char* dropZoneName, IArrayOf<IConstTpDropZone>& dropZoneList,
         bool isECLWatchVisibleOnly, StringArray& serverList);
     IPropertyTree* getAndValidateDropZone(const char * path, const char * host);
     IEspDFUWorkunit* createDFUWUFromSashaListResult(const char* result);
     void setDFUCommand(const char* commandStr, IEspDFUWorkunit* dfuWU);
-    void checkDZScopeAccessAndSetSpraySourceDFUFileSpec(IEspContext& context, const char* srcPlane, const char * srcHost,
+    void setSpraySourceDFUFileSpec(IEspContext& context, const char* srcPlane, const char * srcHost,
         const char* srcFile, MemoryBuffer& srcXML, IDFUfileSpec* srcDFUfileSpec);
 
 public:

--- a/esp/smc/SMCLib/TpWrapper.hpp
+++ b/esp/smc/SMCLib/TpWrapper.hpp
@@ -233,6 +233,7 @@ extern TPWRAPPER_API StringArray & getRoxieDirectAccessPlanes(StringArray & plan
 extern TPWRAPPER_API bool validateDataPlaneName(const char *remoteDali, const char * name);
 extern TPWRAPPER_API bool matchNetAddressRequest(const char* netAddressReg, bool ipReq, IConstTpMachine& tpMachine);
 
+extern TPWRAPPER_API StringBuffer &findDropZonePlaneName(const char* host, const char* path, StringBuffer& planeName);
 extern TPWRAPPER_API bool validateDropZonePath(const char* dropZoneName, const char* netAddr, const char* pathToCheck);
 extern TPWRAPPER_API SecAccessFlags getDZPathScopePermissions(IEspContext& context, const char* dropZoneName, const char* dropZonePath, const char* dropZoneHost);
 extern TPWRAPPER_API SecAccessFlags getDZFileScopePermissions(IEspContext& context, const char* dropZoneName, const char* dropZonePath, const char* dropZoneHost);


### PR DESCRIPTION
1. Move the code of the scope permission validation from the
checkDZScopeAccessAndSetSpraySourceDFUFileSpec() to the
readAndCheckSpraySourceReq().
2. In readAndCheckSpraySourceReq(), parse the file requests inside the
SourcePath request. For each file request, validating the scope permission.
If a file request contains a host/ip, validate the host/ip and local file
path. If a file request does not contain a host/ip, validate the file path.
3. Rename the checkDZScopeAccessAndSetSpraySourceDFUFileSpec() to
setSpraySourceDFUFileSpec().
4. Validate localhost in getDropZoneHost().

Signed-off-by: wangkx <kevin.wang@lexisnexis.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [ ] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [ ] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [ ] I have read the CONTRIBUTORS document.
- [ ] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
