### PR TITLE
HPCC-28555 Add blocked reader for unfiltered serial index reading

### DIFF
--- a/common/thorhelper/thorfile.hpp
+++ b/common/thorhelper/thorfile.hpp
@@ -55,7 +55,7 @@ interface IKeyIndex;
 THORHELPER_API bool checkIndexMetaInformation(IDistributedFile * file, bool force);
 THORHELPER_API bool calculateDerivedIndexInformation(DerivedIndexInformation & result, IDistributedFile * file, bool force);
 THORHELPER_API void mergeDerivedInformation(DerivedIndexInformation & result, const DerivedIndexInformation & other);
-THORHELPER_API IKeyIndex *openKeyFile(IDistributedFilePart & keyFile);
+THORHELPER_API IKeyIndex *openKeyFile(IDistributedFilePart & keyFile, size32_t blockedIndexFileIOSize=0);
 
 
 #endif

--- a/dali/base/dautils.cpp
+++ b/dali/base/dautils.cpp
@@ -103,23 +103,17 @@ void getPlaneHosts(StringArray &hosts, IPropertyTree *plane)
     }
 }
 
-constexpr const char * lz_plane_path = "storage/planes[@category='lz']";
-
 IPropertyTreeIterator * getDropZonePlanesIterator(const char * name)
 {
-    StringBuffer xpath(lz_plane_path);
-    if (!isEmptyString(name))
-        xpath.appendf("[@name='%s']", name);
-    return getGlobalConfigSP()->getElements(xpath);
+    return getPlanesIterator("lz", name);
 }
 
 IPropertyTree * getDropZonePlane(const char * name)
 {
     if (isEmptyString(name))
         throw makeStringException(-1, "Drop zone name required");
-    StringBuffer xpath(lz_plane_path);
-    xpath.appendf("[@name='%s']", name);
-    return getGlobalConfigSP()->getPropTree(xpath);
+    Owned<IPropertyTreeIterator> iter = getDropZonePlanesIterator(name);
+    return iter->first() ? &iter->get() : nullptr;
 }
 
 IPropertyTree * findPlane(const char *category, const char * path, const char * host, bool ipMatch, bool mustMatch)

--- a/ecl/hthor/hthorkey.cpp
+++ b/ecl/hthor/hthorkey.cpp
@@ -594,7 +594,15 @@ void CHThorIndexReadActivityBase::killPart()
 
 bool CHThorIndexReadActivityBase::setCurrentPart(unsigned whichPart)
 {
-    keyIndex.setown(openKeyFile(df->queryPart(whichPart)));
+    IDistributedFilePart &part = df->queryPart(whichPart);
+    size32_t blockedSize = 0;
+    if (!helper.hasSegmentMonitors()) // unfiltered
+    {
+        StringBuffer planeName;
+        df->getClusterName(part.copyClusterNum(0), planeName);
+        blockedSize = getBlockedFileIOSize(planeName);
+    }
+    keyIndex.setown(openKeyFile(part, blockedSize));
     if(df->numParts() == 1)
         verifyIndex(keyIndex);
     initPart();

--- a/helm/hpcc/values.schema.json
+++ b/helm/hpcc/values.schema.json
@@ -544,6 +544,11 @@
             "waitForMount": {
               "type": "boolean"
             },
+            "blockedFileIOKB": {
+              "description": "Optimal block size for efficient reading from this plane. Implementations will use if they can",
+              "type": "integer",
+              "default": 0
+            },
             "components": {},
             "prefix": {},
             "subPath": {},

--- a/system/jlib/jfile.cpp
+++ b/system/jlib/jfile.cpp
@@ -7568,6 +7568,16 @@ IPropertyTree * getRemoteStorage(const char * name)
     return global->getPropTree(xpath);
 }
 
