### PR TITLE
HPCC-33768: Make deferred changes to event data reading

### DIFF
--- a/system/jlib/jevent.cpp
+++ b/system/jlib/jevent.cpp
@@ -126,13 +126,13 @@ static constexpr EventAttrInformation attrInformation[] = {
     DEFINE_ATTR(Path, string),
     DEFINE_ATTR(ConnectId, u8),
     DEFINE_ATTR(Enabled, bool),
-    DEFINE_ATTR(SysFileSize, u8),
-    DEFINE_ATTR(SysStartTimestamp, u8),
-    DEFINE_ATTR(SysOption, string),
-    DEFINE_ATTR(SysOffsetNs, u8),
-    DEFINE_ATTR(SysTraceId, string),
-    DEFINE_ATTR(SysThreadId, u8),
-    DEFINE_ATTR(SysStackTrace, string),
+    DEFINE_ATTR(RecordedFileSize, u8),
+    DEFINE_ATTR(RecordedTimestamp, u8),
+    DEFINE_ATTR(RecordedOption, string),
+    DEFINE_ATTR(EventTimeOffset, u8),
+    DEFINE_ATTR(EventTraceId, string),
+    DEFINE_ATTR(EventThreadId, u8),
+    DEFINE_ATTR(EventStackTrace, string),
 };
 
 static_assert(_elements_in(attrInformation) == EvAttrMax);
@@ -612,178 +612,124 @@ EventRecorder eventRecorder;
 
 //---------------------------------------------------------------------------------------------------------------------
 
