### PR TITLE
HPCC-33635 Optimize updates to file properties following disk reads

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -262,7 +262,7 @@ extern da_decl void updateOwnersCostAndNumReads(IDistributedFile * file, stat_ty
     }
 }
 
-// Update logical file's cost sand numReads
+// Update logical file's costs and numReads
 // (numDiskReads required. curReadCost is optional)
 extern da_decl cost_type updateCostAndNumReads(IDistributedFile *file, stat_type numDiskReads, cost_type curReadCost)
 {

--- a/dali/base/dadfs.hpp
+++ b/dali/base/dadfs.hpp
@@ -894,6 +894,7 @@ extern da_decl cost_type calcFileAtRestCost(const char * cluster, double sizeGB,
 extern da_decl cost_type calcFileAccessCost(const char * cluster, __int64 numDiskWrites, __int64 numDiskReads);
 extern da_decl cost_type calcFileAccessCost(IDistributedFile *f, __int64 numDiskWrites, __int64 numDiskReads);
 extern da_decl cost_type calcDiskWriteCost(const StringArray & clusters, stat_type numDiskWrites);
+extern da_decl void updateOwnersCostAndNumReads(IDistributedFile * file, stat_type numDiskReads, cost_type curReadCost=0);
 extern da_decl cost_type updateCostAndNumReads(IDistributedFile *file, stat_type numDiskReads, cost_type curReadCost=0); // Update readCost and numDiskReads - return calculated read cost
 constexpr bool defaultPrivilegedUser = true;
 constexpr bool defaultNonPrivilegedUser = false;

--- a/dali/ft/filecopy.cpp
+++ b/dali/ft/filecopy.cpp
@@ -3884,6 +3884,7 @@ cost_type FileSprayer::updateSourceProperties()
                     totalReadCost += calcFileAccessCost(distributedSource, 0, curProgress.numReads);
                 }
             }
+            updateCostAndNumReads(distributedSource, totalNumReads, totalReadCost);
             updateOwnersCostAndNumReads(distributedSource, totalNumReads, totalReadCost);
             return totalReadCost;
         }

--- a/dali/ft/filecopy.cpp
+++ b/dali/ft/filecopy.cpp
@@ -3884,11 +3884,14 @@ cost_type FileSprayer::updateSourceProperties()
                     totalReadCost += calcFileAccessCost(distributedSource, 0, curProgress.numReads);
                 }
             }
+            updateOwnersCostAndNumReads(distributedSource, totalNumReads, totalReadCost);
             return totalReadCost;
         }
         else
         {
-            return updateCostAndNumReads(distributedSource, totalNumReads);
+            cost_type totalReadCost = updateCostAndNumReads(distributedSource, totalNumReads);
+            updateOwnersCostAndNumReads(distributedSource, totalNumReads, totalReadCost);
+            return totalReadCost;
         }
     }
     return 0;

--- a/ecl/hthor/hthor.cpp
+++ b/ecl/hthor/hthor.cpp
@@ -8538,7 +8538,6 @@ unsigned __int64 CHThorDiskReadBaseActivity::getLocalFilePosition(const void * r
 
 void CHThorDiskReadBaseActivity::closepart()
 {
-    std::vector<stat_type> numReadsForSubFiles;
     if (opened && inputfileio && ldFile && partNum > 0)
     {
         unsigned previousPartNum = partNum-1;
@@ -8556,7 +8555,7 @@ void CHThorDiskReadBaseActivity::closepart()
                         IDistributedSuperFile * super = dFile->querySuperFile();
                         IDistributedFile & subfile = super->querySubFile(subfileNum, true);
                         // Update numDiskReads and cost for the subfile
-                        // (numDisReads and cost in owning files updated in CHThorDiskReadBaseActivity::close)
+                        // (numDiskReads and cost in owning files updated in CHThorDiskReadBaseActivity::close)
                         updateCostAndNumReads(&subfile, curDiskReads, 0);
                     }
                 }

--- a/ecl/hthor/hthor.cpp
+++ b/ecl/hthor/hthor.cpp
@@ -8517,7 +8517,11 @@ void CHThorDiskReadBaseActivity::close()
     {
         IDistributedFile * dFile = ldFile->queryDistributedFile();
         if(dFile)
+        {
+            cost_type readCost = updateCostAndNumReads(dFile, numDiskReads, 0);
+            updateOwnersCostAndNumReads(dFile, numDiskReads, readCost);
             dFile->setAccessed();
+        }
         ldFile.clear();
     }
 }
@@ -8534,6 +8538,7 @@ unsigned __int64 CHThorDiskReadBaseActivity::getLocalFilePosition(const void * r
 
 void CHThorDiskReadBaseActivity::closepart()
 {
+    std::vector<stat_type> numReadsForSubFiles;
     if (opened && inputfileio && ldFile && partNum > 0)
     {
         unsigned previousPartNum = partNum-1;
@@ -8550,11 +8555,11 @@ void CHThorDiskReadBaseActivity::closepart()
                     {
                         IDistributedSuperFile * super = dFile->querySuperFile();
                         IDistributedFile & subfile = super->querySubFile(subfileNum, true);
-                        updateCostAndNumReads(&subfile, curDiskReads);
+                        // Update numDiskReads and cost for the subfile
+                        // (numDisReads and cost in owning files updated in CHThorDiskReadBaseActivity::close)
+                        updateCostAndNumReads(&subfile, curDiskReads, 0);
                     }
                 }
-                else
-                    updateCostAndNumReads(dFile, curDiskReads);
             }
             numDiskReads += curDiskReads;
         }


### PR DESCRIPTION
Updates to numDiskReads and readCost by thor and hthor has been modified to improve performance:
* When the superfile is read, the stats for the superfile and any subfiles read through the superfile is updated.
* The numDiskReads and readCosts updates to superfile stats are made once per activity.
* Where the subfiles being updated belong to other superfiles (in addition to the superfile being read), other owning superfiles stats will not be updated.  The reason for not updating all owning superfiles is to avoid negatively impacting performance. That does mean that where a subfile belongs to more than one superfile, the superfile stats will not always be an aggregate of the stats in its subfile.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [x] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
