### PR TITLE
HPCC-31468 Prevent propagation of AKS remote file meta info

### DIFF
--- a/dali/dfu/dfuutil.cpp
+++ b/dali/dfu/dfuutil.cpp
@@ -419,17 +419,20 @@ public:
             // for now, only use source file descriptor as cloned source if it's from
             // wsdfs file backed by remote storage using dafilesrv (NB: if it is '_remoteStoragePlane' will be set)
             // JCSMORE: it may be this can replace the need for the other 'clone*' attributes altogether.
-            if (srcfdesc->queryProperties().hasProp("_remoteStoragePlane"))
+            if (srcfdesc->queryProperties().hasProp("_remoteStoragePlane") && srcdali && !srcdali->endpoint().isNull())
             {
-                if (srcdali && !srcdali->endpoint().isNull())
-                {
-                    attrs.setPropTree("cloneFromFDesc", createPTreeFromIPT(srcTree));
-                    StringBuffer host;
-                    attrs.setProp("@cloneFrom", srcdali->endpoint().getEndpointHostText(host).str());
-                    if (prefix.length())
-                        attrs.setProp("@cloneFromPrefix", prefix.get());
-                    return;
-                }
+                attrs.setPropTree("cloneFromFDesc", createPTreeFromIPT(srcTree));
+                StringBuffer host;
+                attrs.setProp("@cloneFrom", srcdali->endpoint().getEndpointHostText(host).str());
+                if (prefix.length())
+                    attrs.setProp("@cloneFromPrefix", prefix.get());
+                return;
+            }
+            else
+            {
+                attrs.removeProp("cloneFromFDesc");
+                attrs.removeProp("@cloneFrom");
+                attrs.removeProp("@cloneFromPrefix");
             }
 
             while(attrs.removeProp("cloneFromGroup"));


### PR DESCRIPTION
When a k8s logical file's meta data is retrieved, it is supplemented with info. about the remote plane characteristics the remote file resides on. This is used by the clients DFS to know how to map file into in lookup calls to the k8s dafilesrv service.

The logical file meta data as a whole can be stored as extra meta data by the roxie file deploy mechanism, which is then used as a source when Roxie is starting, to copy locally.

If a secondary Roxie uses a Roxie which copied from a k8s, it will also see and use this remote plane info spuriously, and then use it to manipulate the group/file paths, to point to the original k8s source.

Suppress this info. being propagated.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