+IPropertyTreeIterator * getPlanesIterator(const char * category, const char *name)
+{
+    StringBuffer xpath("storage/planes");
+    if (!isEmptyString(category))
+        xpath.appendf("[@category='%s']", category);
+    if (!isEmptyString(name))
+        xpath.appendf("[@name='%s']", name);
+    return getGlobalConfigSP()->getElements(xpath);
+}
+
 IAPICopyClient * createApiCopyClient(IStorageApiInfo * source, IStorageApiInfo * target)
 {
     ReadLockBlock block(containedFileHookLock);
@@ -7578,4 +7588,102 @@ IAPICopyClient * createApiCopyClient(IStorageApiInfo * source, IStorageApiInfo *
             return copyClient;
     }
     return nullptr;
+}
+
+
+// NB: This implementation is not thread-safe.
+// Therefore it should only be used by use cases that are single threaded
+class CBlockedFileIO : public CSimpleInterfaceOf<IFileIO>
+{
+    Owned<IFileIO> io;
+    size32_t blockSize = 0;
+    size32_t readLen = 0;
+    void *buffer = nullptr;
+    offset_t lastReadPos = (offset_t)-1;
+    MemoryBuffer mb;
+public:
+    CBlockedFileIO(IFileIO *_io, size32_t _blockSize) : io(_io), blockSize(_blockSize)
+    {
+        buffer = mb.reserveTruncate(blockSize);
+    }
+    virtual size32_t read(offset_t pos, size32_t len, void *data) override
+    {
+        if (len > blockSize)
+            return io->read(pos, len, data);
+        size32_t totalCopied = 0;
+        byte *dest = (byte *) data;
+        while (len)
+        {
+            offset_t readPos = (pos / blockSize) * blockSize; // NB: could be beyond end of file
+            if (readPos != lastReadPos)
+            {
+                readLen = io->read(readPos, blockSize, buffer); // NB: can be less than blockSize (and 0 if beyodn end of file)
+                lastReadPos = readPos;
+            }
+            size32_t endPos = readPos+readLen;
+            size32_t copyNow;
+            if (pos+len <= endPos) // common case hopefully
+                copyNow = len;
+            else if (pos < endPos)
+                copyNow = endPos-pos;
+            else // nothing to copy
+                break;
+            memcpy(dest, ((byte *)buffer) + pos-readPos, copyNow);
+            len -= copyNow;
+            pos += copyNow;
+            dest += copyNow;
+            totalCopied += copyNow;
+        }
+        return totalCopied;
+    }
+    virtual offset_t size() override { return io->size(); }
+    virtual size32_t write(offset_t pos, size32_t len, const void * data) override { throwUnexpected(); }
+    virtual offset_t appendFile(IFile *file, offset_t pos=0, offset_t len=(offset_t)-1) override { throwUnexpected(); }
+    virtual void setSize(offset_t size) override { throwUnexpected(); }
+    virtual void flush() override { throwUnexpected(); }
+    virtual void close() override { io->close(); }
+    virtual unsigned __int64 getStatistic(StatisticKind kind) override { return io->getStatistic(kind); }
+};
+
+extern IFileIO *createBlockedIO(IFileIO *base, size32_t blockSize)
+{
+    return new CBlockedFileIO(base, blockSize);
+}
+
+// Cache/update plane index blocked IO settings
+static unsigned planeBlockIOMapCBId = 0;
+static std::unordered_map<std::string, size32_t> planeBlockedIOMap;
+static CriticalSection planeBlockedIOMapCrit;
+MODULE_INIT(INIT_PRIORITY_STANDARD)
+{
+    auto updateFunc = [&](const IPropertyTree *oldComponentConfiguration, const IPropertyTree *oldGlobalConfiguration)
+    {
+        CriticalBlock b(planeBlockedIOMapCrit);
+        planeBlockedIOMap.clear();
+        Owned<IPropertyTreeIterator> planesIter = getPlanesIterator(nullptr, nullptr);
+        ForEach(*planesIter)
+        {
+            const IPropertyTree &plane = planesIter->query();
+            size32_t blockedFileIOSize = plane.getPropInt("@blockedFileIOKB") * 1024;
+            planeBlockedIOMap[plane.queryProp("@name")] = blockedFileIOSize;
+        }
+    };
+    planeBlockIOMapCBId = installConfigUpdateHook(updateFunc, true);
+    return true;
+}
+
+MODULE_EXIT()
+{
+    removeConfigUpdateHook(planeBlockIOMapCBId);
+}
+
+
+size32_t getBlockedFileIOSize(const char *planeName, size32_t defaultSize)
+{
+    CriticalBlock b(planeBlockedIOMapCrit);
+    auto it = planeBlockedIOMap.find(planeName);
+    if (it != planeBlockedIOMap.end())
+        return it->second;
+    else
+        return defaultSize;
 }

