### PR TITLE
HPCC-29721 setReplicateDir fails if config dir ends with path seperator

### DIFF
--- a/dali/base/dafdesc.cpp
+++ b/dali/base/dafdesc.cpp
@@ -1721,7 +1721,10 @@ public:
             if (!sc)
                 sc = getPathSepChar(dirname);
             StringBuffer tmp;
-            tmp.append(queryBaseDirectory(grp_unknown, 0, SepCharBaseOs(sc))).append(sc).append(s);
+            tmp.append(queryBaseDirectory(grp_unknown, 0, SepCharBaseOs(sc)));
+            if (sc != tmp.charAt(tmp.length()-1))
+                tmp.append(sc);
+            tmp.append(s);
             directory.set(tmp.str());
         }
         else
@@ -2934,23 +2937,52 @@ bool setReplicateDir(const char *dir,StringBuffer &out,bool isrep,const char *ba
     unsigned count = 0;
     unsigned i;
     for (i=0;d[i]&&dir[i]&&(d[i]==dir[i]);i++)
-        if (isPathSepChar(dir[i])) {
+    {
+        if (isPathSepChar(dir[i]))
+        {
             match = i;
             count++;
         }
+    }
     const char *r = repDir?repDir:queryBaseDirectory(grp_unknown, isrep ? 1 : 0,os);
-    if (d[i]==0) {
-        if ((dir[i]==0)||isPathSepChar(dir[i])) {
-            out.append(r).append(dir+i);
+    if (d[i]==0)
+    {
+        if (dir[i]==0)
+        {
+            // dir was an exact match for the base directory, return replica directory in output
+            out.append(r);
+            return true;
+        }
+        else if (isPathSepChar(dir[i]))
+        {
+            // dir matched the prefix of the base directory and the remaining part leads with a path separator
+            // replace the base directory with the replica directory in the output, and append the remaining part of dir
+            out.append(r);
+            if (isPathSepChar(out.charAt(out.length()-1))) // if r has trailing path separator, skip the leading one in dir
+                i++;
+            out.append(dir+i);
+            return true;
+        }
+        else if (i>0 && isPathSepChar(d[i-1])) // implies dir[i-1] is also a pathsepchar
+        {
+            // dir matched the prefix of the base directory, including the trailing path separator
+            // replace the base directory with the replica directory in the output, and append the remaining part of dir
+            out.append(r);
+            addPathSepChar(out); // NB: this is an ensure-has-trailing-path-separator
+            out.append(dir+i); // NB: dir+i is beyond a path separator in dir
             return true;
         }
     }
-    else if (count) { // this is a bit of a kludge to handle roxie backup
+    else if (count) // this is a bit of a kludge to handle roxie backup
+    {
         const char *s = r;
         const char *b = s;
-        while (s&&*s) {
-            if (isPathSepChar(*s)) {
-                if (--count==0) {
+        while (s&&*s)
+        {
+            if (isPathSepChar(*s))
+            {
+                if (--count==0)
+                {
                     out.append(s-b,b).append(dir+match);
                     return true;
                 }


### PR DESCRIPTION
Causing unittest CDaliDFSStressTests testDFSRename failures.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
