### PR TITLE
HPCC-33836: Update evtool to use IBufferedSerialOutputStream

### DIFF
--- a/system/jlib/jevent.cpp
+++ b/system/jlib/jevent.cpp
@@ -1219,18 +1219,18 @@ protected: // new abstract method(s)
     virtual void recordAttribute(const char* name, const char* value, bool quoted) = 0;
 
 public:
-    CDumpStreamEventVisitor(std::ostream& _out)
-        : out(_out)
+    CDumpStreamEventVisitor(IBufferedSerialOutputStream& _out)
+        : out(&_out)
     {
     }
 
 protected:
     void dump(bool eoln)
     {
-        out << markup.str();
+        out->put(markup.length(), markup.str());
         markup.clear();
         if (eoln)
-            out << std::endl;
+            out->put(1, "\n");
     }
 
     bool inHeader() const { return State::Header == state; }
@@ -1245,7 +1245,7 @@ protected:
         Footer,
     };
     State state{State::Idle};
-    std::ostream& out;
+    Linked<IBufferedSerialOutputStream> out;
     StringBuffer markup;
 };
 
@@ -1316,7 +1316,7 @@ protected:
     }
 };
 
-IEventVisitor* createDumpTextEventVisitor(std::ostream& out)
+IEventVisitor* createDumpTextEventVisitor(IBufferedSerialOutputStream& out)
 {
     return new CDumpTextEventVisitor(out);
 }
@@ -1400,7 +1400,7 @@ private:
     unsigned indentLevel{0};
 };
 
-IEventVisitor* createDumpXMLEventVisitor(std::ostream& out)
+IEventVisitor* createDumpXMLEventVisitor(IBufferedSerialOutputStream& out)
 {
     return new CDumpXMLEventVisitor(out);
 }
@@ -1534,7 +1534,7 @@ private:
     bool firstEvent{true};
 };
 
-IEventVisitor* createDumpJSONEventVisitor(std::ostream& out)
+IEventVisitor* createDumpJSONEventVisitor(IBufferedSerialOutputStream& out)
 {
     return new CDumpJSONEventVisitor(out);
 }
@@ -1630,7 +1630,7 @@ protected:
     uint8_t indentLevel{0};
 };
 
-IEventVisitor* createDumpYAMLEventVisitor(std::ostream& out)
+IEventVisitor* createDumpYAMLEventVisitor(IBufferedSerialOutputStream& out)
 {
     return new CDumpYAMLEventVisitor(out);
 }
@@ -1704,7 +1704,7 @@ private:
     Attributes eventAttrs;
 };
 
-IEventVisitor* createDumpCSVEventVisitor(std::ostream& out)
+IEventVisitor* createDumpCSVEventVisitor(IBufferedSerialOutputStream& out)
 {
     return new CDumpCSVEventVisitor(out);
 }

--- a/system/jlib/jevent.hpp
+++ b/system/jlib/jevent.hpp
@@ -18,12 +18,11 @@
 #ifndef JEVENT_HPP
 #define JEVENT_HPP
 
-#include <ostream>
-
 #include "jscm.hpp"
 #include "jatomic.hpp"
 #include "jbuff.hpp"
 #include "jptree.hpp"
+#include "jstream.hpp"
 #include "jstring.hpp"
 #include "jstats.h"
 
@@ -260,19 +259,19 @@ interface IEventVisitor : extends IInterface
 };
 
 // Get a visitor that streams visited event data in JSON format.
-extern jlib_decl IEventVisitor* createDumpJSONEventVisitor(std::ostream& out);
+extern jlib_decl IEventVisitor* createDumpJSONEventVisitor(IBufferedSerialOutputStream& out);
 
 // Get a visitor that streams visited event data in a flat text format.
-extern jlib_decl IEventVisitor* createDumpTextEventVisitor(std::ostream& out);
+extern jlib_decl IEventVisitor* createDumpTextEventVisitor(IBufferedSerialOutputStream& out);
 
 // Get a visitor that streams visited event data in XML format.
