### PR TITLE
HPCC-33137 Add support for executing the cost optimizers in Thor

### DIFF
--- a/common/workunit/workunit.hpp
+++ b/common/workunit/workunit.hpp
@@ -1788,6 +1788,10 @@ extern WORKUNIT_API double getThorManagerRate();
 extern WORKUNIT_API double getThorWorkerRate();
 extern WORKUNIT_API double getThorRate(unsigned numberOfWorkers);
 extern WORKUNIT_API double calculateThorCost(unsigned __int64 ms, unsigned numberOfWorkers);
+inline double calculateThorCostPerHour(unsigned numberOfWorkers)
+{
+    return calculateThorCost(1000*60*60, numberOfWorkers);
+}
 
 extern WORKUNIT_API IPropertyTree * getWUGraphProgress(const char * wuid, bool readonly);
 
@@ -1822,6 +1826,14 @@ extern WORKUNIT_API bool isValidMemoryValue(const char * memoryUnit);
 
 constexpr bool defaultThorMultiJobLinger = true;
 constexpr unsigned defaultThorLingerPeriod = 60;
+
+constexpr bool defaultAnalyzeWhenComplete = isContainerized() ? false : true;
+// Non-containerized: the analyzer is executed in the eclagent (legacy behavior)
+// Containerized: the analyzer is executed in Thor by default because the eclagent cannot
+//                calculate the cost of issues as it doesn't have access to thor cost values
+// (Note: it is not presently possible to analyze with defaultAnalyzeWhenComplete option and in thor)
+constexpr bool defaultAnalyzeInEclAgent = isContainerized() ? false : true;
+
 extern WORKUNIT_API void executeThorGraph(const char * graphName, IConstWorkUnit &workunit, const IPropertyTree &config);
 
 extern WORKUNIT_API TraceFlags loadTraceFlags(IConstWorkUnit * wu, const std::initializer_list<TraceOption> & y, TraceFlags dft);

--- a/common/wuanalysis/anacommon.hpp
+++ b/common/wuanalysis/anacommon.hpp
@@ -91,6 +91,7 @@ enum WutOptionType
     watOptMinRowsPerNode,
     watPreFilteredKJThreshold,
     watClusterCostPerHour,
+    watOptMaxExecuteTime,
     watOptMax
 };
 

--- a/common/wuanalysis/anawu.hpp
+++ b/common/wuanalysis/anawu.hpp
@@ -26,9 +26,9 @@
 
 #include "anacommon.hpp"
 
-void WUANALYSIS_API analyseWorkunit(IWorkUnit * wu, const char *optGraph, IPropertyTree *options, double costPerHour);
+void WUANALYSIS_API analyseWorkunit(IConstWorkUnit &workunit, const char *optGraph, IPropertyTree *options, double costPerHour);
 void WUANALYSIS_API analyseAndPrintIssues(IConstWorkUnit * wu, const char *optGraph, double costPerHour, bool updatewu);
-
+void WUANALYSIS_API runWorkunitAnalyser(IConstWorkUnit &workunit, IPropertyTree *cfg, const char * optGraph, bool inEclAgent, double costPerHour);
 //---------------------------------------------------------------------------------------------------------------------
 
 class WuScope;

--- a/ecl/eclagent/eclagent.cpp
+++ b/ecl/eclagent/eclagent.cpp
@@ -40,7 +40,6 @@
 #include "rtlds_imp.hpp"
 #include "rtlcommon.hpp"
 #include "rtldynfield.hpp"
-#include "workunit.hpp"
 #include "eventqueue.hpp"
 #include "schedulectrl.hpp"
 #include "jhtree.hpp"
@@ -1844,27 +1843,6 @@ void EclAgent::setRetcode(int code)
     retcode = code;
 }
 
