### PR TITLE
HPCC-31691 Fix securesocket readtms when min_size = 0

### DIFF
--- a/system/jlib/jsocket.cpp
+++ b/system/jlib/jsocket.cpp
@@ -1931,6 +1931,8 @@ void CSocket::readtms(void* buf, size32_t min_size, size32_t max_size, size32_t 
     if (state != ss_open)
         THROWJSOCKEXCEPTION(JSOCKERR_not_opened);
 
+    // NB: The semantics here, effectively mean min_size is always >0, because it first waits on wait_read
+    // i.e. something has to be on socket to continue (or error/graceful close).
     CCycleTimer timer;
     while (true)
     {

--- a/system/security/securesocket/securesocket.cpp
+++ b/system/security/securesocket/securesocket.cpp
@@ -879,17 +879,10 @@ void CSecureSocket::readtms(void* buf, size32_t min_size, size32_t max_size, siz
             // NB: if timeout != WAIT_FOREVER, nonBlocking should always be true here
             if (nonBlocking && (ssl_err == SSL_ERROR_WANT_READ || ssl_err == SSL_ERROR_WANT_WRITE)) // NB: SSL_read can cause SSL_ERROR_WANT_WRITE
             {
-                if (0 == sizeRead)
-                {
-                    // special case. We have read nothing, but we are here because wait_read said there was something to read.
-                    // However, SSL_read returned SSL_ERROR_WANT_READ/SSL_ERROR_WANT_WRITE, indicating infact there is nothing
-                    // ready yet.
+                // NB: we must be below min_size if here (otherwise would have exited in (rc > 0) block above)
 
-                    // To maintain consistent semantics with jsocket. Continue waiting.
-                    // NB: jsocket::readtms always blocks (wait_read) initially, meaning in effect min_size is always >0
-                }
-                else if (sizeRead >= min_size) // could have read some before, but now would block and above min_size, exit.
-                    break;
+                // To maintain consistent semantics with jsocket, we continue waiting even in the min_size = 0 case.
+                // NB: jsocket::readtms always blocks (wait_read) initially, meaning in effect min_size is always treated as >0
             }
             else
             {


### PR DESCRIPTION
Match semantics of jsocket readtms when min_size is 0. jsocket always blocks initially, which means in effect, min_size > 0

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
