### PR TITLE
HPCC-31290 Fix Sasha Thor QMon switching issues

### DIFF
--- a/common/workunit/workunit.hpp
+++ b/common/workunit/workunit.hpp
@@ -85,7 +85,7 @@ typedef unsigned __int64 __uint64;
 interface IQueueSwitcher : extends IInterface
 {
     virtual void * getQ(const char * qname, const char * wuid) = 0;
-    virtual void putQ(const char * qname, const char * wuid, void * qitem) = 0;
+    virtual void putQ(const char * qname, void * qitem) = 0;
     virtual bool isAuto() = 0;
 };
 
@@ -1374,7 +1374,7 @@ interface IWorkUnit : extends IConstWorkUnit
     virtual void noteFileRead(IDistributedFile * file) = 0;
     virtual void noteFieldUsage(IPropertyTree * file) = 0;
     virtual void resetBeforeGeneration() = 0;
-    virtual bool switchThorQueue(const char * newcluster, IQueueSwitcher * qs) = 0;
+    virtual bool switchThorQueue(const char * newcluster, IQueueSwitcher * qs, const char *item) = 0;
     virtual void setAllowedClusters(const char * value) = 0;
     virtual void setAllowAutoQueueSwitch(bool val) = 0;
     virtual void setLibraryInformation(const char * name, unsigned interfaceHash, unsigned definitionHash) = 0;

--- a/common/workunit/workunit.ipp
+++ b/common/workunit/workunit.ipp
@@ -385,7 +385,7 @@ public:
     IWorkUnit &lockRemote(bool commit);
     void unlockRemote();
     void abort();
-    bool switchThorQueue(const char *cluster, IQueueSwitcher *qs);
+    bool switchThorQueue(const char *cluster, IQueueSwitcher *qs, const char *item);
     void setAllowedClusters(const char *value);
     IStringVal & getAllowedClusters(IStringVal & str) const;
     void remoteCheckAccess(IUserDescriptor *user, bool writeaccess) const;

--- a/ecl/wutest/wujobqtest2.cpp
+++ b/ecl/wutest/wujobqtest2.cpp
@@ -41,7 +41,7 @@ bool switchWorkunitQueue(const char *wuid, const char *cluster)
             Owned<IJobQueue> q = createJobQueue(qname);
             return q->take(wuid);
         }
-        void putQ(const char * qname, const char * wuid, void * qitem)
+        void putQ(const char * qname, void * qitem)
         {
             Owned<IJobQueue> q = createJobQueue(qname);
             q->enqueue((IJobQueueItem *)qitem);
@@ -56,6 +56,6 @@ bool switchWorkunitQueue(const char *wuid, const char *cluster)
     Owned<IWorkUnit> wu = factory->updateWorkUnit(wuid);
     if (!wu)
         return false;
-    return wu->switchThorQueue(cluster, &switcher);
+    return wu->switchThorQueue(cluster, &switcher, nullptr);
 }
 


### PR DESCRIPTION
Automatic and manual queue switching by the Sasha QMon service have not worked since 7.12.
Changes to the format of the queued thor job items meant it did not find any queued items to swap.
This meant that workunits submitted with 'allowedclusters' and 'allowautoqueueswitch', that should have automatically
switched to an idle Thor queue in the 'allowedclusters' set when the queue they were submitted to was busy, did not.

Also fix the qmon tracing, which was supposed to trace the current workunits in flight running on Thor instances. That appears not to have worked well before 7.12.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
