### PR TITLE
HPCC-33635 Optimize updates to file properties following disk reads

### DIFF
--- a/dali/base/dadfs.hpp
+++ b/dali/base/dadfs.hpp
@@ -41,6 +41,7 @@
 #include "dafdesc.hpp"
 #include "seclib.hpp"
 #include "errorlist.h"
+#include "jlog.hpp"
 
 #include <vector>
 #include <string>
@@ -332,6 +333,12 @@ interface ICodeContext;
 /**
  * A distributed file, composed of one or more DistributedFileParts.
  */
+typedef std::pair<const char*, unsigned __int64> AttrValuePair;
+inline AttrValuePair makeAttrValuePair(const char * attr, unsigned __int64 val)
+{
+    return std::make_pair(attr, val);
+}
+
 interface IDistributedFile: extends IInterface
 {
     virtual unsigned numParts() = 0;
@@ -367,6 +374,7 @@ interface IDistributedFile: extends IInterface
     virtual void setAccessedTime(const CDateTime &dt) = 0;                      // set date and time last accessed
     virtual void setAccessed() = 0;                                             // set date and time last accessed to now (local time)
     virtual void addAttrValue(const char *attr, unsigned __int64 value) = 0;    // atomic add to attribute value
+    virtual void addAttrValues(std::initializer_list<AttrValuePair> attrs) = 0; // for each pair of attribute name and value, atomic add to attribute value
     virtual unsigned numCopies(unsigned partno) = 0;                            // number of copies
 
     virtual bool existsPhysicalPartFiles(unsigned short port) = 0;              // returns true if physical patrs all exist (on primary OR secondary)
@@ -384,7 +392,7 @@ interface IDistributedFile: extends IInterface
     virtual IDistributedSuperFileIterator *getOwningSuperFiles(IDistributedFileTransaction *_transaction=NULL)=0;           // returns iterator for all parents
     virtual bool isCompressed(bool *blocked=NULL)=0;
 
-    virtual StringBuffer &getClusterName(unsigned clusternum,StringBuffer &name) = 0;
+    virtual StringBuffer &getClusterName(unsigned clusternum,StringBuffer &name) const = 0;
     virtual unsigned getClusterNames(StringArray &clusters)=0;                  // returns ordinality
                                                                                       // (use findCluster)
     virtual unsigned numClusters()=0;
@@ -434,6 +442,10 @@ interface IDistributedFile: extends IInterface
     virtual int  getExpire(StringBuffer *expirationDate) = 0;
     virtual void setExpire(int expireDays) = 0;
     virtual void getCost(const char * cluster, cost_type & atRestCost, cost_type & accessCost) = 0;
+    virtual bool getNumReads(stat_type &numReads) const = 0;
+    virtual bool getNumWrites(stat_type &numWrites) const = 0;
+    virtual bool getReadCost(cost_type &cost, bool calculateIfMissing=false) const = 0;
+    virtual bool getWriteCost(cost_type &cost, bool calculateIfMissing=false) const = 0;
 };
 
 
