### PR TITLE
HPCC-32554 Fix WorkUnitWaiter so it can be used to spot abort correctly

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -6427,7 +6427,7 @@ public:
             return WUStateUnknown;
         }
 
-        Owned<WorkUnitWaiter> waiter = new WorkUnitWaiter(wuid, SubscribeOptionState);
+        Owned<WorkUnitWaiter> waiter = new WorkUnitWaiter(wuid, (WUSubscribeOptions)(SubscribeOptionState|SubscribeOptionAbort));
         LocalIAbortHandler abortHandler(*waiter);
         if (conn)
         {
@@ -6501,7 +6501,7 @@ public:
                     waiter->wait(20000);  // recheck state every 20 seconds, in case eclagent has crashed.
                     if (waiter->isAborted())
                     {
-                        ret = WUStateUnknown;  // MORE - throw an exception?
+                        ret = WUStateAborting;
                         break;
                     }
                 }
@@ -14407,13 +14407,13 @@ void executeThorGraph(const char * graphName, IConstWorkUnit &workunit, const IP
         unsigned runningTimeLimit = workunit.getDebugValueInt("maxRunTime", 0);
         runningTimeLimit = runningTimeLimit ? runningTimeLimit : INFINITE;
 
-        std::list<WUState> expectedStates = { WUStateRunning, WUStateWait, WUStateFailed };
+        std::list<WUState> expectedStates = { WUStateRunning, WUStateWait, WUStateAborting, WUStateFailed };
         unsigned __int64 blockedTime = 0;
         for (unsigned i=0; i<2; i++)
         {
             WUState state = waitForWorkUnitToComplete(wuid, timelimit*1000, expectedStates);
             DBGLOG("Got state: %s", getWorkunitStateStr(state));
-            if ((WUStateWait == state) || (WUStateFailed == state)) // already finished or failed
+            if ((WUStateWait == state) || (WUStateFailed == state) || (WUStateAborting == state)) // already finished or failed or aborting
             {
                 // workunit may have spent time in blocked state, but then transitioned to
                 // wait or failed state quickly such that this code did not see its running state.

--- a/common/workunit/workunit.ipp
+++ b/common/workunit/workunit.ipp
@@ -696,20 +696,33 @@ class WorkUnitWaiter : public CInterface, implements IAbortHandler, implements I
 {
     Semaphore changed;
     Owned<IWorkUnitWatcher> watcher;
-    bool aborted;
+    mutable bool aborted = false;
+    mutable bool abortDirty = false;
+    StringAttr wuid;
 public:
     IMPLEMENT_IINTERFACE;
-    WorkUnitWaiter(const char *wuid, WUSubscribeOptions watchFor)
+    WorkUnitWaiter(const char *_wuid, WUSubscribeOptions watchFor) : wuid(_wuid)
     {
         Owned<IWorkUnitFactory> factory = getWorkUnitFactory();
         watcher.setown(factory->getWatcher(this, watchFor, wuid));
-        aborted = false;
+        if (watchFor & SubscribeOptionAbort)
+            abortDirty = true;
     }
     ~WorkUnitWaiter()
     {
         unsubscribe();
     }
-    bool isAborted() const { return aborted; }
+    bool isAborted() const
+    {
+        if (!aborted && abortDirty)
+        {
+            Owned<IWorkUnitFactory> factory = getWorkUnitFactory();
+            if (factory->isAborting(wuid))
+                aborted = true;
+            abortDirty = false;
+        }
+        return aborted;
+    }
     bool wait(unsigned timeout)
     {
         return changed.wait(timeout) && !aborted;
@@ -725,6 +738,8 @@ public:
 // IWorkUnitSubscriber
     virtual void notify(WUSubscribeOptions flags, unsigned valueLen, const void *valueData) override
     {
+        if (SubscribeOptionAbort == flags)
+             abortDirty = true;
         changed.signal();
     }
 // IAbortHandler

--- a/plugins/cassandra/cassandrawu.cpp
+++ b/plugins/cassandra/cassandrawu.cpp
@@ -3893,7 +3893,7 @@ public:
             {
                 waiter->wait(20000);  // recheck state every 20 seconds, in case eclagent has crashed.
                 if (waiter->isAborted())
-                    return WUStateUnknown;  // MORE - throw an exception?
+                    return WUStateAborting;
             }
             else if (waited > timeout || !waiter->wait(timeout-waited))
                 return WUStateUnknown;  // MORE - throw an exception?


### PR DESCRIPTION
Queued k8s jobs were not being aborted. The WorkUnitWaiter was used to monitor the state, but it was not told to spot abort conditions (SubscribeOptionAbort), and the implementation didn't correctly detect the aborting condition.
Fix and ensure waitForWorkUnit returns 'aborting'. Also ensure that Thor doesn't overwrite aborting (or aborted) state with failed.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
