### PR TITLE
HPCC-31963 Improve LDAP server initialization failure log messages

### DIFF
--- a/system/security/LdapSecurity/ldaputils.cpp
+++ b/system/security/LdapSecurity/ldaputils.cpp
@@ -302,12 +302,26 @@ int LdapUtils::getServerInfo(const char* ldapserver, const char* userDN, const c
             ld = ldapInitAndSimpleBind(ldapserver, nullptr, nullptr, "ldap", 389, cipherSuite, timeout, &err);
         }
 
-        // for new versions of openldap, version 2.2.*
-        if(nullptr == ld   &&  err == LDAP_PROTOCOL_ERROR  &&  stype != ACTIVE_DIRECTORY)
-            DBGLOG("If you're trying to connect to an OpenLdap server, make sure you have \"allow bind_v2\" enabled in slapd.conf");
-
-        if(nullptr == ld)
+        if (ld == nullptr)
+        {
+            if (err == LDAP_PROTOCOL_ERROR && stype != ACTIVE_DIRECTORY)
+            {
+                WARNLOG("Unable to connect. If you're trying to connect to an OpenLdap server, make sure you have \"allow bind_v2\" enabled in slapd.conf");
+            }
+            else
+            {
+                // If no cipher suite is specified, tell user they may need to provide one, otherwise tell them they may need to provide a different one
+                if (isEmptyString(cipherSuite))
+                {
+                    WARNLOG("Unable to connect. if you're trying to connect to an LDAPS server, you may need to specify a cipher suite using the 'ldapCipherSuite' attribute in the LDAP configuration.");
+                }
+                else
+                {
+                    WARNLOG("Unable to connect. If you're trying to connect to an LDAPS server, you may need to specify a different cipher suite using the 'ldapCipherSuite' attribute in the LDAP configuration.");
+                }
+            }
             return err;//unable to connect, give up
+        }
     }
 
     LDAPMessage* msg = NULL;
@@ -316,7 +330,7 @@ int LdapUtils::getServerInfo(const char* ldapserver, const char* userDN, const c
     err = ldap_search_ext_s(ld, NULL, LDAP_SCOPE_BASE, "objectClass=*", attrs, false, NULL, NULL, &timeOut, LDAP_NO_LIMIT, &msg);
     if(err != LDAP_SUCCESS)
     {
-        DBGLOG("ldap_search_ext_s error: %s", ldap_err2string( err ));
+        WARNLOG("ldap_search_ext_s error: %s", ldap_err2string( err ));
         if (msg)
             ldap_msgfree(msg);
         return err;


### PR DESCRIPTION
Added additional information to log messages issued when initial connection to the Active Directory fails during initialization

Signed-Off-By: Kenneth Rowland kenneth.rowland@lexisnexisrisk.com

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [x] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [x] Scalability
  - [x] Performance
  - [x] Security
  - [x] Thread-safety
  - [x] Cloud-compatibility
  - [x] Premature optimization
  - [x] Existing deployed queries will not be broken
  - [x] This change fixes the problem, not just the symptom
  - [x] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