-
-void EclAgent::runWorkunitAnalyser(IWorkUnit * w, const char * optGraph)
-{
-    if (w->getDebugValueBool("analyzeWorkunit", agentTopology->getPropBool("@analyzeWorkunit", true)))
-    {
-        double costPerHour = calculateThorCost(3600000 /*milliseconds in an hour*/, getNodes());
-        IPropertyTree *analyzerOptions = agentTopology->queryPropTree("analyzerOptions");
-        analyseWorkunit(w, optGraph, analyzerOptions, costPerHour);
-    }
-}
-
-static constexpr bool defaultAnalyzeWhenComplete = true;
-void EclAgent::runWorkunitAnalyserAfterGraph(const char * graph)
-{
-    if (!wuRead->getDebugValueBool("analyzeWhenComplete", agentTopology->getPropBool("@analyzeWhenComplete", defaultAnalyzeWhenComplete)))
-    {
-        Owned<IWorkUnit> wu(updateWorkUnit());
-        runWorkunitAnalyser(wu, graph);
-    }
-}
-
 void EclAgent::doProcess()
 {
 #ifdef _DEBUG
@@ -2031,22 +2009,6 @@ void EclAgent::doProcess()
             break;
         }
 
-
-        if (getClusterType(clusterType)==ThorLCRCluster)
-        {
-            if (w->getDebugValueBool("analyzeWhenComplete", agentTopology->getPropBool("@analyzeWhenComplete", defaultAnalyzeWhenComplete)))
-            {
-                switch (w->getState())
-                {
-                case WUStateFailed:
-                case WUStateAborted:
-                case WUStateCompleted:
-                    runWorkunitAnalyser(w, nullptr);
-                    break;
-                }
-            }
-        }
-
         if(w->queryEventScheduledCount() > 0)
             switch(w->getState())
             {
@@ -2135,6 +2097,11 @@ void EclAgent::doProcess()
         e->Release();
     }
     DBGLOG("Workunit written complete");
+
+    if (getClusterType(clusterType)==ThorLCRCluster)
+    {
+        runWorkunitAnalyser(*wuRead, getComponentConfigSP(), nullptr, true, calculateThorCostPerHour(getNodes()));
+    }
 }
 
 void EclAgent::runProcess(IEclProcess *process)

--- a/ecl/eclagent/eclagent.ipp
+++ b/ecl/eclagent/eclagent.ipp
@@ -431,8 +431,6 @@ private:
     EclAgentQueryLibrary * loadEclLibrary(const char * libraryName, unsigned expectedInterfaceHash, const char * embeddedGraphName);
     virtual bool getWorkunitResultFilename(StringBuffer & diskFilename, const char * wuid, const char * name, int seq);
     virtual IDebuggableContext *queryDebugContext() const { return debugContext; };
-    void runWorkunitAnalyser(IWorkUnit * w, const char * optGraph);
-    void runWorkunitAnalyserAfterGraph(const char * optGraph);
 
     //protected by critical section
     EclGraph * addGraph(const char * graphName);

--- a/ecl/eclagent/eclgraph.cpp
+++ b/ecl/eclagent/eclgraph.cpp
@@ -37,6 +37,7 @@
 #include "thorfile.hpp"
 #include "commonext.hpp"
 #include "thorcommon.hpp"
+#include "anawu.hpp"
 
 #include <list>
 #include <string>
@@ -1616,11 +1617,11 @@ void EclAgent::executeGraph(const char * graphName, bool realThor, size32_t pare
         try
         {
             executeThorGraph(graphName, *wuRead, *agentTopology);
-            runWorkunitAnalyserAfterGraph(graphName);
+            runWorkunitAnalyser(*wuRead, getComponentConfigSP(), graphName, true, calculateThorCostPerHour(getNodes()));
         }
         catch (...)
         {
-            runWorkunitAnalyserAfterGraph(graphName);
+            runWorkunitAnalyser(*wuRead, getComponentConfigSP(), graphName, true, calculateThorCostPerHour(getNodes()));
             throw;
         }
     }

--- a/helm/hpcc/templates/_helpers.tpl
+++ b/helm/hpcc/templates/_helpers.tpl
@@ -310,6 +310,19 @@ tracing:
 {{- end -}}
 {{- end -}}
 