-//Read a strongly typed value from a buffered stream.
-template<typename T>
-static T readToken(IBufferedSerialInputStream& stream, T& token, size32_t& bytesRead)
+class CEventFileReader : public CInterface
 {
-    if (stream.read(sizeof(token), &token) != sizeof(token))
-        throw makeStringException(-1, "unexpected eof");
-    bytesRead += sizeof(token);
-    return token;
-}
-
-//Read either a NULL terminated are fixed length string from a buffered stream.
-static StringBuffer& readToken(IBufferedSerialInputStream& stream, StringBuffer& token, size32_t len, size32_t& bytesRead)
-{
-    size32_t got = 0;
-    if (len)
-    {
-        const char* s = (const char*)stream.peek(len, got);
-        if (got < len)
-            throw makeStringExceptionV(-1, "eof before end of %u byte string", len);
-        token.append(len, s);
-        stream.skip(len);
-        bytesRead += len;
-    }
-    else
-    {
-        for (;;) {
-            const char *s = (const char*)stream.peek(1,got);
-            if (!s)
-                throw makeStringExceptionV(-1, "eof before end of NULL terminated string");
-            const char *p = s;
-            const char *e = p + got;
-            while (p != e)
-            {
-                if (!*p)
-                {
-                    token.append(p - s, s);
-                    stream.skip(p - s + 1);
-                    bytesRead += token.length() + 1;
-                    return token;
-                }
-                p++;
-            }
-            token.append(got, s);
-            stream.skip(got);
-        }
-    }
-    return token;
-}
-
-//Abstract interface for binary event file traversal.
-interface IEventFile : extends IInterface
-{
-    virtual bool traverse(IEventVisitor& visitor) = 0;
-};
-
-struct CEventFileV1 : public CInterfaceOf<IEventFile>
-{
-    IBufferedSerialInputStream& stream;
-    IFile& file;
+private:
+    Owned<IBufferedSerialInputStream> stream;
+    Owned<IFile> file;
+    Linked<IEventVisitor> visitor;
     unsigned version{0};
     uint32_t options{0};
-    size32_t bytesRead{sizeof(version)};
+    size32_t bytesRead{0};
+    bool mute{false};
 
-    CEventFileV1(IBufferedSerialInputStream& _stream, IFile& _file, unsigned _version = 1)
-        : stream(_stream)
-        , file(_file)
-        , version(_version)
+public:
+    bool traverse(const char* filename, IEventVisitor& _visitor)
     {
+        file.setown(locateEventFile(filename));
+        stream.setown(openEventFileForReading(*file));
+        visitor.set(&_visitor);
+
+        readToken(version);
+        //MORE: Need to handle multiple file versions
+        if (version != currentVersion)
+            throw makeStringExceptionV(-1, "unsupported file version %u (required %u)", version, currentVersion);
+
+        return traverseHeader() && traverseEvents() && traverseFooter();
     }
 
-    bool traverse(IEventVisitor& visitor)
-    {
-        return traverseHeader(visitor) && traverseEvents(visitor) && traverseFooter(visitor);
-    }
-
+private:
     inline bool continuing(IEventVisitor::Continuation continuation) const
     {
         return (IEventVisitor::visitContinue == continuation);
     }
 
-    bool traverseHeader(IEventVisitor& visitor)
+    bool traverseHeader()
     {
         uint64_t startTimestamp;
-        uint64_t fileSize = file.size();
+        uint64_t fileSize = file->size();
 
-        readToken(stream, options, bytesRead);
-        readToken(stream, startTimestamp, bytesRead);
-        return (visitor.visitFile(file.queryFilename(), version) &&
-            continuing(visitor.visitAttribute(EvAttrSysFileSize, fileSize)) &&
-            continuing(visitor.visitAttribute(EvAttrSysStartTimestamp, startTimestamp)) &&
-            (!(options & ERFtraceid) || continuing(visitor.visitAttribute(EvAttrSysOption, "traceid"))) &&
-            (!(options & ERFthreadid) || continuing(visitor.visitAttribute(EvAttrSysOption, "threadid"))) &&
-            (!(options & ERFstacktrace) || continuing(visitor.visitAttribute(EvAttrSysOption, "stack"))));
+        readToken(options);
+        readToken(startTimestamp);
+        return (visitor->visitFile(file->queryFilename(), version) &&
+            continuing(visitor->visitAttribute(EvAttrRecordedFileSize, fileSize)) &&
+            continuing(visitor->visitAttribute(EvAttrRecordedTimestamp, startTimestamp)) &&
+            (!(options & ERFtraceid) || continuing(visitor->visitAttribute(EvAttrRecordedOption, "traceid"))) &&
+            (!(options & ERFthreadid) || continuing(visitor->visitAttribute(EvAttrRecordedOption, "threadid"))) &&
+            (!(options & ERFstacktrace) || continuing(visitor->visitAttribute(EvAttrRecordedOption, "stack"))));
     }
 
-    bool traverseEvents(IEventVisitor& visitor)
+    bool traverseEvents()
     {
-        bool mute = false;
         for (;;)
         {
             // no more data means no more events
             size32_t got = 0;
-            stream.peek(1, got);
+            stream->peek(1, got);
             if (!got)
                 break;
 
             EventType eventType;
-            readToken(stream, eventType, bytesRead);
+            readToken(eventType);
             if (eventType >= EventMax)
                 throw makeStringExceptionV(-1, "invalid event type %u", eventType);
-            if (!reactToVisit(visitor.visitEvent(eventInformation[eventType].type), mute))
+            if (!reactToVisit(visitor->visitEvent(eventInformation[eventType].type)))
                 return false;
 
-            if ((EventNone != eventType) && !traverseAttributes(visitor, mute))
+            if ((EventNone != eventType) && !traverseAttributes())
                 return false;
         }
         return true;
     }
 
-    bool traverseAttributes(IEventVisitor& visitor, bool mute)
+    bool traverseAttributes()
     {
-        if (!finishAttribute<uint64_t>(EvAttrSysOffsetNs, visitor, mute))
+        if (!finishAttribute<uint64_t>(EvAttrEventTimeOffset))
             return false;
-        if ((options & ERFtraceid) && !finishAttribute(EvAttrSysTraceId, 32, visitor, mute))
+        if ((options & ERFtraceid) && !finishAttribute(EvAttrEventTraceId, 32))
             return false;
-        if ((options & ERFthreadid) && !finishAttribute<uint64_t>(EvAttrSysThreadId, visitor, mute))
+        if ((options & ERFthreadid) && !finishAttribute<uint64_t>(EvAttrEventThreadId))
             return false;
         for (;;)
         {
             EventAttr attr;
-            readToken(stream, attr, bytesRead);
+            readToken(attr);
             if (EvAttrNone == attr)
-            {
-                if (!finishAttribute(attr, visitor, mute))
-                    return false;
-                break;
-            }
+                return finishEvent();
             if (attr >= EvAttrMax)
                 throw makeStringExceptionV(-1, "invalid attribute type %u", attr);
             switch (attrInformation[attr].type)
             {
             case EATnone:
-                if (!finishAttribute(attr, visitor, mute))
-                    return false;
+                throw makeStringExceptionV(-1, "no data type for attribute %u", attr);
                 break;
             case EATbool:
-                if (!finishAttribute<bool>(attr, visitor, mute))
+                if (!finishAttribute<bool>(attr))
                     return false;
                 break;
             case EATu1:
-                if (!finishAttribute<uint8_t>(attr, visitor, mute))
+                if (!finishAttribute<uint8_t>(attr))
                     return false;
                 break;
             case EATu2:
-                if (!finishAttribute<uint16_t>(attr, visitor, mute))
+                if (!finishAttribute<uint16_t>(attr))
                     return false;
                 break;
             case EATu4:
-                if (!finishAttribute<uint32_t>(attr, visitor, mute))
+                if (!finishAttribute<uint32_t>(attr))
                     return false;
                 break;
             case EATu8:
             case EATtimestamp:
-                if (!finishAttribute<uint64_t>(attr, visitor, mute))
+                if (!finishAttribute<uint64_t>(attr))
                     return false;
                 break;
             case EATstring:
-                if (!finishAttribute(attr, 0, visitor, mute))
+                if (!finishAttribute(attr))
                     return false;
                 break;
             case EATtraceid:
-                if (!finishAttribute(attr, 32, visitor, mute))
+                if (!finishAttribute(attr, 32))
                     return false;
                 break;
             }
@@ -791,39 +737,51 @@ struct CEventFileV1 : public CInterfaceOf<IEventFile>
         return true;
     }
 
-    bool traverseFooter(IEventVisitor& visitor)
+    bool traverseFooter()
     {
-        (void)visitor.leaveFile(bytesRead);
+        (void)visitor->departFile(bytesRead);
         return true;
     }
 
-    bool finishAttribute(EventAttr attr, IEventVisitor& visitor, bool& mute)
+    bool finishEvent()
     {
-        if (mute)
-            return true;
-        return reactToVisit(visitor.visitAttribute(attr), mute);
+        bool result = true;
+        if (!mute)
+            result = visitor->departEvent();
+        else
+            mute = false; // reset for next event
+        return result;
     }
 
     template <typename T>
-    bool finishAttribute(EventAttr attr, IEventVisitor& visitor, bool& mute)
+    bool finishAttribute(EventAttr attr)
     {
         T value;
-        readToken(stream, value, bytesRead);
+        readToken(value);
         if (mute)
             return true;
-        return reactToVisit(visitor.visitAttribute(attr, value), mute);
+        return reactToVisit(visitor->visitAttribute(attr, value));
     }
 
-    bool finishAttribute(EventAttr attr, size32_t len, IEventVisitor& visitor, bool& mute)
+    bool finishAttribute(EventAttr attr)
     {
         StringBuffer value;
-        readToken(stream, value, len, bytesRead);
+        readToken(value);
         if (mute)
             return true;
-        return reactToVisit(visitor.visitAttribute(attr, value.str()), mute);
+        return reactToVisit(visitor->visitAttribute(attr, value.str()));
     }
 
-    bool reactToVisit(IEventVisitor::Continuation result, bool& mute)
+    bool finishAttribute(EventAttr attr, size32_t len)
+    {
+        StringBuffer value;
+        readToken(value, len);
+        if (mute)
+            return true;
+        return reactToVisit(visitor->visitAttribute(attr, value.str()));
+    }
+
+    bool reactToVisit(IEventVisitor::Continuation result)
     {
         switch (result)
         {
@@ -837,64 +795,90 @@ struct CEventFileV1 : public CInterfaceOf<IEventFile>
         }
         return true;
     }
-};
 
-static IFile* locateEventFile(const char* filename)
-{
-    if (isEmptyString(filename))
-        return nullptr;
-    const char * path = filename;
-#if 0
-    StringBuffer outputFilename;
-    if (!isAbsolutePath(filename))
+    //Read a strongly typed value from a buffered stream.
+    template<typename T>
+    T readToken(T& token)
     {
-        getTempFilePath(outputFilename, "eventrecorder", nullptr);
-        outputFilename.append(PATHSEPCHAR).append(filename);
-        path = outputFilename.str();
+        if (stream->read(sizeof(token), &token) != sizeof(token))
+            throw makeStringException(-1, "unexpected eof");
+        bytesRead += sizeof(token);
+        return token;
     }
-#endif
-    Owned<IFile> file = createIFile(path);
-    if (!file || !file->exists())
-        throw makeStringExceptionV(-1, "file '%s' not found", path);
-    return file.getClear();
-}
 
-static IBufferedSerialInputStream* openEventFileForReading(IFile& file)
-{
-    Owned<IFileIO> fileIO = file.open(IFOread);
-    if (!fileIO)
-        throw makeStringExceptionV(-1, "file '%s' not opened for reading", file.queryFilename());
-    Owned<ISerialInputStream> baseStream = createSerialInputStream(fileIO);
-    if (!baseStream)
-        throw makeStringExceptionV(-1, "file '%s' input stresm not created", file.queryFilename());
-    Owned<IBufferedSerialInputStream> bufferedStream = createBufferedInputStream(baseStream, 0x100000, false);
-    if (!bufferedStream)
-        throw makeStringExceptionV(-1, "file '%s' buffered stream not created", file.queryFilename());
-    return bufferedStream.getClear();
-}
+    //Read a fixed length, unterminated, string from a buffered stream.
+    StringBuffer& readToken(StringBuffer& token, size32_t len)
+    {
+        assertex(len);
+        token.setLength(len);
+        if (stream->read(len, const_cast<char*>(token.str())) != len)
+            throw makeStringExceptionV(-1, "eof before end of %u byte string", len);
+        bytesRead += len;
+        return token;
+    }
+
+    //Read a NULL terminated string from a buffered stream.
+    StringBuffer& readToken(StringBuffer& token)
+    {
+        size32_t got = 0;
+        for (;;) {
+            const char *s = (const char*)stream->peek(1,got);
+            if (!s)
+                throw makeStringExceptionV(-1, "eof before end of NULL terminated string");
+            const char *p = s;
+            const char *e = p + got;
+            while (p != e)
+            {
+                if (!*p)
+                {
+                    token.append(p - s, s);
+                    stream->skip(p - s + 1);
+                    bytesRead += token.length() + 1;
+                    return token;
+                }
+                p++;
+            }
+            token.append(got, s);
+            stream->skip(got);
+        }
+        return token;
+    }
+
+    IFile* locateEventFile(const char* filename)
+    {
+        if (isEmptyString(filename))
+            return nullptr;
+        const char * path = filename;
+    #if 0
+        StringBuffer outputFilename;
+        if (!isAbsolutePath(filename))
+        {
+            getTempFilePath(outputFilename, "eventrecorder", nullptr);
+            outputFilename.append(PATHSEPCHAR).append(filename);
+            path = outputFilename.str();
+        }
+    #endif
+        Owned<IFile> file = createIFile(path);
+        if (!file || !file->exists())
+            throw makeStringExceptionV(-1, "file '%s' not found", path);
+        return file.getClear();
+    }
+
+    IBufferedSerialInputStream* openEventFileForReading(IFile& file)
+    {
+        Owned<IFileIO> fileIO = file.open(IFOread);
+        if (!fileIO)
+            throw makeStringExceptionV(-1, "file '%s' not opened for reading", file.queryFilename());
+        Owned<ISerialInputStream> baseStream = createSerialInputStream(fileIO);
+        Owned<IBufferedSerialInputStream> bufferedStream = createBufferedInputStream(baseStream, 0x100000, false);
+        return bufferedStream.getClear();
+    }
+};
 
 bool readEvents(const char* filename, IEventVisitor& visitor)
 {
-    Owned<IFile> inputFile = locateEventFile(filename);
-    Owned<IBufferedSerialInputStream> bufferedStream = openEventFileForReading(*inputFile);
-
-    unsigned version = 0;
-    size32_t bytesRead = 0;
-    readToken(*bufferedStream, version, bytesRead);
-    //MORE: Need to handle multiple file versions
-    if (version != currentVersion)
-        throw makeStringExceptionV(-1, "unsupported file version %u (required %u)", version, currentVersion);
-    Owned<IEventFile> reader;
-    switch (version)
-    {
-    case 1:
-        reader.setown(new CEventFileV1(*bufferedStream, *inputFile, version));
-        break;
-    default:
-        throw makeStringExceptionV(-1, "unsupported file version %u", version);
-    }
-
-    return reader->traverse(visitor);
+    CEventFileReader reader;
+    return reader.traverse(filename, visitor);
 }
 
 class jlib_decl CDumpVisitsEventVisitor : public CInterfaceOf<IEventVisitor>