@@ -890,11 +902,25 @@ extern da_decl cost_type calcFileAtRestCost(const char * cluster, double sizeGB,
 extern da_decl cost_type calcFileAccessCost(const char * cluster, __int64 numDiskWrites, __int64 numDiskReads);
 extern da_decl cost_type calcFileAccessCost(IDistributedFile *f, __int64 numDiskWrites, __int64 numDiskReads);
 extern da_decl cost_type calcDiskWriteCost(const StringArray & clusters, stat_type numDiskWrites);
-extern da_decl cost_type updateCostAndNumReads(IDistributedFile *file, stat_type numDiskReads, cost_type curReadCost=0); // Update readCost and numDiskReads - return calculated read cost
+extern da_decl cost_type updateCostAndNumReads(IDistributedFile *file, stat_type numDiskReads, cost_type curReadCost); // Update readCost and numDiskReads - return calculated read cost
 constexpr bool defaultPrivilegedUser = true;
 constexpr bool defaultNonPrivilegedUser = false;
 
 extern da_decl void configurePreferredPlanes();
+
+template<typename Source>
+inline cost_type calcLegacyReadCost(const IPropertyTree & fileAttr, Source source)
+{
+    // Calculate legacy read cost from numDiskReads
+    // (However, it is not possible to accurately calculate read cost for key
+    // files, as the reads may have been from page cache and not from disk.)
+    if (!isFileKey(fileAttr) && source)
+    {
+        stat_type numDiskReads = fileAttr.getPropInt64(getDFUQResultFieldName(DFUQRFnumDiskReads), 0);
+        return calcFileAccessCost(source, 0, numDiskReads);
+    }
+    return 0;
+}
 
 // Get read cost from readCost field or calculate legacy read cost
 // - migrateLegacyCost: if true, update readCost field with legacy read cost
@@ -905,19 +931,11 @@ inline cost_type getReadCost(IPropertyTree & fileAttr, Source source, bool migra
         return fileAttr.getPropInt64(getDFUQResultFieldName(DFUQRFreadCost), 0);
     else
     {
-        // Calculate legacy read cost from numDiskReads
-        // (However, it is not possible to accurately calculate read cost for key
-        // files, as the reads may have been from page cache and not from disk.)
-        if (!isFileKey(fileAttr) && source)
-        {
-            stat_type numDiskReads = fileAttr.getPropInt64(getDFUQResultFieldName(DFUQRFnumDiskReads), 0);
-            cost_type readCost = calcFileAccessCost(source, 0, numDiskReads);
-            if (migrateLegacyCost)
-                fileAttr.setPropInt64(getDFUQResultFieldName(DFUQRFreadCost), readCost);
-            return readCost;
-        }
+        cost_type readCost = calcLegacyReadCost(fileAttr, source);
+        if (migrateLegacyCost)
+            fileAttr.setPropInt64(getDFUQResultFieldName(DFUQRFreadCost), readCost);
+        return readCost;
     }
-    return 0;
 }
 
 // Get read cost from readCost field or calculate legacy read cost
@@ -927,15 +945,16 @@ inline cost_type getReadCost(const IPropertyTree & fileAttr, Source source)
     if (fileAttr.hasProp(getDFUQResultFieldName(DFUQRFreadCost)))
         return fileAttr.getPropInt64(getDFUQResultFieldName(DFUQRFreadCost), 0);
     else
+        return calcLegacyReadCost(fileAttr, source);
+}
+
+template<typename Source>
+inline cost_type calcLegacyWriteCost(const IPropertyTree & fileAttr, Source source)
+{
+    if (source)
     {
-        // Calculate legacy read cost from numDiskReads
-        // (However, it is not possible to accurately calculate read cost for key
-        // files, as the reads may have been from page cache and not from disk.)
-        if (!isFileKey(fileAttr) && source)
-        {
-            stat_type numDiskReads = fileAttr.getPropInt64(getDFUQResultFieldName(DFUQRFnumDiskReads), 0);
-            return calcFileAccessCost(source, 0, numDiskReads);
-        }
+        stat_type numDiskWrites = fileAttr.getPropInt64(getDFUQResultFieldName(DFUQRFnumDiskWrites), 0);
+        return calcFileAccessCost(source, numDiskWrites, 0);
     }
     return 0;
 }
@@ -949,17 +968,11 @@ inline cost_type getWriteCost(IPropertyTree & fileAttr, Source source, bool migr
         return fileAttr.getPropInt64(getDFUQResultFieldName(DFUQRFwriteCost), 0);
     else
     {
-        // Calculate legacy write cost from numDiskWrites
-        if (source)
-        {
-            stat_type numDiskWrites = fileAttr.getPropInt64(getDFUQResultFieldName(DFUQRFnumDiskWrites), 0);
-            cost_type writeCost = calcFileAccessCost(source, numDiskWrites, 0);
-            if (migrateLegacyCost)
-                fileAttr.setPropInt64(getDFUQResultFieldName(DFUQRFwriteCost), writeCost);
-            return writeCost;
-        }
+        cost_type writeCost = calcLegacyWriteCost(fileAttr, source);
+        if (migrateLegacyCost)
+            fileAttr.setPropInt64(getDFUQResultFieldName(DFUQRFwriteCost), writeCost);
+        return writeCost;
     }
-    return 0;
 }
 
 // Get write cost from writeCost field or calculate legacy write cost
