### PR TITLE
 HPCC-30365 Add XREF Sasha service to K8s

### DIFF
--- a/dali/base/dadfs.hpp
+++ b/dali/base/dadfs.hpp
@@ -815,14 +815,15 @@ enum DistributedFileSystemError
 
 
 // utility routines (used by xref and dfu)
-extern da_decl RemoteFilename &constructPartFilename(IGroup *grp,unsigned partno,unsigned partmax,const char *name,const char *partmask,const char *partdir,unsigned copy,ClusterPartDiskMapSpec &mspec,RemoteFilename &rfn);
+extern da_decl RemoteFilename &constructPartFilename(IGroup *grp,unsigned partNo,unsigned copy,unsigned max,unsigned lfnHash,int replicateOffset,bool dirPerPart,const char *lname,const char *prefix,const char *pmask,unsigned numDevices,RemoteFilename &rfn);
+extern da_decl RemoteFilename &deprecatedConstructPartFilename(IGroup *grp,unsigned partno,unsigned partmax,const char *name,const char *partmask,const char *partdir,unsigned copy,ClusterPartDiskMapSpec &mspec,RemoteFilename &rfn);
 // legacy version
-inline RemoteFilename &constructPartFilename(IGroup *grp,unsigned partno,unsigned partmax,const char *name,const char *partmask,const char *partdir,bool replicate,int replicateoffset,RemoteFilename &rfn,bool localmount=false)
+inline RemoteFilename &deprecatedConstructPartFilename(IGroup *grp,unsigned partno,unsigned partmax,const char *name,const char *partmask,const char *partdir,bool replicate,int replicateoffset,RemoteFilename &rfn,bool localmount=false)
 {
     // local mount ignored!
     ClusterPartDiskMapSpec mspec;
     mspec.replicateOffset = replicateoffset;
-    return constructPartFilename(grp,partno,partmax,name,partmask,partdir,replicate?1:0,mspec,rfn);
+    return deprecatedConstructPartFilename(grp,partno,partmax,name,partmask,partdir,replicate?1:0,mspec,rfn);
 }
 
 extern da_decl IDFPartFilter *createPartFilter(const char *filter);

