### PR TITLE
HPCC-33955 Add getDefaultDropZoneName to fileservices

### DIFF
--- a/ecllibrary/std/File.ecl
+++ b/ecllibrary/std/File.ecl
@@ -1059,7 +1059,22 @@ EXPORT varstring GetEspURL(const varstring username = '', const varstring userPW
 EXPORT varstring GetDefaultDropZone() :=
     lib_fileservices.FileServices.GetDefaultDropZone();
 
+
  /**
+ * Returns the name of the default Drop Zone
+ *
+ *
+ * @return              A string containing the name of the default Drop Zone.
+ *                      If more than one Drop Zone
+ *                      process is defined then the first found will
+ *                      be returned; will return an empty string if a Drop Zone
+ *                      cannot be found
+ */
+EXPORT varstring GetDefaultDropZoneName() :=
+    lib_fileservices.FileServices.GetDefaultDropZoneName();
+
+
+    /**
  * Returns a dataset with full paths to all Drop Zones
  *
  *

--- a/plugins/fileservices/fileservices.cpp
+++ b/plugins/fileservices/fileservices.cpp
@@ -2996,7 +2996,6 @@ FILESERVICES_API void FILESERVICES_CALL fsDeleteExternalFile(ICodeContext *ctx,c
 {
     implementDeleteExternalFile(ctx,location,path,nullptr);
 }
-
 FILESERVICES_API void FILESERVICES_CALL fsDeleteExternalFile_v2(ICodeContext *ctx,const char *location,const char *path,const char *planename)
 {
     implementDeleteExternalFile(ctx,location,path,planename);
@@ -3334,6 +3333,15 @@ FILESERVICES_API char * FILESERVICES_CALL fsGetDefaultDropZone()
     if (dropZones->first())
         dropZones->query().getProp("@prefix", dropZonePath);        // Why the directory? seems a very stange choice
     return strdup(dropZonePath.str());
+}
+
+FILESERVICES_API char * FILESERVICES_CALL fsGetDefaultDropZoneName()
+{
+    StringBuffer dropZoneName;
+    Owned<IPropertyTreeIterator> dropZones = getGlobalConfigSP()->getElements("storage/planes[@category='lz']");
+    if (dropZones->first())
+        dropZones->query().getProp("@name", dropZoneName);
+    return strdup(dropZoneName.str());
 }
 
 FILESERVICES_API void FILESERVICES_CALL fsGetDropZones(ICodeContext *ctx, size32_t & __lenResult, void * & __result)

--- a/plugins/fileservices/fileservices.hpp
+++ b/plugins/fileservices/fileservices.hpp
@@ -196,6 +196,7 @@ FILESERVICES_API void FILESERVICES_CALL fsProtectLogicalFile(ICodeContext * ctx,
 FILESERVICES_API void FILESERVICES_CALL fsDfuPlusExec(ICodeContext * ctx,const char *_cmd);
 FILESERVICES_API char * FILESERVICES_CALL fsGetEspURL(const char *username, const char *userPW);
 FILESERVICES_API char * FILESERVICES_CALL fsGetDefaultDropZone();
+FILESERVICES_API char * FILESERVICES_CALL fsGetDefaultDropZoneName();
 FILESERVICES_API void FILESERVICES_CALL fsGetDropZones(ICodeContext *ctx,size32_t & __lenResult,void * & __result);
 FILESERVICES_API void FILESERVICES_CALL fsGetLandingZones(ICodeContext *ctx,size32_t & __lenResult,void * & __result);
 FILESERVICES_API int FILESERVICES_CALL fsGetExpireDays(ICodeContext * ctx, const char *lfn);

--- a/plugins/proxies/lib_fileservices.ecllib
+++ b/plugins/proxies/lib_fileservices.ecllib
@@ -107,6 +107,7 @@ export FileServices := SERVICE : plugin('fileservices'), time
   DfuPlusExec(const varstring cmdline) : c,context,entrypoint='fsDfuPlusExec';
   varstring GetEspURL(const varstring username = '', const varstring userPW = '') : c,once,entrypoint='fsGetEspURL';
   varstring GetDefaultDropZone() : c,once,entrypoint='fsGetDefaultDropZone';
+  varstring GetDefaultDropZoneName() : c,once,entrypoint='fsGetDefaultDropZoneName';
   dataset(FsDropZoneRecord) GetDropZones() : c,context,entrypoint='fsGetDropZones';
   dataset(FsLandingZoneRecord) GetLandingZones() : c,context,entrypoint='fsGetLandingZones';
   integer4 GetExpireDays(const varstring lfn) : c,context,entrypoint='fsGetExpireDays';

--- a/testing/regress/ecl/parquetTypes.ecl
+++ b/testing/regress/ecl/parquetTypes.ecl
@@ -29,6 +29,7 @@ compressionType := #IFDEFINED(root.compressionType, 'UNCOMPRESSED');
 IMPORT Std;
 IMPORT Parquet;
 
+dropZoneName := Std.File.GetDefaultDropZoneName();
 dropzoneDirectory := Std.File.GetDefaultDropZone() + '/regress/parquet/' + WORKUNIT + '-';
 
 // Covers data types supported by ECL and Arrow
@@ -359,17 +360,17 @@ SEQUENTIAL(
     OUTPUT(setResult, NAMED('SetTest')),
     // Clean up temporary files
     PARALLEL(
-        FileServices.DeleteExternalFile('.', dropzoneDirectory + 'BooleanTest.parquet'),
-        FileServices.DeleteExternalFile('.', dropzoneDirectory + 'IntegerTest.parquet'),
-        FileServices.DeleteExternalFile('.', dropzoneDirectory + 'UnsignedTest.parquet'),
-        FileServices.DeleteExternalFile('.', dropzoneDirectory + 'RealTest.parquet'),
-        FileServices.DeleteExternalFile('.', dropzoneDirectory + 'DecimalTest.parquet'),
-        FileServices.DeleteExternalFile('.', dropzoneDirectory + 'StringTest.parquet'),
-        FileServices.DeleteExternalFile('.', dropzoneDirectory + 'DataTest.parquet'),
-        FileServices.DeleteExternalFile('.', dropzoneDirectory + 'VarStringTest.parquet'),
-        FileServices.DeleteExternalFile('.', dropzoneDirectory + 'QStringTest.parquet'),
-        FileServices.DeleteExternalFile('.', dropzoneDirectory + 'UTF8Test.parquet'),
-        FileServices.DeleteExternalFile('.', dropzoneDirectory + 'UnicodeTest.parquet'),
-        FileServices.DeleteExternalFile('.', dropzoneDirectory + 'SetTest.parquet')
+        FileServices.DeleteExternalFile('', dropzoneDirectory + 'BooleanTest.parquet', dropZoneName),
+        FileServices.DeleteExternalFile('', dropzoneDirectory + 'IntegerTest.parquet', dropZoneName),
+        FileServices.DeleteExternalFile('', dropzoneDirectory + 'UnsignedTest.parquet', dropZoneName),
+        FileServices.DeleteExternalFile('', dropzoneDirectory + 'RealTest.parquet', dropZoneName),
+        FileServices.DeleteExternalFile('', dropzoneDirectory + 'DecimalTest.parquet', dropZoneName),
+        FileServices.DeleteExternalFile('', dropzoneDirectory + 'StringTest.parquet', dropZoneName),
+        FileServices.DeleteExternalFile('', dropzoneDirectory + 'DataTest.parquet', dropZoneName),
+        FileServices.DeleteExternalFile('', dropzoneDirectory + 'VarStringTest.parquet', dropZoneName),
+        FileServices.DeleteExternalFile('', dropzoneDirectory + 'QStringTest.parquet', dropZoneName),
+        FileServices.DeleteExternalFile('', dropzoneDirectory + 'UTF8Test.parquet', dropZoneName),
+        FileServices.DeleteExternalFile('', dropzoneDirectory + 'UnicodeTest.parquet', dropZoneName),
+        FileServices.DeleteExternalFile('', dropzoneDirectory + 'SetTest.parquet', dropZoneName)
     )
 );


### PR DESCRIPTION
And alter regression suite query parquetFiles.ecl to use it, vs "." for host which never makes sense in a containerized setup.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