@@ -969,15 +982,7 @@ inline cost_type getWriteCost(const IPropertyTree & fileAttr, Source source)
     if (fileAttr.hasProp(getDFUQResultFieldName(DFUQRFwriteCost)))
         return fileAttr.getPropInt64(getDFUQResultFieldName(DFUQRFwriteCost), 0);
     else
-    {
-        // Calculate legacy write cost from numDiskWrites
-        if (source)
-        {
-            stat_type numDiskWrites = fileAttr.getPropInt64(getDFUQResultFieldName(DFUQRFnumDiskWrites), 0);
-            return calcFileAccessCost(source, numDiskWrites, 0);
-        }
-    }
-    return 0;
+        return calcLegacyWriteCost(fileAttr, source);
 }
 
 extern da_decl bool doesPhysicalMatchMeta(IPartDescriptor &partDesc, IFile &iFile, offset_t &expectedSize, offset_t &actualSize);

--- a/dali/base/dafdesc.cpp
+++ b/dali/base/dafdesc.cpp
@@ -504,7 +504,7 @@ public:
         return group.get();
     }
 
-    StringBuffer &getGroupName(StringBuffer &ret,IGroupResolver *resolver)
+    StringBuffer &getGroupName(StringBuffer &ret,IGroupResolver *resolver) const
     {
         if (name.isEmpty()) {
             if (group)
@@ -601,7 +601,7 @@ public:
             basedir.append(mspec.defaultReplicateDir);
     }
 
-    StringBuffer &getClusterLabel(StringBuffer &ret)
+    StringBuffer &getClusterLabel(StringBuffer &ret) const
     {
         return getGroupName(ret, NULL);
     }

--- a/dali/base/dafdesc.hpp
+++ b/dali/base/dafdesc.hpp
@@ -314,7 +314,7 @@ interface ISuperFileDescriptor: extends IFileDescriptor
 interface IStoragePlane;
 interface IClusterInfo: extends IInterface  // used by IFileDescriptor and IDistributedFile
 {
-    virtual StringBuffer &getGroupName(StringBuffer &name,IGroupResolver *resolver=NULL)=0;
+    virtual StringBuffer &getGroupName(StringBuffer &name,IGroupResolver *resolver=NULL) const = 0;
     virtual const char *queryGroupName()=0;     // may be NULL
     virtual IGroup *queryGroup()=0;           // may be NULL
     virtual ClusterPartDiskMapSpec  &queryPartDiskMapping()=0;
@@ -327,7 +327,7 @@ interface IClusterInfo: extends IInterface  // used by IFileDescriptor and IDist
     virtual void setGroupName(const char *name)=0;
     virtual void getBaseDir(StringBuffer &basedir, DFD_OS os)=0;
     virtual void getReplicateDir(StringBuffer &basedir, DFD_OS os)=0;
-    virtual StringBuffer &getClusterLabel(StringBuffer &name)=0; // node group name
+    virtual StringBuffer &getClusterLabel(StringBuffer &name) const = 0; // node group name
     virtual void applyPlane(IStoragePlane *plane) = 0;
 };
 

--- a/dali/base/dautils.cpp
+++ b/dali/base/dautils.cpp
@@ -3785,3 +3785,104 @@ void logNullUser(IUserDescriptor * userDesc)
     }
 }
 #endif
