### PR TITLE
HPCC-29809 Stop esdlStore null dereference

### DIFF
--- a/esp/services/ws_esdlconfig/ws_esdlconfigservice.cpp
+++ b/esp/services/ws_esdlconfig/ws_esdlconfigservice.cpp
@@ -186,8 +186,8 @@ void CWsESDLConfigEx::init(IPropertyTree *cfg, const char *process, const char *
     if(servicecfg == NULL)
         throw MakeStringException(-1, "config not found for service %s/%s",process, service);
 
-    m_isDetachedFromDali = false;
     m_esdlStore.setown(createEsdlCentralStore());
+    m_isDetachedFromDali = (nullptr == m_esdlStore);
 }
 
 // Build two independent lists. First an array of IEspMethodConfig elements that lists
@@ -1117,22 +1117,6 @@ bool CWsESDLConfigEx::onConfigureESDLBindingLogTransform(IEspContext &context, I
     resp.updateStatus().setCode(success);
 
     return true;
-}
-
-int CWsESDLConfigEx::getBindingXML(const char * bindingId, StringBuffer & bindingXml, StringBuffer & msg)
-{
-    Owned<IPropertyTree> esdlBinding = m_esdlStore->getBindingTree(bindingId, msg);
-    if (esdlBinding)
-    {
-        toXML(esdlBinding, bindingXml, 0,0);
-        msg.setf("Successfully fetched binding %s", bindingId);
-        return 0;
-    }
-    else
-    {
-        msg.setf("Could not fetch binding %s", bindingId);
-        return -1;
-    }
 }
 
 bool CWsESDLConfigEx::onGetESDLBinding(IEspContext &context, IEspGetESDLBindingRequest &req, IEspGetESDLBindingResponse &resp)

--- a/esp/services/ws_esdlconfig/ws_esdlconfigservice.hpp
+++ b/esp/services/ws_esdlconfig/ws_esdlconfigservice.hpp
@@ -38,7 +38,6 @@ class CWsESDLConfigEx : public CWsESDLConfig
 private:
     Owned<IEsdlStore> m_esdlStore;
     IPropertyTree * getEspProcessRegistry(const char * espprocname, const char * espbingingport, const char * servicename);
-    int getBindingXML(const char * bindingId, StringBuffer & bindingXml, StringBuffer & msg);
     void buildServiceMethodsResponse(IEsdlDefinitionInfo* defInfo, IArrayOf<IEspMethodConfig>& methodList, StringArray& serviceList, const char* svc = nullptr);
     void buildServiceWithMethodsResponse(IEsdlDefinitionInfo* defInfo, IArrayOf<IEspESDLService>& serviceList, const char* svc = nullptr);
     void wrapWithDefinitionElement(IEsdlDefinitionInfo* defInfo, StringBuffer& def);
@@ -66,8 +65,14 @@ public:
 
     bool attachServiceToDali() override
     {
-        m_isDetachedFromDali = false;
-        return true;
+        if(nullptr == m_esdlStore)
+        {
+            m_esdlStore.setown(createEsdlCentralStore());
+            m_isDetachedFromDali = (nullptr == m_esdlStore);
+        }
+        else
+            m_isDetachedFromDali = false;
+        return !m_isDetachedFromDali;
     }
 
     bool detachServiceFromDali() override


### PR DESCRIPTION
Set the m_isDetachedFromDali flag to true when we have a null esdlStore pointer. Ensure each function using the esdlStore is prefaced with a check of the isDetachedFromDali flag.

Then we won't attempt to use the esdlStore when there is no dali connection.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [x] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [x] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->
Manual testing in helm and bare metal deployments.

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