-extern jlib_decl IEventVisitor* createDumpXMLEventVisitor(std::ostream& out);
+extern jlib_decl IEventVisitor* createDumpXMLEventVisitor(IBufferedSerialOutputStream& out);
 
 // Get a visitor that streams visited event data in YAML format.
-extern jlib_decl IEventVisitor* createDumpYAMLEventVisitor(std::ostream& out);
+extern jlib_decl IEventVisitor* createDumpYAMLEventVisitor(IBufferedSerialOutputStream& out);
 
 // Get a visitor that streams visited event data in CSV format.
-extern jlib_decl IEventVisitor* createDumpCSVEventVisitor(std::ostream& out);
+extern jlib_decl IEventVisitor* createDumpCSVEventVisitor(IBufferedSerialOutputStream& out);
 
 // Encapsulation of a visitor that stores visited event data in a property tree and
 // access to the tree.

--- a/testing/unittests/jlibtests2.cpp
+++ b/testing/unittests/jlibtests2.cpp
@@ -347,11 +347,11 @@ attribute: bytesRead = 16
             CPPUNIT_ASSERT(recorder.startRecording("all=true", "eventtrace.evt", false));
             CPPUNIT_ASSERT(recorder.isRecording());
             CPPUNIT_ASSERT(recorder.stopRecording(nullptr));
-            std::stringstream out;
+            StringBuffer out;
             Owned<IEventVisitor> visitor = createVisitor(out);
             CPPUNIT_ASSERT(visitor.get());
             CPPUNIT_ASSERT(readEvents("eventtrace.evt", *visitor));
-            CPPUNIT_ASSERT_EQUAL(std::string(expect), out.str());
+            CPPUNIT_ASSERT_EQUAL_STR(expect, out.str());
         }
         catch (IException * e)
         {
@@ -386,11 +386,11 @@ attribute: bytesRead = 71
             CPPUNIT_ASSERT(recorder.isRecording());
             recorder.recordIndexEviction(12345, 67890, NodeBranch, 4567);
             CPPUNIT_ASSERT(recorder.stopRecording(nullptr));
-            std::stringstream out;
+            StringBuffer out;
             Owned<IEventVisitor> visitor = createVisitor(out);
             CPPUNIT_ASSERT(visitor.get());
             CPPUNIT_ASSERT(readEvents("eventtrace.evt", *visitor));
-            CPPUNIT_ASSERT_EQUAL(std::string(expect), out.str());
+            CPPUNIT_ASSERT_EQUAL_STR(expect, out.str());
         }
         catch (IException * e)
         {
@@ -436,11 +436,11 @@ attribute: bytesRead = 156
             recorder.recordIndexEviction(12345, 67890, NodeBranch, 4567);
             recorder.recordDaliConnect("/Workunits/Workunit/abc.wu", 98765, 100, 73);
             CPPUNIT_ASSERT(recorder.stopRecording(nullptr));
-            std::stringstream out;
+            StringBuffer out;
             Owned<IEventVisitor> visitor = createVisitor(out);
             CPPUNIT_ASSERT(visitor.get());
             CPPUNIT_ASSERT(readEvents("eventtrace.evt", *visitor));
-            CPPUNIT_ASSERT_EQUAL(std::string(expect), out.str());
+            CPPUNIT_ASSERT_EQUAL_STR(expect, out.str());
         }
         catch (IException * e)
         {
@@ -451,9 +451,10 @@ attribute: bytesRead = 156
         }
     }
 
-    IEventVisitor* createVisitor(std::stringstream& out)
+    IEventVisitor* createVisitor(StringBuffer& out)
     {
-        Owned<IEventVisitor> visitor = createDumpTextEventVisitor(out);
+        Owned<IBufferedSerialOutputStream> stream = createBufferedSerialOutputStream(out);
+        Owned<IEventVisitor> visitor = createDumpTextEventVisitor(*stream);
         return new MockEventVisitor(*visitor);
     }
 };