+
+// FileReadPropertiesUpdater:
+// - aggregates the readCost and the numDiskReads for each logical file (using addCostAndNumReads method).
+// - upon publishing (calling publish method), it:
+//   - it traverses up the owning superfiles, computing the cumulative readCost and numDiskReads for the subfile owners.
+//   - it subsequently updates file properties for both the files and their owning superfiles with the newly derived statistics.
+// It is designed to optimize the update process for readCost and read count by:
+// * reducing the frequency of getOwningSuperFiles calls, as these operations are resource-intensive.
+// * performing a single-pass update of file properties (e.g. at the end of a graph execution).
+class FileReadPropertiesUpdater : public CSimpleInterfaceOf<IFileReadPropertiesUpdater>
+{
+    struct FileStatItem
+    {
+        Owned<IDistributedFile> file;
+        stat_type numDiskReads = 0;
+        cost_type readCost = 0;
+    };
+    using FileStatMap = std::unordered_map<std::string, FileStatItem>;
+    FileStatMap stats;
+    Linked<IUserDescriptor> udesc;
+
+    // Add the readCost and numDiskReads to owners stats
+    FileStatItem & appendOwnersCostAndNumReads(FileStatMap & ownerStats, IDistributedFile * file, stat_type numDiskReads, cost_type curReadCost)
+    {
+        FileStatItem & curStatItem = ownerStats[file->queryLogicalName()];
+        if (!curStatItem.file)
+            curStatItem.file.set(file);
+        curStatItem.numDiskReads += numDiskReads;
+        curStatItem.readCost += curReadCost;
+        return curStatItem;
+    }
+    // Update the readCost and numDiskReads for owning superfiles
+    // - this will recurse up the superfiles tree updating the owning superfiles
+    // n.b. fileStatItem.file must be set to a valid IDistributedFile
+    void updateOwnersStats(FileStatMap & ownerStats, const FileStatItem & fileStatItem)
+    {
+        // getOwningSuperFiles iterator is slow, so only call it once (say at the end of graph)
+        Owned<IDistributedSuperFileIterator> iter = fileStatItem.file->getOwningSuperFiles();
+        ForEach(*iter)
+        {
+            IDistributedSuperFile & cur = iter->query();
+            const FileStatItem & owningFileStatItem = appendOwnersCostAndNumReads(ownerStats, &cur, fileStatItem.numDiskReads, fileStatItem.readCost);
+            updateOwnersStats(ownerStats, owningFileStatItem);
+        }
+    }
+
+public:
+    FileReadPropertiesUpdater(IUserDescriptor * udesc) : udesc(udesc) {}
+
+    // Track and accumulate the readCost and numDiskReads to stats tracking map (to be written to properties later)
+    // - if curReadCost is 0, it will be calculated using calcFileAccessCost
+    virtual cost_type addCostAndNumReads(IDistributedFile * file, stat_type numDiskReads, cost_type curReadCost) override
+    {
+        if (!numDiskReads)
+            return 0;
+
+        if (!curReadCost)
+            curReadCost = calcFileAccessCost(file, 0, numDiskReads);
+        // Add the readCost and numDiskReads to stats tracking map
+        FileStatItem & curStatItem = stats[file->queryLogicalName()];
+        curStatItem.numDiskReads += numDiskReads;
+        curStatItem.readCost += curReadCost;
+        return curReadCost;
+    }
+
+    // Publish the readCost and numDiskReads to the file properties and for owning superfiles
+    // N.b. It is ok for fileStatItem.file to be null when calling this function
+    virtual void publish() override
+    {
+        FileStatMap ownerStats;
+        // Iterate through files, updating the ownerStats
+        // (Also, set FileStatItem::file to a valid IDistributedFile, if possible)
+        for (auto & [logicalName, curStatItem] : stats)
+        {
+            curStatItem.file.setown(queryDistributedFileDirectory().lookup(logicalName.c_str(), udesc, AccessMode::tbdRead,false,false,nullptr,defaultNonPrivilegedUser));
+            if (!curStatItem.file) // File may have been deleted
+            {
+                OERRLOG("FileReadPropertiesUpdater: File not found: %s", logicalName.c_str());
+                continue;
+            }
+            updateOwnersStats(ownerStats, curStatItem);
+        }
+        // Update the file properties with the new stats
+        for (auto & [logicalName, curStatItem] : stats)
+        {
+            if (curStatItem.file)
+                updateCostAndNumReads(curStatItem.file, curStatItem.numDiskReads, curStatItem.readCost);
+        }
+        // Update the owner file propertiers owners stats
+        for (auto & [logicalName, curStatItem] : ownerStats)
+        {
+            updateCostAndNumReads(curStatItem.file, curStatItem.numDiskReads, curStatItem.readCost);
+        }
+        stats.clear(); // ensure all IDistributedFiles are released
+    }
+};
+
+IFileReadPropertiesUpdater * createFileReadPropertiesUpdater(IUserDescriptor * udesc)
+{
+    return new FileReadPropertiesUpdater(udesc);
+}

