### PR TITLE
HPCC-33811 Optimize kubectl get pods call in ws_cloudService

### DIFF
--- a/esp/scm/ws_cloud.ecm
+++ b/esp/scm/ws_cloud.ecm
@@ -21,9 +21,29 @@ ESPrequest GetPODsRequest
 {
 };
 
+ESPstruct Port
+{
+    int ContainerPort;
+    string Name;
+    string Protocol;
+};
+
+ESPstruct PodItem
+{
+    string Name;
+    string Status;
+    string CreationTimestamp;
+    string ContainerName;
+    int ContainerCount;
+    int ContainerReadyCount;
+    int ContainerRestartCount;
+    ESParray<ESPstruct Port, Port> Ports;
+};
+
 ESPresponse [encode(0)] GetPODsResponse
 {
-    [json_inline(1)] string Result;
+    [depr_ver("1.02"),json_inline(1)] string Result;
+    [min_ver("1.02")] ESParray<ESPstruct PodItem, Pod> Pods;
 };
 
 ESPrequest GetServicesRequest
@@ -35,7 +55,7 @@ ESPresponse [encode(0)] GetServicesResponse
     [json_inline(1)] string Result;
 };
 
-ESPservice [auth_feature("CloudAccess:ACCESS"), version("1.01"), generated_client_version("0.0"), exceptions_inline("./smc_xslt/exceptions.xslt")] WsCloud
+ESPservice [auth_feature("CloudAccess:ACCESS"), version("1.02"), generated_client_version("0.0"), exceptions_inline("./smc_xslt/exceptions.xslt")] WsCloud
 {
     ESPmethod [auth_feature("CloudAccess:READ")] GetPODs(GetPODsRequest, GetPODsResponse);
     ESPmethod [auth_feature("CloudAccess:READ"), min_ver("1.01")] GetServices(GetServicesRequest, GetServicesResponse);


### PR DESCRIPTION
* Limit the information returned to just what is needed for the ECL Watch UI by using a jsonpath filter and metatdata label selector.
* Perform filtering and pre-processing formerly done in the typescript usePods function.
* Update method interface to return structured data rather than a json blob.
* The implementation doesn't allow us to be backward compatible or support versions <1.02. Any requests on lower versions return an exception and deprecation message.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [x] I have added tests to cover my changes.
  - [x] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [x] Scalability
  - [x] Performance
  - [x] Security
  - [x] Thread-safety
  - [x] Cloud-compatibility
  - [x] Premature optimization
  - [x] Existing deployed queries will not be broken
  - [x] This change fixes the problem, not just the symptom
  - [x] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
Tested in local helm deployment. valgrind tests not run yet due to issue https://hpccsystems.atlassian.net/browse/HPCC-34047
