### PR TITLE
HPCC-31411 Make work unit IDs case insensitive

### DIFF
--- a/common/workunit/workunit.cpp
+++ b/common/workunit/workunit.cpp
@@ -14985,3 +14985,12 @@ void recordTraceDebugOptions(IWorkUnit * target, const IProperties * source)
         }
     }
 }
+
+WuidPattern::WuidPattern(const char* _pattern)
+    : pattern(_pattern)
+{
+    if (!pattern.isEmpty())
+        pattern.trim();
+    if (!pattern.isEmpty() && islower(pattern.charAt(0)))
+        pattern.setCharAt(0, toupper(pattern.charAt(0)));
+}

--- a/common/workunit/workunit.hpp
+++ b/common/workunit/workunit.hpp
@@ -1843,4 +1843,17 @@ private:
     const StatisticsMapping & mapping;
 };
 
+class WORKUNIT_API WuidPattern
+{
+private:
+    StringBuffer pattern;
+public:
+    WuidPattern(const char* _pattern);
+    inline bool isEmpty() const { return pattern.isEmpty(); }
+    inline const char* str() const { return pattern.str(); }
+    inline operator const char* () const { return pattern.str(); }
+    inline operator const StringBuffer& () const { return pattern; }
+    inline operator StringBuffer& () { return pattern; }
+};
+
 #endif

--- a/dali/sasha/saarch.cpp
+++ b/dali/sasha/saarch.cpp
@@ -1166,7 +1166,7 @@ protected:
             getWorkUnitCreateTime(wuid,time);
         }
         virtual ~cDFUWUBranchItem() {}
-        bool isempty() { return (wuid[0]!='D')||iserr; }
+        bool isempty() { return (toupper(wuid[0])!='D')||iserr; }
         bool qualifies() 
         { 
             if (isprotected)

--- a/esp/services/ws_fs/ws_fsService.cpp
+++ b/esp/services/ws_fs/ws_fsService.cpp
@@ -924,10 +924,9 @@ bool CFileSprayEx::onGetDFUWorkunits(IEspContext &context, IEspGetDFUWorkunits &
     {
         context.ensureFeatureAccess(DFU_WU_URL, SecAccess_Read, ECLWATCH_DFU_WU_ACCESS_DENIED, "Access to DFU workunit is denied.");
 
-        StringBuffer wuidStr(req.getWuid());
-        const char* wuid = wuidStr.trim().str();
-        if (wuid && *wuid && looksLikeAWuid(wuid, 'D'))
-            return getOneDFUWorkunit(context, wuid, resp);
+        WuidPattern wuidPattern(req.getWuid());
+        if (!wuidPattern.isEmpty() && looksLikeAWuid(wuidPattern, 'D'))
+            return getOneDFUWorkunit(context, wuidPattern, resp);
 
         double version = context.getClientVersion();
         if (version > 1.02)
@@ -1055,11 +1054,11 @@ bool CFileSprayEx::onGetDFUWorkunits(IEspContext &context, IEspGetDFUWorkunits &
                 filterbuf.append("");
         }
 
-        if(wuid && *wuid)
+        if(!isEmptyString(wuidPattern))
         {
             filters[filterCount] = DFUsf_wildwuid;
             filterCount++;
-            filterbuf.append(wuid);
+            filterbuf.append(wuidPattern);
         }
 
         if(clusterName && *clusterName)

--- a/esp/services/ws_smc/ws_smcService.cpp
+++ b/esp/services/ws_smc/ws_smcService.cpp
@@ -1237,7 +1237,7 @@ void CWsSMCEx::addWUsToResponse(IEspContext &context, const IArrayOf<IEspActiveW
     {
         IEspActiveWorkunit& wu = aws.item(i);
         const char* wuid = wu.getWuid();
-        if (wuid[0] == 'D')//DFU WU
+        if (toupper(wuid[0]) == 'D')//DFU WU
         {
             awsReturned.append(*LINK(&wu));
             continue;

--- a/testing/unittests/wutests.cpp
+++ b/testing/unittests/wutests.cpp
@@ -23,6 +23,7 @@ class wuTests : public CppUnit::TestFixture
 {
     CPPUNIT_TEST_SUITE( wuTests );
         CPPUNIT_TEST(testLooksLikeAWuid);
+        CPPUNIT_TEST(testWuidPattern);
     CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -73,6 +74,11 @@ public:
         CPPUNIT_ASSERT_MESSAGE("looksLikeAWuid should fail", !looksLikeAWuid("W12345678-12345", 'W'));
         CPPUNIT_ASSERT_MESSAGE("looksLikeAWuid should fail", !looksLikeAWuid("W12345678-123456-", 'W'));
         CPPUNIT_ASSERT_MESSAGE("looksLikeAWuid should fail", !looksLikeAWuid("*", 'W'));
+    }
+
+    void testWuidPattern()
+    {
+        CPPUNIT_ASSERT_MESSAGE("wuidPattern should pass", looksLikeAWuid(WuidPattern(" \t\rw12345678-123456 \t\r"), 'W'));
     }
 };
 


### PR DESCRIPTION
- Accept either 'w' or 'W' at the start of WUID filter patterns.
- Improve reliability of ignoring leading and trailing whitespace.
- Introduce a WUID pattern encapsulation that will grow to include more robust and standardized pattern analysis.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