--- a/dali/base/dautils.hpp
+++ b/dali/base/dautils.hpp
@@ -590,4 +590,13 @@ extern da_decl void logNullUser(IUserDescriptor *userDesc);
 inline void logNullUser(IUserDescriptor *userDesc) { }
 #endif
 
+interface IFileReadPropertiesUpdater : extends IInterface
+{
+public:
+    virtual cost_type addCostAndNumReads(IDistributedFile * file, stat_type numDiskReads, cost_type curReadCost) = 0;
+    virtual void publish() = 0;
+};
+
+extern da_decl IFileReadPropertiesUpdater * createFileReadPropertiesUpdater(IUserDescriptor * udesc);
+
 #endif

--- a/dali/ft/filecopy.cpp
+++ b/dali/ft/filecopy.cpp
@@ -41,6 +41,7 @@
 #include "jlog.hpp"
 #include "dalienv.hpp"
 #include "ftbase.ipp"
+#include "dautils.hpp"
 
 #ifdef _CONTAINERIZED
 //Temporary see HPCC-25822
@@ -3848,13 +3849,14 @@ cost_type FileSprayer::updateTargetProperties()
 cost_type FileSprayer::updateSourceProperties()
 {
     TimeSection timer("FileSprayer::updateSourceProperties() time");
-    // Update file readCost and numReads in file properties and do the same for subfiles
+    // Update file readCost and numReads in file properties and do the same for owning super files
     if (distributedSource)
     {
+        Owned<IFileReadPropertiesUpdater> fileReadPropertiesUpdater = createFileReadPropertiesUpdater(nullptr);
         IDistributedSuperFile * superSrc = distributedSource->querySuperFile();
+        cost_type totalCost = 0;
         if (superSrc && superSrc->numSubFiles() > 0)
         {
-            cost_type totalReadCost = 0;
             Owned<IFileDescriptor> fDesc = superSrc->getFileDescriptor();
             ISuperFileDescriptor *superFDesc = fDesc->querySuperFileDescriptor();
             ForEachItemIn(idx, partition)
@@ -3876,20 +3878,16 @@ cost_type FileSprayer::updateSourceProperties()
                         // so query the first (and only) subfile
                         subfile = &superSrc->querySubFile(0);
                     }
-                    totalReadCost += updateCostAndNumReads(subfile, curProgress.numReads);
-                }
-                else
-                {
-                    // not sure if src superfile can have whichInput==-1 (but if so, this is best effort to calc cost)
-                    totalReadCost += calcFileAccessCost(distributedSource, 0, curProgress.numReads);
+                    totalCost += fileReadPropertiesUpdater->addCostAndNumReads(subfile, curProgress.numReads, 0);
                 }
             }
-            return updateCostAndNumReads(distributedSource, totalNumReads, totalReadCost);
         }
         else
         {
-            return updateCostAndNumReads(distributedSource, totalNumReads);
+            totalCost += fileReadPropertiesUpdater->addCostAndNumReads(distributedSource, totalNumReads, 0);
         }
+        fileReadPropertiesUpdater->publish();
+        return totalCost;
     }
     return 0;
 }

