### PR TITLE
HPCC-33292 Common-up code for creating roxie connection map

### DIFF
--- a/esp/services/ws_ecl/CMakeLists.txt
+++ b/esp/services/ws_ecl/CMakeLists.txt
@@ -52,6 +52,8 @@ include_directories (
          ./../../../common/fileview2
          ./../../../dali/base
          ${HPCC_SOURCE_DIR}/common/thorhelper
+         ${HPCC_SOURCE_DIR}/esp/smc/SMCLib
+         ${HPCC_SOURCE_DIR}/dali/sasha
     )
 
 ADD_DEFINITIONS( -D_USRDLL )
@@ -77,6 +79,7 @@ target_link_libraries ( ws_ecl
          hql
          fileview2
          xmllib
+         SMCLib
          ${COMMON_ESP_SERVICE_LIBS}
     )
 

--- a/esp/smc/SMCLib/TpWrapper.hpp
+++ b/esp/smc/SMCLib/TpWrapper.hpp
@@ -227,6 +227,16 @@ extern TPWRAPPER_API unsigned getContainerWUClusterInfo(CConstWUClusterInfoArray
 extern TPWRAPPER_API unsigned getWUClusterInfo(CConstWUClusterInfoArray& clusters);
 extern TPWRAPPER_API IConstWUClusterInfo* getWUClusterInfoByName(const char* clustName);
 
+/**
+ * Get pipe-delimited list of roxie server addresses and TLS config from roxie process `roxieCluster` configuration.
+ * @param env           environment configuration
+ * @param roxieCluster  roxie process configuration to get addresses and TLS config from
+ * @param addrList      pipe-delimited list of roxie server addresses
+ * @param tlsConfig     TLS configuration
+ * @param daliAddress   optional dali address to use for ws_ecl service if `@netAddress` not found in `server` configuration
+ * @return void
+ */
+extern TPWRAPPER_API void getAddressesAndTlsConfigForRoxieProcess(IPropertyTree& env, IPropertyTree& roxieCluster, StringBuffer& addrList, Owned<IPropertyTree> & tlsConfig, const char* daliAddress);
 extern TPWRAPPER_API void initContainerRoxieTargets(MapStringToMyClass<ISmartSocketFactory>& connMap);
 extern TPWRAPPER_API void initBareMetalRoxieTargets(MapStringToMyClass<ISmartSocketFactory>& connMap);
 extern TPWRAPPER_API unsigned getThorClusterNames(StringArray& targetNames, StringArray& queueNames);


### PR DESCRIPTION
- Move common code to shared functions in SMCLib.
- Rename initBareMetalRoxieTargets implementation in ws_ecl to indicate it has behavior specific to ws_ecl. The major differences that couldn't be commoned up are that it maps roxie targets by logical name and alias instead of by physical name, and it may use VIPs or a daliServer as endpoints.
- Use applicable shared function from SMCLib in ws_ecl.
- Note that this will change ws_ecl behavior in a small but positive way. It now prefers a secure roxie server endpoint over a non-secure.
- Update CMake files to include and link SMCLib in ws_ecl.
- Remove SDS_LOCK_TIMEOUT define from ws_ecl_service.cpp that wasn't used and conflicted with another newly-included definition.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [x] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [x] I have checked that this change does not introduce memory leaks.
  - [x] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [x] Scalability
  - [x] Performance
  - [x] Security
  - [x] Thread-safety
  - [x] Cloud-compatibility
  - [x] Premature optimization
  - [x] Existing deployed queries will not be broken
  - [x] This change fixes the problem, not just the symptom
  - [x] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->
Manual testing of the creation of the connection map under different configuration combinations of physical and logical roxie clusters using secure and unsecure ports in different positions of the list of farms, and using different port numbers.

Tested `ecl roxie` CLI operations that send roxie control messages under the same set of configurations.

Saw some leaks on shutdown in valgrind, but testing a version prior to my PR showed they were present before this change. Opened https://hpccsystems.atlassian.net/browse/HPCC-33400 to track and fix that separately.

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
