### PR TITLE
HPCC-33667: Support structured text event data dumps

### DIFF
--- a/system/jlib/jevent.hpp
+++ b/system/jlib/jevent.hpp
@@ -23,6 +23,7 @@
 #include "jscm.hpp"
 #include "jatomic.hpp"
 #include "jbuff.hpp"
+#include "jptree.hpp"
 #include "jstring.hpp"
 #include "jstats.h"
 
@@ -258,13 +259,28 @@ interface IEventVisitor : extends IInterface
     virtual void departFile(uint32_t bytesRead) = 0;
 };
 
-// Return a new event visitor that writes to standard output for every visit.
-// `visitFile` adds two lines of text, and all other methods add one line of text.
-extern jlib_decl IEventVisitor* createVisitTrackingEventVisitor();
+// Get a visitor that streams visited event data in JSON format.
+extern jlib_decl IEventVisitor* createDumpJSONEventVisitor(std::ostream& out);
 
-// Return a new event visitor that writes to the given output stream for every visit.
-// `visitFile` adds two lines of text, and all other methods add one line of text.
-extern jlib_decl IEventVisitor* createVisitTrackingEventVisitor(std::ostream& out);
+// Get a visitor that streams visited event data in a flat text format.
+extern jlib_decl IEventVisitor* createDumpTextEventVisitor(std::ostream& out);
+
+// Get a visitor that streams visited event data in XML format.
+extern jlib_decl IEventVisitor* createDumpXMLEventVisitor(std::ostream& out);
+
+// Get a visitor that streams visited event data in YAML format.
+extern jlib_decl IEventVisitor* createDumpYAMLEventVisitor(std::ostream& out);
+
+// Encapsulation of a visitor that stores visited event data in a property tree and
+// access to the tree.
+interface IEventPTreeCreator : extends IInterface
+{
+    virtual IEventVisitor& queryVisitor() = 0;
+    virtual IPTree* queryTree() const = 0;
+};
+
+// Get an event property tree creator.
+extern jlib_decl IEventPTreeCreator* createEventPTreeCreator();
 
 // Opens and parses a single binary event data file. Parsed data is passed to the given visitor
 // until parsing completes or the visitor requests it to stop.

--- a/testing/unittests/jlibtests2.cpp
+++ b/testing/unittests/jlibtests2.cpp
@@ -334,14 +334,14 @@ public:
         //Test reading an empty file
         try
         {
-            static const char* expect=R"!!!(name: eventtrace.evt
-version: 1
+            static const char* expect=R"!!!(attribute: filename = 'eventtrace.evt'
+attribute: version = 1
 attribute: RecordedFileSize = 16
 attribute: RecordedTimestamp = 1000
-attribute: RecordedOption = 'traceid'
-attribute: RecordedOption = 'threadid'
-attribute: RecordedOption = 'stack'
-bytesRead: 16
+attribute: traceid = true
+attribute: threadid = true
+attribute: stack = true
+attribute: bytesRead = 16
 )!!!";
             EventRecorder& recorder = queryRecorder();
             CPPUNIT_ASSERT(recorder.startRecording("all=true", "eventtrace.evt", false));
@@ -362,14 +362,16 @@ bytesRead: 16
         }
         try
         {
-            static const char* expect = R"!!!(name: eventtrace.evt
-version: 1
+            static const char* expect = R"!!!(attribute: filename = 'eventtrace.evt'
+attribute: version = 1
 attribute: RecordedFileSize = 71
 attribute: RecordedTimestamp = 1000
-attribute: RecordedOption = 'traceid'
-attribute: RecordedOption = 'threadid'
-attribute: RecordedOption = 'stack'
+attribute: traceid = true
+attribute: threadid = true
+attribute: stack = true
 event: IndexEviction
+attribute: name = 'IndexEviction'
+attribute: id = 3
 attribute: EventTimeOffset = 10
 attribute: EventTraceId = '00000000000000000000000000000000'
 attribute: EventThreadId = 100
@@ -377,8 +379,7 @@ attribute: FileId = 12345
 attribute: FileOffset = 67890
 attribute: NodeKind = 0
 attribute: ExpandedSize = 4567
-departEvent
-bytesRead: 71
+attribute: bytesRead = 71
 )!!!";
             EventRecorder& recorder = queryRecorder();
             CPPUNIT_ASSERT(recorder.startRecording("all=true", "eventtrace.evt", false));
@@ -400,14 +401,16 @@ bytesRead: 71
         }
         try
         {
-            static const char* expect = R"!!!(name: eventtrace.evt
-version: 1
+            static const char* expect = R"!!!(attribute: filename = 'eventtrace.evt'
+attribute: version = 1
 attribute: RecordedFileSize = 156
 attribute: RecordedTimestamp = 1000
-attribute: RecordedOption = 'traceid'
-attribute: RecordedOption = 'threadid'
-attribute: RecordedOption = 'stack'
+attribute: traceid = true
+attribute: threadid = true
+attribute: stack = true
 event: IndexEviction
+attribute: name = 'IndexEviction'
+attribute: id = 3
 attribute: EventTimeOffset = 10
 attribute: EventTraceId = '00000000000000000000000000000000'
 attribute: EventThreadId = 100
@@ -415,8 +418,9 @@ attribute: FileId = 12345
 attribute: FileOffset = 67890
 attribute: NodeKind = 0
 attribute: ExpandedSize = 4567
-departEvent
 event: DaliConnect
+attribute: name = 'DaliConnect'
+attribute: id = 6
 attribute: EventTimeOffset = 10
 attribute: EventTraceId = '00000000000000000000000000000000'
 attribute: EventThreadId = 100
@@ -424,8 +428,7 @@ attribute: Path = '/Workunits/Workunit/abc.wu'
 attribute: ConnectId = 98765
 attribute: ElapsedTime = 100
 attribute: DataSize = 73
-departEvent
-bytesRead: 156
+attribute: bytesRead = 156
 )!!!";
             EventRecorder& recorder = queryRecorder();
             CPPUNIT_ASSERT(recorder.startRecording("all=true", "eventtrace.evt", false));
@@ -450,7 +453,7 @@ bytesRead: 156
 
     IEventVisitor* createVisitor(std::stringstream& out)
     {
-        Owned<IEventVisitor> visitor = createVisitTrackingEventVisitor(out);
+        Owned<IEventVisitor> visitor = createDumpTextEventVisitor(out);
         return new MockEventVisitor(*visitor);
     }
 };


### PR DESCRIPTION
- `evtool dump <filename>` streams a sequential list of visited data
- `evtool dump -j <filename>` streams JSON-formatted visited data
- `evtool dump -x <filename>` streams XML-formatted visited data
- `evtool dump -y <filename>` streams YAML-formatted visited data
- `evtool dump -p <filename>` populates a property tree then outputs YAML

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
