### PR TITLE
HPCC-32241 Temp size for sort to use disk size and track actual graph temp disk usage

### DIFF
--- a/thorlcr/graph/thgraph.hpp
+++ b/thorlcr/graph/thgraph.hpp
@@ -630,7 +630,7 @@ class graph_decl CGraphBase : public CGraphStub, implements IEclGraphResults
     CChildGraphTable childGraphsTable;
     CGraphStubArrayCopy orderedChildGraphs;
     Owned<IGraphTempHandler> tmpHandler;
-
+    Owned<CFileSizeTracker> tempFileSizeTracker;
     void clean();
 
 protected:
@@ -805,7 +805,24 @@ public:
     virtual void end();
     virtual void abort(IException *e) override;
     virtual IThorGraphResults *createThorGraphResults(unsigned num);
-
+    CFileSizeTracker * queryTempFileSizeTracker()
+    {
+        if (!tempFileSizeTracker)
+            tempFileSizeTracker.setown(new CFileSizeTracker);
+        return tempFileSizeTracker;
+    }
+    offset_t queryPeakTempSize()
+    {
+        if (tempFileSizeTracker)
+            return tempFileSizeTracker->queryPeakSize();
+        return 0;
+    }
+    offset_t queryActiveTempSize()
+    {
+        if (tempFileSizeTracker)
+            return tempFileSizeTracker->queryActiveSize();
+        return 0;
+    }
 // IExceptionHandler
     virtual bool fireException(IException *e);
 
@@ -1175,7 +1192,7 @@ public:
     CFileSizeTracker * queryTempFileSizeTracker()
     {
         if (!tempFileSizeTracker)
-            tempFileSizeTracker.setown(new CFileSizeTracker);
+            tempFileSizeTracker.setown(new CFileSizeTracker(queryGraph().queryParent()->queryTempFileSizeTracker()));
         return tempFileSizeTracker;
     }
     offset_t queryActiveTempSize() const

--- a/thorlcr/graph/thgraphslave.cpp
+++ b/thorlcr/graph/thgraphslave.cpp
@@ -1323,20 +1323,7 @@ bool CSlaveGraph::serializeStats(MemoryBuffer &mb)
     if (tempHandler)
         stats.mergeStatistic(StSizeGraphSpill, sizeGraphSpill);
 
-    // calculate peak spill size
-    if (started&&initialized)
-    {
-        offset_t activeTempSize = 0;
-        Owned<IThorActivityIterator> iter = getConnectedIterator();
-        ForEach (*iter)
-        {
-            CGraphElementBase &element = iter->query();
-            CSlaveActivity &activity = (CSlaveActivity &)*element.queryActivity();
-            activeTempSize += activity.queryActiveTempSize();
-        }
-        if (activeTempSize > peakTempSize)
-            peakTempSize = activeTempSize;
-    }
+    offset_t peakTempSize = queryPeakTempSize();
     if (peakTempSize)
         stats.mergeStatistic(StSizePeakTempDisk, peakTempSize);
     if (peakTempSize + sizeGraphSpill)

--- a/thorlcr/graph/thgraphslave.hpp
+++ b/thorlcr/graph/thgraphslave.hpp
@@ -522,7 +522,6 @@ class graphslave_decl CSlaveGraph : public CGraphBase
     bool doneInit = false;
     std::atomic_bool progressActive;
     ProcessInfo processStartInfo;
-    offset_t peakTempSize = 0;
 
 public:
 

--- a/thorlcr/msort/tsorts.cpp
+++ b/thorlcr/msort/tsorts.cpp
@@ -257,8 +257,8 @@ public:
         }
         output->flush();
         offset_t end = output->getPosition();
+        dataFile->noteSize(output->getStatistic(StSizeDiskWrite));
         output.clear();
-        dataFile->noteSize(end);
         writeidxofs(end);
         if (idxFileIO)
         {


### PR DESCRIPTION
SizePeakTempDisk for graphs was previous calculated by summing the each
activity's active temp file size. However, as this was done at internals,
spikes in temp file sizes between intervals were not recorded in the
SizePeakTempDisk stats. This change uses a TempFileSize tracker at the
graph level to track the actual peak/active temp file size for the graph.

Sort activities was using the size of the uncompressed data as the size
of the temp file. This change uses the actual size of temp file for sort
activity's peak/active temp file size

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [x] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
