### PR TITLE
HPCC-34067: Display evtool timestamps as text and not integers

### DIFF
--- a/system/jlib/jevent.cpp
+++ b/system/jlib/jevent.cpp
@@ -135,9 +135,9 @@ static constexpr EventAttrInformation attrInformation[] = {
     DEFINE_ATTR(ConnectId, u8),
     DEFINE_ATTR(Enabled, bool),
     DEFINE_ATTR(FileSize, u8),
-    DEFINE_ATTR(RecordedTimestamp, u8),
+    DEFINE_ATTR(RecordedTimestamp, timestamp),
     DEFINE_ATTR(RecordedOption, string),
-    DEFINE_ATTR(EventTimestamp, u8),
+    DEFINE_ATTR(EventTimestamp, timestamp),
     DEFINE_ATTR(EventTraceId, string),
     DEFINE_ATTR(EventThreadId, u8),
     DEFINE_ATTR(EventStackTrace, string),
@@ -1164,6 +1164,17 @@ protected:
 
     void doVisitAttribute(EventAttr id, const char* name, __uint64 value)
     {
+        if (attrInformation[id].type == EATtimestamp)
+        {
+            StringBuffer timestamp;
+            CDateTime dt;
+            dt.setTimeStampNs(value);
+            dt.getString(timestamp);
+            // assumes CDateTime output is in microseconds
+            timestamp.appendf("%03llu", value % 1000);
+            recordAttribute(id, name, timestamp, true);
+            return;
+        }
         recordAttribute(id, name, StringBuffer().append(value), false);
     }
 

--- a/system/jlib/jtime.cpp
+++ b/system/jlib/jtime.cpp
@@ -373,6 +373,12 @@ void CDateTime::setTimeStamp(timestamp_type ts)
     nanosec = (ts % 1000000) * 1000;
 }
 
+void CDateTime::setTimeStampNs(timestamp_type ts)
+{
+    set((time_t)(ts / 1000000000));
+    nanosec = (ts % 1000000000);
+}
+
 void CDateTime::adjustTime(int deltaMins)
 {
     time_t simple = getSimple();
@@ -436,6 +442,11 @@ time_t CDateTime::getSimple() const
 unsigned __int64 CDateTime::getTimeStamp() const
 {
     return (unsigned __int64)getSimple() * 1000000 + (nanosec / 1000);
+}
+
+unsigned __int64 CDateTime::getTimeStampNs() const
+{
+    return (unsigned __int64)getSimple() * 1000000000 + nanosec;
 }
 
 StringBuffer & CDateTime::getString(StringBuffer & str, bool local) const

--- a/system/jlib/jtime.hpp
+++ b/system/jlib/jtime.hpp
@@ -82,6 +82,7 @@ public:
     void set(time_t simple);
     void setFromFILETIME(__int64 fileTime);
     void setTimeStamp(timestamp_type ts);
+    void setTimeStampNs(timestamp_type ts);
 
     void setString(char const * str, char const * * end = NULL, bool local = false); // Sets to date and time given as yyyy-mm-ddThh:mm:ss[.nnnnnnnnn]
     void setDateString(char const * str, char const * * end = NULL); // Sets to midnight UTC on date given as yyyy-mm-dd
@@ -94,6 +95,7 @@ public:
     void getTime(unsigned & hour, unsigned & minute, unsigned & second, unsigned & nano, bool local = false) const;
     time_t getSimple() const;
     unsigned __int64 getTimeStamp() const;
+    unsigned __int64 getTimeStampNs() const;
     StringBuffer & getString(StringBuffer & str, bool local = false) const;
     StringBuffer & getDateString(StringBuffer & str, bool local = false) const;
     StringBuffer & getTimeString(StringBuffer & str, bool local = false) const;

--- a/testing/unittests/jlibtests2.cpp
+++ b/testing/unittests/jlibtests2.cpp
@@ -80,14 +80,18 @@ class MockEventVisitor : public CNoOpEventVisitorDecorator
 public:
     virtual Continuation visitAttribute(EventAttr id, __uint64 value) override
     {
+        // Timestamps and thread ID are not predictable. Hard code predictable values.
+        CDateTime dt;
         switch (id)
         {
             case EvAttrRecordedTimestamp:
-                value = 1000;
-                break;
+                dt.setString("2025-05-08T00:00:00.000001000");
+                value = dt.getTimeStampNs();
+                return CNoOpEventVisitorDecorator::visitAttribute(id, value);
             case EvAttrEventTimestamp:
-                value = 1010;
-                break;
+                dt.setString("2025-05-08T00:00:00.000001010");
+                value = dt.getTimeStampNs();
+                return CNoOpEventVisitorDecorator::visitAttribute(id, value);
             case EvAttrEventThreadId:
                 value = 100;
                 break;
@@ -325,7 +329,7 @@ public:
         {
             static const char* expect=R"!!!(attribute: filename = 'eventtrace.evt'
 attribute: version = 1
-attribute: RecordedTimestamp = 1000
+attribute: RecordedTimestamp = '2025-05-08T00:00:00.000001000'
 attribute: traceid = true
 attribute: threadid = true
 attribute: stack = true
@@ -353,13 +357,13 @@ attribute: bytesRead = 21
         {
             static const char* expect = R"!!!(attribute: filename = 'eventtrace.evt'
 attribute: version = 1
-attribute: RecordedTimestamp = 1000
+attribute: RecordedTimestamp = '2025-05-08T00:00:00.000001000'
 attribute: traceid = true
 attribute: threadid = true
 attribute: stack = true
 event: IndexEviction
 attribute: name = 'IndexEviction'
-attribute: EventTimestamp = 1010
+attribute: EventTimestamp = '2025-05-08T00:00:00.000001010'
 attribute: EventTraceId = '00000000000000000000000000000000'
 attribute: EventThreadId = 100
 attribute: FileId = 12345
@@ -391,13 +395,13 @@ attribute: bytesRead = 76
         {
             static const char* expect = R"!!!(attribute: filename = 'eventtrace.evt'
 attribute: version = 1
-attribute: RecordedTimestamp = 1000
+attribute: RecordedTimestamp = '2025-05-08T00:00:00.000001000'
 attribute: traceid = true
 attribute: threadid = true
 attribute: stack = true
 event: IndexEviction
 attribute: name = 'IndexEviction'
-attribute: EventTimestamp = 1010
+attribute: EventTimestamp = '2025-05-08T00:00:00.000001010'
 attribute: EventTraceId = '00000000000000000000000000000000'
 attribute: EventThreadId = 100
 attribute: FileId = 12345
@@ -406,7 +410,7 @@ attribute: NodeKind = 0
 attribute: ExpandedSize = 4567
 event: DaliConnect
 attribute: name = 'DaliConnect'
-attribute: EventTimestamp = 1010
+attribute: EventTimestamp = '2025-05-08T00:00:00.000001010'
 attribute: EventTraceId = '00000000000000000000000000000000'
 attribute: EventThreadId = 100
 attribute: Path = '/Workunits/Workunit/abc.wu'


### PR DESCRIPTION
- Add CDateTime support for getting and setting time as nanoseconds.
- Correctly define timestamp attributes as timestamps and not integers.
- Change CDumpEventVisitor to convert timestamp attribute integers to text.
- Update unit tests to replace timestamp attribute integers with meaningful values that effectively demonstrate that timestamp text representation output matches input.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [x] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