--- a/dali/base/dafdesc.cpp
+++ b/dali/base/dafdesc.cpp
@@ -3576,10 +3576,19 @@ void GroupInformation::createStoragePlane(IPropertyTree * storage, unsigned copy
         return;
 
     IPropertyTree * plane = storage->addPropTree("planes");
+
+    // Revisit: Ignore hthor planes when running XRef on storage planes
+    if (groupType == grp_hthor)
+        plane->setPropBool("@hthorplane", true);
+
     StringBuffer mirrorname;
     const char * planeName = name;
     if (copy != 0)
+    {
         planeName = mirrorname.append(name).append("_mirror");
+        // Set copy to true to be able to avoid running XRef on mirror planes
+        plane->setPropBool("@copy", true);
+    }
 
     plane->setProp("@name", planeName);
 

--- a/dali/base/dautils.cpp
+++ b/dali/base/dautils.cpp
@@ -3890,6 +3890,7 @@ extern da_decl void parseFileName(const char *name,StringBuffer &mname,unsigned 
                         mname.append(s);
                     num = pn;
                     max = mn;
+                    break;
                 }
                 else
                     throw makeStringExceptionV(-1, "Incorrect max part number(%d) and part number (%d) in file %s", mn, pn, filename);

--- a/dali/base/dautils.hpp
+++ b/dali/base/dautils.hpp
@@ -590,4 +590,6 @@ extern da_decl void logNullUser(IUserDescriptor *userDesc);
 inline void logNullUser(IUserDescriptor *userDesc) { }
 #endif
 
+extern da_decl void parseFileName(const char *name,StringBuffer &mname,unsigned &num,unsigned &max,unsigned &stripeNum,unsigned &dirPerPart,bool &replicate);
+
 #endif

--- a/dali/datest/datest.cpp
+++ b/dali/datest/datest.cpp
@@ -80,7 +80,7 @@ static void addTestFile(const char *name,unsigned n)
     StringBuffer path;
     for (unsigned m=0; m<n; m++) {
         RemoteFilename rfn;
-        constructPartFilename(group,m+1,n,NULL,partmask.str(),dir.str(),false,1,rfn);
+        constructPartFilename(group,m+1,1,n,0,0,false,"",dir.str(),partmask.str(),0,rfn);
         rfn.getLocalPath(path.clear());
         Owned<IPropertyTree> pp = createPTree("Part");
         pp->setPropInt64("@size",1234*(m+1));
@@ -3327,7 +3327,6 @@ void usage(const char *error=NULL)
 }
 
 struct ReleaseAtomBlock { ~ReleaseAtomBlock() { releaseAtoms(); } };
-
 
 int main(int argc, char* argv[])
 {   

--- a/dali/dfuXRefLib/CMakeLists.txt
+++ b/dali/dfuXRefLib/CMakeLists.txt
@@ -46,6 +46,7 @@ include_directories (
          ./../../common/environment 
          ./../../common/workunit
          ./../../system/security/shared
+         ${HPCC_SOURCE_DIR}/testing/unittests
     )
 
 ADD_DEFINITIONS( -D_USRDLL -DDFUXREFLIB_EXPORTS )
@@ -57,7 +58,8 @@ target_link_libraries ( dfuXRefLib
          mp 
          hrpc 
          dafsclient 
-         dalibase 
+         dalibase
+         ${CppUnit_LIBRARIES}
     )
 
 if (NOT CONTAINERIZED)

--- a/dali/sasha/saserver.cpp
+++ b/dali/sasha/saserver.cpp
@@ -435,8 +435,8 @@ int main(int argc, const char* argv[])
                     servers.append(*createSashaFileExpiryServer());
                 else if (strieq(service, "thor-qmon"))
                     servers.append(*createSashaQMonitorServer());
-                //else if (strieq(service, "xref")) // TODO
-                //    servers.append(*createSashaXrefServer());
+                else if (strieq(service, "xref"))
+                   servers.append(*createSashaXrefServer());
                 else
                     throw makeStringExceptionV(0, "Unrecognised 'service': %s", service);
 #else

--- a/esp/src/src-react/components/Xrefs.tsx
+++ b/esp/src/src-react/components/Xrefs.tsx
@@ -66,13 +66,21 @@ export const Xrefs: React.FunctionComponent<XrefsProps> = ({
             .then(({ DFUXRefListResponse }) => {
                 const xrefNodes = DFUXRefListResponse?.DFUXRefListResult?.XRefNode;
                 if (xrefNodes) {
-                    setData(xrefNodes.map((item, idx) => {
-                        return {
-                            name: item.Name,
-                            modified: item.Modified,
-                            status: item.Status
-                        };
-                    }));
+                    if (Array.isArray(xrefNodes)) {
+                        setData(xrefNodes.map((item, idx) => {
+                            return {
+                                name: item.Name,
+                                modified: item.Modified,
+                                status: item.Status
+                            };
+                        }));
+                    } else {
+                        setData([{
+                            name: xrefNodes.Name,
+                            modified: xrefNodes.Modified,
+                            status: xrefNodes.Status
+                        }]);
+                    }
                 }
             })
             .catch(err => logger.error(err))

--- a/helm/examples/vault-pki-remote/values-hpcc1.yaml
+++ b/helm/examples/vault-pki-remote/values-hpcc1.yaml
@@ -52,6 +52,8 @@ sasha:
     disabled: true
   file-expiry:
     disabled: true
+  xref:
+    disabled: true
 
 esp:
 - name: eclwatch

--- a/helm/hpcc/templates/_helpers.tpl
+++ b/helm/hpcc/templates/_helpers.tpl
@@ -1700,7 +1700,7 @@ prometheusMetricsReporter: "yes"
 {{- end -}}
 
 {{/*
-Return access permssions for a given service
+Return access permissions for a given service
 */}}
 {{- define "hpcc.getSashaServiceAccess" }}
 {{- if (eq "coalescer" .name) -}}
@@ -1715,6 +1715,8 @@ dali
 dali data
 {{- else if (eq "thor-qmon" .name) -}}
 dali queues
+{{- else if (eq "xref" .name) -}}
+data
 {{- else -}}
 {{- $_ := fail (printf "Unknown sasha service:" .name ) -}}
 {{- end -}}

--- a/helm/hpcc/values.schema.json
+++ b/helm/hpcc/values.schema.json
@@ -3058,6 +3058,24 @@
       },
       "additionalProperties": false
     },
+    "sasha-xref": {
+        "type": "object",
+        "allOf": [{ "$ref": "#/definitions/sashacommon" }],
+        "properties": {
+          "eclwatchProvider": {
+            "type": "boolean",
+            "description": "Run xref using saxref if true",
+            "default": true
+          },
+          "checkSuperFiles": {
+            "type": "boolean",
+            "description": "Check superfiles when running XRef",
+            "default": false
+          },
+          "disabled": {}
+        },
+        "additionalProperties": false
+    },
     "sashaservice": {
       "oneOf": [
         {
@@ -3081,6 +3099,9 @@
             },
             "thor-qmon": {
               "$ref": "#/definitions/sasha-thor-qmon"
+            },
+            "xref": {
+              "$ref": "#/definitions/sasha-xref"
             },
             "disabled": {
               "type": "boolean"

--- a/helm/hpcc/values.yaml
+++ b/helm/hpcc/values.yaml
@@ -513,6 +513,11 @@ sasha:
     #switchMinTime: 1
     #queues: "*"
 
+  xref: {} # NB: no properties defined, use defaults
+    #disabled: true
+    #interval: 1
+    #suspendCoalescerDuringXref: false
+    #ignoreLazyLost: false
 
 dfuserver:
 - name: dfuserver

--- a/helm/hpcc/values.yaml
+++ b/helm/hpcc/values.yaml
@@ -516,7 +516,6 @@ sasha:
   xref: {} # NB: no properties defined, use defaults
     #disabled: true
     #interval: 1
-    #suspendCoalescerDuringXref: false
     #ignoreLazyLost: false
 
 dfuserver:

--- a/system/jlib/jutil.cpp
+++ b/system/jlib/jutil.cpp
@@ -1899,13 +1899,24 @@ void clearThreadLocal()
 
 #endif
 
-StringBuffer &expandMask(StringBuffer &buf, const char *mask, unsigned p, unsigned n)
+StringBuffer &expandMask(StringBuffer &buf, const char *mask, unsigned p, unsigned n, unsigned stripeNum, bool dirPerPart)
 {
+    if (stripeNum>0)
+        addPathSepChar(buf.append('d').append(stripeNum));
     const char *s=mask;
     if (s)
         while (*s) {
             char next = *(s++);
             if (next=='$') {
+                if (dirPerPart)
+                {
+                    const char * start = buf.str();
+                    const char * slash = start + buf.length();
+                    while (slash > start && *slash != PATHSEPCHAR)
+                        slash--;
+                    buf.insert(slash-start, PATHSEPCHAR);
+                    buf.insert((slash+1)-start, p+1);
+                }
                 char pc = toupper(s[0]);
                 if (pc&&(s[1]=='$')) {
                     if (pc=='P') {

--- a/system/jlib/jutil.hpp
+++ b/system/jlib/jutil.hpp
@@ -349,7 +349,7 @@ extern jlib_decl void clearThreadLocal();
 
 
 extern jlib_decl bool matchesMask(const char *fn, const char *mask, unsigned p, unsigned n);
-extern jlib_decl StringBuffer &expandMask(StringBuffer &buf, const char *mask, unsigned p, unsigned n);
+extern jlib_decl StringBuffer &expandMask(StringBuffer &buf, const char *mask, unsigned p, unsigned n, unsigned stripeNum = 0, bool dirPerPart = 0);
 extern jlib_decl bool constructMask(StringAttr &attr, const char *fn, unsigned p, unsigned n);
 extern jlib_decl bool deduceMask(const char *fn, bool expandN, StringAttr &mask, unsigned &p, unsigned &n); // p is 0 based in these routines
 

--- a/testing/unittests/dalitests.cpp
+++ b/testing/unittests/dalitests.cpp
@@ -480,9 +480,11 @@ public:
         ClusterPartDiskMapSpec mspec;
         Owned<IGroup> grp = createIGroup("10.150.10.1-3");
         RemoteFilename rfn;
+        IStoragePlane *plane = getDataStoragePlane("mystorageplane", true);
         for (unsigned i=0;i<3;i++)
-            for (unsigned ic=0;ic<mspec.defaultCopies;ic++) {
-                constructPartFilename(grp,i+1,3,(i==1)?"test.txt":NULL,"test._$P$_of_$N$","/c$/thordata/test",ic,mspec,rfn);
+            for (unsigned ic=0;ic<mspec.defaultCopies;ic++)
+            {
+                constructPartFilename(grp,i+1,ic,3,0,0,false,(i==1)?"test.txt":NULL,"/c$/thordata/test","test._$P$_of_$N$",0,rfn);
                 StringBuffer tmp;
                 printf("%d,%d: %s\n",i,ic,rfn.getRemotePath(tmp).str());
             }

--- a/testing/unittests/unittests.cpp
+++ b/testing/unittests/unittests.cpp
@@ -119,6 +119,20 @@ static constexpr const char * defaultYaml = R"!!(
 version: "1.0"
 unittests:
   name: unittests
+global:
+  storage:
+    planes:
+    - name: mystorageplane
+      storageClass: ""
+      storageSize: 1Gi
+      prefix: "/var/lib/HPCCSystems/hpcc-data"
+      category: data
+    - name: mystripedplane
+      storageClass: ""
+      storageSize: 1Gi
+      prefix: "/var/lib/HPCCSystems/hpcc-data-two"
+      numDevices: 111
+      category: data
 )!!";
 
 int main(int argc, const char *argv[])
@@ -136,7 +150,7 @@ int main(int argc, const char *argv[])
     bool useDefaultLocations = true;
     bool unloadDlls = false;
 
-    //NB: not actually used for now, but required initialization for anything that may call getGlobalConfig*() or getComponentConfig*()
+    //NB: required initialization for anything that may call getGlobalConfig*() or getComponentConfig*()
     Owned<IPropertyTree> globals = loadConfiguration(defaultYaml, argv, "unittests", nullptr, nullptr, nullptr, nullptr, false);
 
     for (int argNo = 1; argNo < argc; argNo++)


### PR DESCRIPTION
These changes add Xref functionality to the containerized version of the platform. There were a couple changes because thor file parts were striped across multiple directories.

I'm not sure that I correctly added the new XRef pod because everything still runs on the ECL Watch pod.

What is the best way to make this toggleable? An additional #ifdef? Should I still be using _CONTAINERIZED?

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [x] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [ ] I have read the CONTRIBUTORS document.
- [ ] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [x] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
