### PR TITLE
HPCC-30683 Fix planes bug when forcePermissions and numDevices>1

### DIFF
--- a/helm/hpcc/templates/_helpers.tpl
+++ b/helm/hpcc/templates/_helpers.tpl
@@ -326,6 +326,28 @@ Add ConfigMap volume for a component
 {{- end -}}
 
 {{/*
+Get mount details
+Pass in plane
+Returns dictionary with "results" of mount details
+*/}}
+{{- define "hpcc.getMountDetails" -}}
+{{- $plane := .plane -}}
+{{- $mountPath := $plane.prefix -}}
+{{- $numMounts := int ( $plane.numMounts | default $plane.numDevices | default 1 ) -}}
+{{- $mountDetails := list -}}
+{{- if le $numMounts 1 -}}
+ {{- $mountDetails = append $mountDetails (dict "name" (lower (printf "%s-volume" $plane.name)) "path" $mountPath) -}}
+{{- else -}}
+ {{- range $elem := untilStep 1 (int (add $numMounts 1)) 1 -}}
+  {{- $name := lower (printf "%s-volume-many-%d" $plane.name $elem) -}}
+  {{- $path := printf "%s/d%d" $mountPath $elem -}}
+  {{- $mountDetails = append $mountDetails (dict "name" $name "path" $path) -}}
+ {{- end -}}
+{{- end -}}
+{{- $_ := set . "results" $mountDetails -}}
+{{- end -}}
+
+{{/*
 Add volume mounts
 Pass in root, me (the component), includeCategories (optional) and/or includeNames (optional), container identifier (optional)
 Note: if there are multiple planes (other than dll, dali and spill planes), they should be all called with a single call
@@ -349,14 +371,12 @@ to addVolumeMounts so that if a plane can be used for multiple purposes then dup
     {{- if not (hasKey $previousMounts $plane.prefix) }}
      {{- $mountPath := $plane.prefix }}
      {{- $numMounts := int ( $plane.numMounts | default $plane.numDevices | default 1 ) }}
-     {{- if le $numMounts 1 }}
-- name: {{ lower $plane.name }}-volume
-  mountPath: {{ $mountPath | quote }}
-     {{- else }}
-      {{- range $elem := untilStep 1 (int (add $numMounts 1)) 1 }}
-- name: {{ lower $plane.name }}-volume-many-{{ $elem }}
-  mountPath: {{ printf "%s/d%d" $mountPath $elem | quote }}
-      {{- end }}
+     {{- $mountDetails := dict "plane" $plane }}
+     {{- include "hpcc.getMountDetails" $mountDetails }}
+     {{- range $elem := untilStep 1 (int (add $numMounts 1)) 1 }}
+      {{- $multiMountDetails := index $mountDetails.results (sub $elem 1) }}
+- name: {{ $multiMountDetails.name }}
+  mountPath: {{ $multiMountDetails.path | quote }}
      {{- end }}
     {{- end }}
     {{- $_ := set $previousMounts $plane.prefix true -}}
@@ -878,13 +898,22 @@ A kludge to ensure mounted storage (e.g. for nfs, minikube or docker for desktop
 {{- $permCmd := "" -}}
 {{- $uid := .uid -}}
 {{- $gid := .gid -}}
-{{- range $index, $volume := .volumes }}
- {{- if ne $index 0 }}
-  {{- $permCmd = printf "%s & " $permCmd -}}
- {{- end -}}
- {{- $permCmd = printf "%s(chown -R %v:%v %s || true)" $permCmd $uid $gid $volume.path }}
+{{- $component := .component -}}
+{{- $volumeNames := list -}}
+{{- $count := 0 -}}
+{{- range $plane := .planes }}
+ {{- $volumeNames = append $volumeNames $plane.name }}
+ {{- $mountDetails := dict "plane" $plane }}
+ {{- include "hpcc.getMountDetails" $mountDetails }}
+ {{- range $result := $mountDetails.results }}
+  {{- if ne $count 0 }}
+   {{- $permCmd = printf "%s & " $permCmd -}}
+  {{- end -}}
+  {{- $permCmd = printf "%s(chown -R %v:%v %s || true)" $permCmd $uid $gid $result.path }}
+  {{- $count = add $count 1 }}
+ {{- end }}
 {{- end }}
-{{- if gt (len .volumes) 1 -}}
+{{- if gt $count 1 -}}
  {{- $permCmd = printf "%s; wait" $permCmd -}}
 {{- end }}
 - name: volume-mount-hack
@@ -895,10 +924,7 @@ A kludge to ensure mounted storage (e.g. for nfs, minikube or docker for desktop
              "{{ $permCmd }}"
            ]
   volumeMounts:
-{{- range $volume := .volumes }}
-    - name: {{ $volume.name | quote}}
-      mountPath: {{ $volume.path | quote }}
-{{- end }}
+{{ include "hpcc.addVolumeMounts" (dict "root" .root "component" $component "includeNames" $volumeNames) | indent 2 }}
 {{- end }}
 
 
@@ -941,11 +967,7 @@ NB: uid=10000 and gid=10001 are the uid/gid of the hpcc user, built into platfor
 {{- end -}}
 {{- $volumes := list -}}
 {{- if len $planesToChown -}}
- {{- range $plane := $planesToChown -}}
-  {{- $volumeName := (printf "%s-volume" $plane.name) -}}
-  {{- $volumes = append $volumes (dict "name" $volumeName "path" $plane.prefix) -}}
- {{- end -}}
- {{- include "hpcc.changeMountPerms" (dict "root" $root "uid" $uid "gid" $gid "volumes" $volumes) | nindent 0 }}
+ {{- include "hpcc.changeMountPerms" (dict "root" $root "component" $component "uid" $uid "gid" $gid "planes" $planesToChown) | nindent 0 }}
 {{- end -}}
 {{- include "hpcc.configContainer" . | nindent 0 -}}
 {{- end -}}


### PR DESCRIPTION
With forcePermissions was on and numDevices>1, the generated init container for forcePermissions, was not using the correct mount points.
As a consequence, the init container failed to initialize.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
