### PR TITLE
HPCC-30628 Add initNullConfiguration for CLI's without configuration

### DIFF
--- a/dali/dalidiag/dalidiag.cpp
+++ b/dali/dalidiag/dalidiag.cpp
@@ -532,6 +532,8 @@ int main(int _argc, char* argv[])
     }
 
     try {
+        initNullConfiguration();
+
         Owned<IGroup> group = createIGroup(epa);
         assertex(group);
         initClientProcess(group, DCR_DaliDiag, 0, NULL, NULL, MP_WAIT_FOREVER);

--- a/dali/dalistop/dalistop.cpp
+++ b/dali/dalistop/dalistop.cpp
@@ -24,6 +24,13 @@
 #include "daclient.hpp"
 
 
+static void usage()
+{
+    printf("usage: dalistop <server_ip:port> [/nowait]\n");
+    printf("eg:  dalistop .                          -- stop dali server running locally\n");
+    printf("     dalistop eq0001016                  -- stop dali server running remotely\n");
+}
+
 int main(int argc, const char* argv[])
 {
     InitModuleObjects();
@@ -34,23 +41,25 @@ int main(int argc, const char* argv[])
         const char *server = nullptr;
         if (argc<2)
         {
-            // with no args, use port from daliconfig if present (used by init scripts)
-            Owned<IFile> daliConfigFile = createIFile("daliconf.xml");
-            if (daliConfigFile->exists())
-            {
-                Owned<IPropertyTree> daliConfig = createPTree(*daliConfigFile, ipt_caseInsensitive);
-                port = daliConfig->getPropInt("@port", DALI_SERVER_PORT);
-                server = ".";
-            }
+            if (isContainerized())
+                usage();
             else
             {
-                printf("usage: dalistop <server_ip:port> [/nowait]\n");
-                printf("eg:  dalistop .                          -- stop dali server running locally\n");
-                printf("     dalistop eq0001016                  -- stop dali server running remotely\n");
+                // with no args, use port from daliconfig if present (used by init scripts)
+                Owned<IFile> daliConfigFile = createIFile("daliconf.xml");
+                if (daliConfigFile->exists())
+                {
+                    Owned<IPropertyTree> daliConfig = createPTree(*daliConfigFile, ipt_caseInsensitive);
+                    port = daliConfig->getPropInt("@port", DALI_SERVER_PORT);
+                    server = ".";
+                }
+                else
+                    usage();
             }
         }
         else
         {
+            initNullConfiguration();
             server = argv[1];
             port = DALI_SERVER_PORT;
         }

--- a/dali/sasha/sasha.cpp
+++ b/dali/sasha/sasha.cpp
@@ -406,6 +406,8 @@ int main(int argc, char* argv[])
     EnableSEHtoExceptionMapping();
     Thread::setDefaultStackSize(0x10000);
     try {
+        initNullConfiguration();
+
         startMPServer(0);
         attachStandardFileLogMsgMonitor("sasha.log", NULL, MSGFIELD_STANDARD, MSGAUD_all, MSGCLS_all, TopDetail, LOGFORMAT_table, true);
         queryStderrLogMsgHandler()->setMessageFields(MSGFIELD_prefix);

--- a/system/jlib/jptree.cpp
+++ b/system/jlib/jptree.cpp
@@ -9099,6 +9099,14 @@ void replaceComponentConfig(IPropertyTree *newComponentConfig, IPropertyTree *ne
     executeConfigUpdaterCallbacks();
 }
 
+void initNullConfiguration()
+{
+    if (componentConfiguration || globalConfiguration)
+        throw makeStringException(99, "Configuration has already been initialised");
+    componentConfiguration.setown(createPTree());
+    globalConfiguration.setown(createPTree());
+}
+
 class CYAMLBufferReader : public CInterfaceOf<IPTreeReader>
 {
 protected:

--- a/system/jlib/jptree.hpp
+++ b/system/jlib/jptree.hpp
@@ -320,6 +320,7 @@ jlib_decl IPropertyTree * loadArgsIntoConfiguration(IPropertyTree *config, const
 jlib_decl IPropertyTree * loadConfiguration(IPropertyTree * defaultConfig, const char * * argv, const char * componentTag, const char * envPrefix, const char * legacyFilename, IPropertyTree * (mapper)(IPropertyTree *), const char *altNameAttribute=nullptr, bool monitor=true);
 jlib_decl IPropertyTree * loadConfiguration(const char * defaultYaml, const char * * argv, const char * componentTag, const char * envPrefix, const char * legacyFilename, IPropertyTree * (mapper)(IPropertyTree *), const char *altNameAttribute=nullptr, bool monitor=true);
 jlib_decl void replaceComponentConfig(IPropertyTree *newComponentConfig, IPropertyTree *newGlobalConfig);
+jlib_decl void initNullConfiguration();
 jlib_decl IPropertyTree * getCostsConfiguration();
 
 //The following can only be called after loadConfiguration has been called.  All components must call loadConfiguration().


### PR DESCRIPTION
Call initNullConfiguration() in tools that have no configuration, allowing them to be used in k8s in circumstances where they previously failed when underlying common code called getComponentConfig or getGlobalConfig.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
