### PR TITLE
HPCC-23064 Improve error messages when no access to ECL WUs

### DIFF
--- a/esp/services/ws_workunits/ws_workunitsHelpers.cpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.cpp
@@ -91,35 +91,46 @@ SecAccessFlags getWsWorkunitAccess(IEspContext& ctx, IConstWorkUnit& cw)
     return accessFlag;
 }
 
-bool validateWsWorkunitAccess(IEspContext& ctx, const char* wuid, SecAccessFlags minAccess)
+bool validateWsWorkunitAccess(IEspContext& ctx, IConstWorkUnit& cw, SecAccessFlags minAccess, StringBuffer& secAccessFeature)
+{
+    secAccessFeature.set(getWuAccessType(cw, ctx.queryUserId()));
+    return ctx.validateFeatureAccess(secAccessFeature, minAccess, false);
+}
+
+bool validateWsWorkunitAccess(IEspContext& ctx, const char* wuid, SecAccessFlags minAccess, StringBuffer& secAccessFeature)
 {
     Owned<IWorkUnitFactory> wf = getWorkUnitFactory(ctx.querySecManager(), ctx.queryUser());
     Owned<IConstWorkUnit> cw = wf->openWorkUnit(wuid);
     if (!cw)
         throw MakeStringException(ECLWATCH_CANNOT_OPEN_WORKUNIT, "Failed to open workunit %s when validating workunit access", wuid);
-    return ctx.validateFeatureAccess(getWuAccessType(*cw, ctx.queryUserId()), minAccess, false);
+    return validateWsWorkunitAccess(ctx, *cw, minAccess, secAccessFeature);
 }
 
-bool validateWsWorkunitAccessByOwnerId(IEspContext& ctx, const char* owner, SecAccessFlags minAccess)
+bool validateWsWorkunitAccessByOwnerId(IEspContext& ctx, const char* owner, SecAccessFlags minAccess, StringBuffer& secAccessFeature)
 {
-    return ctx.validateFeatureAccess(getWuAccessType(owner, ctx.queryUserId()), minAccess, false);
+    secAccessFeature.set(getWuAccessType(owner, ctx.queryUserId()));
+    return ctx.validateFeatureAccess(secAccessFeature, minAccess, false);
 }
 
 void ensureWsWorkunitAccessByOwnerId(IEspContext& ctx, const char* owner, SecAccessFlags minAccess)
 {
-    if (!ctx.validateFeatureAccess(getWuAccessType(owner, ctx.queryUserId()), minAccess, false))
+    const char * secAccessFeature = getWuAccessType(owner, ctx.queryUserId());
+    if (!ctx.validateFeatureAccess(secAccessFeature, minAccess, false))
     {
         ctx.setAuthStatus(AUTH_STATUS_NOACCESS);
-        throw MakeStringException(ECLWATCH_ECL_WU_ACCESS_DENIED, "Failed to access workunit. Permission denied.");
+        throw makeStringExceptionV(ECLWATCH_ECL_WU_ACCESS_DENIED, "Failed to access workunit. Resource %s : Permission denied. %s Access Required.",
+            secAccessFeature, getSecAccessFlagName(minAccess));
     }
 }
 
 void ensureWsWorkunitAccess(IEspContext& ctx, IConstWorkUnit& cw, SecAccessFlags minAccess)
 {
-    if (!ctx.validateFeatureAccess(getWuAccessType(cw, ctx.queryUserId()), minAccess, false))
+    const char * secAccessFeature = getWuAccessType(cw, ctx.queryUserId());
+    if (!ctx.validateFeatureAccess(secAccessFeature, minAccess, false))
     {
         ctx.setAuthStatus(AUTH_STATUS_NOACCESS);
-        throw MakeStringException(ECLWATCH_ECL_WU_ACCESS_DENIED, "Failed to access workunit. Permission denied.");
+        throw makeStringExceptionV(ECLWATCH_ECL_WU_ACCESS_DENIED, "Failed to access workunit %s. Resource %s : Permission denied. %s Access Required.",
+            cw.queryWuid(), secAccessFeature, getSecAccessFlagName(minAccess));
     }
 }
 
@@ -137,7 +148,7 @@ void ensureWsCreateWorkunitAccess(IEspContext& ctx)
     if (!ctx.validateFeatureAccess(OWN_WU_ACCESS, SecAccess_Write, false))
     {
         ctx.setAuthStatus(AUTH_STATUS_NOACCESS);
-        throw MakeStringException(ECLWATCH_ECL_WU_ACCESS_DENIED, "Failed to create workunit. Permission denied.");
+        throw makeStringExceptionV(ECLWATCH_ECL_WU_ACCESS_DENIED, "Failed to create workunit. Resource %s : Permission denied. Write Access Required.", OWN_WU_ACCESS);
     }
 }
 

--- a/esp/services/ws_workunits/ws_workunitsHelpers.hpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.hpp
@@ -81,8 +81,9 @@ void ensureWsWorkunitAccess(IEspContext& cxt, IConstWorkUnit& cw, SecAccessFlags
 void ensureWsWorkunitAccess(IEspContext& context, const char* wuid, SecAccessFlags minAccess);
 void ensureWsWorkunitAccessByOwnerId(IEspContext& context, const char* owner, SecAccessFlags minAccess);
 void ensureWsCreateWorkunitAccess(IEspContext& cxt);
-bool validateWsWorkunitAccess(IEspContext& context, const char* wuid, SecAccessFlags minAccess);
-bool validateWsWorkunitAccessByOwnerId(IEspContext& context, const char* owner, SecAccessFlags minAccess);
+bool validateWsWorkunitAccess(IEspContext& context, IConstWorkUnit& cw, SecAccessFlags minAccess, StringBuffer& secAccessFeature);
+bool validateWsWorkunitAccess(IEspContext& context, const char* wuid, SecAccessFlags minAccess, StringBuffer& secAccessFeature);
+bool validateWsWorkunitAccessByOwnerId(IEspContext& context, const char* owner, SecAccessFlags minAccess, StringBuffer& secAccessFeature);
 
 const char *getGraphNum(const char *s,unsigned &num);
 


### PR DESCRIPTION
When access denied to ECL WUs, the WsWorkunits should report which access feature (OwnWorkunitsAccess or OthersWorkunitsAccess) is denied so that an administrator may know how to change user's access permission.
The code changes are:
1. add the code to report which access feature is validated in the validateWsWorkunitAccess() and validateWsWorkunitAccessByOwnerId(). If the validation fails, the feature name can be used inside error messages.
2. Change the validateWsWorkunitAccess() function to 2 validateWsWorkunitAccess() functions: one for IConstWorkUnit input and one for wuid input. The 1st one is called by the 2nd one and other functions.
3. In the functions below, if the WU access validation fails, add the name of the access feature into the error message:
  ensureWsWorkunitAccess()
  ensureWsWorkunitAccessByOwnerId()
  ensureWsCreateWorkunitAccess()
  doAction().
4. In the doWUQueryByFile(), call the validateWsWorkunitAccess() to validate WU access. Change the error message if the validation fails. Also clean the code.
5. Simplify the onWUQuery by switching validateWsWorkunitAccess() call to the ensureWsWorkunitAccess() call.
6. In the onStartUpload(), when importing a WU ZAP report, change the error message if the user does not have the access permission.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