--- a/ecl/eclagent/eclagent.ipp
+++ b/ecl/eclagent/eclagent.ipp
@@ -1051,6 +1051,9 @@ typedef MapBetween<graphid_t, graphid_t, EclSubGraphPtr, EclSubGraphPtr> SubGrap
 
 class EclGraph : public CInterface
 {
+    AtomicShared<IFileReadPropertiesUpdater> fileReadPropsUpdater;
+    CriticalSection fileReadPropsUpdaterCrit;
+
     RedirectedAgentContext graphAgentContext;
     class SubGraphCodeContext : public IndirectCodeContextEx
     {
@@ -1115,7 +1118,7 @@ public:
 
     inline bool queryLibrary() const { return isLibrary; }
     inline unsigned queryWfid() const { return wfid; }
-
+    IFileReadPropertiesUpdater * queryFileReadPropsUpdater();
 protected:
     IAgentContext * agent;
     CIArrayOf<EclSubGraph> graphs;

--- a/ecl/eclagent/eclgraph.cpp
+++ b/ecl/eclagent/eclgraph.cpp
@@ -1298,6 +1298,8 @@ void EclGraph::execute(const byte * parentExtract)
             wu->setGraphState(queryGraphName(), wfid, WUGraphFailed);
         throw;
     }
+    if (fileReadPropsUpdater.query())
+        fileReadPropsUpdater.query()->publish();
 }
 
 void EclGraph::executeLibrary(const byte * parentExtract, IHThorGraphResults * results)
@@ -1362,6 +1364,11 @@ void EclGraph::updateLibraryProgress()
         Owned<IStatisticCollection> statsCollection = stats.getResult();
         agent->mergeAggregatorStats(*statsCollection, wfid, queryGraphName(), cur.id);
     }
+}
+
+IFileReadPropertiesUpdater * EclGraph::queryFileReadPropsUpdater()
+{
+    return fileReadPropsUpdater.query([this] { return createFileReadPropertiesUpdater(this->agent->queryCodeContext()->queryUserDescriptor()); }, fileReadPropsUpdaterCrit);
 }
 
 //---------------------------------------------------------------------------

--- a/ecl/hthor/hthor.cpp
+++ b/ecl/hthor/hthor.cpp
@@ -8545,14 +8545,18 @@ void CHThorDiskReadBaseActivity::closepart()
             {
                 if (superfile)
                 {
-                    unsigned subfile, lnum;
-                    if (superfile->mapSubPart(previousPartNum, subfile, lnum))
+                    unsigned subfileNum, lnum;
+                    if (superfile->mapSubPart(previousPartNum, subfileNum, lnum))
                     {
-                        IDistributedSuperFile *super = dFile->querySuperFile();
-                        dFile = &(super->querySubFile(subfile, true));
+                        IDistributedSuperFile * super = dFile->querySuperFile();
+                        IDistributedFile & subfile = super->querySubFile(subfileNum, true);
+                        graph.queryFileReadPropsUpdater()->addCostAndNumReads(&subfile, curDiskReads, 0);
                     }
                 }
-                updateCostAndNumReads(dFile, curDiskReads);
+                else
+                {
+                    graph.queryFileReadPropsUpdater()->addCostAndNumReads(dFile, curDiskReads, 0);
+                }
             }
             numDiskReads += curDiskReads;
         }

--- a/esp/clients/ws_dfsclient/ws_dfsclient.cpp
+++ b/esp/clients/ws_dfsclient/ws_dfsclient.cpp
@@ -199,7 +199,7 @@ public:
         return new CDistributedSuperFileIterator(dfsFile, superOwners);
     }
     virtual bool isCompressed(bool *blocked=NULL) override { return legacyDFSFile->isCompressed(blocked); }
-    virtual StringBuffer &getClusterName(unsigned clusternum,StringBuffer &name) override { return legacyDFSFile->getClusterName(clusternum,name); }
+    virtual StringBuffer &getClusterName(unsigned clusternum,StringBuffer &name) const override { return legacyDFSFile->getClusterName(clusternum,name); }
     virtual unsigned getClusterNames(StringArray &clusters) override { return legacyDFSFile->getClusterNames(clusters); }                                                                                      // (use findCluster)
     virtual unsigned numClusters() override { return legacyDFSFile->numClusters(); }
     virtual unsigned findCluster(const char *clustername) override { return legacyDFSFile->findCluster(clustername); }
@@ -236,7 +236,22 @@ public:
     virtual bool getSkewInfo(unsigned &maxSkew, unsigned &minSkew, unsigned &maxSkewPart, unsigned &minSkewPart, bool calculateIfMissing) override { return legacyDFSFile->getSkewInfo(maxSkew, minSkew, maxSkewPart, minSkewPart, calculateIfMissing); }
     virtual int getExpire(StringBuffer *expirationDate) override { return legacyDFSFile->getExpire(expirationDate); }
     virtual void getCost(const char * cluster, cost_type & atRestCost, cost_type & accessCost) override { legacyDFSFile->getCost(cluster, atRestCost, accessCost); }
