### PR TITLE
HPCC-32298 ECL Watch v9 fix File Details "Protected" save

### DIFF
--- a/esp/src/src-react/components/IndexFileSummary.tsx
+++ b/esp/src/src-react/components/IndexFileSummary.tsx
@@ -64,7 +64,7 @@ export const IndexFileSummary: React.FunctionComponent<IndexFileSummaryProps> = 
 
     React.useEffect(() => {
         setDescription(file?.Description || "");
-        setProtected(file?.ProtectList?.DFUFileProtect?.length > 0 || false);
+        setProtected(isProtected);
         setRestricted(file?.IsRestricted || false);
 
         if ((file?.filePartsOnCluster() ?? []).length > 0) {
@@ -78,7 +78,7 @@ export const IndexFileSummary: React.FunctionComponent<IndexFileSummaryProps> = 
             setReplicateFlag(_replicate);
         }
 
-    }, [file]);
+    }, [file, isProtected]);
 
     const canSave = React.useMemo(() => {
         return file && (
@@ -91,15 +91,11 @@ export const IndexFileSummary: React.FunctionComponent<IndexFileSummaryProps> = 
     const buttons = React.useMemo((): ICommandBarItemProps[] => [
         {
             key: "refresh", text: nlsHPCC.Refresh, iconProps: { iconName: "Refresh" },
-            onClick: () => {
-                refresh();
-            }
+            onClick: () => refresh()
         },
         {
             key: "copyFilename", text: nlsHPCC.CopyLogicalFilename, iconProps: { iconName: "Copy" },
-            onClick: () => {
-                navigator?.clipboard?.writeText(logicalFile);
-            }
+            onClick: () => navigator?.clipboard?.writeText(logicalFile)
         },
         { key: "divider_1", itemType: ContextualMenuItemType.Divider, onRender: () => <ShortVerticalDivider /> },
         {
@@ -194,9 +190,15 @@ export const IndexFileSummary: React.FunctionComponent<IndexFileSummaryProps> = 
                         break;
                     case "isProtected":
                         setProtected(value);
+                        file?.update({
+                            Protect: value ? WsDfu.DFUChangeProtection.Protect : WsDfu.DFUChangeProtection.Unprotect,
+                        }).catch(err => logger.error(err));
                         break;
                     case "isRestricted":
                         setRestricted(value);
+                        file?.update({
+                            Restrict: value ? WsDfu.DFUChangeRestriction.Restrict : WsDfu.DFUChangeRestriction.Unrestricted,
+                        }).catch(err => logger.error(err));
                         break;
                 }
             }} />

--- a/esp/src/src-react/components/LogicalFileSummary.tsx
+++ b/esp/src/src-react/components/LogicalFileSummary.tsx
@@ -69,7 +69,7 @@ export const LogicalFileSummary: React.FunctionComponent<LogicalFileSummaryProps
 
     React.useEffect(() => {
         setDescription(file?.Description || "");
-        setProtected(file?.ProtectList?.DFUFileProtect?.length > 0 || false);
+        setProtected(isProtected);
         setRestricted(file?.IsRestricted || false);
 
         if ((file?.filePartsOnCluster() ?? []).length > 0) {
@@ -83,7 +83,7 @@ export const LogicalFileSummary: React.FunctionComponent<LogicalFileSummaryProps
             setReplicateFlag(_replicate);
         }
 
-    }, [file]);
+    }, [file, isProtected]);
 
     const canSave = React.useMemo(() => {
         return file && (
@@ -96,15 +96,11 @@ export const LogicalFileSummary: React.FunctionComponent<LogicalFileSummaryProps
     const buttons = React.useMemo((): ICommandBarItemProps[] => [
         {
             key: "refresh", text: nlsHPCC.Refresh, iconProps: { iconName: "Refresh" },
-            onClick: () => {
-                refresh();
-            }
+            onClick: () => refresh()
         },
         {
             key: "copyFilename", text: nlsHPCC.CopyLogicalFilename, iconProps: { iconName: "Copy" },
-            onClick: () => {
-                navigator?.clipboard?.writeText(logicalFile);
-            }
+            onClick: () => navigator?.clipboard?.writeText(logicalFile)
         },
         { key: "divider_1", itemType: ContextualMenuItemType.Divider, onRender: () => <ShortVerticalDivider /> },
         {
@@ -216,9 +212,15 @@ export const LogicalFileSummary: React.FunctionComponent<LogicalFileSummaryProps
                         break;
                     case "isProtected":
                         setProtected(value);
+                        file?.update({
+                            Protect: value ? WsDfu.DFUChangeProtection.Protect : WsDfu.DFUChangeProtection.Unprotect,
+                        }).catch(err => logger.error(err));
                         break;
                     case "isRestricted":
                         setRestricted(value);
+                        file?.update({
+                            Restrict: value ? WsDfu.DFUChangeRestriction.Restrict : WsDfu.DFUChangeRestriction.Unrestricted,
+                        }).catch(err => logger.error(err));
                         break;
                 }
             }} />

--- a/esp/src/src-react/components/SuperFileSummary.tsx
+++ b/esp/src/src-react/components/SuperFileSummary.tsx
@@ -33,9 +33,9 @@ export const SuperFileSummary: React.FunctionComponent<SuperFileSummaryProps> = 
 
     React.useEffect(() => {
         setDescription(file?.Description || "");
-        setProtected(file?.ProtectList?.DFUFileProtect?.length > 0 || false);
+        setProtected(isProtected);
         setRestricted(file?.IsRestricted || false);
-    }, [file]);
+    }, [file, isProtected]);
 
     const [DeleteConfirm, setShowDeleteConfirm] = useConfirm({
         title: nlsHPCC.Delete,
@@ -65,9 +65,7 @@ export const SuperFileSummary: React.FunctionComponent<SuperFileSummaryProps> = 
     const buttons = React.useMemo((): ICommandBarItemProps[] => [
         {
             key: "refresh", text: nlsHPCC.Refresh, iconProps: { iconName: "Refresh" },
-            onClick: () => {
-                refresh();
-            }
+            onClick: () => refresh()
         },
         { key: "divider_1", itemType: ContextualMenuItemType.Divider, onRender: () => <ShortVerticalDivider /> },
         {
@@ -124,6 +122,9 @@ export const SuperFileSummary: React.FunctionComponent<SuperFileSummaryProps> = 
                         break;
                     case "isProtected":
                         setProtected(value);
+                        file?.update({
+                            Protect: value ? WsDfu.DFUChangeProtection.Protect : WsDfu.DFUChangeProtection.Unprotect,
+                        }).catch(err => logger.error(err));
                         break;
                 }
             }} />

--- a/esp/src/src-react/hooks/file.ts
+++ b/esp/src/src-react/hooks/file.ts
@@ -19,13 +19,13 @@ export function useFile(cluster: string, name: string): [LogicalFile, boolean, n
         let handle;
         const fetchInfo = singletonDebounce(file, "fetchInfo");
         fetchInfo()
-            .then(() => {
+            .then((response) => {
                 if (active) {
                     setFile(file);
-                    setIsProtected(file.ProtectList?.DFUFileProtect?.length > 0 || false);
+                    setIsProtected(response.ProtectList?.DFUFileProtect?.length > 0 || false);
                     setLastUpdate(Date.now());
                     handle = file.watch(() => {
-                        setIsProtected(file.ProtectList?.DFUFileProtect?.length > 0 || false);
+                        setIsProtected(response.ProtectList?.DFUFileProtect?.length > 0 || false);
                         setLastUpdate(Date.now());
                     });
                 }


### PR DESCRIPTION
Makes the ECL Watch v9 UI consistent with the behavior of the v5 UI so that clicking the "Protected" or "Restricted" checkboxes on the File Details page will actually POST that change to /WsDfu/DFUInfo instead of requiring the user to click the "Save" button.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [x] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
