### PR TITLE
HPCC-31900 ECL Watch v9 global search DFU WU & File tabs

### DIFF
--- a/esp/src/eclwatch/GetDFUWorkunitsWidget.js
+++ b/esp/src/eclwatch/GetDFUWorkunitsWidget.js
@@ -369,8 +369,6 @@ define([
         initWorkunitsGrid: function () {
             var context = this;
             var filter = this.filter.toObject();
-            filter.includeTimings = true;
-            filter.includeTransferRate = true;
             var store = this.params.searchResults ? this.params.searchResults : new ESPDFUWorkunit.CreateWUQueryStore();
             this.workunitsGrid = new declare([ESPUtil.Grid(true, true, false, false, "GetDFUWorkunitsWidget")])({
                 store: store,
@@ -477,8 +475,6 @@ define([
 
         refreshGrid: function (clearSelection) {
             var filter = this.filter.toObject();
-            filter.includeTimings = true;
-            filter.includeTransferRate = true;
             this.workunitsGrid.set("query", filter);
             if (clearSelection) {
                 this.workunitsGrid.clearSelection();

--- a/esp/src/eclwatch/templates/DFUQueryWidget.html
+++ b/esp/src/eclwatch/templates/DFUQueryWidget.html
@@ -69,7 +69,7 @@
                                         <input id="${id}CopyPreserveCompression" title="${i18n.PreserveCompression}:" checked="true" name="preserveCompression" data-dojo-type="dijit.form.CheckBox" />
                                         <input id="${id}CopyTargetReplicate" title="${i18n.Replicate}:" name="replicate" data-dojo-type="dijit.form.CheckBox" />
                                         <input id="${id}CopyExpireDays" title="${i18n.ExpireDays}:" name="ExpireDays" data-dojo-type="dijit.form.NumberTextBox" />
-                                        <input id="${i18n.NoCommon}" title="${i18n.NoCommon}:" checked="true" name="noCommon" data-dojo-type="dijit.form.CheckBox"/>
+                                        <input title="${i18n.NoCommon}:" checked="true" name="noCommon" data-dojo-type="dijit.form.CheckBox"/>
                                         <input id="${id}MaxConnections" title="${i18n.MaxConnections}:" name="maxConnections" data-dojo-type="dijit.form.NumberTextBox" />
                                     </div>
                                 </div>

--- a/esp/src/src-react/components/DFUWorkunits.tsx
+++ b/esp/src/src-react/components/DFUWorkunits.tsx
@@ -39,8 +39,6 @@ function formatQuery(_filter): { [id: string]: any } {
     if (filter.Type === true) {
         filter.Type = "archived workunits";
     }
-    filter.includeTimings = true;
-    filter.includeTransferRate = true;
     return filter;
 }
 
@@ -83,7 +81,7 @@ export const DFUWorkunits: React.FunctionComponent<DFUWorkunitsProps> = ({
 
     //  Grid ---
     const gridStore = React.useMemo(() => {
-        return store || ESPDFUWorkunit.CreateWUQueryStore({});
+        return store || ESPDFUWorkunit.CreateWUQueryStore();
     }, [store]);
 
     const query = React.useMemo(() => {

--- a/esp/src/src/ESPLogicalFile.ts
+++ b/esp/src/src/ESPLogicalFile.ts
@@ -472,7 +472,7 @@ export function Get(Cluster, Name, data?) {
     }
     const store = new Store();
     const retVal = store.get(createID(Cluster, Name));
-    if (data) {
+    if (data && !retVal.__hpcc_id) {
         lang.mixin(data, {
             __hpcc_id: createID(data.NodeGroup, data.Name),
             __hpcc_isDir: false,

--- a/esp/src/src/FileSpray.ts
+++ b/esp/src/src/FileSpray.ts
@@ -327,6 +327,8 @@ export function CreateLandingZonesFilterStore(options) {
 }
 
 export function GetDFUWorkunits(params) {
+    params.request.includeTimings = true;
+    params.request.includeTransferRate = true;
     return ESPRequest.send("FileSpray", "GetDFUWorkunits", params);
 }
 


### PR DESCRIPTION
Fix issue where from the global search results, switching to the DFU Workunits tab would show an empty list and switching to the Files tab would crash ECL Watch with an unhandled JavaScript exception

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [x] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
