### PR TITLE
HPCC-29549 Handle fully qualified path when validating DZ scope access

### DIFF
--- a/dali/base/dautils.cpp
+++ b/dali/base/dautils.cpp
@@ -122,6 +122,11 @@ IPropertyTree * getDropZonePlane(const char * name)
     return getGlobalConfigSP()->getPropTree(xpath);
 }
 
+bool isPathInPlane(IPropertyTree *plane, const char *path)
+{
+    return isEmptyString(path) || startsWith(path, plane->queryProp("@prefix"));
+}
+
 bool validateDropZone(IPropertyTree * plane, const char * path, const char * host, bool ipMatch)
 {
     if (host)
@@ -133,7 +138,7 @@ bool validateDropZone(IPropertyTree * plane, const char * path, const char * hos
         return false;
 
     //Match path
-    return isEmptyString(path) || startsWith(path, plane->queryProp("@prefix"));
+    return isPathInPlane(plane, path);
 }
 
 IPropertyTree * findPlane(const char *category, const char * path, const char * host, bool ipMatch, bool mustMatch)

--- a/dali/base/dautils.hpp
+++ b/dali/base/dautils.hpp
@@ -548,6 +548,7 @@ extern da_decl bool validateDropZone(IPropertyTree *plane, const char *path, con
 extern da_decl bool isHostInPlane(IPropertyTree *plane, const char *host, bool ipMatch);
 extern da_decl bool getPlaneHost(StringBuffer &host, IPropertyTree *plane, unsigned which);
 extern da_decl void getPlaneHosts(StringArray &hosts, IPropertyTree *plane);
+extern da_decl bool isPathInPlane(IPropertyTree *plane, const char *path);
 extern da_decl void setPageCacheTimeoutMilliSeconds(unsigned timeoutSeconds);
 extern da_decl void setMaxPageCacheItems(unsigned _maxPageCacheItems);
 extern da_decl IRemoteConnection* connectXPathOrFile(const char* path, bool safe, StringBuffer& xpath);

--- a/esp/services/ws_fs/ws_fsService.hpp
+++ b/esp/services/ws_fs/ws_fsService.hpp
@@ -66,14 +66,14 @@ public:
 
 class CFileSprayEx : public CFileSpray
 {
-    void readAndCheckSpraySourceReq(MemoryBuffer& srcxml, const char* srcIP, const char* srcPath, const char* srcplane,
+    void readAndCheckSpraySourceReq(IEspContext& context, MemoryBuffer& srcxml, const char* srcIP, const char* srcPath, const char* srcplane,
         StringBuffer& sourcePlaneReq, StringBuffer& sourceIPReq, StringBuffer& sourcePathReq);
     void getServersInDropZone(const char* dropZoneName, IArrayOf<IConstTpDropZone>& dropZoneList,
         bool isECLWatchVisibleOnly, StringArray& serverList);
     IPropertyTree* getAndValidateDropZone(const char * path, const char * host);
     IEspDFUWorkunit* createDFUWUFromSashaListResult(const char* result);
     void setDFUCommand(const char* commandStr, IEspDFUWorkunit* dfuWU);
-    void checkDZScopeAccessAndSetSpraySourceDFUFileSpec(IEspContext& context, const char* srcPlane, const char * srcHost,
+    void setSpraySourceDFUFileSpec(IEspContext& context, const char* srcPlane, const char * srcHost,
         const char* srcFile, MemoryBuffer& srcXML, IDFUfileSpec* srcDFUfileSpec);
 
 public:


### PR DESCRIPTION
1. Move the code of the scope permission validation from the checkDZScopeAccessAndSetSpraySourceDFUFileSpec() to the readAndCheckSpraySourceReq().
2. Rename the checkDZScopeAccessAndSetSpraySourceDFUFileSpec() to setSpraySourceDFUFileSpec().
3. In readAndCheckSpraySourceReq(), parse the file requests inside the SourcePath request. For each file request, validating the scope permission. If a file request contains a host/ip, validate the host/ip and local file path. If a file request does not contain a host/ip, validate the file path.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
