### PR TITLE
HPCC-32193 Fix some issues with spill stats in smart join activity

### DIFF
--- a/thorlcr/activities/lookupjoin/thlookupjoinslave.cpp
+++ b/thorlcr/activities/lookupjoin/thlookupjoinslave.cpp
@@ -950,7 +950,7 @@ protected:
         }
     } *rowProcessor;
 
-    CriticalSection rhsRowLock;
+    mutable CriticalSection rhsRowLock;
     Owned<CBroadcaster> broadcaster;
     CBroadcaster *channel0Broadcaster;
     CriticalSection *broadcastLock;
@@ -1092,7 +1092,10 @@ protected:
         {
             CThorSpillableRowArray *rows = rhsSlaveRows.item(a);
             if (rows)
+            {
+                mergeRemappedStats(inactiveStats, rows, diskToTempStatsMap);
                 rows->kill();
+            }
         }
         rhs.kill();
     }
@@ -1808,6 +1811,8 @@ protected:
     // NB: Only used by channel 0
     Owned<CFileOwner> overflowWriteFile;
     Owned<IExtRowWriter> overflowWriteStream;
+    OwnedIFileIO overflowWriteFileIO;
+    mutable CriticalSection critOverflowWriteFileIO;
     rowcount_t overflowWriteCount;
     OwnedMalloc<IChannelDistributor *> channelDistributors;
     unsigned nextRhsToSpill = 0;
@@ -2096,7 +2101,6 @@ protected:
             if (isSmart())
             {
                 overflowWriteCount = 0;
-                overflowWriteFile.clear();
                 overflowWriteStream.clear();
                 rightRowManager->addRowBuffer(this);
             }
@@ -2107,7 +2111,15 @@ protected:
                 CriticalBlock b(broadcastSpillingLock);
                 rhsRows = getGlobalRHSTotal(); // flushes all rhsSlaveRows arrays to calculate total.
                 if (hasFailedOverToLocal())
+                {
+                    if (overflowWriteFileIO)
+                    {
+                        mergeRemappedStats(PARENT::inactiveStats, overflowWriteFileIO, diskToTempStatsMap);
+                        overflowWriteFile->noteSize(overflowWriteFileIO->getStatistic(StSizeDiskWrite));
+                        overflowWriteFileIO.clear();
+                    }
                     overflowWriteStream.clear(); // broadcast has finished, no more can be written
+                }
             }
             if (!hasFailedOverToLocal())
             {
@@ -2155,6 +2167,7 @@ protected:
                     ForEachItemIn(a, rhsSlaveRows)
                     {
                         CThorSpillableRowArray &rows = *rhsSlaveRows.item(a);
+                        mergeRemappedStats(PARENT::inactiveStats, &rows, diskToTempStatsMap);
                         rhs.appendRows(rows, true); // NB: This should not cause spilling, rhs is already sized and we are only copying ptrs in
                         rows.kill(); // free up ptr table asap
                     }
@@ -2479,6 +2492,7 @@ protected:
         Owned<IThorRowLoader> rowLoader = createThorRowLoader(*this, queryRowInterfaces(leftITDL), helper->isLeftAlreadyLocallySorted() ? NULL : compareLeft);
         rowLoader->setTracingPrefix("Join left");
         left.setown(rowLoader->load(left, abortSoon, false));
+        mergeRemappedStats(PARENT::inactiveStats, rowLoader, diskToTempStatsMap);
         leftITDL = queryInput(0); // reset
         ActPrintLog("LHS loaded/sorted");
 
@@ -2550,6 +2564,7 @@ protected:
          */
 
         Owned<IThorRowCollector> rightCollector;
+        Owned<IException> exception;
         try
         {
             CMarker marker(*this);
@@ -2674,12 +2689,19 @@ protected:
         catch (IException *e)
         {
             if (!isOOMException(e))
-                throw e;
-            IOutputMetaData *inputOutputMeta = rightITDL->queryFromActivity()->queryContainer().queryHelper()->queryOutputMeta();
-            // rows may either be in separate slave row arrays or in single rhs array, or split.
-            rowcount_t total = rightCollector ? rightCollector->numRows() : (getGlobalRHSTotal() + rhs.ordinality());
-            throw checkAndCreateOOMContextException(this, e, "gathering RHS rows for lookup join", total, inputOutputMeta, NULL);
+                exception.setown(e);
+            else
+            {
+                IOutputMetaData *inputOutputMeta = rightITDL->queryFromActivity()->queryContainer().queryHelper()->queryOutputMeta();
+                // rows may either be in separate slave row arrays or in single rhs array, or split.
+                rowcount_t total = rightCollector ? rightCollector->numRows() : (getGlobalRHSTotal() + rhs.ordinality());
+                exception.setown(checkAndCreateOOMContextException(this, e, "gathering RHS rows for lookup join", total, inputOutputMeta, NULL));
+            }
         }
+        if (rightCollector && rightCollector->hasSpilt())
+            mergeRemappedStats(PARENT::inactiveStats, rightCollector, diskToTempStatsMap);
+        if (exception)
+            throw exception.getClear();
     }
 public:
     static bool needDedup(IHThorHashJoinArg *helper)
@@ -2943,7 +2965,7 @@ public:
                 return true;
         }
         CriticalBlock b(rhsRowLock);
