### PR TITLE
HPCC-28101 Report '[??? rows]' for getResultTotalRowCount -1

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -4748,6 +4748,7 @@ public:
     virtual IStringVal& getResultXml(IStringVal &str, bool hidePasswords) const;
     virtual unsigned    getResultFetchSize() const;
     virtual __int64     getResultTotalRowCount() const;
+    virtual StringBuffer& getResultTotalRowCountString(StringBuffer &str) const;
     virtual __int64     getResultRowCount() const;
     virtual void        getResultDataset(IStringVal & ecl, IStringVal & defs) const;
     virtual IStringVal& getResultLogicalName(IStringVal &ecl) const;
@@ -11214,6 +11215,16 @@ unsigned CLocalWUResult::getResultFetchSize() const
 __int64 CLocalWUResult::getResultTotalRowCount() const
 {
     return p->getPropInt64("totalRowCount", -1);
+}
+
+StringBuffer &CLocalWUResult::getResultTotalRowCountString(StringBuffer &str) const
+{
+    __int64 count = getResultTotalRowCount();
+    if (count == -1)
+        str.append("[??? rows]");
+    else
+        str.append('[').append(count).append(" rows]");
+    return str;
 }
 
 __int64 CLocalWUResult::getResultRowCount() const

--- a/common/workunit/workunit.hpp
+++ b/common/workunit/workunit.hpp
@@ -275,6 +275,7 @@ interface IConstWUResult : extends IInterface
     virtual IStringVal & getResultXml(IStringVal & str, bool hidePasswords) const = 0;
     virtual unsigned getResultFetchSize() const = 0;
     virtual __int64 getResultTotalRowCount() const = 0;
+    virtual StringBuffer & getResultTotalRowCountString(StringBuffer & str) const = 0;
     virtual __int64 getResultRowCount() const = 0;
     virtual void getResultDataset(IStringVal & ecl, IStringVal & defs) const = 0;
     virtual IStringVal & getResultLogicalName(IStringVal & ecl) const = 0;

--- a/esp/services/ws_workunits/ws_workunitsHelpers.cpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.cpp
@@ -1883,7 +1883,7 @@ void WsWuInfo::getResult(IConstWUResult &r, IArrayOf<IEspECLResult>& results, un
     }
     else
     {
-        value.append('[').append(r.getResultTotalRowCount()).append(" rows]");
+        r.getResultTotalRowCountString(value);
         if((r.getResultSequence()>=0) && (!filename.length() || (df && df->queryAttributes().hasProp("ECL"))))
             link.append(r.getResultSequence());
     }

--- a/esp/smc/SMCLib/WUXMLInfo.cpp
+++ b/esp/smc/SMCLib/WUXMLInfo.cpp
@@ -261,9 +261,8 @@ bool CWUXMLInfo::buildXmlResultList(IConstWorkUnit &wu,IPropertyTree& XMLStructu
                 }
                 else
                 {
-                    value.append("   [");
-                    value.append(r.getResultTotalRowCount());
-                    value.append(" rows]");
+                    value.append("   ");
+                    r.getResultTotalRowCountString(value);
                     link.append(r.getResultSequence());
                 }
                 IPropertyTree* result = resultsTree->addPropTree("WUResult", createPTree(ipt_caseInsensitive));


### PR DESCRIPTION
For a WU result with unknown rowcount, the existing WsWorkunits returns '[-1 rows]' because the getResultTotalRowCount() returns -1. In this PR, the '[-1 rows]' is changed to '[??? rows]'.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
