### PR TITLE
HPCC-32636 Add a fsync/retry mechanism on close

### DIFF
--- a/system/jlib/jfile.hpp
+++ b/system/jlib/jfile.hpp
@@ -46,7 +46,7 @@ enum IFOmode { IFOcreate, IFOread, IFOwrite, IFOreadwrite, IFOcreaterw };    // 
 enum IFSHmode { IFSHnone, IFSHread=0x8, IFSHfull=0x10};   // sharing modes
 enum IFSmode { IFScurrent = FILE_CURRENT, IFSend = FILE_END, IFSbegin = FILE_BEGIN };    // seek mode
 enum CFPmode { CFPcontinue, CFPcancel, CFPstop };    // modes for ICopyFileProgress::onProgress return
-enum IFEflags { IFEnone=0x0, IFEnocache=0x1, IFEcache=0x2, IFEsync=0x4 };    // mask
+enum IFEflags { IFEnone=0x0, IFEnocache=0x1, IFEcache=0x2, IFEsync=0x4, IFEsyncAtClose=0x8 }; // mask
 constexpr offset_t unknownFileSize = -1;
 
 class CDateTime;
@@ -756,12 +756,19 @@ enum PlaneAttributeType
 {
     BlockedSequentialIO,
     BlockedRandomIO,
+    FileSyncMaxRetrySecs,
     PlaneAttributeCount
 };
 extern jlib_decl const char *getPlaneAttributeString(PlaneAttributeType attr);
 extern jlib_decl unsigned __int64 getPlaneAttributeValue(const char *planeName, PlaneAttributeType planeAttrType, unsigned __int64 defaultValue);
+extern jlib_decl const char *findPlaneFromPath(const char *filePath, StringBuffer &result);
+//returns true if plane exists, fills resultValue with defaultValue if attribute is unset
+extern jlib_decl bool findPlaneAttrFromPath(const char *filePath, PlaneAttributeType planeAttrType, unsigned __int64 defaultValue, unsigned __int64 &resultValue);
 extern jlib_decl size32_t getBlockedFileIOSize(const char *planeName, size32_t defaultSize=0);
 extern jlib_decl size32_t getBlockedRandomIOSize(const char *planeName, size32_t defaultSize=0);
+constexpr int fileSyncRetryDisabled = -2;
+constexpr int defaultGlobalFileSyncMaxRetrySecs = fileSyncRetryDisabled;
+extern jlib_decl int getMaxFileSyncSecs(const char *planeName, int defaultSecs = defaultGlobalFileSyncMaxRetrySecs);
 
 //---- Pluggable file type related functions ----------------------------------------------
 

--- a/system/jlib/jfile.ipp
+++ b/system/jlib/jfile.ipp
@@ -87,7 +87,6 @@ protected:
     unsigned flags;
 };
 
-
 class jlib_decl CFileIO : implements IFileIO, public CInterface
 {
 public:
@@ -121,6 +120,7 @@ protected:
     IFOmode             openmode;
     IFEflags            extraFlags;
     FileIOStats         stats;
+    int fileSyncMaxRetrySecs = fileSyncRetryDisabled; // enabled conditionally in ctor
     RelaxedAtomic<unsigned> unflushedReadBytes; // more: If this recorded flushedReadBytes it could have a slightly lower overhead
     RelaxedAtomic<unsigned> unflushedWriteBytes;
 private:

--- a/system/jlib/jlz4.cpp
+++ b/system/jlib/jlz4.cpp
@@ -276,7 +276,7 @@ public:
 
             for (;;)
             {
-                //Try and compress into the current target buffer.  If too small increase size and repeat
+                //Try and decompress into the current target buffer.  If too small increase size and repeat
                 written = LZ4_decompress_safe((const char *)in, (char *)target.reserve(maxOut), szchunk, maxOut);
                 if ((int)written > 0)
                 {

--- a/thorlcr/activities/thactivityutil.cpp
+++ b/thorlcr/activities/thactivityutil.cpp
@@ -800,6 +800,7 @@ IFileIO *createMultipleWrite(CActivityBase *activity, IPartDescriptor &partDesc,
     {
         unsigned compMethod = COMPRESS_METHOD_LZ4;
         // rowdif used if recordSize > 0, else fallback to compMethod
+        IFEflags fileIOExtaFlags = IFEnone;
         if (!ecomp)
         {
             if (twFlags & TW_Temporary)
@@ -822,7 +823,7 @@ IFileIO *createMultipleWrite(CActivityBase *activity, IPartDescriptor &partDesc,
             else if (activity->getOptBool(THOROPT_COMP_FORCELZ4HC, false))
                 compMethod = COMPRESS_METHOD_LZ4HC;
         }
-        fileio.setown(createCompressedFileWriter(file, recordSize, 0 != (twFlags & TW_Extend), true, ecomp, compMethod));
+        fileio.setown(createCompressedFileWriter(file, recordSize, 0 != (twFlags & TW_Extend), true, ecomp, compMethod, fileIOExtaFlags));
         if (!fileio)
         {
             compress = false;


### PR DESCRIPTION
Configured off by default.
Configurable with expert/@fileSyncMaxRetrySecs at the component or global level, or at a plane level e.g.

At plane level, 10 minute retry:
```
planes:
- name: data
  category: data
  expert:
    fileSyncMaxRetrySecs: 600
```

At global or component level (all planes)
// 10 minute retry
```
expert:
  fileSyncMaxRetrySecs: 600
```
// no retry, but fsync on close and validate
```
expert:
  fileSyncMaxRetrySecs: 0
```

// disable
```
expert:
  fileSyncMaxRetrySecs: -2
```

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
