### PR TITLE
HPCC-33418 Remove inappropriate calls to queryEnvironmentConf

### DIFF
--- a/plugins/pyembed/pyembed.cpp
+++ b/plugins/pyembed/pyembed.cpp
@@ -317,7 +317,10 @@ public:
         PyEval_InitThreads();
         preservedScopes.setown(PyDict_New());
         tstate = PyEval_SaveThread();
-        skipPythonCleanup = queryEnvironmentConf().getPropBool("skipPythonCleanup", true);
+        if (isContainerized())
+            skipPythonCleanup = getConfigBool("expert/@skipPythonCleanup", true);
+        else
+            skipPythonCleanup = queryEnvironmentConf().getPropBool("skipPythonCleanup", true);
         initialized = true;
     }
     ~Python27GlobalState()

--- a/system/jlib/jdebug.cpp
+++ b/system/jlib/jdebug.cpp
@@ -2948,8 +2948,14 @@ public:
         hook.set(_hook);
         term = false;
         latestCPU = 0;
+
         // UDP stats reported unless explicitly disabled
-        if (queryEnvironmentConf().getPropBool("udp_stats", true))
+        if (isContainerized())
+        {
+            if (getConfigBool("expert/@udpStats", true))
+                traceMode |= PerfMonUDP;
+        }
+        else if (queryEnvironmentConf().getPropBool("udp_stats", true))
             traceMode |= PerfMonUDP;
 #ifdef _WIN32
         primaryfs.append("C:");

--- a/system/jlib/jfile.cpp
+++ b/system/jlib/jfile.cpp
@@ -3125,10 +3125,14 @@ static inline bool isPCFlushAllowed()
     CriticalBlock block(flushsect);
     if (gbl_flush_allowed == FLUSH_INIT)
     {
-        if (queryEnvironmentConf().getPropBool("allow_pgcache_flush", true))
+        gbl_flush_allowed = FLUSH_DISALLOWED;
+        if (isContainerized())
+        {
+            if (getConfigBool("expert/@allowPGCacheFlush", true))
+                gbl_flush_allowed = FLUSH_ALLOWED;
+        }
+        else if (queryEnvironmentConf().getPropBool("allow_pgcache_flush", true))
             gbl_flush_allowed = FLUSH_ALLOWED;
-        else
-            gbl_flush_allowed = FLUSH_DISALLOWED;
     }
     if (gbl_flush_allowed == FLUSH_ALLOWED)
         return true;

--- a/system/jlib/jptree.cpp
+++ b/system/jlib/jptree.cpp
@@ -8669,6 +8669,30 @@ Owned<IPropertyTree> getGlobalConfigSP()
     return getGlobalConfig();
 }
 
+template <typename T>
+static T getConfigValue(const char *xpath, T defaultValue, T (IPropertyTree::*getPropFunc)(const char *, T) const)
+{
+    return (getComponentConfigSP()->*getPropFunc)(xpath, (getGlobalConfigSP()->*getPropFunc)(xpath, defaultValue));
+}
+
+bool getConfigBool(const char *xpath, bool defaultValue)
+{
+    return getConfigValue(xpath, defaultValue, &IPropertyTree::getPropBool);
+}
+
+__int64 getConfigInt64(const char *xpath, __int64 defaultValue)
+{
+    return getConfigValue(xpath, defaultValue, &IPropertyTree::getPropInt64);
+}
+
+bool getConfigString(const char *xpath, StringBuffer &result)
+{
+    if (getComponentConfigSP()->getProp(xpath, result))
+        return true;
+    else
+        return getGlobalConfigSP()->getProp(xpath, result);
+}
+
 const char * queryComponentName()
 {
     //componentName is thread safe, since initialised when config is first loaded, and not modified afterwards

--- a/system/jlib/jptree.hpp
+++ b/system/jlib/jptree.hpp
@@ -330,6 +330,12 @@ jlib_decl Owned<IPropertyTree> getGlobalConfigSP(); // get smart pointer
 jlib_decl Owned<IPropertyTree> getComponentConfigSP(); // get smart pointer
 jlib_decl const char * queryComponentName();
 
+// utility functions that check component configuration 1st, then global configuration, then default to the provided default value
+jlib_decl bool getConfigBool(const char *xpath, bool defaultValue=false);
+jlib_decl __int64 getConfigInt64(const char *xpath, __int64 defaultValue=0);
+jlib_decl bool getConfigString(const char *xpath, StringBuffer &result);
+
+
 // ConfigUpdateFunc calls are made in a mutex, but after new confis are swapped in
 typedef std::function<void (const IPropertyTree *oldComponentConfiguration, const IPropertyTree *oldGlobalConfiguration)> ConfigUpdateFunc;
 typedef std::function<void (IPropertyTree * newComponentConfiguration, IPropertyTree * newGlobalConfiguration)> ConfigModifyFunc;


### PR DESCRIPTION
also introduce some generic helper funcs to get options from config - that look in component config 1st, then default to global.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [x] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [ ] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