@@ -909,11 +893,6 @@ public:
     virtual Continuation visitEvent(EventType id) override
     {
         *out << "event: " << queryEventName(id) << std::endl;
-        return visitContinue;
-    }
-    virtual Continuation visitAttribute(EventAttr id) override
-    {
-        *out << "attribute: " << queryEventAttributeName(id) << std::endl;
         return visitContinue;
     }
     virtual Continuation visitAttribute(EventAttr id, const char * value) override
@@ -946,7 +925,12 @@ public:
         *out << "attribute: " << queryEventAttributeName(id) << " = " << value << std::endl;
         return visitContinue;
     }
-    virtual void leaveFile(uint32_t bytesRead) override
+    virtual bool departEvent() override
+    {
+        *out << "departEvent" << std::endl;
+        return true;
+    }
+    virtual void departFile(uint32_t bytesRead) override
     {
         *out << "bytesRead: " << bytesRead << std::endl;
     }

--- a/system/jlib/jevent.hpp
+++ b/system/jlib/jevent.hpp
@@ -58,13 +58,13 @@ enum EventAttr : byte
     EvAttrPath,
     EvAttrConnectId,
     EvAttrEnabled,
-    EvAttrSysFileSize,
-    EvAttrSysStartTimestamp,
-    EvAttrSysOption,
-    EvAttrSysOffsetNs,
-    EvAttrSysTraceId,
-    EvAttrSysThreadId,
-    EvAttrSysStackTrace,
+    EvAttrRecordedFileSize,
+    EvAttrRecordedTimestamp,
+    EvAttrRecordedOption,
+    EvAttrEventTimeOffset,
+    EvAttrEventTraceId,
+    EvAttrEventThreadId,
+    EvAttrEventStackTrace,
     EvAttrMax
 };
 