+
+{{/*
+Generate analyzerOptions
+*/}}
+{{- define "hpcc.generateAnalyzerOptions" -}}
+{{- $analyzerOptions := deepCopy (.me.analyzerOptions | default dict) | mergeOverwrite dict (.root.Values.global.analyzerOptions | default dict) -}}
+{{- if not (empty $analyzerOptions) }}
+analyzerOptions:
+{{ toYaml $analyzerOptions | indent 2 }}
+{{- end -}}
+{{- end -}}
+
+
 {{/*
 Generate local metrics configuration, merged with global
 Pass in dict with root and me
@@ -2623,7 +2636,7 @@ globalExcludeList below is a hard-coded list of global keys to exclude.
 
 */}}
 {{- define "hpcc.getConfigSHA" }}
-{{- $globalExcludeList := list "~.*::logging" "~.*::replicas" "~.*::vaults" "~.*::warnings" -}}
+{{- $globalExcludeList := list "~.*::logging" "~.*::replicas" "~.*::vaults" "~.*::warnings" "~.*::analyzerOptions" -}}
 {{- $globalExcludeSectionRegexList := list ".*-job.yaml$" -}}
 {{- $componentExcludeList := ternary (splitList "," (.excludeKeys | default "")) list (hasKey . "excludeKeys") -}}
 {{- $combinedExcludeKeyList := concat $globalExcludeList $componentExcludeList -}}

--- a/helm/hpcc/templates/thor.yaml
+++ b/helm/hpcc/templates/thor.yaml
@@ -53,6 +53,7 @@ data:
 {{- include "hpcc.generateLoggingConfig" (dict "root" .root "me" $thorScope) | indent 6 }}
 {{- include "hpcc.generateTracingConfig" (dict "root" .root "me" $thorScope) | indent 6 }}
 {{ include "hpcc.generateVaultConfig" . | indent 6 }}
+{{ include "hpcc.generateAnalyzerOptions" (dict "root" .root "me" $thorScope) | indent 6 }}
     {{ $eclAgentType }}: # hthor or roxie
 {{ toYaml (omit $hthorScope "logging" "tracing") | indent 6 }}
       platform:
@@ -61,10 +62,12 @@ data:
 {{- include "hpcc.generateLoggingConfig" (dict "root" .root "me" $hthorScope ) | indent 6 }}
 {{- include "hpcc.generateTracingConfig" (dict "root" .root "me" $hthorScope ) | indent 6 }}
 {{ include "hpcc.generateVaultConfig" . | indent 6 }}
+{{ include "hpcc.generateAnalyzerOptions" (dict "root" .root "me" $hthorScope) | indent 6 }}
       queues:
 {{ include "hpcc.generateConfigMapQueues" .root | indent 6 }}
     eclagent: # main agent Q handler
 {{ toYaml (omit $eclAgentScope "logging" "tracing") | indent 6 }}
+{{ include "hpcc.generateAnalyzerOptions" (dict "root" .root "me" $thorScope) | indent 6 }}
 {{- include "hpcc.generateLoggingConfig" (dict "root" .root "me" $eclAgentScope) | indent 6 }}
 {{- include "hpcc.generateTracingConfig" (dict "root" .root "me" $eclAgentScope) | indent 6 }}
     thoragent: # Thor graph handler

--- a/helm/hpcc/values.schema.json
+++ b/helm/hpcc/values.schema.json
@@ -361,6 +361,42 @@
             }
           }
         },
+        "analyzerOptions": {
+          "description": "Default cost optimizer options",
+          "type": "object",
+          "properties": {
+            "disabled": {
+                "type": "boolean",
+                "default": false
+            },
+            "analyzeInEclAgent" : {
+                "description": "Analyse workunit in ECL Agent (if false, workunit will be analysed by Thor manager)",
+                "type": "boolean",
+                "default": false
+            },
+            "analyzeWhenComplete" : {
+                "description": "Analyse workunit after completion (if false, the analysis willl be executed incrementally after each graph completes)",
+                "type": "boolean",
+                "default": false
+            },
+            "minInterestingCost": {
+              "description": "Only report issues that may be costing more than this value (decimal $ value)",
+              "type": "number"
+            },
+            "minInterestingTimeWaste": {
+              "description": "Only report issues that may be wasting more than this time (milliseconds)",
+              "type": "number"
+            },
+            "minInterestingTime": {
+              "description": "Only analyse activities that have a longer execute time than this threshold (milliseconds)",
+              "type": "number"
+            },
+            "skewThreshold": {
+              "description": "Only report issues that exceed this threshold (for skew related issued only report)",
+              "type": "number"
+            }
+          }
+        },
         "expert": {
           "$ref": "#/definitions/expert"
         },

