### PR TITLE
HPCC-32845 Guard against KJ reading TLKs as regular index parts

### DIFF
--- a/thorlcr/activities/hashdistrib/thhashdistrib.cpp
+++ b/thorlcr/activities/hashdistrib/thhashdistrib.cpp
@@ -26,6 +26,7 @@
 #include "thorport.hpp"
 #include "thbufdef.hpp"
 #include "thexception.hpp"
+#include "thormisc.hpp"
 
 #define NUMINPARALLEL 16
 
@@ -115,7 +116,7 @@ public:
         checkFormatCrc(this, file, helper->getFormatCrc(), nullptr, helper->getFormatCrc(), nullptr, true);
         Owned<IFileDescriptor> fileDesc = file->getFileDescriptor();
         Owned<IPartDescriptor> tlkDesc = fileDesc->getPart(fileDesc->numParts()-1);
-        if (!tlkDesc->queryProperties().hasProp("@kind") || 0 != stricmp("topLevelKey", tlkDesc->queryProperties().queryProp("@kind")))
+        if (!hasTLK(*file, this))
             throw MakeActivityException(this, 0, "Cannot distribute using a non-distributed key: '%s'", scoped.str());
         unsigned location;
         OwnedIFile iFile;

--- a/thorlcr/activities/indexwrite/thindexwrite.cpp
+++ b/thorlcr/activities/indexwrite/thindexwrite.cpp
@@ -159,9 +159,9 @@ public:
             checkFormatCrc(this, _f, helper->getFormatCrc(), nullptr, helper->getFormatCrc(), nullptr, true);
             IDistributedFile *f = _f->querySuperFile();
             if (!f) f = _f;
-            Owned<IDistributedFilePart> existingTlk = f->getPart(f->numParts()-1);
-            if (!existingTlk->queryAttributes().hasProp("@kind") || 0 != stricmp("topLevelKey", existingTlk->queryAttributes().queryProp("@kind")))
+            if (!hasTLK(*f, this))
                 throw MakeActivityException(this, 0, "Cannot build new key '%s' based on non-distributed key '%s'", fileName.get(), diName.get());
+            Owned<IDistributedFilePart> existingTlk = f->getPart(f->numParts()-1);
             IPartDescriptor *tlkDesc = fileDesc->queryPart(fileDesc->numParts()-1);
             IPropertyTree &props = tlkDesc->queryProperties();
             if (existingTlk->queryAttributes().hasProp("@size"))

--- a/thorlcr/activities/keydiff/thkeydiff.cpp
+++ b/thorlcr/activities/keydiff/thkeydiff.cpp
@@ -71,10 +71,7 @@ public:
 
         originalDesc.setown(originalIndexFile->getFileDescriptor());
         newIndexDesc.setown(newIndexFile->getFileDescriptor());
-        Owned<IPartDescriptor> tlkDesc = originalDesc->getPart(originalDesc->numParts()-1);
-        const char *kind = tlkDesc->queryProperties().queryProp("@kind");
-        local = NULL == kind || 0 != stricmp("topLevelKey", kind);
-
+        local = !hasTLK(*originalIndexFile, this);
         if (!local)
             width--; // 1 part == No n distributed / Monolithic key
         if (width > container.queryJob().querySlaves())

--- a/thorlcr/activities/keypatch/thkeypatch.cpp
+++ b/thorlcr/activities/keypatch/thkeypatch.cpp
@@ -71,11 +71,7 @@ public:
 
         originalDesc.setown(originalIndexFile->getFileDescriptor());
         patchDesc.setown(patchFile->getFileDescriptor());
-
-        Owned<IPartDescriptor> tlkDesc = originalDesc->getPart(originalDesc->numParts()-1);
-        const char *kind = tlkDesc->queryProperties().queryProp("@kind");
-        local = NULL == kind || 0 != stricmp("topLevelKey", kind);
-
+        local = !hasTLK(*originalIndexFile, this);
         if (!local && width > 1)
             width--; // 1 part == No n distributed / Monolithic key
         if (width > container.queryJob().querySlaves())

--- a/thorlcr/thorutil/thormisc.cpp
+++ b/thorlcr/thorutil/thormisc.cpp
@@ -29,6 +29,8 @@
 #include "jsocket.hpp"
 #include "jmutex.hpp"
 
+#include "jhtree.hpp"
+
 #include "commonext.hpp"
 #include "dadfs.hpp"
 #include "dasds.hpp"
@@ -1702,4 +1704,36 @@ void saveWuidToFile(const char *wuid)
         throw makeStringException(0, "Failed to create file 'wuid' to store current workunit for post mortem script");
     wuidFileIO->write(0, strlen(wuid), wuid);
     wuidFileIO->close();
+}
+
+bool hasTLK(IDistributedFile &file, CActivityBase *activity)
+{
+    unsigned np = file.numParts();
+    if (np<=1) // NB: a better test would be to only continue if this is a width that is +1 of group it's based on, but not worth checking
+        return false;
+    IDistributedFilePart &part = file.queryPart(np-1);
+    bool keyHasTlk = strisame("topLevelKey", part.queryAttributes().queryProp("@kind"));
+    if (!keyHasTlk)
+    {
+        // See HPCC-32845 - check if TLK flag is missing from TLK part
+        // It is very likely the last part should be a TLK. Even a local key (>1 parts) has a TLK by default (see buildLocalTlks)
+        RemoteFilename rfn;
+        part.getFilename(rfn);
+        StringBuffer filename;
+        rfn.getPath(filename);
+        Owned<IKeyIndex> index = createKeyIndex(filename, 0, false, 0);
+        dbgassertex(index);
+        if (index->isTopLevelKey())
+        {
+            if (activity)
+            {
+                Owned<IException> e = MakeActivityException(activity, 0, "TLK file part of file %s is missing kind=\"topLevelKey\" flag. The meta data should be fixed!", file.queryLogicalName());
+                reportExceptionToWorkunitCheckIgnore(activity->queryJob().queryWorkUnit(), e, SeverityWarning);
+                StringBuffer errMsg;
+                UWARNLOG("%s", e->errorMessage(errMsg).str());
+            }
+            keyHasTlk = true;
+        }
+    }
+    return keyHasTlk;
 }

--- a/thorlcr/thorutil/thormisc.hpp
+++ b/thorlcr/thorutil/thormisc.hpp
@@ -723,4 +723,6 @@ public:
 
 extern graph_decl void saveWuidToFile(const char *wuid);
 
+extern graph_decl bool hasTLK(IDistributedFile &file, CActivityBase *activity);
+
 #endif


### PR DESCRIPTION
Also remove some redundant 'delayed' functionality.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [x] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
