### PR TITLE
HPCC-32960 Fix epoll memory corruption issues

### DIFF
--- a/system/jlib/jsocket.cpp
+++ b/system/jlib/jsocket.cpp
@@ -4327,7 +4327,7 @@ struct SelectItem
     T_SOCKET handle;
     ISocketSelectNotify *nfy;
     byte mode;
-    bool del; // only used in select handler method
+    bool del;
     bool operator == (const SelectItem & other) const { return sock == other.sock; }
 };
 
@@ -4406,13 +4406,12 @@ protected:
     Semaphore ticksem;
     std::atomic_uint tickwait;
     unsigned offset;
-    bool selectvarschange;
+    std::atomic<bool> selectvarschange;
     unsigned waitingchange;
     Semaphore waitingchangesem;
     int validateselecterror;
     unsigned validateerrcount;
     const char *selecttrace;
-    unsigned basesize;
 #ifdef _USE_PIPE_FOR_SELECT_TRIGGER
     T_SOCKET dummysock[2];
 #else
@@ -4547,6 +4546,7 @@ public:
 class CSocketSelectThread: public CSocketBaseThread
 {
     SelectItemArray items;
+    unsigned basesize;
 
     void opendummy()
     {
@@ -4709,9 +4709,10 @@ public:
 
     Owned<IException> termexcept;
 
+    // JCSMORE: this is very similar to the version in CSocketEpollThread. Could be commoned if items used common structure.
     void updateItems()
     {
-        // must be in CriticalBlock block(sect); 
+        // must be in CriticalBlock block(sect);
         unsigned n = items.ordinality();
 #ifdef _WIN32
         bool hashupdateneeded = (n!=basesize); // additions all come at end
@@ -4751,6 +4752,7 @@ public:
         basesize = n;
     }
 
+    // JCSMORE: this is very similar to the version in CSocketEpollThread. Could be commoned if items used common structure.
     bool checkSocks()
     {
         bool ret = false;
@@ -4798,9 +4800,12 @@ public:
         unsigned n=0;
         ForEachItemIn(i,items) {
             SelectItem &si = items.element(i);
-            if (!si.del) {
-                if (si.sock==sock) {
+            if (!si.del)
+            {
+                if (si.sock==sock)
+                {
                     si.del = true;
+                    break;
                 }
                 else 
                     n++;
@@ -5182,6 +5187,7 @@ public:
 #ifdef _HAS_EPOLL_SUPPORT
 # define SOCK_ADDED   0x1
 # define SOCK_REMOVED 0x2
+# define SOCK_FAILED  0x4
 class CSocketEpollThread: public CSocketBaseThread
 {
     int epfd;
@@ -5213,15 +5219,51 @@ class CSocketEpollThread: public CSocketBaseThread
         }
     }
 
+    // JCSMORE: this is very similar to the version in CSocketSelectThread. Could be commoned if items used common structure.
+    void updateItems()
+    {
+        // must be in CriticalBlock block(sect);
+        unsigned n = items.ordinality();
+        for (unsigned i=0;i<n;)
+        {
+            SelectItem *si = items.element(i);
+            if (si->del)
+            {
+                // Release/dtors should not throw but leaving try/catch here until all paths checked
+                try
+                {
+#ifdef SOCKTRACE
+                    PROGLOG("CSocketSelectThread::updateItems release %d",si.handle);
+#endif
+                    si->nfy->Release();
+                    si->sock->Release();
+                    delete si;
+                }
+                catch (IException *e)
+                {
+                    EXCLOG(e,"CSocketSelectThread::updateItems");
+                    e->Release();
+                }
+                n--;
+                if (i < n)
+                    items.swap(i, n);
+                items.remove(n);
+            }
+            else
+                i++;
+        }
+    }
+
     void opendummy()
     {
         CriticalBlock block(sect);
         if (!dummysockopen)
         {
+            // NB: not notified when triggered, because explicitly spotted and handled before tonotify loop
             sidummy = new SelectItem;
             sidummy->sock = nullptr;
             sidummy->nfy = nullptr;
-            sidummy->del = true;  // so its not added to tonotify ...
+            sidummy->del = false;
             sidummy->mode = 0;
 #ifdef _USE_PIPE_FOR_SELECT_TRIGGER
             if(pipe(dummysock))
@@ -5281,32 +5323,32 @@ class CSocketEpollThread: public CSocketBaseThread
         }
     }
 
-    void delSelItem(SelectItem *si)
-    {
-        epoll_op(epfd, EPOLL_CTL_DEL, si, 0);
-        // Release/dtors should not throw but leaving try/catch here until all paths checked
-        try
-        {
-            si->nfy->Release();
-            si->sock->Release();
-            delete si;
-        }
-        catch (IException *e)
-        {
-            EXCLOG(e,"CSocketEpollThread::delSelItem()");
-            e->Release();
-        }
-    }
+    // void delSelItem(SelectItem *si)
+    // {
+    //     epoll_op(epfd, EPOLL_CTL_DEL, si, 0);
+    //     // Release/dtors should not throw but leaving try/catch here until all paths checked
+    //     try
+    //     {
+    //         si->nfy->Release();
+    //         si->sock->Release();
+    //         delete si;
+    //     }
+    //     catch (IException *e)
+    //     {
+    //         EXCLOG(e,"CSocketEpollThread::delSelItem()");
+    //         e->Release();
+    //     }
+    // }
 
-    void delSelItemPos(SelectItem *si, unsigned pos)
-    {
-        unsigned last = items.ordinality();
-        delSelItem(si);
-        last--;
-        if (pos < last)
-            items.swap(pos, last);
-        items.remove(last);
-    }
+    // void delSelItemPos(SelectItem *si, unsigned pos)
+    // {
+    //     unsigned last = items.ordinality();
+    //     delSelItem(si);
+    //     last--;
+    //     if (pos < last)
+    //         items.swap(pos, last);
+    //     items.remove(last);
+    // }
 
 public:
     CSocketEpollThread(const char *trc, unsigned _hdlPerThrd)
@@ -5357,9 +5399,21 @@ public:
         closedummy();
         ForEachItemIn(i, items)
         {
-            SelectItem *si = items.element(i);
-            delSelItem(si);
+            // Release/dtors should not throw but leaving try/catch here until all paths checked
+            try
+            {
+                SelectItem *si = items.element(i);
+                si->nfy->Release();
+                si->sock->Release();
+                delete si;
+            }
+            catch (IException *e)
+            {
+                EXCLOG(e,"~CSocketSelectThread");
+                e->Release();
+            }
         }
+
         if (epfd >= 0)
         {
 # ifdef EPOLLTRACE
@@ -5373,52 +5427,52 @@ public:
 
     Owned<IException> termexcept;
 
+    // JCSMORE: this is very similar to the version in CSocketSelectThread. Could be commoned if items used common structure.
     bool checkSocks()
     {
         bool ret = false;
-        // must be holding CriticalBlock (sect)
-        unsigned n = items.ordinality();
-        for (unsigned i=0;i<n;)
+        ForEachItemIn(i, items)
         {
-            SelectItem *si = items.element(i);
-            if (!sockOk(si->handle))
+            SelectItem &si = *items.element(i);
+            if (si.del)
+                ret = true; // maybe that bad one
+            else if (!sockOk(si.handle))
             {
-                delSelItemPos(si, i);
-                n--;
+                si.del = true;
                 ret = true;
             }
-            else
-                i++;
         }
         return ret;
     }
 
-    bool removeSock(ISocket *sock)
-    {
-        // must be holding CriticalBlock (sect)
-        unsigned n = items.ordinality();
-        for (unsigned i=0;i<n;)
-        {
-            SelectItem *si = items.element(i);
-            if (si->sock==sock)
-            {
-                delSelItemPos(si, i);
-                n--;
-                return true;
-            }
-            else
-                i++;
-        }
-        return false;
-    }
+    // bool removeSock(ISocket *sock)
+    // {
+    //     // must be holding CriticalBlock (sect)
+    //     unsigned n = items.ordinality();
+    //     for (unsigned i=0;i<n;)
+    //     {
+    //         SelectItem *si = items.element(i);
+    //         if (si->sock==sock)
+    //         {
+    //             delSelItemPos(si, i);
+    //             n--;
+    //             return true;
+    //         }
+    //         else
+    //             i++;
+    //     }
+    //     return false;
+    // }
 
     bool remove(ISocket *sock)
     {
-        CriticalBlock block(sect);
         if (terminating)
-            return false;
-        if (sock==NULL)
-        { // wait until no changes outstanding
+            return true; // pretend is, to short-circuit caller
+        CriticalBlock block(sect);
+
+        // JCS - I can't see when sock can be null
+        if (sock==NULL) // wait until no changes outstanding
+        {
             while (selectvarschange)
             {
                 waitingchange++;
@@ -5427,33 +5481,59 @@ public:
             }
             return true;
         }
-        if (removeSock(sock))
+
+        ForEachItemIn(i, items)
         {
-            selectvarschange = true;
-            // NB: could set terminating here if no more hdls on
-            // this thread and at least one other thread is present
-            triggerselect();
-            return true;
+            SelectItem *si = items.element(i);
+            if (!si->del && (si->sock==sock))
+            {
+                // epoll_wait (in the CSocketEpollThread thread) may have pending events on socket this is about to remove
+                // so we must not remove the SelectItem here, just mark it as deleted (deletion performed in updateEpollVars)
+                epoll_op(epfd, EPOLL_CTL_DEL, si, 0);
+                si->del = true;
+                selectvarschange = true;
+                triggerselect();
+                // JCSMORE see comment in CSocketEpollThread::run re. need for CS.
+                // I think the array could be manipulated here, as long as the SelectItem isn't deleted.
+                // It may also be more efficient if it used a double linked list to remove items.
+                return true;
+            }
         }
         return false;
     }
 
-    unsigned add(ISocket *sock,unsigned mode,ISocketSelectNotify *nfy)
+    unsigned add(ISocket *sock, unsigned mode, ISocketSelectNotify *nfy)
     {
         if ( !sock || !nfy ||
              !(mode & (SELECTMODE_READ|SELECTMODE_WRITE|SELECTMODE_EXCEPT)) )
         {
             IWARNLOG("EPOLL: adding fd but sock or nfy is NULL or mode is empty");
             dbgassertex(false);
-            return 0;
+            return SOCK_FAILED;
         }
         CriticalBlock block(sect);
         if (terminating)
-            return 0;
+            return SOCK_FAILED;
+
+        // JCSMORE may be more efficient to use a double linked list to avoid this scan (and array/expansion)
         unsigned rm = 0;
-        if (removeSock(sock))
-            rm = SOCK_REMOVED;
-        unsigned n = items.ordinality();
+        unsigned n=0;
+        ForEachItemIn(i, items)
+        {
+            SelectItem &si = *items.element(i);
+            if (!si.del)
+            {
+                if (si.sock==sock)
+                {
+                    si.del = true;
+                    rm = SOCK_REMOVED;
+                    break;
+                }
+                else
+                    n++;
+            }
+        }
+
         // new handler thread
         if (n >= hdlPerThrd)
             return (0|rm);
@@ -5471,6 +5551,7 @@ public:
             ep_mode |= EPOLLOUT;
         if (mode & SELECTMODE_EXCEPT)
             ep_mode |= EPOLLPRI;
+        // JCSMORE - we are in a CS, but it is thread-safe to epoll_wait concurrently with epoll_op
         epoll_op(epfd, EPOLL_CTL_ADD, sn, ep_mode);
         selectvarschange = true;
         triggerselect();
@@ -5502,6 +5583,7 @@ public:
 #ifndef _USE_PIPE_FOR_SELECT_TRIGGER
         opendummy();
 #endif
+        updateItems();
         ni = items.ordinality();
         validateselecterror = 0;
     }
@@ -5571,6 +5653,11 @@ public:
                     totnum++;
                     SelectItemArray tonotify;
                     {
+                        // JCSMORE - I don't think this CS is needed.
+                        // It is in the CSocketSelectThread version because the items array needs protecting)
+                        // But in the epoll version, we reference the SelectItem pointers only, the items array isn't referenced,
+                        // and epoll_op's are thread-safe. But we must ensure the SelectItem's are only deleted by this thread,
+                        // since even if in a mutex, pending events may referene them.
                         CriticalBlock block(sect);
 
                         // retrieve events, without waiting, while holding CS ...
@@ -5580,20 +5667,26 @@ public:
                         {
                             int tfd = -1;
                             SelectItem *epsi = (SelectItem *)epevents[j].data.ptr;
-                            if (epsi)
+                            if (epsi && !epsi->del) // NB: could receive an event for a pending deleted item
                                 tfd = epsi->handle;
 # ifdef EPOLLTRACE
                             DBGLOG("EPOLL: j = %d, fd = %d, emask = %u", j, tfd, epevents[j].events);
 # endif
                             if (tfd >= 0)
                             {
-# ifdef _USE_PIPE_FOR_SELECT_TRIGGER
-                                if ( (dummysockopen) && (tfd == dummysock[0]) )
+                                if (dummysockopen)
                                 {
-                                    resettrigger();
-                                    continue;
-                                }
+# ifdef _USE_PIPE_FOR_SELECT_TRIGGER
+                                    if (tfd == dummysock[0])
+                                    {
+                                        resettrigger();
+                                        continue;
+                                    }
+#else
+                                    // would still need to resettrigger and ignore dummysock (but subtly different code)
+                                    throwUnimplemented();
 # endif
+                                }
                                 unsigned int ep_mode = 0;
                                 if (epevents[j].events & (EPOLLINX | EPOLLHUP | EPOLLERR))
                                     ep_mode |= SELECTMODE_READ;
@@ -5626,6 +5719,7 @@ public:
                         const SelectItem &si = tonotify.item(j);
                         try
                         {
+                            // is it worth checking si.del again? we can't guarantee that this is a socket that has been marked deleted.
                             si.nfy->notifySelected(si.sock,si.mode); // ignore return
                         }
                         catch (IException *e)
@@ -5736,7 +5830,9 @@ public:
             if (!(addrm & SOCK_ADDED))
             {
                 addrm |= threads.item(i).add(sock,mode,nfy);
-                if (addrm & (SOCK_ADDED | SOCK_REMOVED))
+                // if both added and removed, we're done
+                if (((addrm & (SOCK_ADDED | SOCK_REMOVED)) == (SOCK_ADDED | SOCK_REMOVED)) ||
+                    (addrm & SOCK_FAILED))
                     return;
             }
             else if (!(addrm & SOCK_REMOVED))


### PR DESCRIPTION
Although the SelectItem 'items' array is protected by a CS, epoll_wait can receive pending events for SelectItems that have been deleted, which were then link counted and caused corruption.

Like the select handler version, avoid deleting the SelectItem's when items are removed, instead mark them deleted and let the triggerselect() approach remove them on the main thread.

Also fix a theoretical issue when adding a existing socket to CSocketEpollThread, it did not check other CSocketEpollThread's to see if it needed to be removed. (given default hdlPerThrd is UINT_MAX, it will not have happened).

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