-    
+    virtual bool getNumReads(stat_type &numReads) const override
+    {
+        return legacyDFSFile->getNumReads(numReads);
+    }
+    virtual bool getNumWrites(stat_type &numWrites) const override
+    {
+        return legacyDFSFile->getNumWrites(numWrites);
+    }
+    virtual bool getReadCost(cost_type &cost, bool calculateIfMissing) const override
+    {
+        return legacyDFSFile->getReadCost(cost, calculateIfMissing);
+    }
+    virtual bool getWriteCost(cost_type &cost, bool calculateIfMissing) const override
+    {
+        return legacyDFSFile->getWriteCost(cost, calculateIfMissing);
+    }
 // setters (change file meta data)
     virtual void setPreferredClusters(const char *clusters) override { legacyDFSFile->setPreferredClusters(clusters); }
     virtual void setSingleClusterOnly() override { legacyDFSFile->setSingleClusterOnly(); }
@@ -266,6 +281,10 @@ public:
     virtual void addAttrValue(const char *attr, unsigned __int64 value) override
     {
         legacyDFSFile->addAttrValue(attr, value);
+    }
+    virtual void addAttrValues(std::initializer_list<AttrValuePair> attrs) override
+    {
+        legacyDFSFile->addAttrValues(attrs);
     }
     virtual void setExpire(int expireDays) override
     {

--- a/thorlcr/graph/thgraphmaster.ipp
+++ b/thorlcr/graph/thgraphmaster.ipp
@@ -32,6 +32,7 @@
 #include "thgraphmaster.hpp"
 #include "thmfilemanager.hpp"
 #include "thgraphmanager.hpp"
+#include "dautils.hpp"
 
 
 interface ILoadedDllEntry;
@@ -106,6 +107,8 @@ class graphmaster_decl CMasterGraph : public CGraphBase
     bool sentGlobalInit = false;
     CThorStatsCollection graphStats;
     CReplyCancelHandler activityInitMsgHandler, bcastMsgHandler, executeReplyMsgHandler;
+    AtomicShared<IFileReadPropertiesUpdater> fileReadPropsUpdater;
+    CriticalSection fileReadPropsUpdaterCrit;
 
     void sendQuery();
     void jobDone();
@@ -141,7 +144,8 @@ public:
     IThorResult *createResult(CActivityBase &activity, unsigned id, IThorGraphResults *results, IThorRowInterfaces *rowIf, ThorGraphResultType resultType, unsigned spillPriority=SPILL_PRIORITY_RESULT);
     IThorResult *createResult(CActivityBase &activity, unsigned id, IThorRowInterfaces *rowIf, ThorGraphResultType resultType, unsigned spillPriority=SPILL_PRIORITY_RESULT);
     IThorResult *createGraphLoopResult(CActivityBase &activity, IThorRowInterfaces *rowIf, ThorGraphResultType resultType, unsigned spillPriority=SPILL_PRIORITY_RESULT);
-
+    IFileReadPropertiesUpdater * queryFileReadPropsUpdater();
+    virtual void end() override;
 // IExceptionHandler
     virtual bool fireException(IException *e);
 // IThorChildGraph impl.


### PR DESCRIPTION
Updates to numDiskReads and readCost by thor and hthor have been modified to improve performance:
* The numDiskReads and readCosts updates to a file's properties are made once per activity.
* When a subfile is read, both the superfile's properties and the subfile's properties are updated.  However, where a subfile being updated belong to other superfiles (in addition to the superfile being read), then other owning superfile's properties will not be updated.  The reason for not updating all owning superfiles is to avoid negatively impacting performance. That does mean that where a subfile belongs to more than one superfile, the superfile properties stats will not always be an aggregate of the stats in its subfile.
* Updates to file properties are bypassed, if numDiskReads and readCost are 0.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [ ] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [x] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
