### PR TITLE
HPCC-30998 Fix post-mortem files being attached to wrong workunit.

### DIFF
--- a/initfiles/bin/check_executes
+++ b/initfiles/bin/check_executes
@@ -109,6 +109,9 @@ if [ $PMD_ALWAYS = true ] || [ $retVal -ne 0 ]; then
   fi
   dmesg -xT > $POST_MORTEM_DIR/dmesg.log
   if [[ -n "${PMD_DALISERVER}" ]] && [[ -n "${PMD_WORKUNIT}" ]]; then
+    if [[ -s wuid ]]; then # takes precedence over command line option
+      PMD_WORKUNIT=$(cat wuid)
+    fi
     wutool postmortem ${PMD_WORKUNIT} DALISERVER=${PMD_DALISERVER} PMD=${POST_MORTEM_DIR}
     echo Updated workunit ${PMD_WORKUNIT}
   fi

--- a/thorlcr/master/thgraphmanager.cpp
+++ b/thorlcr/master/thgraphmanager.cpp
@@ -1473,6 +1473,7 @@ void thorMain(ILogMsgHandler *logHandler, const char *wuid, const char *graphNam
                                     // NB: this set of pods could still already be published, if so, publishPodNames will not re-add.
                                 }
                                 currentWuid.set(wuid); // NB: will always be same if !multiJobLinger
+                                saveWuidToFile(currentWuid);
                                 break; // success
                             }
                             else if (ret < 0)

--- a/thorlcr/master/thmastermain.cpp
+++ b/thorlcr/master/thmastermain.cpp
@@ -1002,6 +1002,7 @@ int main( int argc, const char *argv[]  )
         bool doWorkerRegistration = false;
         if (isContainerized())
         {
+            saveWuidToFile(workunit);
             LogMsgJobId thorJobId = queryLogMsgManager()->addJobId(workunit);
             thorJob.setJobID(thorJobId);
             setDefaultJobId(thorJobId);

--- a/thorlcr/slave/slavmain.cpp
+++ b/thorlcr/slave/slavmain.cpp
@@ -1788,6 +1788,7 @@ public:
                         StringAttr wuid, graphName;
                         StringBuffer soPath;
                         msg.read(wuid);
+                        saveWuidToFile(wuid);
                         msg.read(graphName);
 
                         Owned<ILoadedDllEntry> querySo;

--- a/thorlcr/thorutil/thormisc.cpp
+++ b/thorlcr/thorutil/thormisc.cpp
@@ -1691,3 +1691,13 @@ void CThorPerfTracer::stop()
         ::Release(E);
     }
 }
+
+void saveWuidToFile(const char *wuid)
+{
+    // Store current wuid to a local file, so post mortem script can find it (and if necessary publish files to it)
+    Owned<IFile> wuidFile = createIFile("wuid"); // NB: each pod is in it's own private working directory
+    Owned<IFileIO> wuidFileIO = wuidFile->open(IFOcreate);
+    if (!wuidFileIO)
+        throw makeStringException(0, "Failed to create file 'wuid' to store current workunit for post mortem script");
+    wuidFileIO->write(0, strlen(wuid), wuid);
+}

--- a/thorlcr/thorutil/thormisc.hpp
+++ b/thorlcr/thorutil/thormisc.hpp
@@ -716,5 +716,7 @@ public:
     void stop();
 };
 
+extern graph_decl void saveWuidToFile(const char *wuid);
+
 #endif
 


### PR DESCRIPTION
With multiJobLinger on (now the default), post-mortem files were being attached to the 1st workunit than ran on a started Thor instance, rather than the one that had most recently ran and caused the reports.

Fix by recording the current wuid to a local temp file, for check_executes.sh to use when attaching post-mortem files.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
