### PR TITLE
HPCC-33356 Capture post-mortem logging on job failure

### DIFF
--- a/initfiles/bin/collect_postmortem.sh
+++ b/initfiles/bin/collect_postmortem.sh
@@ -97,7 +97,7 @@ POST_MORTEM_DIR="$directory"
 if [[ -n "${workunit}" ]]; then
   POST_MORTEM_DIR="${directory}/${workunit}"
 fi
-POST_MORTEM_DIR=${POST_MORTEM_DIR}/${container}/${process}/$(hostname)/$(date -Iseconds)
+POST_MORTEM_DIR=${POST_MORTEM_DIR}/$(date -Iseconds)/$(hostname)/${container}/${process}
 mkdir -p ${POST_MORTEM_DIR}
 echo "Post-mortem info gathered in $POST_MORTEM_DIR"
 

--- a/system/jlib/jlog.hpp
+++ b/system/jlib/jlog.hpp
@@ -909,6 +909,8 @@ inline LogMsgCategory MCexception(IException * e, LogMsgClass cls = MSGCLS_error
 
 extern jlib_decl ILogMsgManager * queryLogMsgManager();
 extern jlib_decl ILogMsgHandler * queryStderrLogMsgHandler();
+extern jlib_decl ILogMsgHandler * queryPostMortemLogMsgHandler();
+extern jlib_decl bool copyPostMortemLogging(const char *target, bool clear);
 extern jlib_decl void setupContainerizedLogMsgHandler();
 
 //extern jlib_decl ILogMsgManager * createLogMsgManager(); // use with care! (needed by mplog listener facility)

--- a/system/jlib/jlog.ipp
+++ b/system/jlib/jlog.ipp
@@ -543,6 +543,8 @@ class PostMortemLogMsgHandler : public CInterfaceOf<ILogMsgHandler>
 {
 public:
     PostMortemLogMsgHandler(const char * _filebase, unsigned _maxLinesToKeep, unsigned _messageFields=MSGFIELD_all);
+    void copyTo(const char *target, bool clear);
+
     virtual ~PostMortemLogMsgHandler();
     virtual void handleMessage(const LogMsg & msg) override;
     virtual bool needsPrep() const override { return false; }

--- a/thorlcr/graph/thgraph.cpp
+++ b/thorlcr/graph/thgraph.cpp
@@ -2755,6 +2755,7 @@ void CJobBase::init()
     failOnLeaks = getOptBool(THOROPT_FAIL_ON_LEAKS);
     maxLfnBlockTimeMins = getOptInt(THOROPT_MAXLFN_BLOCKTIME_MINS, DEFAULT_MAXLFN_BLOCKTIME_MINS);
     soapTraceLevel = getOptInt(THOROPT_SOAP_TRACE_LEVEL, 1);
+    jobInfoCaptureBehaviour = static_cast<JobInfoCaptureBehaviour>(getOptInt(THOROPT_JOBINFO_CAPTURE_BEHAVIOUR, (int)JobInfoCaptureBehaviour::onFailure));
     StringBuffer tmpSepString;
     getOpt(THOROPT_SOAP_LOG_SEP_STRING, tmpSepString);
     setSoapSepString(tmpSepString.str());

--- a/thorlcr/graph/thgraph.hpp
+++ b/thorlcr/graph/thgraph.hpp
@@ -895,6 +895,7 @@ protected:
     memsize_t keyNodeCacheBytes = 0;
     memsize_t keyLeafCacheBytes = 0;
     memsize_t keyBlobCacheBytes = 0;
+    JobInfoCaptureBehaviour jobInfoCaptureBehaviour = JobInfoCaptureBehaviour::onFailure;
 
 
     class CThorPluginCtx : public SimplePluginCtx

--- a/thorlcr/graph/thgraphmaster.ipp
+++ b/thorlcr/graph/thgraphmaster.ipp
@@ -181,6 +181,7 @@ public:
     bool go();
     void pause(bool abort);
     void issueWorkerDebugCmd(const char *rawText, unsigned workerNum, std::function<void(unsigned, MemoryBuffer &mb)> responseFunc);
+    void captureJobInfo(IConstWorkUnit &wu, JobInfoCaptureType flags);
 
     virtual IConstWorkUnit &queryWorkUnit() const
     {

--- a/thorlcr/thorutil/thormisc.cpp
+++ b/thorlcr/thorutil/thormisc.cpp
@@ -25,6 +25,7 @@
 #include <stdio.h>
 #include <time.h>
 
+#include "jcontainerized.hpp"
 #include "jexcept.hpp"
 #include "jfile.hpp"
 #include "jmisc.hpp"
@@ -1787,4 +1788,18 @@ std::vector<std::string> captureDebugInfo(const char *_dir, const char *prefix, 
         return { };
     }
     return { stacksFName.str() }; // JCSMORE capture/return other files
+}
+
+// NB: this mirrors the directory structure formed in collect_postmortem.sh
+StringBuffer &addInstanceContextPaths(StringBuffer &dst)
+{
+    addPathSepChar(dst);
+    dst.append(k8s::queryMyPodName());
+    addPathSepChar(dst);
+    dst.append(k8s::queryMyContainerName());
+    addPathSepChar(dst);
+    RemoteFilename rfn;
+    rfn.setLocalPath(queryCurrentProcessPath());
+    rfn.getTail(dst);
+    return dst;
 }

--- a/thorlcr/thorutil/thormisc.hpp
+++ b/thorlcr/thorutil/thormisc.hpp
@@ -127,7 +127,7 @@
 #define THOROPT_LOOKAHEAD_COMPRESSIONTOTALK "readAheadCompressionTotalK"          // Splitter total compression buffer size (shared between writer and readers) (K) (default = 3MB)
 #define THOROPT_LOOKAHEAD_TEMPFILE_GRANULARITY "readAheadTempFileGranularity"     // Splitter temp file granularity (default = 1GB)
 #define THOROPT_ROXIEMEM_GLOBALSORT_PARTITION "useRoxieMemGlobalSortPartition"    // Use roxiemem for global sort partitioning (default = true)
-
+#define THOROPT_JOBINFO_CAPTURE_BEHAVIOUR "jobInfoCaptureBehaviour"               // controls behaviour of job info collection (default = 0)
 #define INITIAL_SELFJOIN_MATCH_WARNING_LEVEL 20000 // max of row matches before selfjoin emits warning
 
 #define THOR_SEM_RETRY_TIMEOUT 2
@@ -710,6 +710,23 @@ inline void readUnderlyingType(MemoryBuffer &mb, T &v)
 constexpr unsigned thorDetailedLogLevel = 200;
 constexpr LogMsgCategory MCthorDetailedDebugInfo(MCdebugInfo(thorDetailedLogLevel));
 
+enum class JobInfoCaptureType : byte
+{
+    none   = 0x0000,
+    logs   = 0x0001,
+    stacks = 0x0002,
+};
+BITMASK_ENUM(JobInfoCaptureType);
+
+enum class JobInfoCaptureBehaviour : byte
+{
+    none      = 0x0000,
+    onFailure = 0x0001,
+    always    = 0x0002, // NB: would cause every thor workflow graph to generate a job info capture
+    clearLogs = 0x0004,
+};
+BITMASK_ENUM(JobInfoCaptureBehaviour);
+
 class graph_decl CThorPerfTracer : protected PerfTracer
 {
     PerfTracer perf;
@@ -725,5 +742,5 @@ extern graph_decl void saveWuidToFile(const char *wuid);
 
 extern graph_decl bool hasTLK(IDistributedFile &file, CActivityBase *activity);
 extern graph_decl std::vector<std::string> captureDebugInfo(const char *dir, const char *prefix, const char *suffix);
-
+extern graph_decl StringBuffer &addInstanceContextPaths(StringBuffer &dst);
 #endif


### PR DESCRIPTION
This extends capture of the verbose post-mortem logging to an [compressed] archive to occur (optionally) whenever a workunit fails.
NB: if there is a subsequent follow on error and the process or container exits badly, the managing scripts will also capture and associate post mortem logging with the workunit.

By default, all workunits that fail will capture post mortem logging and associate it with the workunit.
It can be configured at values yaml level, or at the workunit level, e.g. with:

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