--- a/system/jlib/jfile.hpp
+++ b/system/jlib/jfile.hpp
@@ -774,8 +774,14 @@ jlib_decl IFileEventWatcher *createFileEventWatcher(FileWatchFunc callback);
 
 //---- Storage plane related functions ----------------------------------------------------
 
+interface IPropertyTree;
+interface IPropertyTreeIterator;
 extern jlib_decl IPropertyTree * getHostGroup(const char * name, bool required);
 extern jlib_decl IPropertyTree * getStoragePlane(const char * name);
 extern jlib_decl IPropertyTree * getRemoteStorage(const char * name);
+extern jlib_decl IPropertyTreeIterator * getPlanesIterator(const char * category, const char *name);
+
+extern jlib_decl IFileIO *createBlockedIO(IFileIO *base, size32_t blockSize);
+extern jlib_decl size32_t getBlockedFileIOSize(const char *planeName, size32_t defaultSize=0);
 
 #endif

--- a/system/jlib/jptree.cpp
+++ b/system/jlib/jptree.cpp
@@ -9089,10 +9089,14 @@ jlib_decl IPropertyTree * loadConfiguration(const char * defaultYaml, const char
     return loadConfiguration(componentDefault, argv, componentTag, envPrefix, legacyFilename, mapper, altNameAttribute, monitor);
 }
 
-void replaceComponentConfig(IPropertyTree *newComponentConfig)
+void replaceComponentConfig(IPropertyTree *newComponentConfig, IPropertyTree *newGlobalConfig)
 {
-    CriticalBlock b(configCS);
-    componentConfiguration.set(newComponentConfig);
+    {
+        CriticalBlock b(configCS);
+        componentConfiguration.set(newComponentConfig);
+        globalConfiguration.set(newGlobalConfig);
+    }
+    executeConfigUpdaterCallbacks();
 }
 
 class CYAMLBufferReader : public CInterfaceOf<IPTreeReader>