-        if (overflowWriteFile)
+        if (overflowWriteFileIO)
         {
             /* Tried to do outside crit above, but if empty, and now overflow, need to inside
              * Will be one off if at all
@@ -2956,7 +2978,7 @@ public:
             overflowWriteCount += rhsInRowsTemp.ordinality();
             ForEachItemIn(r, rhsInRowsTemp)
                 overflowWriteStream->putRow(rhsInRowsTemp.getClear(r));
-            overflowWriteFile->noteSize(overflowWriteStream->getStatistic(StSizeDiskWrite));
+            overflowWriteFile->noteSize(overflowWriteFileIO->getStatistic(StSizeDiskWrite));
             return true;
         }
         if (hasFailedOverToLocal())
@@ -3001,12 +3023,13 @@ public:
         GetTempFilePath(tempFilename, "lookup_local");
         ActPrintLog("Overflowing RHS broadcast rows to spill file: %s", tempFilename.str());
         overflowWriteFile.setown(container.queryActivity()->createOwnedTempFile(tempFilename.str()));
-        overflowWriteStream.setown(createRowWriter(&(overflowWriteFile->queryIFile()), queryRowInterfaces(rightITDL), rwFlags));
+        overflowWriteFileIO.setown(overflowWriteFile->queryIFile().open(IFOcreate));
+        overflowWriteStream.setown(createRowWriter(overflowWriteFileIO, queryRowInterfaces(rightITDL), rwFlags));
 
         overflowWriteCount += rhsInRowsTemp.ordinality();
         ForEachItemIn(r, rhsInRowsTemp)
             overflowWriteStream->putRow(rhsInRowsTemp.getClear(r));
-        overflowWriteFile->noteSize(overflowWriteStream->getStatistic(StSizeDiskWrite));
+        overflowWriteFile->noteSize(overflowWriteFileIO->getStatistic(StSizeDiskWrite));
         return true;
     }
     virtual void gatherActiveStats(CRuntimeStatisticCollection &activeStats) const
@@ -3017,6 +3040,19 @@ public:
             if (isGlobal())
                 activeStats.setStatistic(StNumSmartJoinDegradedToLocal, aggregateFailoversToLocal); // NB: is going to be same for all slaves.
             activeStats.setStatistic(StNumSmartJoinSlavesDegradedToStd, aggregateFailoversToStandard);
+        }
+        {
+            CriticalBlock b(critOverflowWriteFileIO);
+            if (overflowWriteFileIO)
+                mergeRemappedStats(activeStats, overflowWriteFileIO, diskToTempStatsMap);
+        }
+        {
+            CriticalBlock b(rhsRowLock);
+            ForEachItemIn(a, rhsSlaveRows)
+            {
+                CThorSpillableRowArray &rows = *rhsSlaveRows.item(a);
+                mergeRemappedStats(activeStats, &rows, diskToTempStatsMap);
+            }
         }
     }
 };
@@ -3360,6 +3396,7 @@ protected:
                     ForEachItemIn(a, rhsSlaveRows)
                     {
                         CThorSpillableRowArray &rows = *rhsSlaveRows.item(a);
+                        mergeRemappedStats(PARENT::inactiveStats, &rows, diskToTempStatsMap);
                         rhs.appendRows(rows, true);
                         rows.kill(); // free up ptr table asap
                     }

--- a/thorlcr/activities/nsplitter/thnsplitterslave.cpp
+++ b/thorlcr/activities/nsplitter/thnsplitterslave.cpp
@@ -405,7 +405,7 @@ public:
     {
         PARENT::gatherActiveStats(activeStats);
         if (sharedRowStream)
-            ::mergeStats(activeStats, sharedRowStream);
+            mergeRemappedStats(activeStats, sharedRowStream, diskToTempStatsMap);
     }
 // ISharedSmartBufferCallback impl.
     virtual void paged() { pagedOut = true; }

--- a/thorlcr/msort/tsorts.cpp
+++ b/thorlcr/msort/tsorts.cpp
@@ -1338,7 +1338,7 @@ public:
             throw;
         }
 
-        mergeStats(spillStats, sortedloader);
+        mergeRemappedStats(spillStats, sortedloader, diskToTempStatsMap);
 
         if (!abort)
         {

--- a/thorlcr/thorutil/thmem.hpp
+++ b/thorlcr/thorutil/thmem.hpp
@@ -413,7 +413,7 @@ class graph_decl CThorSpillableRowArray : private CThorExpandingRowArray, implem
     mutable CriticalSection cs;
     ICopyArrayOf<IWritePosCallback> writeCallbacks;
     size32_t compBlkSz = 0; // means use default
-
+    CRuntimeStatisticCollection stats; // reset after each kill
     bool _flush(bool force);
     void doFlush();
     inline bool needToMoveRows(bool force) { return (firstRow != 0 && (force || (firstRow >= commitRows/2))); }
@@ -484,6 +484,10 @@ public:
 
     inline rowidx_t numCommitted() const { return commitRows - firstRow; } //MORE::Not convinced this is very safe!
     inline rowidx_t queryTotalRows() const { return CThorExpandingRowArray::ordinality(); } // includes uncommited rows
+    inline unsigned __int64 getStatistic(StatisticKind kind) const
+    {
+        return stats.getStatisticValue(kind);
+    }
 
 // access to
     void swap(CThorSpillableRowArray &src);
@@ -542,7 +546,7 @@ interface IThorRowCollectorCommon : extends IInterface, extends IThorArrayLock
     virtual void setup(ICompare *iCompare, StableSortFlag stableSort=stableSort_none, RowCollectorSpillFlags diskMemMix=rc_mixed, unsigned spillPriority=50) = 0;
     virtual void resize(rowidx_t max) = 0;
     virtual void setOptions(unsigned options) = 0;
-    virtual unsigned __int64 getStatistic(StatisticKind kind) = 0;
+    virtual unsigned __int64 getStatistic(StatisticKind kind) const = 0;
     virtual bool hasSpilt() const = 0; // equivalent to numOverlows() >= 1
     virtual void setTracingPrefix(const char *tracing) = 0;
     virtual void reset() = 0;

--- a/thorlcr/thorutil/thormisc.cpp
+++ b/thorlcr/thorutil/thormisc.cpp
@@ -97,6 +97,7 @@ const StatisticsMapping hashDedupActivityStatistics({}, spillStatistics, diskWri
 const StatisticsMapping hashDistribActivityStatistics({StNumLocalRows, StNumRemoteRows, StSizeRemoteWrite}, basicActivityStatistics);
 const StatisticsMapping loopActivityStatistics({StNumIterations}, basicActivityStatistics);
 const StatisticsMapping graphStatistics({StNumExecutions, StSizeSpillFile, StSizeGraphSpill, StSizePeakTempDisk, StSizePeakEphemeralDisk, StTimeUser, StTimeSystem, StNumContextSwitches, StSizeMemory, StSizePeakMemory, StSizeRowMemory, StSizePeakRowMemory}, executeStatistics);
+const StatisticsMapping tempFileStatistics({StNumSpills}, diskRemoteStatistics);
 
 const StatKindMap diskToTempStatsMap
 ={ {StSizeDiskWrite, StSizeSpillFile},

--- a/thorlcr/thorutil/thormisc.hpp
+++ b/thorlcr/thorutil/thormisc.hpp
@@ -167,6 +167,8 @@ extern graph_decl const StatisticsMapping soapcallActivityStatistics;
 extern graph_decl const StatisticsMapping indexReadFileStatistics;
 extern graph_decl const StatisticsMapping hashDedupActivityStatistics;
 extern graph_decl const StatisticsMapping hashDistribActivityStatistics;
+extern graph_decl const StatisticsMapping tempFileStatistics;
+
 
 // Maps disk related stats to spill stats
 extern graph_decl const std::map<StatisticKind, StatisticKind> diskToTempStatsMap;


### PR DESCRIPTION
The current temp file statistics for smartjoin did not include all stats from all temp files:
1) temp files were closed before its sizes were recorded in the stats
2) stats from some types of temp files were not being tracked such as overflowWriteFile from RHS
3) stats from temp files that were closed in CSpillableStreamBase were not preserved
4) peak temp file size was not tracked in CThorSpillableRowArray
5) make CThorRowCollectorBase use of stats from CThorSpillableRowArray for more accurate and simpler temp stats tracking (for CThorRowCollectorBase)


<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [ ] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [ ] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [x] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
