### PR TITLE
HPCC-30429 Fix WsECL display for 'Create Workunit' option

### DIFF
--- a/esp/services/ws_ecl/ws_ecl_service.cpp
+++ b/esp/services/ws_ecl/ws_ecl_service.cpp
@@ -1568,12 +1568,17 @@ int CWsEclBinding::getGenForm(IEspContext &context, CHttpRequest* request, CHttp
     xform->setParameter("useTextareaForStringArray", "1");
 
 #ifdef _CONTAINERIZED
-    bool isRoxie = wsecl->connMap.getValue(wuinfo.qsetname) != nullptr;
-#else
+    VStringBuffer xpath("queues[@name='%s']", wuinfo.qsetname.get());
+    IPropertyTree *queue = getComponentConfigSP()->queryPropTree(xpath.str());
+    if (queue && strieq(queue->queryProp("@type"), "roxie"))
+        xform->setParameter("includeRoxieOptions", queue->getPropBool("@queriesOnly") ? "2" : "3");
+    else
+        xform->setParameter("includeRoxieOptions", "0");
+ #else
     Owned<IConstWUClusterInfo> clusterInfo = getTargetClusterInfo(wuinfo.qsetname);
     bool isRoxie = clusterInfo && (clusterInfo->getPlatform() == RoxieCluster);
-#endif
     xform->setParameter("includeRoxieOptions", isRoxie ? "1" : "0");
+#endif
 
     // set the prop noDefaultValue param
     IProperties* props = context.queryRequestParameters();
@@ -2134,8 +2139,18 @@ void CWsEclBinding::sendRoxieRequest(const char *target, StringBuffer &req, Stri
     }
 }
 
+static void checkWorkunitCompatibleOptions(IEspContext &context, bool submitWorkunit)
+{
+    bool statsToWorkunit = context.queryRequestParameters()->getPropBool("@statsToWorkunit", false);
+    bool summaryStats = context.queryRequestParameters()->getPropBool("@summaryStats", false);
+    if (submitWorkunit && (statsToWorkunit || summaryStats))
+        throw makeStringException(-1, "Neither 'Save stats to workunit' or 'Get summary stats' are supported for the 'Create Workunit' option");
+}
+
 int CWsEclBinding::onSubmitQueryOutput(IEspContext &context, CHttpRequest* request, CHttpResponse* response, WsEclWuInfo &wsinfo, const char *format, bool forceCreateWorkunit)
 {
+    checkWorkunitCompatibleOptions(context, forceCreateWorkunit);
+
     StringBuffer status;
     StringBuffer output;
 
@@ -2200,6 +2215,8 @@ int CWsEclBinding::onSubmitQueryOutput(IEspContext &context, CHttpRequest* reque
 
 int CWsEclBinding::onSubmitQueryOutputView(IEspContext &context, CHttpRequest* request, CHttpResponse* response, WsEclWuInfo &wsinfo, bool forceCreateWorkunit)
 {
+    checkWorkunitCompatibleOptions(context, forceCreateWorkunit);
+
     IConstWorkUnit *wu = wsinfo.ensureWorkUnit();
 
     StringBuffer soapmsg;

--- a/esp/xslt/wsecl3_form.xsl
+++ b/esp/xslt/wsecl3_form.xsl
@@ -311,7 +311,7 @@ function switchInputForm()
                      </span>
               </td>
             </tr>
-            <xsl:if test="$includeRoxieOptions=1">
+            <xsl:if test="$includeRoxieOptions=1 or $includeRoxieOptions=2">
             <tr>
                <td class='input' align='left'>
                   <span>
@@ -337,6 +337,16 @@ function switchInputForm()
                   <xsl:if test="$includeRoxieOptions=1">
                     <select id="job_type">
                       <option value="QUERY">Call Query</option>
+                      <option value="WORKUNIT">Create Workunit</option>
+                    </select>&nbsp;
+                  </xsl:if>
+                  <xsl:if test="$includeRoxieOptions=2">
+                    <select id="job_type">
+                      <option value="QUERY">Call Query</option>
+                    </select>&nbsp;
+                  </xsl:if>
+                  <xsl:if test="$includeRoxieOptions=3">
+                    <select id="job_type">
                       <option value="WORKUNIT">Create Workunit</option>
                     </select>&nbsp;
                   </xsl:if>


### PR DESCRIPTION
The 'Create Workunit' option should not be available for a queriesOnly roxie.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