@@ -199,17 +199,17 @@ inline bool recordingEvents() { return EventRecorderInternal::eventRecorder.isRe
 //
 // For each compatibile file the visitor can expect:
 // 1. One call to visitFile
-// 2. One call to visitAttribute for EvAttrSysFileSize
-// 3. One call to visitAttribute for EvAttrSysStartTimestamp
-// 4. Zero or more calls to visitAttribute for EvAttrSysOption
+// 2. One call to visitAttribute for EvAttrRecordedFileSize
+// 3. One call to visitAttribute for EvAttrRecordedTimestamp
+// 4. Zero or more calls to visitAttribute for EvAttrRecordedOption
 // 5. Zero or more sequences of:
 //    a. One call to visitEvent
 //    b. Zero or more calls to visitAttribute
-//    c. One call to visitAttribute for EvAttrNone
-// 6. One call to leaveFile
+//    c. One call to departEvent
+// 6. One call to departFile
 //
 // Implementations may implement limited filtering during visitation. All methods, except
-// `leaveFile`, may abort visitation. Both `visitEvent` and `visitAttribute` (in the context of
+// `departFile`, may abort visitation. Both `visitEvent` and `visitAttribute` (in the context of
 // an event) may suppress visitation of the remainder of the current event.
 //
 // Reasons for aborting a file include:
@@ -229,14 +229,14 @@ interface IEventVisitor : extends IInterface
     };
     virtual bool visitFile(const char* filename, uint32_t version) = 0;
     virtual Continuation visitEvent(EventType id) = 0;