--- a/tools/evtool/evtool.h
+++ b/tools/evtool/evtool.h
@@ -18,15 +18,19 @@
 #pragma once
 
 #include "jiface.hpp"
-#include <ostream>
+#include "jstream.hpp"
 
 // Core interface for tool commands. `dispatch` processes individual requests. `usage` provides
 // help text for the command.
 interface IEvToolCommand : extends IInterface
 {
     virtual int dispatch(int argc, const char* argv[], int pos) = 0;
-    virtual void usage(int argc, const char* argv[], int pos, std::ostream& out) = 0;
+    virtual void usage(int argc, const char* argv[], int pos, IBufferedSerialOutputStream& out) = 0;
 };
+
+extern IBufferedSerialOutputStream& consoleOut();
+extern IBufferedSerialOutputStream& consoleErr();
+extern void cleanupConsole();
 
 // Command factory functions.
 extern IEvToolCommand* createDumpCommand();

--- a/tools/evtool/evtool.hpp
+++ b/tools/evtool/evtool.hpp
@@ -33,7 +33,7 @@ protected:
     virtual bool acceptTerseOption(char opt);
     virtual bool acceptVerboseOption(const char* opt);
     virtual bool acceptParameter(const char* arg);
-    void usagePrefix(int argc, const char* argv[], int pos, std::ostream& out);
+    void usagePrefix(int argc, const char* argv[], int pos, IBufferedSerialOutputStream& out);
 protected:
     bool isHelp = false;
 };

--- a/tools/evtool/evtsim.cpp
+++ b/tools/evtool/evtsim.cpp
@@ -19,7 +19,7 @@
 #include "jevent.hpp"
 #include "jfile.hpp"
 #include "jptree.hpp"
-#include <iostream>
+#include "jstream.hpp"
 
 // The simulation command is included as an aid in the development and testing of evtool. It may
 // be impacted by changes to the event recording API. Authors of changes to that API are requiired
@@ -218,24 +218,26 @@ public:
         }
         catch (IException* e)
         {
-            StringBuffer msg;
+            StringBuffer msg("exception simulating event file: ");
             e->errorMessage(msg);
             e->Release();
-            std::cerr << msg.str() << std::endl;
+            msg.append('\n');
+            consoleErr().put(msg.length(), msg.str());
             return 1;
         }
     }
 
-    virtual void usage(int argc, const char* argv[], int pos, std::ostream& out) override
+    virtual void usage(int argc, const char* argv[], int pos, IBufferedSerialOutputStream& out) override
     {
         usagePrefix(argc, argv, pos, out);
-        out << "[options] <filename>" << std::endl << std::endl;
-        out << "Create a binary event file containing the events specified in an external" << std::endl;
-        out << "configuration file. The configuration may use either XML or YAML formats." << std::endl << std::endl;
-        out << "  -?, -h, --help  show this help message and exit" << std::endl;
-        out << "  <filename>      full path to an XML or YAML file containing simulated" << std::endl;
-        out << "                  events" << std::endl;
-        out << std::endl;
+        StringBuffer usage;
+        usage << "[options] <filename>" << "\n\n";
+        usage << "Create a binary event file containing the events specified in an external" << "\n";
+        usage << "configuration file. The configuration may use either XML or YAML formats." << "\n\n";
+        usage << "  -?, -h, --help  show this help message and exit" << "\n";
+        usage << "  <filename>      full path to an XML or YAML file containing simulated" << "\n";
+        usage << "                  events" << "\n";
+        out.put(usage.length(), usage.str());
     }
 
 protected:


### PR DESCRIPTION
- Change all text output visitors from std::ostream.
- Use IFile-based buffered output streams in place of std::cout and std::cerr.
- Update unit tests to replace std::stringstream with CStringBufferSerialOutputStream.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [x] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [ ] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
