### PR TITLE
HPCC-31498 Kafka shared library not constructing/destructing properly

### DIFF
--- a/plugins/kafka/kafka.cpp
+++ b/plugins/kafka/kafka.cpp
@@ -51,12 +51,6 @@ namespace KafkaPlugin
     const __int32 POLL_TIMEOUT = 1000;
 
     //--------------------------------------------------------------------------
-    // Static Variables
-    //--------------------------------------------------------------------------
-
-    static std::once_flag pubCacheInitFlag;
-
-    //--------------------------------------------------------------------------
     // Static Methods (internal)
     //--------------------------------------------------------------------------
 
@@ -697,7 +691,7 @@ namespace KafkaPlugin
      *
      * Class used to create and cache publisher objects and connections
      */
-    static class PublisherCacheObj
+    class PublisherCacheObj
     {
         private:
 
@@ -712,6 +706,15 @@ namespace KafkaPlugin
             PublisherCacheObj()
             {
 
+            }
+
+            /**
+             * Destructor
+             *
+             */
+            ~PublisherCacheObj()
+            {
+                deleteAll();
             }
 
             void deleteAll()
@@ -735,44 +738,39 @@ namespace KafkaPlugin
 
             /**
              * Remove previously-created objects that have been inactive
-             * for awhile
+             * for awhile; assumes a lock is held while modifying cachedPublishers
              */
             void expire()
             {
-                if (!cachedPublishers.empty())
+                time_t oldestAllowedTime = time(NULL) - OBJECT_EXPIRE_TIMEOUT_SECONDS;
+                __int32 expireCount = 0;
+
+                for (ObjMap::iterator x = cachedPublishers.begin(); x != cachedPublishers.end(); /* increment handled explicitly */)
                 {
-                    CriticalBlock block(lock);
-
-                    time_t oldestAllowedTime = time(NULL) - OBJECT_EXPIRE_TIMEOUT_SECONDS;
-                    __int32 expireCount = 0;
-
-                    for (ObjMap::iterator x = cachedPublishers.begin(); x != cachedPublishers.end(); /* increment handled explicitly */)
+                    // Expire only if the publisher has been inactive and if
+                    // there are no messages in the outbound queue
+                    if (x->second && x->second->getTimeTouched() < oldestAllowedTime && x->second->messagesWaitingInQueue() == 0)
                     {
-                        // Expire only if the publisher has been inactive and if
-                        // there are no messages in the outbound queue
-                        if (x->second && x->second->getTimeTouched() < oldestAllowedTime && x->second->messagesWaitingInQueue() == 0)
-                        {
-                            // Shutdown the attached poller before deleting
-                            x->second->shutdownPoller();
+                        // Shutdown the attached poller before deleting
+                        x->second->shutdownPoller();
 
-                            // Delete the object
-                            delete(x->second);
+                        // Delete the object
+                        delete(x->second);
 
-                            // Erase from map
-                            cachedPublishers.erase(x++);
+                        // Erase from map
+                        cachedPublishers.erase(x++);
 
-                            ++expireCount;
-                        }
-                        else
-                        {
-                            x++;
-                        }
+                        ++expireCount;
                     }
-
-                    if (doTrace(traceKafka) && expireCount > 0)
+                    else
                     {
-                        DBGLOG("Kafka: Expired %d cached publisher%s", expireCount, (expireCount == 1 ? "" : "s"));
+                        x++;
                     }
+                }
+
+                if (doTrace(traceKafka) && expireCount > 0)
+                {
+                    DBGLOG("Kafka: Expired %d cached publisher%s", expireCount, (expireCount == 1 ? "" : "s"));
                 }
             }
 
@@ -822,6 +820,9 @@ namespace KafkaPlugin
                         {
                             DBGLOG("Kafka: Created and cached new publisher object: %s @ %s", topic.c_str(), brokers.c_str());
                         }
+
+                        // Expire any old publishers before returning the new one
+                        expire();
                     }
                 }
 
@@ -837,77 +838,16 @@ namespace KafkaPlugin
 
             ObjMap          cachedPublishers;   //!< std::map of created Publisher object pointers
             CriticalSection lock;               //!< Mutex guarding modifications to cachedPublishers
-    } *publisherCache;
+    };
 
     //--------------------------------------------------------------------------
+    // Singleton Initialization
+    //--------------------------------------------------------------------------
 
