### PR TITLE
HPCC-33837: Event reading interface and output cleanup

### DIFF
--- a/system/jlib/jevent.hpp
+++ b/system/jlib/jevent.hpp
@@ -250,10 +250,7 @@ interface IEventVisitor : extends IInterface
     virtual Continuation visitEvent(EventType id) = 0;
     virtual Continuation visitAttribute(EventAttr id, const char * value) = 0;
     virtual Continuation visitAttribute(EventAttr id, bool value) = 0;
-    virtual Continuation visitAttribute(EventAttr id, uint8_t value) = 0;
-    virtual Continuation visitAttribute(EventAttr id, uint16_t value) = 0;
-    virtual Continuation visitAttribute(EventAttr id, uint32_t value) = 0;
-    virtual Continuation visitAttribute(EventAttr id, uint64_t value) = 0;
+    virtual Continuation visitAttribute(EventAttr id, __uint64 value) = 0;
     virtual bool departEvent() = 0;
     virtual void departFile(uint32_t bytesRead) = 0;
 };

--- a/testing/unittests/jlibtests2.cpp
+++ b/testing/unittests/jlibtests2.cpp
@@ -57,19 +57,7 @@ public:
     {
         return visitor->visitAttribute(id, value);
     }
-    virtual Continuation visitAttribute(EventAttr id, uint8_t value) override
-    {
-        return visitor->visitAttribute(id, value);
-    }
-    virtual Continuation visitAttribute(EventAttr id, uint16_t value) override
-    {
-        return visitor->visitAttribute(id, value);
-    }
-    virtual Continuation visitAttribute(EventAttr id, uint32_t value) override
-    {
-        return visitor->visitAttribute(id, value);
-    }
-    virtual Continuation visitAttribute(EventAttr id, uint64_t value) override
+    virtual Continuation visitAttribute(EventAttr id, __uint64 value) override
     {
         return visitor->visitAttribute(id, value);
     }
@@ -90,7 +78,7 @@ public:
 class MockEventVisitor : public CNoOpEventVisitorDecorator
 {
 public:
-    virtual Continuation visitAttribute(EventAttr id, uint64_t value) override
+    virtual Continuation visitAttribute(EventAttr id, __uint64 value) override
     {
         switch (id)
         {
@@ -371,7 +359,6 @@ attribute: threadid = true
 attribute: stack = true
 event: IndexEviction
 attribute: name = 'IndexEviction'
-attribute: id = 3
 attribute: EventTimeOffset = 10
 attribute: EventTraceId = '00000000000000000000000000000000'
 attribute: EventThreadId = 100
@@ -410,7 +397,6 @@ attribute: threadid = true
 attribute: stack = true
 event: IndexEviction
 attribute: name = 'IndexEviction'
-attribute: id = 3
 attribute: EventTimeOffset = 10
 attribute: EventTraceId = '00000000000000000000000000000000'
 attribute: EventThreadId = 100
@@ -420,7 +406,6 @@ attribute: NodeKind = 0
 attribute: ExpandedSize = 4567
 event: DaliConnect
 attribute: name = 'DaliConnect'
-attribute: id = 6
 attribute: EventTimeOffset = 10
 attribute: EventTraceId = '00000000000000000000000000000000'
 attribute: EventThreadId = 100

--- a/tools/evtool/evtdump.cpp
+++ b/tools/evtool/evtdump.cpp
@@ -197,14 +197,13 @@ public:
         usage << "    |   └── ... (other header properties)" << '\n';
         usage << "    ├── Event" << '\n';
         usage << "    |   ├── @name" << '\n';
-        usage << "    |   ├── @id" << '\n';
         usage << "    |   └── ... (other event properties)" << '\n';
         usage << "    ├── ... (more events)" << '\n';
         usage << "    └── Footer" << '\n';
         usage << "        ├── @bytesRead" << '\n';
         usage << '\n';
-        usage << "CSV output includes columns for event name and ID, plus one for each" << '\n';
-        usage << "event attribute used by the event recorder." << '\n';
+        usage << "CSV output includes columns for event name, plus one for each event" << '\n';
+        usage << "attribute used by the event recorder." << '\n';
         out.put(usage.length(), usage.str());
     }
     CEvtDumpCommand()


### PR DESCRIPTION
- Remove uint8_t, uint16_t, and uint32_t variants of `visitAttribute`.
- Remove event `id` attribute from dump output.
- Rename openObject, closeObject to openElement/closeElement.
- Optimize CSV generation.
- Replace uint64_t with __uint64

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [x] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
