### PR TITLE
HPCC-31048 Fix the scope for SSTdfuworkunit

### DIFF
--- a/plugins/fileservices/fileservices.cpp
+++ b/plugins/fileservices/fileservices.cpp
@@ -635,7 +635,8 @@ static void blockUntilComplete(const char * label, IClientFileSpray &server, ICo
         if (wu.get()) { // if updatable (e.g. not hthor with no agent context)
             aborting = wu->aborting();
             StringBuffer wuScope, ElapsedLabel, RemainingLabel;
-            wuScope.appendf("%s-%s", label, dfuwu.getID());
+            StringBuffer labelbuf(label);
+            wuScope.appendf("dfu:%s:%s", labelbuf.toLowerCase().str(), dfuwu.getID());
             ElapsedLabel.append(wuScope).append(" (Elapsed) ");
             RemainingLabel.append(wuScope).append(" (Remaining) ");
             //MORE: I think this are intended to replace the timing information, but will currently combine

--- a/system/jlib/jstatcodes.h
+++ b/system/jlib/jstatcodes.h
@@ -28,6 +28,7 @@
 #define ChildGraphScopePrefix "c"
 #define FileScopePrefix "p"
 #define ChannelScopePrefix "x"
+#define DFUWorkunitScopePrefix "D"
 
 #define MATCHES_CONST_PREFIX(search, prefix) (strncmp(search, prefix, strlen(prefix)) == 0)
 

--- a/system/jlib/jstats.cpp
+++ b/system/jlib/jstats.cpp
@@ -1429,6 +1429,8 @@ StringBuffer & StatsScopeId::getScopeText(StringBuffer & out) const
         return out.append(FileScopePrefix).append(name);
     case SSTchannel:
         return out.append(ChannelScopePrefix).append(id);
+    case SSTdfuworkunit:
+        return out.append(DFUWorkunitScopePrefix).append(name);
     case SSTunknown:
         return out.append(name);
     case SSTglobal:
@@ -1447,6 +1449,7 @@ unsigned StatsScopeId::getHash() const
     {
     case SSTfunction:
     case SSTunknown:
+    case SSTdfuworkunit:
         return hashcz((const byte *)name.get(), (unsigned)scopeType);
     default:
         return hashc((const byte *)&id, sizeof(id), (unsigned)scopeType);
@@ -1496,6 +1499,7 @@ void StatsScopeId::describe(StringBuffer & description) const
         break;
     case SSTfile:
     case SSTfunction:
+    case SSTdfuworkunit:
         description.append(' ').append(name);
         break;
     default:
@@ -1544,6 +1548,7 @@ void StatsScopeId::deserialize(MemoryBuffer & in, unsigned version)
         break;
     case SSTfile:
     case SSTfunction:
+    case SSTdfuworkunit:
         in.read(name);
         break;
     default:
@@ -1571,6 +1576,7 @@ void StatsScopeId::serialize(MemoryBuffer & out) const
         break;
     case SSTfile:
     case SSTfunction:
+    case SSTdfuworkunit:
         out.append(name);
         break;
     default:
@@ -1675,6 +1681,15 @@ bool StatsScopeId::setScopeText(const char * text, const char * * _next)
             return true;
         }
         break;
+    case DFUWorkunitScopePrefix[0]:
+        if (MATCHES_CONST_PREFIX(text, DFUWorkunitScopePrefix))
+        {
+            setDfuWorkunitId(text+ strlen(DFUWorkunitScopePrefix));
+            if (_next)
+                *_next = text + strlen(text);
+            return true;
+        }
+        break;
     case '\0':
         setId(SSTglobal, 0);
         return true;
@@ -1740,7 +1755,11 @@ void StatsScopeId::setChildGraphId(unsigned _id)
 {
     setId(SSTchildgraph, _id);
 }
-
+void StatsScopeId::setDfuWorkunitId(const char * _name)
+{
+    scopeType = SSTdfuworkunit;
+    name.set(_name);
+}
 //--------------------------------------------------------------------------------------------------------------------
 
 enum

--- a/system/jlib/jstats.h
+++ b/system/jlib/jstats.h
@@ -87,7 +87,7 @@ public:
     void setSubgraphId(unsigned _id);
     void setWorkflowId(unsigned _id);
     void setChildGraphId(unsigned _id);
-
+    void setDfuWorkunitId(const char * _name);
     int compare(const StatsScopeId & other) const;
 
     bool operator == (const StatsScopeId & other) const { return matches(other); }


### PR DESCRIPTION
Modify the scope for SSTdfuworkunit as follows 1) parent scope: "dfu" 2) dfu operation 3) dfu workunit id

This fix ensures that the SSTdfuworkunit scopes are handled correctly by scope iterators and other related statistic features.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