--- a/helm/hpcc/values.yaml
+++ b/helm/hpcc/values.yaml
@@ -34,6 +34,15 @@ global:
     resourceAttributes: # used to declare OTEL Resource Attribute config values
       deploymentEnvironment: development # used to anotate tracing spans' environment identifier (development/production/statiging/etc)
 
+  #analyzerOptions:
+  #  disabled: false
+  #  analyzeInEclAgent: false
+  #  analyzeWhenComplete: false
+  #  minInterestingTime: 1000 # ms
+  #  minInterestingCost: 1.0 # $
+  #  minInterestingTimeWaste: 30000 #ms
+  #  skewThreshold: 20
+
   ## resource settings for stub components
   #stubInstanceResources:
   #  memory: "200Mi"

--- a/initfiles/componentfiles/configxml/thor.xsl
+++ b/initfiles/componentfiles/configxml/thor.xsl
@@ -228,6 +228,7 @@
           </xsl:if>
         </xsl:for-each>
       </SSH>
+      <xsl:copy-of select="analyzerOptions"/>
     </Thor>
   </xsl:template>
 

--- a/thorlcr/master/CMakeLists.txt
+++ b/thorlcr/master/CMakeLists.txt
@@ -58,6 +58,7 @@ include_directories (
          ${CMAKE_BINARY_DIR}/oss
          ./../../system/security/shared
          ./../../system/security/securesocket
+         ${HPCC_SOURCE_DIR}/common/wuanalysis
     )
 
 ADD_DEFINITIONS( -D_CONSOLE )
@@ -87,6 +88,7 @@ target_link_libraries (  thormaster_lcr
          graphmaster_lcr 
          activitymasters_lcr 
          swapnodelib
+         wuanalysis
     )
 
 if (USE_OPENSSL)

--- a/thorlcr/master/thgraphmanager.cpp
+++ b/thorlcr/master/thgraphmanager.cpp
@@ -57,6 +57,8 @@
 #include "roxiehelper.hpp"
 #include "securesocket.hpp"
 #include "environment.hpp"
+#include "anawu.hpp"
+#include "workunit.hpp"
 
 static const StatisticsMapping podStatistics({StNumPods});
 
@@ -1173,6 +1175,7 @@ bool CJobManager::executeGraph(IConstWorkUnit &workunit, const char *graphName, 
 
     fatalHdlr->clear();
 
+    runWorkunitAnalyser(workunit, getComponentConfigSP(), graphName, false, calculateThorCostPerHour(queryNodeClusterWidth()));
     setWuid(NULL);
     return allDone;
 }


### PR DESCRIPTION
Cost optimizer will execute in Thor for containerized deployments.  It will continue to execute in EclAgent for non-containerized deployment.

The reason for this change is that in containerized deployments EclAgent cannot calculate the cost of the Thor cluster and so cannot not assigned the cost of issues reported by the cost optimizer.  It cannot calculate the cost of the Thor cluster because Thor's cost parameters and resource configuration is not available to EclAgent - this information is only available in the Thor's configuration.

Note, that as the Thor manager executes on a per job basis, it executes the analyzer after every graph executes.  The concept of "end of workunit" does not exist at present in Thor so the analyzeWhenComplete==true has not been implemented for Thor.

The changes:

* Support for executing cost optimizer in Thor.  This the default in containerized.
* New 'analyzeInEclAgent' option - if true, the analyzer executes in EclAgent, otherwise it executes in Thor Manager.
* By default 'analyzeInEclAgent' is true in bare-metal and false in containerized
* The defaults for 'analyzeWhenComplete' has changed for containerized.  It is now false by default in containerized.  It remains true in bare-metal.
* New 'disabled' option is available within analyzerOptions to disable cost optimizer.  'disabled' is false by default.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [x] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
