### PR TITLE
HPCC-30746 Add support for bare-metal DFS TLS

### DIFF
--- a/dali/dfuplus/dfuplus.cpp
+++ b/dali/dfuplus/dfuplus.cpp
@@ -131,7 +131,7 @@ bool CDfuPlusHelper::runLocalDaFileSvr(SocketEndpoint &listenep,bool requireauth
             addlPort.appendf("port %u", sslport);
         else if (connectMethod == SSLFirst)
             addlPort.appendf("ports %u:%u", sslport, port);
-        else
+        else // inc UnsecureAndSSL
             addlPort.appendf("ports %u:%u", port, sslport);
         progress("Started local Dali file server on %s\n", addlPort.str());
     }
@@ -146,7 +146,7 @@ bool CDfuPlusHelper::runLocalDaFileSvr(SocketEndpoint &listenep,bool requireauth
             printep.port = sslport;
             addlPort.appendf(":%u", port);
         }
-        else
+        else // inc UnsecureAndSSL
         {
             printep.port = port;
             addlPort.appendf(":%u", sslport);
@@ -197,7 +197,7 @@ bool CDfuPlusHelper::checkLocalDaFileSvr(const char *eps,SocketEndpoint &epout)
         dafsPort = sslport;
         addlPort.appendf("ports %u:%u", sslport, port);
     }
-    else
+    else // inc UnsecureAndSSL
     {
         dafsPort = port;
         addlPort.appendf("ports %u:%u", port, sslport);

--- a/docs/EN_US/HPCCSystemAdmin/HPCCSystemAdministratorsGuide.xml
+++ b/docs/EN_US/HPCCSystemAdmin/HPCCSystemAdministratorsGuide.xml
@@ -1259,7 +1259,7 @@ mpStart=7101
 mpEnd=7500
 mpSoMaxConn=128
 mpTraceLevel=0
-# enable SSL for dafilesrv remote file access (SSLNone/false | SSLOnly/true | SSLFirst | UnsecureFirst)
+# enable SSL for dafilesrv remote file access (SSLNone/false | SSLOnly/true | SSLFirst | UnsecureFirst | UnsecureAndSSL)
 # Enabling requires setting the HPCCPassPhrase, HPCCCertFile, and HPCCPrivateKeyFile values
 #dfsUseSSL=SSLNone
 

--- a/docs/PT_BR/HPCCSystemAdmin/HPCCSystemAdministratorsGuide.xml
+++ b/docs/PT_BR/HPCCSystemAdmin/HPCCSystemAdministratorsGuide.xml
@@ -1198,7 +1198,7 @@ mpStart=7101
 mpEnd=7500
 mpSoMaxConn=128
 mpTraceLevel=0
-# enable SSL for dafilesrv remote file access (SSLNone/false | SSLOnly/true | SSLFirst | UnsecureFirst)
+# enable SSL for dafilesrv remote file access (SSLNone/false | SSLOnly/true | SSLFirst | UnsecureFirst | UnsecureAndSSL)
 # Enabling requires setting the HPCCPassPhrase, HPCCCertFile, and HPCCPrivateKeyFile values
 #dfsUseSSL=SSLNone
 

--- a/esp/clients/ws_dfsclient/ws_dfsclient.cpp
+++ b/esp/clients/ws_dfsclient/ws_dfsclient.cpp
@@ -333,7 +333,32 @@ public:
             IPropertyTree *filePlane = dfsFile->queryCommonMeta()->queryPropTree(planeXPath);
             assertex(filePlane);
             if (remoteStorage->getPropBool("@useDafilesrv"))
-                dafileSrvRemoteFilePlane = filePlane;
+            {
+                // Some info needs to be propagated down to the workers and then used by dafilesrv connections.
+                // Since the workers are currently only serialized IPartDescriptor/IFileDescriptors,
+                // this info. is conveyed via attributes in the IFileDescriptor.
+
+                file->setPropTree("Attr/_remoteStoragePlane", createPTreeFromIPT(filePlane));
+
+                const char *serviceUrl = remoteStorage->queryProp("@service");
+                if (serviceUrl && startsWith(serviceUrl, "https"))
+                {
+                    // if remote storage service is secure, dafilesrv connections must be also.
+                    // this flag is used by consumers of this IFleDescriptor to tell whether they need to make
+                    // secure connections to the dafilesrv's
+                    file->setPropBool("Attr/@_remoteSecure", true);
+
+                    // Propagate whether the remote definition has supplied a explicit secret (if not it will be auto-generated based on service URLs)
+                    if (remoteStorage->hasProp("@secret"))
+                    {
+                        const char *secret = remoteStorage->queryProp("@secret");
+                        if (isEmptyString(secret)) // i.e. no secret, meaning TLS only.
+                            secret = "<TLS>";  // placeholder, picked up by dafilesrv at connect time when determining if TLS or secret based
+
+                        file->setProp("Attr/@_remoteSecret", secret);
+                    }
+                }
+            }
             else
             {
                 // Path translation is necessary, because the local plane will not necessarily have the same
@@ -393,19 +418,6 @@ public:
                         newPath.append(dir); // add remaining tail of path
                     DBGLOG("Remapping logical file directory to '%s'", newPath.str());
                     file->setProp("@directory", newPath.str());
-                }
-            }
-            if (dafileSrvRemoteFilePlane)
-            {
-                file->setPropTree("Attr/_remoteStoragePlane", createPTreeFromIPT(dafileSrvRemoteFilePlane));
-
-                const char *serviceUrl = remoteStorage->queryProp("@service");
-                if (serviceUrl && startsWith(serviceUrl, "https"))
-                {
-                    // if remote storage service is secure, dafilesrv connections must be also.
-                    // this flag is used by consumers of this IFleDescriptor to tell whether they need to make
-                    // secure secret based connections to the dafilesrv's
-                    file->setPropBool("Attr/@_remoteSecure", true);
                 }
             }
         }
