### PR TITLE
HPCC-26634 Check query status only on QueriesOnly roxies

### DIFF
--- a/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
+++ b/esp/services/ws_workunits/ws_workunitsQuerySets.cpp
@@ -1837,34 +1837,21 @@ void CWsWorkunitsEx::getSuspendedQueriesByCluster(MapStringTo<bool> &suspendedQu
     if (!isEmptyString(queryID))
         queryIDs.append(queryID);
 
+    StringArray roxieTargets;
     if (!isEmptyString(querySet))
-    {
-#ifndef _CONTAINERIZED
-        Owned<IPropertyTree> queriesOnCluster = getQueriesOnCluster(querySet, querySet, &queryIDs, checkAllNodes);
-#else
-        Owned<IPropertyTree> queriesOnCluster = getQueriesOnCluster(querySet, querySet, &queryIDs, checkAllNodes, roxieConnMap);
-#endif
-        addSuspendedQueryIDs(suspendedQueries, queriesOnCluster, querySet);
-    }
+        roxieTargets.append(querySet);
     else
-    {
-#ifdef _CONTAINERIZED
-        Owned<IStringIterator> targets = getContainerTargetClusters("roxie", nullptr);
-#else
-        Owned<IStringIterator> targets = getTargetClusters("RoxieCluster", nullptr);
-#endif
-        ForEach(*targets)
-        {
-            SCMStringBuffer target;
-            targets->str(target);
+        getRoxieTargetsSupportingPublishedQueries(roxieTargets);
 
+    ForEachItemIn(i, roxieTargets)
+    {
+        const char *roxieTarget = roxieTargets.item(i);
 #ifndef _CONTAINERIZED
-            Owned<IPropertyTree> queriesOnCluster = getQueriesOnCluster(target.str(), target.str(), &queryIDs, checkAllNodes);
+        Owned<IPropertyTree> queriesOnCluster = getQueriesOnCluster(roxieTarget, roxieTarget, &queryIDs, checkAllNodes);
 #else
-            Owned<IPropertyTree> queriesOnCluster = getQueriesOnCluster(target.str(), target.str(), &queryIDs, checkAllNodes, roxieConnMap);
+        Owned<IPropertyTree> queriesOnCluster = getQueriesOnCluster(roxieTarget, roxieTarget, &queryIDs, checkAllNodes, roxieConnMap);
 #endif
-            addSuspendedQueryIDs(suspendedQueries, queriesOnCluster, target.str());
-        }
+        addSuspendedQueryIDs(suspendedQueries, queriesOnCluster, roxieTarget);
     }
 }
 

--- a/esp/smc/SMCLib/TpContainer.cpp
+++ b/esp/smc/SMCLib/TpContainer.cpp
@@ -689,6 +689,17 @@ extern TPWRAPPER_API void initContainerRoxieTargets(MapStringToMyClass<ISmartSoc
     }
 }
 
+extern TPWRAPPER_API void getRoxieTargetsSupportingPublishedQueries(StringArray& names)
+{
+    Owned<IPropertyTreeIterator> queues = getComponentConfigSP()->getElements("queues[@type='roxie']");
+    ForEach(*queues)
+    {
+        IPropertyTree& queue = queues->query();
+        if (queue.getPropBool("@queriesOnly"))
+            names.append(queue.queryProp("@name"));
+    }
+}
+
 extern TPWRAPPER_API unsigned getThorClusterNames(StringArray& targetNames, StringArray& queueNames)
 {
     Owned<IStringIterator> targets = getContainerTargetClusters("thor", nullptr);

--- a/esp/smc/SMCLib/TpWrapper.cpp
+++ b/esp/smc/SMCLib/TpWrapper.cpp
@@ -2093,6 +2093,22 @@ extern TPWRAPPER_API void initContainerRoxieTargets(MapStringToMyClass<ISmartSoc
     }
 }
 
+extern TPWRAPPER_API void getRoxieTargetsSupportingPublishedQueries(StringArray& names)
+{
+    CConstWUClusterInfoArray clusters;
+    getEnvironmentClusterInfo(clusters);
+    ForEachItemIn(i, clusters)
+    {
+        IConstWUClusterInfo& clusterInfo = clusters.item(i);
+        if (clusterInfo.canPublishQueries())
+        {
+            SCMStringBuffer name;
+            clusterInfo.getName(name);
+            names.append(name.str());
+        }
+    }
+}
+
 extern TPWRAPPER_API unsigned getThorClusterNames(StringArray& targetNames, StringArray& queueNames)
 {
     StringArray thorNames, groupNames;

--- a/esp/smc/SMCLib/TpWrapper.hpp
+++ b/esp/smc/SMCLib/TpWrapper.hpp
@@ -230,6 +230,7 @@ extern TPWRAPPER_API IConstWUClusterInfo* getWUClusterInfoByName(const char* clu
 extern TPWRAPPER_API IStringIterator *getContainerTargetClusters(const char* processType, const char* processName);
 extern TPWRAPPER_API void initContainerRoxieTargets(MapStringToMyClass<ISmartSocketFactory>& connMap);
 extern TPWRAPPER_API unsigned getThorClusterNames(StringArray& targetNames, StringArray& queueNames);
+extern TPWRAPPER_API void getRoxieTargetsSupportingPublishedQueries(StringArray& names);
 extern TPWRAPPER_API void validateTargetName(const char* target);
 extern TPWRAPPER_API bool getSashaService(StringBuffer &serviceAddress, const char *service, bool failIfNotFound);
 extern TPWRAPPER_API bool getSashaServiceEP(SocketEndpoint &serviceEndpoint, const char *service, bool failIfNotFound);


### PR DESCRIPTION
For containerized, the existing WUListQueries tries to check suspended queries for both queriesOnly roxie and non-queriesOnly roxie. the existing WUListQueries returns a query not found error if there is a non-queriesOnly roxie. For bare metal, the existing WUListQueries tries to get suspended queries for every target which contains a RoxieCluster process. The same error occurs for the target which has both RoxieCluster process and ThorCluster process (ex. thor_roxie). The WUListQueries should not check suspended queries for the non-queriesOnly roxie and the target which has both RoxieCluster process and ThorCluster process.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
