### PR TITLE
HPCC-32448 Parquet plugin defaults to wrong size for some types

### DIFF
--- a/plugins/parquet/parquetembed.cpp
+++ b/plugins/parquet/parquetembed.cpp
@@ -743,9 +743,17 @@ arrow::Status ParquetWriter::fieldToNode(const RtlFieldInfo *field, std::vector<
             {
                 arrowFields.push_back(std::make_shared<arrow::Field>(name.str(), arrow::int64()));
             }
-            else
+            else if (field->type->length > 2)
             {
                 arrowFields.push_back(std::make_shared<arrow::Field>(name.str(), arrow::int32()));
+            }
+            else if (field->type->length > 1)
+            {
+                arrowFields.push_back(std::make_shared<arrow::Field>(name.str(), arrow::int16()));
+            }
+            else
+            {
+                arrowFields.push_back(std::make_shared<arrow::Field>(name.str(), arrow::int8()));
             }
         }
         else
@@ -754,14 +762,29 @@ arrow::Status ParquetWriter::fieldToNode(const RtlFieldInfo *field, std::vector<
             {
                 arrowFields.push_back(std::make_shared<arrow::Field>(name.str(), arrow::uint64()));
             }
-            else
+            else if (field->type->length > 2)
             {
                 arrowFields.push_back(std::make_shared<arrow::Field>(name.str(), arrow::uint32()));
+            }
+            else if (field->type->length > 1)
+            {
+                arrowFields.push_back(std::make_shared<arrow::Field>(name.str(), arrow::uint16()));
+            }
+            else
+            {
+                arrowFields.push_back(std::make_shared<arrow::Field>(name.str(), arrow::uint8()));
             }
         }
         break;
     case type_real:
-        arrowFields.push_back(std::make_shared<arrow::Field>(name.str(), arrow::float64()));
+        if (field->type->length > 4)
+        {
+            arrowFields.push_back(std::make_shared<arrow::Field>(name.str(), arrow::float64()));
+        }
+        else
+        {
+            arrowFields.push_back(std::make_shared<arrow::Field>(name.str(), arrow::float32()));
+        }
         break;
     case type_char:
     case type_string:
@@ -770,8 +793,17 @@ arrow::Status ParquetWriter::fieldToNode(const RtlFieldInfo *field, std::vector<
     case type_utf8:
     case type_unicode:
     case type_varunicode:
+        if (field->type->length > 4 || field->type->length == 0)
+        {
+            arrowFields.push_back(std::make_shared<arrow::Field>(name.str(), arrow::large_utf8()));
+        }
+        else
+        {
+            arrowFields.push_back(std::make_shared<arrow::Field>(name.str(), arrow::utf8()));
+        }
+        break;
     case type_decimal:
-        arrowFields.push_back(std::make_shared<arrow::Field>(name.str(), arrow::utf8())); // TODO: add decimal encoding
+        arrowFields.push_back(std::make_shared<arrow::Field>(name.str(), arrow::large_utf8())); // TODO: add decimal encoding
         break;
     case type_data:
         if (field->type->length > 0)
@@ -1004,6 +1036,12 @@ void ParquetWriter::addFieldToBuilder(const RtlFieldInfo *field, unsigned len, c
         {
             arrow::StringBuilder *stringBuilder = static_cast<arrow::StringBuilder *>(fieldBuilder);
             reportIfFailure(stringBuilder->Append(data, len));
+            break;
+        }
+        case arrow::Type::LARGE_STRING:
+        {
+            arrow::LargeStringBuilder *largeStringBuilder = static_cast<arrow::LargeStringBuilder *>(fieldBuilder);
+            reportIfFailure(largeStringBuilder->Append(data, len));
             break;
         }
         case arrow::Type::LARGE_BINARY:
@@ -1763,6 +1801,18 @@ void ParquetRecordBinder::processInt(__int64 value, const RtlFieldInfo *field)
     arrow::ArrayBuilder *fieldBuilder = parquetWriter->getFieldBuilder(field);
     switch(fieldBuilder->type()->id())
     {
+        case arrow::Type::type::INT8:
+        {
+            arrow::Int8Builder *int8Builder = static_cast<arrow::Int8Builder *>(fieldBuilder);
+            reportIfFailure(int8Builder->Append(value));
+            break;
+        }
+        case arrow::Type::type::INT16:
+        {
+            arrow::Int16Builder *int16Builder = static_cast<arrow::Int16Builder *>(fieldBuilder);
+            reportIfFailure(int16Builder->Append(value));
+            break;
+        }
         case arrow::Type::type::INT32:
         {
             arrow::Int32Builder *int32Builder = static_cast<arrow::Int32Builder *>(fieldBuilder);
@@ -1791,6 +1841,18 @@ void ParquetRecordBinder::processUInt(unsigned __int64 value, const RtlFieldInfo
     arrow::ArrayBuilder *fieldBuilder = parquetWriter->getFieldBuilder(field);
     switch(fieldBuilder->type()->id())
     {
+        case arrow::Type::type::UINT8:
+        {
+            arrow::UInt8Builder *uInt8Builder = static_cast<arrow::UInt8Builder *>(fieldBuilder);
+            reportIfFailure(uInt8Builder->Append(value));
+            break;
+        }
+        case arrow::Type::type::UINT16:
+        {
+            arrow::UInt16Builder *uInt16Builder = static_cast<arrow::UInt16Builder *>(fieldBuilder);
+            reportIfFailure(uInt16Builder->Append(value));
+            break;
+        }
         case arrow::Type::type::UINT32:
         {
             arrow::UInt32Builder *uInt32Builder = static_cast<arrow::UInt32Builder *>(fieldBuilder);
@@ -1821,6 +1883,11 @@ void ParquetRecordBinder::processReal(double value, const RtlFieldInfo *field)
     {
         arrow::DoubleBuilder *doubleBuilder = static_cast<arrow::DoubleBuilder *>(fieldBuilder);
         reportIfFailure(doubleBuilder->Append(value));
+    }
+    else if (fieldBuilder->type()->id() == arrow::Type::type::FLOAT)
+    {
+        arrow::FloatBuilder *floatBuilder = static_cast<arrow::FloatBuilder *>(fieldBuilder);
+        reportIfFailure(floatBuilder->Append(value));
     }
     else
         failx("Incorrect type for real field %s: %s", field->name, fieldBuilder->type()->ToString().c_str());


### PR DESCRIPTION
When converting ECL Record information to an Arrow Schema the length defined in the record is not being accounted for in some cases.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [x] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [x] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [x] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [x] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
