### PR TITLE
HPCC-31650 Address incorrect analyzer cost calculations and cost threshold

### DIFF
--- a/common/wuanalysis/anacommon.cpp
+++ b/common/wuanalysis/anacommon.cpp
@@ -45,7 +45,7 @@ void PerformanceIssue::print() const
     printf("\n");
 }
 
-void PerformanceIssue::createException(IWorkUnit * wu, double costRate)
+void PerformanceIssue::createException(IWorkUnit * wu)
 {
     ErrorSeverity mappedSeverity = wu->getWarningSeverity(errorCode, (ErrorSeverity)SeverityWarning);
     if (mappedSeverity == SeverityIgnore)
@@ -66,17 +66,15 @@ void PerformanceIssue::createException(IWorkUnit * wu, double costRate)
     StringBuffer s(comment);        // Append scope to comment as scope column is not visible in ECLWatch
     s.appendf(" (%s)", scope.str());
     we->setExceptionMessage(s.str());
-    if (costRate!=0.0)
-    {
-        double timePenaltyPerHour = (double)statUnits2seconds(timePenalty) / 3600;
-        we->setCost(timePenaltyPerHour*costRate);
-    }
+    if (costPenalty!=0)
+        we->setCost(cost_type2money(costPenalty));
     we->setExceptionSource(CostOptimizerName);
 }
 
-void PerformanceIssue::set(AnalyzerErrorCode _errorCode, stat_type _timePenalty, const char * msg, ...)
+void PerformanceIssue::set(AnalyzerErrorCode _errorCode, stat_type _timePenalty, cost_type _costPenalty, const char * msg, ...)
 {
     timePenalty = _timePenalty;
+    costPenalty = _costPenalty;
     errorCode = _errorCode;
     va_list args;
     va_start(args, msg);

--- a/common/wuanalysis/anacommon.hpp
+++ b/common/wuanalysis/anacommon.hpp
@@ -62,12 +62,13 @@ class PerformanceIssue : public CInterface
 public:
     int compareCost(const PerformanceIssue & other) const;
     void print() const;
-    void createException(IWorkUnit * we, double costRate);
+    void createException(IWorkUnit * we);
 
-    void set(AnalyzerErrorCode _errorCode, stat_type _timePenalty, const char * msg, ...) __attribute__((format(printf, 4, 5)));
+    void set(AnalyzerErrorCode _errorCode, stat_type _timePenalty, cost_type _costPenalty, const char * msg, ...) __attribute__((format(printf, 5, 6)));
     void setLocation(const char * definition);
     void setScope(const char *_scope) { scope.set(_scope); }
-    stat_type getTimePenalityCost() const { return timePenalty; }
+    stat_type getTimePenalty() const { return timePenalty; }
+    cost_type getCostPenalty() const { return costPenalty; }
 
 private:
     AnalyzerErrorCode errorCode = ANA_GENERICERROR_ID;
@@ -76,6 +77,7 @@ private:
     unsigned column = 0;
     StringAttr scope;
     stat_type timePenalty = 0; // number of nanoseconds lost as a result.
+    cost_type costPenalty = 0;
     StringBuffer comment;
 };
 
@@ -84,9 +86,11 @@ enum WutOptionType
     watOptFirst=0,
     watOptMinInterestingTime=0,
     watOptMinInterestingCost,
+    watOptMinInterestingWaste,
     watOptSkewThreshold,
     watOptMinRowsPerNode,
     watPreFilteredKJThreshold,
+    watClusterCostPerHour,
     watOptMax
 };
 

--- a/common/wuanalysis/anawu.hpp
+++ b/common/wuanalysis/anawu.hpp
@@ -26,8 +26,8 @@
 
 #include "anacommon.hpp"
 
-void WUANALYSIS_API analyseWorkunit(IWorkUnit * wu, const char *optGraph, IPropertyTree *options, double costPerMs);
-void WUANALYSIS_API analyseAndPrintIssues(IConstWorkUnit * wu, double costPerMs, bool updatewu);
+void WUANALYSIS_API analyseWorkunit(IWorkUnit * wu, const char *optGraph, IPropertyTree *options, double costPerHour);
+void WUANALYSIS_API analyseAndPrintIssues(IConstWorkUnit * wu, double costPerHour, bool updatewu);
 
 //---------------------------------------------------------------------------------------------------------------------
 

--- a/ecl/eclagent/eclagent.cpp
+++ b/ecl/eclagent/eclagent.cpp
@@ -1862,9 +1862,9 @@ void EclAgent::runWorkunitAnalyser(IWorkUnit * w, const char * optGraph)
 {
     if (w->getDebugValueBool("analyzeWorkunit", agentTopology->getPropBool("@analyzeWorkunit", true)))
     {
-        double costPerMs = calculateThorCost(1, getNodes());
+        double costPerHour = calculateThorCost(3600000 /*milliseconds in an hour*/, getNodes());
         IPropertyTree *analyzerOptions = agentTopology->queryPropTree("analyzerOptions");
-        analyseWorkunit(w, optGraph, analyzerOptions, costPerMs);
+        analyseWorkunit(w, optGraph, analyzerOptions, costPerHour);
     }
 }
 

--- a/system/jlib/jstats.h
+++ b/system/jlib/jstats.h
@@ -34,8 +34,8 @@ const unsigned __int64 AnyStatisticValue = MaxStatisticValue; // Use the maximum
 
 inline constexpr stat_type seconds2StatUnits(stat_type secs) { return secs * 1000000000; }
 inline constexpr stat_type msecs2StatUnits(stat_type ms) { return ms * 1000000; }
-inline constexpr stat_type statUnits2seconds(stat_type stat) {return stat / 1000000000; }
-inline constexpr stat_type statUnits2msecs(stat_type stat) {return stat / 1000000; }
+inline constexpr double statUnits2seconds(stat_type stat) {return ((double)stat) / 1000000000; }
+inline constexpr double statUnits2msecs(stat_type stat) {return ((double)stat) / 1000000; }
 
 inline constexpr stat_type statPercent(int value) { return (stat_type)value * 100; }            // Since 1 = 0.01% skew
 inline constexpr stat_type statPercent(double value) { return (stat_type)(value * 100); }
@@ -43,8 +43,8 @@ inline constexpr stat_type statPercent(stat_type  value) { return (stat_type)(va
 inline constexpr stat_type statPercentageOf(stat_type value, stat_type per) { return value * per / 10000; }
 
 inline StatisticKind queryStatsVariant(StatisticKind kind) { return (StatisticKind)(kind & ~StKindMask); }
-inline cost_type money2cost_type(double money) { return money * 1E6; }
-inline double cost_type2money(cost_type cost) { return ((double) cost) / 1E6; }
+constexpr cost_type money2cost_type(const double money) { return money * 1E6; }
+constexpr double cost_type2money(cost_type cost) { return ((double) cost) / 1E6; }
 
 extern jlib_decl void formatTime(StringBuffer & out, unsigned __int64 value);
 //---------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
* The rate used to calculate the cost of issues has been updated so that the unit is consistent and produces valid cost calculation.
* 'minInterestingCost' is a decimal value to set the minimum dollar cost value for reported issues.
* 'minInterestingCost' is compared with the calculated cost of the issue
*  'minInterestingWaste' is a new option to set the minimum time threshold for reported issues.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [ ] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