-    /** @class  PublisherCacheExpirerObj
-     *          Class used to expire old publisher objects held within publisherCache
-     */
-    static class PublisherCacheExpirerObj : public Thread
+    static Singleton<PublisherCacheObj> publisherCache;
+    static PublisherCacheObj & queryPublisherCache()
     {
-        public:
-
-            PublisherCacheExpirerObj()
-                :   Thread("Kafka::PublisherExpirer"),
-                    shouldRun(false)
-            {
-
-            }
-
-            virtual void start()
-            {
-                if (!isAlive())
-                {
-                    shouldRun = true;
-                    Thread::start();
-                }
-            }
-
-            virtual void stop()
-            {
-                if (isAlive())
-                {
-                    shouldRun = false;
-                    join();
-                }
-            }
-
-            virtual int run()
-            {
-                while (shouldRun)
-                {
-                    if (publisherCache)
-                    {
-                        publisherCache->expire();
-                    }
-
-                    usleep(1000);
-                }
-
-                return 0;
-            }
-
-        private:
-
-            std::atomic_bool    shouldRun;      //!< If true, we should execute our thread's main event loop
-    } *publisherCacheExpirer;
-
-    //--------------------------------------------------------------------------
-    // Lazy Initialization
-    //--------------------------------------------------------------------------
-
-    /**
-     * Make sure the publisher object cache is initialized as well as the
-     * associated background thread for expiring idle publishers.  This is
-     * called only once.
-     */
-    static void setupPublisherCache()
-    {
-        KafkaPlugin::publisherCache = new KafkaPlugin::PublisherCacheObj();
-
-        KafkaPlugin::publisherCacheExpirer = new KafkaPlugin::PublisherCacheExpirerObj;
-        KafkaPlugin::publisherCacheExpirer->start();
+        return *publisherCache.query([] () { return new PublisherCacheObj; });
     }
 
     //--------------------------------------------------------------------------
@@ -916,9 +856,7 @@ namespace KafkaPlugin
 
     ECL_KAFKA_API bool ECL_KAFKA_CALL publishMessage(ICodeContext* ctx, const char* brokers, const char* topic, const char* message, const char* key)
     {
-        std::call_once(pubCacheInitFlag, setupPublisherCache);
-
-        Publisher* pubObjPtr = publisherCache->getPublisher(brokers, topic, POLL_TIMEOUT);
+        Publisher* pubObjPtr = queryPublisherCache().getPublisher(brokers, topic, POLL_TIMEOUT);
 
         pubObjPtr->sendMessage(message, key);
 
@@ -927,9 +865,7 @@ namespace KafkaPlugin
 
     ECL_KAFKA_API bool ECL_KAFKA_CALL publishMessage(ICodeContext* ctx, const char* brokers, const char* topic, size32_t lenMessage, const char* message, size32_t lenKey, const char* key)
     {
-        std::call_once(pubCacheInitFlag, setupPublisherCache);
-
-        Publisher*          pubObjPtr = publisherCache->getPublisher(brokers, topic, POLL_TIMEOUT);
+        Publisher*          pubObjPtr = queryPublisherCache().getPublisher(brokers, topic, POLL_TIMEOUT);
         std::string         messageStr(message, rtlUtf8Size(lenMessage, message));
         std::string         keyStr(key, rtlUtf8Size(lenKey, key));
 
@@ -1088,29 +1024,11 @@ ECL_KAFKA_API bool getECLPluginDefinition(ECLPluginDefinitionBlock* pb)
 
 MODULE_INIT(INIT_PRIORITY_STANDARD)
 {
-    KafkaPlugin::publisherCache = NULL;
-    KafkaPlugin::publisherCacheExpirer = NULL;
-
     return true;
 }
 
 MODULE_EXIT()
 {
-    // Delete the background thread expiring items from the publisher cache
-    // before deleting the publisher cache
-    if (KafkaPlugin::publisherCacheExpirer)
-    {
-        KafkaPlugin::publisherCacheExpirer->stop();
-        delete(KafkaPlugin::publisherCacheExpirer);
-        KafkaPlugin::publisherCacheExpirer = NULL;
-    }
-
-     if (KafkaPlugin::publisherCache)
-    {
-        KafkaPlugin::publisherCache->deleteAll();
-        delete(KafkaPlugin::publisherCache);
-        KafkaPlugin::publisherCache = NULL;
-    }
-
+    KafkaPlugin::publisherCache.destroy();
     RdKafka::wait_destroyed(3000);
 }


### PR DESCRIPTION
Use Singleton pattern instead of std::once.

Obscure problems arose with the destruction of a static std::once, when the plugin was loaded and unloaded multiple times in a single job.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [ ] I have read the CONTRIBUTORS document.
- [ ] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

Manual testing with a local Kafka instance, publishing and consuming messages.

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