--- a/system/jlib/jptree.hpp
+++ b/system/jlib/jptree.hpp
@@ -319,7 +319,7 @@ jlib_decl void mergeConfiguration(IPropertyTree & target, const IPropertyTree & 
 jlib_decl IPropertyTree * loadArgsIntoConfiguration(IPropertyTree *config, const char * * argv, std::initializer_list<const std::string> ignoreOptions = {});
 jlib_decl IPropertyTree * loadConfiguration(IPropertyTree * defaultConfig, const char * * argv, const char * componentTag, const char * envPrefix, const char * legacyFilename, IPropertyTree * (mapper)(IPropertyTree *), const char *altNameAttribute=nullptr, bool monitor=true);
 jlib_decl IPropertyTree * loadConfiguration(const char * defaultYaml, const char * * argv, const char * componentTag, const char * envPrefix, const char * legacyFilename, IPropertyTree * (mapper)(IPropertyTree *), const char *altNameAttribute=nullptr, bool monitor=true);
-jlib_decl void replaceComponentConfig(IPropertyTree *newComponentConfig);
+jlib_decl void replaceComponentConfig(IPropertyTree *newComponentConfig, IPropertyTree *newGlobalConfig);
 jlib_decl IPropertyTree * getCostsConfiguration();
 
 //The following can only be called after loadConfiguration has been called.  All components must call loadConfiguration().

--- a/thorlcr/activities/indexread/thindexreadslave.cpp
+++ b/thorlcr/activities/indexread/thindexreadslave.cpp
@@ -308,7 +308,14 @@ public:
 
                 // local key handling
 
-                lazyIFileIO.setown(queryThor().queryFileCache().lookupIFileIO(*this, logicalFilename, part, nullptr, indexReadActivityStatistics));
+                size32_t blockedSize = 0;
+                if (!helper->hasSegmentMonitors()) // unfiltered
+                {
+                    StringBuffer planeName;
+                    part.queryOwner().getClusterLabel(0, planeName);
+                    blockedSize = getBlockedFileIOSize(planeName);
+                }
+                lazyIFileIO.setown(queryThor().queryFileCache().lookupIFileIO(*this, logicalFilename, part, nullptr, indexReadActivityStatistics, blockedSize));
 
                 RemoteFilename rfn;
                 part.getFilename(0, rfn);

--- a/thorlcr/graph/thgraph.hpp
+++ b/thorlcr/graph/thgraph.hpp
@@ -1227,7 +1227,7 @@ interface IExpander;
 interface IThorFileCache : extends IInterface
 {
     virtual bool remove(const char *filename, unsigned crc) = 0;
-    virtual IFileIO *lookupIFileIO(CActivityBase &activity, const char *logicalFilenae, IPartDescriptor &partDesc, IExpander *expander=nullptr, const StatisticsMapping & _statMapping=diskLocalStatistics) = 0;
+    virtual IFileIO *lookupIFileIO(CActivityBase &activity, const char *logicalFilenae, IPartDescriptor &partDesc, IExpander *expander=nullptr, const StatisticsMapping & _statMapping=diskLocalStatistics, size32_t blockedFileIOSize=0) = 0;
 };
 
 class graph_decl CThorResourceBase : implements IThorResource, public CInterface

--- a/thorlcr/graph/thgraphslave.cpp
+++ b/thorlcr/graph/thgraphslave.cpp
@@ -2043,6 +2043,7 @@ class CLazyFileIO : public CInterfaceOf<IFileIO>
     Owned<IFileIO> iFileIO; // real IFileIO
     CActivityBase *activity = nullptr;
     StringAttr filename, id;
+    size32_t blockedFileIOSize = 0;
 
     IFileIO *getFileIO()
     {
@@ -2055,9 +2056,15 @@ class CLazyFileIO : public CInterfaceOf<IFileIO>
         return iFileIO.getClear();
     }
 public:
-    CLazyFileIO(CFileCache &_cache, const char *_filename, const char *_id, IActivityReplicatedFile *_repFile, bool _compressed, IExpander *_expander, const StatisticsMapping & _statMapping=diskLocalStatistics)
-        : cache(_cache), filename(_filename), id(_id), repFile(_repFile), compressed(_compressed), expander(_expander), fileStats(_statMapping)
+    CLazyFileIO(CFileCache &_cache, const char *_filename, const char *_id, IActivityReplicatedFile *_repFile, bool _compressed, IExpander *_expander, const StatisticsMapping & _statMapping, size32_t _blockedFileIOSize)
+        : cache(_cache), filename(_filename), id(_id), repFile(_repFile), compressed(_compressed), expander(_expander),
+          fileStats(_statMapping), blockedFileIOSize(_blockedFileIOSize)
     {
+        if (blockedFileIOSize) // enabled
+        {
+            if (compressed || expander)
+                blockedFileIOSize = 0; // ignore. Compressed files use their own blocked format, but may want to revisit this area.
+        }
     }
     virtual void beforeDispose() override;
     void setActivity(CActivityBase *_activity)
@@ -2189,7 +2196,7 @@ public:
         CriticalBlock b(crit);
         return _remove(id);
     }
