### PR TITLE
HPCC-31213 Add plane name to MoveExternalFile, etc

### DIFF
--- a/ecllibrary/std/File.ecl
+++ b/ecllibrary/std/File.ecl
@@ -358,9 +358,10 @@ EXPORT RfsAction(varstring server, varstring query) :=
  * @param location      The IP address of the remote machine.
  * @param frompath      The path/name of the file to move.
  * @param topath        The path/name of the target file.
+ * @param planename     The name of the data plane containing the file.
  */
-EXPORT MoveExternalFile(varstring location, varstring frompath, varstring topath) :=
-    lib_fileservices.FileServices.MoveExternalFile(location, frompath, topath);
+EXPORT MoveExternalFile(varstring location, varstring frompath, varstring topath, varstring planename='') :=
+    lib_fileservices.FileServices.MoveExternalFile(location, frompath, topath, planename);
 
 /**
  * Removes a single physical file from a remote machine. The
@@ -368,9 +369,10 @@ EXPORT MoveExternalFile(varstring location, varstring frompath, varstring topath
  *
  * @param location      The IP address of the remote machine.
  * @param path          The path/name of the file to remove.
+ * @param planename     The name of the data plane containing the file.
  */
-EXPORT DeleteExternalFile(varstring location, varstring path) :=
-    lib_fileservices.FileServices.DeleteExternalFile(location, path);
+EXPORT DeleteExternalFile(varstring location, varstring path, varstring planename='') :=
+    lib_fileservices.FileServices.DeleteExternalFile(location, path, planename);
 
 /**
  * Creates the path on the location (if it does not already exist). The
@@ -378,9 +380,10 @@ EXPORT DeleteExternalFile(varstring location, varstring path) :=
  *
  * @param location      The IP address of the remote machine.
  * @param path          The path/name of the file to remove.
+ * @param planename     The name of the data plane containing the directory.
  */
-EXPORT CreateExternalDirectory(varstring location, varstring path) :=
-    lib_fileservices.FileServices.CreateExternalDirectory(location, path);
+EXPORT CreateExternalDirectory(varstring location, varstring path, varstring planename='') :=
+    lib_fileservices.FileServices.CreateExternalDirectory(location, path, planename);
 
 /**
  * Returns the value of the given attribute for the specified logicalfilename.

--- a/plugins/fileservices/fileservices.hpp
+++ b/plugins/fileservices/fileservices.hpp
@@ -183,8 +183,11 @@ FILESERVICES_API void FILESERVICES_CALL fsRfsAction(const char *server, const ch
 FILESERVICES_API char *  FILESERVICES_CALL fsfGetHostName(const char *ipaddress);
 FILESERVICES_API char *  FILESERVICES_CALL fsfResolveHostName(const char *hostname);
 FILESERVICES_API void  FILESERVICES_CALL fsMoveExternalFile(ICodeContext * ctx,const char *location,const char *frompath,const char *topath);
+FILESERVICES_API void  FILESERVICES_CALL fsMoveExternalFile_v2(ICodeContext *ctx,const char *location,const char *frompath,const char *topath,const char *planename);
 FILESERVICES_API void  FILESERVICES_CALL fsDeleteExternalFile(ICodeContext * ctx,const char *location,const char *path);
+FILESERVICES_API void  FILESERVICES_CALL fsDeleteExternalFile_v2(ICodeContext * ctx,const char *location,const char *path,const char *planename);
 FILESERVICES_API void  FILESERVICES_CALL fsCreateExternalDirectory(ICodeContext * ctx,const char *location,const char *path);
+FILESERVICES_API void  FILESERVICES_CALL fsCreateExternalDirectory_v2(ICodeContext * ctx,const char *location,const char *path,const char *planename);
 FILESERVICES_API char * FILESERVICES_CALL fsfGetLogicalFileAttribute(ICodeContext * ctx,const char *lfn,const char *attrname);
 FILESERVICES_API void FILESERVICES_CALL fsProtectLogicalFile(ICodeContext * ctx,const char *lfn,bool set);
 FILESERVICES_API void FILESERVICES_CALL fsDfuPlusExec(ICodeContext * ctx,const char *_cmd);

--- a/plugins/proxies/lib_fileservices.ecllib
+++ b/plugins/proxies/lib_fileservices.ecllib
@@ -99,9 +99,9 @@ export FileServices := SERVICE : plugin('fileservices'), time
   RfsAction( const varstring server, const varstring query): c,entrypoint='fsRfsAction';
   varstring GetHostName( const varstring ipaddress ): c,entrypoint='fsfGetHostName';
   varstring ResolveHostName( const varstring hostname ): c,entrypoint='fsfResolveHostName';
-  MoveExternalFile(const varstring location, const varstring frompath, const varstring topath): c,action,context,entrypoint='fsMoveExternalFile';
-  DeleteExternalFile(const varstring location, const varstring path): c,action,context,entrypoint='fsDeleteExternalFile';
-  CreateExternalDirectory(const varstring location, const varstring path): c,action,context,entrypoint='fsCreateExternalDirectory';
+  MoveExternalFile(const varstring location, const varstring frompath, const varstring topath, const varstring planename=''): c,action,context,entrypoint='fsMoveExternalFile_v2';
+  DeleteExternalFile(const varstring location, const varstring path, const varstring planename=''): c,action,context,entrypoint='fsDeleteExternalFile_v2';
+  CreateExternalDirectory(const varstring location, const varstring path, const varstring planename=''): c,action,context,entrypoint='fsCreateExternalDirectory_v2';
   varstring GetLogicalFileAttribute(const varstring lfn,const varstring attrname) : c,context,entrypoint='fsfGetLogicalFileAttribute';
   ProtectLogicalFile(const varstring lfn,boolean set=true) : c,context,entrypoint='fsProtectLogicalFile';
   DfuPlusExec(const varstring cmdline) : c,context,entrypoint='fsDfuPlusExec';

--- a/testing/regress/ecl/despray.ecl
+++ b/testing/regress/ecl/despray.ecl
@@ -315,11 +315,13 @@ SEQUENTIAL(
     // Clean-up
     FileServices.DeleteLogicalFile(SourceFile),
     FileServices.DeleteExternalFile('.', DestFile1),
-    FileServices.DeleteExternalFile('.', DestFile4),
-    FileServices.DeleteExternalFile('.', DestFile5),
-    FileServices.DeleteExternalFile('.', DestFile6),
-    FileServices.DeleteExternalFile('.', DestFile7),
-    FileServices.DeleteExternalFile('.', DestFile8),
+    // The follow files should not exist (see expected failed tests above).
+    // Calling DeleteExternalFile on malformed filenames will result in another error.
+    // FileServices.DeleteExternalFile('.', DestFile4),
+    // FileServices.DeleteExternalFile('.', DestFile5),
+    // FileServices.DeleteExternalFile('.', DestFile6),
+    // FileServices.DeleteExternalFile('.', DestFile7),
+    // FileServices.DeleteExternalFile('.', DestFile8),
     FileServices.DeleteExternalFile('.', DestFile9),
     FileServices.DeleteExternalFile('.', DestFile11),
 );


### PR DESCRIPTION
The STD.File.MoveExternalFile moves files from one landing zone folder to anothor. The existing method can only specify a landing zone using host name. In this PR, a landing zone can be specified by plane name.
Similar functions are added to STD.File.CreateExternalDirectory and STD.File.DeleteExternalFile.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [x] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [x] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
