### PR TITLE
HPCC-29957 Queries using embedded Java with libraries have unexpected class loaders

### DIFF
--- a/common/dllserver/thorplugin.hpp
+++ b/common/dllserver/thorplugin.hpp
@@ -32,7 +32,7 @@ interface ILoadedDllEntry : extends IInterface
     virtual const byte * getResource(unsigned id) const = 0;
     virtual bool getResource(size32_t & len, const void * & data, const char * type, unsigned id, bool trace=true) const = 0;
     virtual IPropertyTree &queryManifest() const = 0;
-    virtual const StringArray &queryManifestFiles(const char *type, const char *tempDir) const = 0;
+    virtual const StringArray &queryManifestFiles(const char *type, const char *id, const char *tempRoot = nullptr) const = 0;
 };
 
 extern DLLSERVER_API ILoadedDllEntry * createDllEntry(const char *name, bool isGlobal, const IFileIO *dllFile, bool resourcesOnly);

--- a/plugins/py3embed/py3embed.cpp
+++ b/plugins/py3embed/py3embed.cpp
@@ -738,11 +738,14 @@ void PythonThreadContext::addManifestFiles(ICodeContext *codeCtx)
                 ForEachItemIn(idx, manifestModules)
                 {
                     const char *path = manifestModules.item(idx);
-                    DBGLOG("Manifest zip %s", path);
-                    OwnedPyObject newPath = PyUnicode_FromString(path);
-                    PyList_Insert(sysPath, 0, newPath);
-                    checkPythonError();
-                    engine->onTermination(Python3xGlobalState::removePath, manifestModules.item(idx), true);
+                    if (path)
+                    {
+                        DBGLOG("Manifest zip %s", path);
+                        OwnedPyObject newPath = PyUnicode_FromString(path);
+                        PyList_Insert(sysPath, 0, newPath);
+                        checkPythonError();
+                        engine->onTermination(Python3xGlobalState::removePath, manifestModules.item(idx), true);
+                    }
                 }
             }
         }

--- a/plugins/pyembed/pyembed.cpp
+++ b/plugins/pyembed/pyembed.cpp
@@ -641,11 +641,14 @@ void PythonThreadContext::addManifestFiles(ICodeContext *codeCtx)
                 ForEachItemIn(idx, manifestModules)
                 {
                     const char *path = manifestModules.item(idx);
-                    DBGLOG("Manifest zip %s", path);
-                    OwnedPyObject newPath = PyString_FromString(path);
-                    PyList_Insert(sysPath, 0, newPath);
-                    checkPythonError();
-                    engine->onTermination(Python27GlobalState::removePath, manifestModules.item(idx), true);
+                    if (path)
+                    {
+                        DBGLOG("Manifest zip %s", path);
+                        OwnedPyObject newPath = PyString_FromString(path);
+                        PyList_Insert(sysPath, 0, newPath);
+                        checkPythonError();
+                        engine->onTermination(Python27GlobalState::removePath, manifestModules.item(idx), true);
+                    }
                 }
             }
         }

--- a/roxie/ccd/ccd.hpp
+++ b/roxie/ccd/ccd.hpp
@@ -458,6 +458,7 @@ extern StringBuffer pluginsList;
 extern StringBuffer queryDirectory;
 extern StringBuffer codeDirectory;
 extern StringBuffer tempDirectory;
+extern StringBuffer spillDirectory;
 
 #undef UNIMPLEMENTED
 #undef throwUnexpected

--- a/roxie/ccd/ccdcontext.cpp
+++ b/roxie/ccd/ccdcontext.cpp
@@ -3076,15 +3076,19 @@ public:
     {
         ILoadedDllEntry *dll = factory->queryDll();
         StringBuffer id;
-        const StringArray &dllFiles = dll->queryManifestFiles(type, getQueryId(id, true).str());
+        const StringArray &dllFiles = dll->queryManifestFiles(type, getQueryId(id, true).str(), tempDirectory);
         ForEachItemIn(idx, dllFiles)
             files.append(dllFiles.item(idx));
         ForEachItemIn(lidx, loadedLibraries)
         {
             IQueryFactory &lfactory = loadedLibraries.item(lidx);
             ILoadedDllEntry *ldll = lfactory.queryDll();
+            // Libraries share the same copy of the jar (and the classloader) for all queries that use the library
             StringBuffer lid;
-            const StringArray &ldllFiles = ldll->queryManifestFiles(type, getQueryId(lid, true).str());
+            lid.append('Q').append(lfactory.queryHash());
+            const StringArray &ldllFiles = ldll->queryManifestFiles(type, lid.str(), tempDirectory);
+            if (ldllFiles.length())
+                files.append(nullptr);
             ForEachItemIn(ldidx, ldllFiles)
                 files.append(ldllFiles.item(ldidx));
         }

--- a/roxie/ccd/ccdmain.cpp
+++ b/roxie/ccd/ccdmain.cpp
@@ -203,6 +203,7 @@ StringBuffer logDirectory;
 StringBuffer pluginDirectory;
 StringBuffer queryDirectory;
 StringBuffer codeDirectory;
+StringBuffer spillDirectory;
 StringBuffer tempDirectory;
 
 ClientCertificate clientCert;
@@ -1253,7 +1254,8 @@ int CCD_API roxie_main(int argc, const char *argv[], const char * defaultYaml)
                 queryDirectory.append(codeDirectory).append("queries");
         }
         addNonEmptyPathSepChar(queryDirectory);
-        getSpillFilePath(tempDirectory, "roxie", topology);
+        getSpillFilePath(spillDirectory, "roxie", topology);
+        getTempFilePath(tempDirectory, "roxie", topology);
 
 #ifdef _WIN32
         topology->addPropBool("@linuxOS", false);

