### PR TITLE
HPCC-29811 Clarify EsdlCentralStore usage

### DIFF
--- a/esp/services/esdl_svc_engine/esdl_binding.cpp
+++ b/esp/services/esdl_svc_engine/esdl_binding.cpp
@@ -1769,7 +1769,7 @@ EsdlBindingImpl::EsdlBindingImpl()
 
 EsdlBindingImpl::EsdlBindingImpl(IPropertyTree* cfg, IPropertyTree* esdlArchive, const char *binding,  const char *process) : CHttpSoapBinding(cfg, binding, process)
 {
-    m_pCentralStore.setown(createEsdlCentralStore());
+    m_pCentralStore.setown(getEsdlCentralStore(true));
     m_bindingName.set(binding);
     m_processName.set(process);
 

--- a/esp/services/esdl_svc_engine/esdl_monitor.cpp
+++ b/esp/services/esdl_svc_engine/esdl_monitor.cpp
@@ -158,7 +158,7 @@ public:
     CEsdlMonitor() : m_isSubscribed(false)
     {
         constructEnvptTemplate();
-        m_pCentralStore.setown(createEsdlCentralStore());
+        m_pCentralStore.setown(getEsdlCentralStore(true));
         m_esdlShare.setown(new CEsdlShare());
         m_esdlShare->start();
         DBGLOG("EsdlMonitor started.");

--- a/esp/services/esdl_svc_engine/esdl_store.cpp
+++ b/esp/services/esdl_svc_engine/esdl_store.cpp
@@ -1458,9 +1458,9 @@ private:
 
 Owned<IEsdlStore> gEsdlCentralStore;
 
-esdl_engine_decl IEsdlStore* createEsdlCentralStore()
+esdl_engine_decl IEsdlStore* getEsdlCentralStore(bool isForLoadingBindings)
 {
-    if (!getComponentConfigSP()->getPropBool("@loadDaliBindings", true))
+    if (isForLoadingBindings && !getComponentConfigSP()->getPropBool("@loadDaliBindings", true))
         return nullptr;
     if (!daliClientActive())
         return nullptr;

--- a/esp/services/esdl_svc_engine/esdl_store.hpp
+++ b/esp/services/esdl_svc_engine/esdl_store.hpp
@@ -92,7 +92,7 @@ interface IEsdlSubscription : public IInterface
     virtual void subscribe() = 0;
 };
 
-esdl_engine_decl IEsdlStore* createEsdlCentralStore();
+esdl_engine_decl IEsdlStore* getEsdlCentralStore(bool isForLoadingBindings);
 esdl_engine_decl IEsdlSubscription* createEsdlSubscription(IEsdlListener* listener);
 
 #endif // _ESDL_STORE_HPP__

--- a/esp/services/ws_esdlconfig/ws_esdlconfigservice.cpp
+++ b/esp/services/ws_esdlconfig/ws_esdlconfigservice.cpp
@@ -186,7 +186,7 @@ void CWsESDLConfigEx::init(IPropertyTree *cfg, const char *process, const char *
     if(servicecfg == NULL)
         throw MakeStringException(-1, "config not found for service %s/%s",process, service);
 
-    m_esdlStore.setown(createEsdlCentralStore());
+    m_esdlStore.setown(getEsdlCentralStore(false));
     m_isDetachedFromDali = (nullptr == m_esdlStore);
 }
 

--- a/esp/services/ws_esdlconfig/ws_esdlconfigservice.hpp
+++ b/esp/services/ws_esdlconfig/ws_esdlconfigservice.hpp
@@ -67,7 +67,7 @@ public:
     {
         if(nullptr == m_esdlStore)
         {
-            m_esdlStore.setown(createEsdlCentralStore());
+            m_esdlStore.setown(getEsdlCentralStore(false));
             m_isDetachedFromDali = (nullptr == m_esdlStore);
         }
         else


### PR DESCRIPTION
Allow us to use the central store in situations where its needed to load bindings or just for inspection of the ESDL assets loaded to dali.

- Change function from "create" to "get" to be more consistent with conventions.
- Add a parameter to the get function to indicate if the store will be used to load bindings, and make its check of the loadDaliBindings config setting conditional on this parameter.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [x] Scalability
  - [x] Performance
  - [x] Security
  - [x] Thread-safety
  - [x] Cloud-compatibility
  - [x] Premature optimization
  - [x] Existing deployed queries will not be broken
  - [x] This change fixes the problem, not just the symptom
  - [x] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->
Manual testing ensuring that ESDL services will load and run transactions on bare metal using init.d startup and using esp application mode. Ensure that ECLWatch has a centralStore object when running containerized.

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