-    virtual IFileIO *lookupIFileIO(CActivityBase &activity, const char *logicalFilename, IPartDescriptor &partDesc, IExpander *expander, const StatisticsMapping & _statMapping) override
+    virtual IFileIO *lookupIFileIO(CActivityBase &activity, const char *logicalFilename, IPartDescriptor &partDesc, IExpander *expander, const StatisticsMapping & _statMapping, size32_t blockedFileIOSize) override
     {
         StringBuffer filename;
         RemoteFilename rfn;
@@ -2199,13 +2206,15 @@ public:
         unsigned crc = partDesc.queryProperties().getPropInt("@fileCrc");
         if (crc)
             id.append(crc);
+        if (blockedFileIOSize)
+            id.append('_').append(blockedFileIOSize);
         CriticalBlock b(crit);
         CLazyFileIO * file = files.find(id);
         if (!file || !file->isAliveAndLink())
         {
             Owned<IActivityReplicatedFile> repFile = createEnsurePrimaryPartFile(logicalFilename, &partDesc);
             bool compressed = partDesc.queryOwner().isCompressed();
-            file = new CLazyFileIO(*this, filename, id, repFile.getClear(), compressed, expander, _statMapping);
+            file = new CLazyFileIO(*this, filename, id, repFile.getClear(), compressed, expander, _statMapping, blockedFileIOSize);
             files.replace(* file); // NB: files does not own 'file', CLazyFileIO will remove itself from cache on destruction
 
             /* NB: there will be 1 CLazyFileIO per physical file part name
@@ -2245,7 +2254,11 @@ IFileIO *CLazyFileIO::getOpenFileIO(CActivityBase &activity)
         else if (compressed)
             iFileIO.setown(createCompressedFileReader(iFile));
         else
+        {
             iFileIO.setown(iFile->open(IFOread));
+            if (blockedFileIOSize)
+                iFileIO.setown(createBlockedIO(iFileIO.getClear(), blockedFileIOSize));
+        }
         if (!iFileIO.get())
             throw MakeThorException(0, "CLazyFileIO: failed to open: %s", filename.get());
     }

--- a/thorlcr/master/thmastermain.cpp
+++ b/thorlcr/master/thmastermain.cpp
@@ -360,6 +360,7 @@ public:
         msg.append(THOR_VERSION_MAJOR).append(THOR_VERSION_MINOR);
         processGroup->serialize(msg);
         globals->serialize(msg);
+        getGlobalConfigSP()->serialize(msg);
         msg.append(masterSlaveMpTag);
         msg.append(kjServiceMpTag);
         if (!queryNodeComm().send(msg, RANK_ALL_OTHER, MPTAG_THORREGISTRATION, MP_ASYNC_SEND))

--- a/thorlcr/slave/thslavemain.cpp
+++ b/thorlcr/slave/thslavemain.cpp
@@ -113,21 +113,22 @@ static bool RegisterSelf(SocketEndpoint &masterEp)
         msg.read(vmajor);
         msg.read(vminor);
         Owned<IGroup> processGroup = deserializeIGroup(msg);
+        Owned<IPropertyTree> masterComponentConfig = createPTree(msg);
+        Owned<IPropertyTree> masterGlobalConfig = createPTree(msg);
         mySlaveNum = (unsigned)processGroup->rank(queryMyNode());
         assertex(NotFound != mySlaveNum);
         mySlaveNum++; // 1 based;
 
         unsigned configSlaveNum = globals->getPropInt("@slavenum", NotFound);
-        Owned<IPropertyTree> masterComponentConfig = createPTree(msg);
         if (NotFound == configSlaveNum)
             globals->setPropInt("@slavenum", mySlaveNum);
         else
             assertex(mySlaveNum == configSlaveNum);
 
-        Owned<IPropertyTree> mergedGlobals = createPTreeFromIPT(globals);
-        mergeConfiguration(*mergedGlobals, *masterComponentConfig);
-        replaceComponentConfig(mergedGlobals);
-        globals.set(mergedGlobals);
+        Owned<IPropertyTree> mergedComponentConfig = createPTreeFromIPT(globals);
+        mergeConfiguration(*mergedComponentConfig, *masterComponentConfig);
+        replaceComponentConfig(mergedComponentConfig, masterGlobalConfig);
+        globals.set(mergedComponentConfig);
 
 #ifdef _DEBUG
         unsigned holdSlave = globals->getPropInt("@holdSlave", NotFound);


### PR DESCRIPTION
Allow indexes to be read with a large granularity.
This is particularly important if reading from storage that
charges per read access.

Signed-off-by: Jake Smith <jake.smith@lexisnexisrisk.com>

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