-    virtual Continuation visitAttribute(EventAttr id) = 0;
     virtual Continuation visitAttribute(EventAttr id, const char * value) = 0;
     virtual Continuation visitAttribute(EventAttr id, bool value) = 0;
     virtual Continuation visitAttribute(EventAttr id, uint8_t value) = 0;
     virtual Continuation visitAttribute(EventAttr id, uint16_t value) = 0;
     virtual Continuation visitAttribute(EventAttr id, uint32_t value) = 0;
     virtual Continuation visitAttribute(EventAttr id, uint64_t value) = 0;
-    virtual void leaveFile(uint32_t bytesRead) = 0;
+    virtual bool departEvent() = 0;
+    virtual void departFile(uint32_t bytesRead) = 0;
 };
 
 // Return a new event visitor that writes to standard output for every visit.

--- a/testing/unittests/jlibtests2.cpp
+++ b/testing/unittests/jlibtests2.cpp
@@ -49,10 +49,6 @@ public:
     {
         return visitor->visitEvent(id);
     }
-    virtual Continuation visitAttribute(EventAttr id) override
-    {
-        return visitor->visitAttribute(id);
-    }
     virtual Continuation visitAttribute(EventAttr id, const char * value) override
     {
         return visitor->visitAttribute(id, value);
@@ -77,9 +73,13 @@ public:
     {
         return visitor->visitAttribute(id, value);
     }
-    virtual void leaveFile(uint32_t bytesRead) override
+    virtual bool departEvent() override
     {
-        return visitor->leaveFile(bytesRead);
+        return visitor->departEvent();
+    }
+    virtual void departFile(uint32_t bytesRead) override
+    {
+        return visitor->departFile(bytesRead);
     }
 protected:
     Linked<IEventVisitor> visitor;
@@ -94,13 +94,13 @@ public:
     {
         switch (id)
         {
-            case EvAttrSysStartTimestamp:
+            case EvAttrRecordedTimestamp:
                 value = 1000;
                 break;
-            case EvAttrSysOffsetNs:
+            case EvAttrEventTimeOffset:
                 value = 10;
                 break;
-            case EvAttrSysThreadId:
+            case EvAttrEventThreadId:
                 value = 100;
                 break;
         }
@@ -337,11 +337,11 @@ public:
         {
             static const char* expect=R"!!!(name: eventtrace.evt
 version: 1
-attribute: SysFileSize = 16
-attribute: SysStartTimestamp = 1000
-attribute: SysOption = 'traceid'
-attribute: SysOption = 'threadid'
-attribute: SysOption = 'stack'
+attribute: RecordedFileSize = 16
+attribute: RecordedTimestamp = 1000
+attribute: RecordedOption = 'traceid'
+attribute: RecordedOption = 'threadid'
+attribute: RecordedOption = 'stack'
 bytesRead: 16
 )!!!";
             EventRecorder& recorder = queryRecorder();
@@ -365,20 +365,20 @@ bytesRead: 16
         {
             static const char* expect = R"!!!(name: eventtrace.evt
 version: 1
-attribute: SysFileSize = 87
-attribute: SysStartTimestamp = 1000
-attribute: SysOption = 'traceid'
-attribute: SysOption = 'threadid'
-attribute: SysOption = 'stack'
+attribute: RecordedFileSize = 87
+attribute: RecordedTimestamp = 1000
+attribute: RecordedOption = 'traceid'
+attribute: RecordedOption = 'threadid'
+attribute: RecordedOption = 'stack'
 event: IndexEviction
-attribute: SysOffsetNs = 10
-attribute: SysTraceId = '00000000000000000000000000000000'
-attribute: SysThreadId = 100
+attribute: EventTimeOffset = 10
+attribute: EventTraceId = '00000000000000000000000000000000'
+attribute: EventThreadId = 100
 attribute: FileId = 12345
 attribute: FileOffset = 67890
 attribute: NodeKind = 0
 attribute: ExpandedSize = 4567
-attribute: None
+departEvent
 bytesRead: 87
 )!!!";
             EventRecorder& recorder = queryRecorder();
@@ -403,33 +403,33 @@ bytesRead: 87
         {
             static const char* expect = R"!!!(name: eventtrace.evt
 version: 1
-attribute: SysFileSize = 233
-attribute: SysStartTimestamp = 1000
-attribute: SysOption = 'traceid'
-attribute: SysOption = 'threadid'
-attribute: SysOption = 'stack'
+attribute: RecordedFileSize = 233
+attribute: RecordedTimestamp = 1000
+attribute: RecordedOption = 'traceid'
+attribute: RecordedOption = 'threadid'
+attribute: RecordedOption = 'stack'
 event: IndexEviction
-attribute: SysOffsetNs = 10
-attribute: SysTraceId = '00000000000000000000000000000000'
-attribute: SysThreadId = 100
+attribute: EventTimeOffset = 10
+attribute: EventTraceId = '00000000000000000000000000000000'
+attribute: EventThreadId = 100
 attribute: FileId = 12345
 attribute: FileOffset = 67890
 attribute: NodeKind = 0
 attribute: ExpandedSize = 4567
-attribute: None
+departEvent
 event: DaliConnect
-attribute: SysOffsetNs = 10
-attribute: SysTraceId = '00000000000000000000000000000000'
-attribute: SysThreadId = 100
+attribute: EventTimeOffset = 10
+attribute: EventTraceId = '00000000000000000000000000000000'
+attribute: EventThreadId = 100
 attribute: Path = '/Workunits/Workunit/abc.wu'
 attribute: ConnectId = 98765
-attribute: None
+departEvent
 event: DaliDisconnect
-attribute: SysOffsetNs = 10
-attribute: SysTraceId = '00000000000000000000000000000000'
-attribute: SysThreadId = 100
+attribute: EventTimeOffset = 10
+attribute: EventTraceId = '00000000000000000000000000000000'
+attribute: EventThreadId = 100
 attribute: ConnectId = 98765
-attribute: None
+departEvent
 bytesRead: 233
 )!!!";
             EventRecorder& recorder = queryRecorder();


### PR DESCRIPTION
- Define one reader class for all file versions.
- Add reader class member variables to simplify method signatures.
- Split string token reading into separate methods for fixed and variable length strings.
- Rename `leaveFile` as `departFile`.
- Add `departEvent` in place of visiting `EvAttrNone`.
- Rename attributes to eliminate `Sys` from the names.
- Remove unneeded stream allocation checks.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [x] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