@@ -662,6 +674,7 @@ IDFSFile *lookupDFSFile(const char *logicalName, AccessMode accessMode, unsigned
     StringBuffer remoteName, remoteLogicalFileName;
     StringBuffer serviceUrl;
     StringBuffer serviceSecret;
+    bool secretProvided = false;
     bool useDafilesrv = false;
     if (lfn.isRemote())
     {
@@ -676,8 +689,17 @@ IDFSFile *lookupDFSFile(const char *logicalName, AccessMode accessMode, unsigned
                 throw makeStringExceptionV(0, "Remote storage '%s' not found", remoteName.str());
             serviceUrl.set(remoteStorage->queryProp("@service"));
 
-            // NB: for legacy support only, if the service url is secure, a secret name will be auto-generated
-            serviceSecret.set(remoteStorage->queryProp("@secret"));
+            if (startsWith(serviceUrl, "https"))
+            {
+                // NB: standard configuration should not supply a secret, the secret name will be auto-generated based on the URL
+                // If a manual secret name is defined, it will be used to connect to the DFS service and the dafilesrv services
+                // A blank secret name can be defined to support connecting to bare-metal DFS services/dafilesrv's that do not support client certificates.
+                if (remoteStorage->hasProp("@secret"))
+                {
+                    secretProvided = true;
+                    serviceSecret.set(remoteStorage->queryProp("@secret"));
+                }
+            }
 
             logicalName = remoteLogicalFileName;
             useDafilesrv = remoteStorage->getPropBool("@useDafilesrv");
@@ -717,13 +739,8 @@ IDFSFile *lookupDFSFile(const char *logicalName, AccessMode accessMode, unsigned
 #endif
     }
     bool useSSL = startsWith(serviceUrl, "https");
-    if (useSSL)
-    {
-        if (0 == serviceSecret.length())
-            generateDynamicUrlSecretName(serviceSecret, serviceUrl, nullptr);
-    }
-    else
-        serviceSecret.clear();
+    if (useSSL && !secretProvided)
+        generateDynamicUrlSecretName(serviceSecret, serviceUrl, nullptr);
 
     DBGLOG("Looking up file '%s' on '%s'", logicalName, serviceUrl.str());
     Owned<IClientWsDfs> dfsClient = getDfsClient(serviceUrl, userDesc);

--- a/esp/services/ws_dfsservice/ws_dfsservice.cpp
+++ b/esp/services/ws_dfsservice/ws_dfsservice.cpp
@@ -44,18 +44,18 @@ static unsigned __int64 getLockId(unsigned __int64 leaseId)
 
 static void populateLFNMeta(const char *logicalName, unsigned __int64 leaseId, bool remap, IPropertyTree *metaRoot, IPropertyTree *meta)
 {
-    Owned<IPropertyTree> tree = queryDistributedFileDirectory().getFileTree(logicalName, nullptr);
-    if (!tree)
-        return;
-    if (remap)
-        remapGroupsToDafilesrv(tree, nullptr);
-
     CDfsLogicalFileName lfn;
     lfn.set(logicalName);
     if (lfn.isForeign())
         ThrowStringException(-1, "foreign file %s. Not supported", logicalName);
 
     assertex(!lfn.isMulti()); // not supported, don't think needs to be/will be.
+
+    Owned<IPropertyTree> tree = queryDistributedFileDirectory().getFileTree(logicalName, nullptr);
+    if (!tree)
+        return;
+    if (remap)
+        remapGroupsToDafilesrv(tree, nullptr);
 
     bool isSuper = streq(tree->queryName(), queryDfsXmlBranchName(DXB_SuperFile));
 

--- a/fs/dafilesrv/dafilesrv.cpp
+++ b/fs/dafilesrv/dafilesrv.cpp
@@ -350,6 +350,8 @@ const char *getSSLMethodText(DAFSConnectCfg connectMethod)
             return "SSLFirst";
         case UnsecureFirst:
             return "UnsecureFirst";
+        case UnsecureAndSSL:
+            return "UnsecureAndSSL";
         default:
             throwUnexpected();
     }
@@ -478,7 +480,7 @@ int main(int argc, const char* argv[])
         locallisten = true;
     if (config->hasProp("@noSSL"))
     {
-        if (connectMethod == SSLOnly || connectMethod == SSLFirst || connectMethod == UnsecureFirst)
+        if (connectMethod != SSLNone)
         {
             PROGLOG("DaFileSrv SSL specified in config but overridden by -NOSSL in command line");
             connectMethod = SSLNone;
@@ -623,7 +625,7 @@ int main(int argc, const char* argv[])
         usage();
         exit(-1);
     }
-    else if ( ((connectMethod == SSLFirst) || (connectMethod == UnsecureFirst)) && ((listenep.port == 0) || (sslport == 0)) )
+    else if ( ((connectMethod == SSLFirst) || (connectMethod == UnsecureFirst) || (connectMethod == UnsecureAndSSL)) && ((listenep.port == 0) || (sslport == 0)) )
     {
         printf("\nError, both port and secure port must not be 0\n");
         usage();
@@ -784,7 +786,7 @@ int main(int argc, const char* argv[])
 
                 if (connectMethod != SSLOnly)
                     PROGLOG("Opening " DAFS_SERVICE_DISPLAY_NAME " on %s", eps.str());
-                if (connectMethod == SSLOnly || connectMethod == SSLFirst || connectMethod == UnsecureFirst)
+                if (connectMethod != SSLNone)
                 {
                     SocketEndpoint sslep(listenep);
                     sslep.port = sslport;
@@ -852,7 +854,7 @@ int main(int argc, const char* argv[])
         listenep.getEndpointHostText(eps);
     if (connectMethod != SSLOnly)
         PROGLOG("Opening Dali File Server on %s", eps.str());
-    if (connectMethod == SSLOnly || connectMethod == SSLFirst || connectMethod == UnsecureFirst)
+    if (connectMethod != SSLNone)
     {
         SocketEndpoint sslep(listenep);
         sslep.port = sslport;

--- a/fs/dafsclient/rmtclient.hpp
+++ b/fs/dafsclient/rmtclient.hpp
@@ -56,6 +56,7 @@ extern DAFSCLIENT_API void setCanAccessDirectly(RemoteFilename & file,bool set);
 extern DAFSCLIENT_API unsigned getRemoteVersion(ISocket * _socket, StringBuffer &ver);
 extern DAFSCLIENT_API unsigned getCachedRemoteVersion(IDaFsConnection &daFsConnection);
 extern DAFSCLIENT_API unsigned getCachedRemoteVersion(const SocketEndpoint &ep, bool secure);
+extern DAFSCLIENT_API unsigned getPreferredDafsClientPort(bool external);
 extern DAFSCLIENT_API int setDafsTrace(ISocket * socket,byte flags);
 extern DAFSCLIENT_API int setDafsThrottleLimit(ISocket * socket, ThrottleClass throttleClass, unsigned throttleLimit, unsigned throttleDelayMs, unsigned throttleCPULimit, unsigned queueLimit, StringBuffer *errMsg=NULL);
 extern DAFSCLIENT_API int getDafsInfo(ISocket * socket, unsigned level, StringBuffer &retstr);

--- a/fs/dafsclient/rmtfile.hpp
+++ b/fs/dafsclient/rmtfile.hpp
@@ -41,8 +41,8 @@ interface IDaFileSrvHook : extends IRemoteFileCreateHook
     virtual IPropertyTree *addMyFilters(IPropertyTree *filters, SocketEndpoint *myEp=NULL) = 0;
     virtual void clearFilters() = 0;
     virtual StringBuffer &getSecretBased(StringBuffer &storageSecret, const RemoteFilename & filename) = 0;
-    virtual void addSecretUrl(const char *url) = 0;
-    virtual void removeSecretUrl(const char *url) = 0;
+    virtual void addSecretEndpoint(const char *endpoint, const char *optSecret) = 0;
+    virtual void removeSecretEndpoint(const char *endpoint) = 0;
 };
 extern DAFSCLIENT_API IDaFileSrvHook *queryDaFileSrvHook();
 

--- a/fs/dafsserver/dafsserver.cpp
+++ b/fs/dafsserver/dafsserver.cpp
@@ -5372,7 +5372,7 @@ public:
             }
         }
 
-        if (_connectMethod == SSLOnly || _connectMethod == SSLFirst || _connectMethod == UnsecureFirst)
+        if (_connectMethod != SSLNone)
         {
             if (sslep.port == 0)
                 throw createDafsException(DAFSERR_serverinit_failed, "Secure dafilesrv port not specified");
@@ -5461,7 +5461,7 @@ public:
                 throw createDafsException(DAFSERR_serverinit_failed, "Invalid non-secure socket");
         }
 
-        if (_connectMethod == SSLOnly || _connectMethod == SSLFirst || _connectMethod == UnsecureFirst)
+        if (_connectMethod != SSLNone)
         {
             if (!securesock)
                 throw createDafsException(DAFSERR_serverinit_failed, "Invalid secure socket");

--- a/initfiles/etc/DIR_NAME/environment.conf.in
+++ b/initfiles/etc/DIR_NAME/environment.conf.in
@@ -30,7 +30,7 @@ mpStart=7101
 mpEnd=7500
 mpSoMaxConn=128
 mpTraceLevel=0
-# enable SSL for dafilesrv remote file access (SSLNone/false | SSLOnly/true | SSLFirst | UnsecureFirst)
+# enable SSL for dafilesrv remote file access (SSLNone/false | SSLOnly/true | SSLFirst | UnsecureFirst | UnsecureAndSSL)
 # Enabling requires setting the HPCCPassPhrase, HPCCCertFile, and HPCCPrivateKeyFile values
 #dfsUseSSL=SSLNone
 

--- a/system/jlib/jlib.hpp
+++ b/system/jlib/jlib.hpp
@@ -271,7 +271,7 @@ public:
     inline bool zap(TYPE * x)                   { return ConstPointerArray::zap(x); }
 };
 
-enum DAFSConnectCfg { SSLNone = 0, SSLOnly, SSLFirst, UnsecureFirst };
+enum DAFSConnectCfg { SSLNone = 0, SSLOnly, SSLFirst, UnsecureFirst, UnsecureAndSSL };
 
 #include "jstring.hpp"
 #include "jarray.hpp"

--- a/system/jlib/jutil.cpp
+++ b/system/jlib/jutil.cpp
@@ -2596,6 +2596,8 @@ jlib_decl bool querySecuritySettings(DAFSConnectCfg *_connectMethod,
             tmpMethod = SSLFirst;
         else if ( strieq(sslMethod.str(), "UnsecureFirst") )
             tmpMethod = UnsecureFirst;
+        else if ( strieq(sslMethod.str(), "UnsecureAndSSL") )
+            tmpMethod = UnsecureAndSSL;
         else // SSLNone or false or ...
             tmpMethod = SSLNone;
 

--- a/thorlcr/thorutil/thormisc.cpp
+++ b/thorlcr/thorutil/thormisc.cpp
@@ -1067,7 +1067,7 @@ bool getBestFilePart(CActivityBase *activity, IPartDescriptor &partDesc, OwnedIF
                 file.setown(createDaliServixFile(rfn));
             }
             else
-                file.setown(createIFile(locationName.str()));
+                file.setown(createIFile(rfn)); // use rfn not locationName, to preserve port through hooking mechanisms
             try
             {
                 if (file->exists())


### PR DESCRIPTION
1) Fix some issues that prevented the DFS service from being useable in bare-metal.
2) Allow dafilesrv in standard (non-SSL) configuration, to also listen for SSL connections.
So that existing bare-metal connections continue to use existing port, and DFS calls can use the TLS route.
3) Modify the dafilesrv secret hook mapping, so that it allows no secret, which means, still establish a secure connection (TLS), but without certificates.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