--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -8576,7 +8576,7 @@ public:
         if (sortAlgorithm==unknownSortAlgorithm)
             sorter.clear();
         else
-            sorter.setown(createSortAlgorithm(sortAlgorithm, compare, ctx->queryRowManager(), meta, ctx->queryCodeContext(), tempDirectory, activityId));
+            sorter.setown(createSortAlgorithm(sortAlgorithm, compare, ctx->queryRowManager(), meta, ctx->queryCodeContext(), spillDirectory, activityId));
     }
 
     virtual void doStart(unsigned parentExtractSize, const byte *parentExtract, bool paused)
@@ -8662,7 +8662,7 @@ public:
                 sorter.clear();
                 OwnedRoxieString algorithmName(helper.getAlgorithm());
                 sortAlgorithm = useAlgorithm(algorithmName, sortFlags);
-                sorter.setown(createSortAlgorithm(sortAlgorithm, compare, ctx->queryRowManager(), meta, ctx->queryCodeContext(), tempDirectory, activityId));
+                sorter.setown(createSortAlgorithm(sortAlgorithm, compare, ctx->queryRowManager(), meta, ctx->queryCodeContext(), spillDirectory, activityId));
             }
             sorter->prepare(inputStream);
             noteStatistic(StTimeSortElapsed, cycle_to_nanosec(sorter->getElapsedCycles(true)));
@@ -12986,12 +12986,12 @@ public:
         if (helper.isLeftAlreadySorted())
             sortedLeft.setown(createDegroupedInputReader(inputStream));
         else
-            sortedLeft.setown(createSortedInputReader(inputStream, createSortAlgorithm(sortAlgorithm, helper.queryCompareLeft(), ctx->queryRowManager(), input->queryOutputMeta(), ctx->queryCodeContext(), tempDirectory, activityId)));
+            sortedLeft.setown(createSortedInputReader(inputStream, createSortAlgorithm(sortAlgorithm, helper.queryCompareLeft(), ctx->queryRowManager(), input->queryOutputMeta(), ctx->queryCodeContext(), spillDirectory, activityId)));
         ICompare *compareRight = helper.queryCompareRight();
         if (helper.isRightAlreadySorted())
             groupedSortedRight.setown(createGroupedInputReader(inputStream1, compareRight));
         else
-            groupedSortedRight.setown(createSortedGroupedInputReader(inputStream1, compareRight, createSortAlgorithm(sortAlgorithm, compareRight, ctx->queryRowManager(), input1->queryOutputMeta(), ctx->queryCodeContext(), tempDirectory, activityId)));
+            groupedSortedRight.setown(createSortedGroupedInputReader(inputStream1, compareRight, createSortAlgorithm(sortAlgorithm, compareRight, ctx->queryRowManager(), input1->queryOutputMeta(), ctx->queryCodeContext(), spillDirectory, activityId)));
         if ((helper.getJoinFlags() & JFlimitedprefixjoin) && helper.getJoinLimit())
         {   //limited match join (s[1..n])
             limitedhelper.setown(createRHLimitedCompareHelper());
@@ -18729,7 +18729,7 @@ public:
                 sortAlgorithm = isStable ? stableSpillingQuickSortAlgorithm : spillingQuickSortAlgorithm;
             else
                 sortAlgorithm = isStable ? stableQuickSortAlgorithm : quickSortAlgorithm;
-            groupedInput.setown(createSortedGroupedInputReader(inputStream, compareLeft, createSortAlgorithm(sortAlgorithm, compareLeft, ctx->queryRowManager(), input->queryOutputMeta(), ctx->queryCodeContext(), tempDirectory, activityId)));
+            groupedInput.setown(createSortedGroupedInputReader(inputStream, compareLeft, createSortAlgorithm(sortAlgorithm, compareLeft, ctx->queryRowManager(), input->queryOutputMeta(), ctx->queryCodeContext(), spillDirectory, activityId)));
         }
         if ((helper.getJoinFlags() & JFlimitedprefixjoin) && helper.getJoinLimit()) 
         {   //limited match join (s[1..n])

--- a/testing/regress/ecl/key/libraryjava.xml
+++ b/testing/regress/ecl/key/libraryjava.xml
@@ -8,3 +8,6 @@
  <Row><fullname>George     Smith              </fullname></Row>
  <Row><fullname>Baby       Smith              </fullname></Row>
 </Dataset>
+<Dataset name='Result 3'>
+ <Row><Result_3>Hello World</Result_3></Row>
+</Dataset>

--- a/testing/regress/ecl/libraryjava.ecl
+++ b/testing/regress/ecl/libraryjava.ecl
@@ -19,6 +19,10 @@
 //nothor
 //The library is defined and built in aaalibraryjava.ecl
 
+IMPORT java;
+
+STRING cat(SET OF STRING s) := IMPORT(java, 'javaembed_ex7.cat:([Ljava/lang/String;)Ljava/lang/String;');
+
 namesRecord := 
             RECORD
 string20        surname;
@@ -50,3 +54,5 @@ integer init := appendDataset(namesTable).initialized : ONCE;
 output(init);
 appended := appendDataset(namesTable);
 output(appended.result);
+// Call java from both query and library
+output(cat(['Hello','World']));

--- a/testing/regress/ecl/libraryjava.manifest
+++ b/testing/regress/ecl/libraryjava.manifest
@@ -1,0 +1,3 @@
+<Manifest>
+ <Resource type='jar' filename='javaembed_ex7.jar'/>
+</Manifest>


### PR DESCRIPTION
Split the URLClassLoaders used according to the source of the corresponding jar files, so that we use the same classloader whenever loading classes from a given manifest jar file (and therefore from a given workunit or library).

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [x] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
Running multiple instances and versions of queries from regression suite and observing logs
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
