### PR TITLE
HPCC-33928 Fix various striping/dirPerPart issues

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -6000,7 +6000,7 @@ public:
         }
 
         // need common attributes
-        Owned<ISuperFileDescriptor> fdesc=createSuperFileDescriptor(at.getClear());
+        Owned<ISuperFileDescriptor> fdesc=createSuperFileDescriptor(at.getClear(), logicalName.isForeign() ? FileDescriptorFlags::foreign : FileDescriptorFlags::none);
         if (interleaved&&(interleaved!=2))
             IWARNLOG("getFileDescriptor: Unsupported interleave value (1)");
         fdesc->setSubMapping(subcounts,interleaved!=0);
@@ -6034,10 +6034,6 @@ public:
             fdesc->setPart(n,part.getFilename(rfn,copy),&part.queryAttributes());
             n++;
         }
-        // turn off dirperpart (if present) because the super descriptor has already encoded the common parent dir + tails above.
-        FileDescriptorFlags flags = static_cast<FileDescriptorFlags>(fdesc->queryProperties().getPropInt("@flags"));
-        flags &= ~FileDescriptorFlags::dirperpart;
-        fdesc->queryProperties().setPropInt("@flags", static_cast<int>(flags));
         fdesc->queryProperties().setPropInt("@accessMode", static_cast<int>(accessMode));
         ClusterPartDiskMapSpec mspec;
         if (subfiles.ordinality()) {
@@ -7329,45 +7325,45 @@ StringBuffer &CDistributedFilePart::getPartDirectory(StringBuffer &ret,unsigned 
     else
     {
         parent.adjustClusterDir(partIndex,copy,dir);
-
-// NB: could be compiled in bare-metal,
-// but bare-metal components without a config would complain as this calls getGlobalConfig()
         unsigned cn = copyClusterNum(copy, nullptr);
         IClusterInfo &cluster = parent.clusters.item(cn);
-        const char *planeName = cluster.queryGroupName();
-        if (!isEmptyString(planeName))
-        {
-            Owned<IStoragePlane> plane;
-#ifdef _CONTAINERIZED
-            plane.setown(getDataStoragePlane(planeName, false));
-#else
-            // this is for the remote useDafilesrv case,
-            // where the remote storage plane may be needed to remap/stripe, see below.
-            IPropertyTree *remoteStoragePlane = parent.queryAttributes().queryPropTree("_remoteStoragePlane");
-            if (remoteStoragePlane)
-                plane.setown(createStoragePlane(remoteStoragePlane));
-#endif
-            if (plane)
-            {
-                StringBuffer planePrefix(plane->queryPrefix());
-                Owned<IStoragePlaneAlias> alias = plane->getAliasMatch(parent.accessMode);
-                if (alias)
-                {
-                    StringBuffer tmp;
-                    StringBuffer newPlanePrefix(alias->queryPrefix());
-                    if (setReplicateDir(dir, tmp, false, planePrefix, newPlanePrefix))
-                    {
-                        planePrefix.swapWith(newPlanePrefix);
-                        dir.swapWith(tmp);
-                    }
-                }
+        Owned<IStoragePlane> plane;
 
-                StringBuffer stripeDir;
-                unsigned numStripedDevices = parent.queryPartDiskMapping(cn).numStripedDevices;
-                addStripeDirectory(stripeDir, dir, planePrefix, partIndex, parent.lfnHash, numStripedDevices);
-                if (!stripeDir.isEmpty())
-                    dir.swapWith(stripeDir);
+        // this is for the remote useDafilesrv case,
+        // where the remote storage plane may be needed to remap/stripe, see below.
+        // NB: striping only supported in containerized environments.
+        IPropertyTree *remoteStoragePlane = parent.queryAttributes().queryPropTree("_remoteStoragePlane");
+        if (remoteStoragePlane) // implies from containerized environment
+            plane.setown(createStoragePlane(remoteStoragePlane));
+        else // local environment
+        {
+            if (isContainerized())
+            {
+                const char *planeName = cluster.queryGroupName();
+                if (!isEmptyString(planeName))
+                    plane.setown(getDataStoragePlane(planeName, false));
             }
+        }
+        if (plane)
+        {
+            StringBuffer planePrefix(plane->queryPrefix());
+            Owned<IStoragePlaneAlias> alias = plane->getAliasMatch(parent.accessMode);
+            if (alias)
+            {
+                StringBuffer tmp;
+                StringBuffer newPlanePrefix(alias->queryPrefix());
+                if (setReplicateDir(dir, tmp, false, planePrefix, newPlanePrefix))
+                {
+                    planePrefix.swapWith(newPlanePrefix);
+                    dir.swapWith(tmp);
+                }
+            }
+
+            StringBuffer stripeDir;
+            unsigned numStripedDevices = parent.queryPartDiskMapping(cn).numStripedDevices;
+            addStripeDirectory(stripeDir, dir, planePrefix, partIndex, parent.lfnHash, numStripedDevices);
+            if (!stripeDir.isEmpty())
+                dir.swapWith(stripeDir);
         }
         if (parent.hasDirPerPart())
             addPathSepChar(dir).append(partIndex+1); // part subdir 1 based

--- a/dali/base/dafdesc.cpp
+++ b/dali/base/dafdesc.cpp
@@ -459,8 +459,11 @@ public:
         mspec =_mspec;
         if (flags & IFDSF_FOREIGN_GROUP)
             foreignGroup = true;
-        checkClusterName(resolver);
-        checkStriped();
+        else
+        {
+            checkClusterName(resolver);
+            checkStriped();
+        }
     }
     CClusterInfo(IPropertyTree *pt,INamedGroupStore *resolver,unsigned flags)
     {
@@ -475,22 +478,25 @@ public:
 
         if ((((flags&IFDSF_EXCLUDE_GROUPS)==0)||name.isEmpty())&&pt->hasProp("Group"))
             group.setown(createIGroup(pt->queryProp("Group")));
-        if (!name.isEmpty()&&!group.get()&&resolver&&!foreignGroup)
+        if (!foreignGroup)
         {
-            StringBuffer defaultDir;
-            GroupType groupType;
-            group.setown(resolver->lookup(name.get(), defaultDir, groupType));
-            // MORE - common some of this with checkClusterName?
-            bool baseDirChanged = mspec.defaultBaseDir.isEmpty() || !strsame(mspec.defaultBaseDir, defaultDir);
-            if (baseDirChanged)
-                mspec.setDefaultBaseDir(defaultDir);   // MORE - should possibly set up the rest of the mspec info from the group info here
+            if (!name.isEmpty()&&!group.get()&&resolver)
+            {
+                StringBuffer defaultDir;
+                GroupType groupType;
+                group.setown(resolver->lookup(name.get(), defaultDir, groupType));
+                // MORE - common some of this with checkClusterName?
+                bool baseDirChanged = mspec.defaultBaseDir.isEmpty() || !strsame(mspec.defaultBaseDir, defaultDir);
+                if (baseDirChanged)
+                    mspec.setDefaultBaseDir(defaultDir);   // MORE - should possibly set up the rest of the mspec info from the group info here
 
-            if (mspec.defaultCopies>1 && (mspec.defaultReplicateDir.isEmpty() || baseDirChanged))
-                mspec.setDefaultReplicateDir(queryBaseDirectory(groupType, 1));  // MORE - not sure this is strictly correct
+                if (mspec.defaultCopies>1 && (mspec.defaultReplicateDir.isEmpty() || baseDirChanged))
+                    mspec.setDefaultReplicateDir(queryBaseDirectory(groupType, 1));  // MORE - not sure this is strictly correct
+            }
+            else
+                checkClusterName(resolver);
+            checkStriped();
         }
-        else
-            checkClusterName(resolver);
-        checkStriped();
     }
 
     const char *queryGroupName()
@@ -1134,10 +1140,11 @@ class CFileDescriptor:  public CFileDescriptorBase, implements ISuperFileDescrip
                 throw MakeStringException(-1,"IFileDescriptor - setup already done");
             setupdone = true;
             ClusterPartDiskMapSpec mspec;
-            clusters.append(*createClusterInfo(NULL,NULL,mspec));
+            unsigned clusterFlags = 0;
+            if (FileDescriptorFlags::none != (fileFlags & FileDescriptorFlags::foreign))
+                clusterFlags = IFDSF_FOREIGN_GROUP;
+            clusters.append(*createClusterInfo(nullptr, nullptr, mspec, nullptr, clusterFlags));
         }
-
-
     }
 
     void doClosePending()
@@ -1309,14 +1316,17 @@ class CFileDescriptor:  public CFileDescriptorBase, implements ISuperFileDescrip
     StringBuffer &getPartDirectory(StringBuffer &buf,unsigned idx,unsigned copy)
     {
         unsigned n = numParts();
-        if (idx<n) {
+        if (idx<n)
+        {
             StringBuffer fullpath;
             StringBuffer tmp1;
             CPartDescriptor &pt = *part(idx);
-            if (!pt.overridename.isEmpty()) {
+            if (!pt.overridename.isEmpty())
+            {
                 if (isSpecialPath(pt.overridename))
                     return buf;
-                if (pt.isMulti()) {
+                if (pt.isMulti())
+                {
                     StringBuffer tmpon; // bit messy but need to ensure dir put back on before removing!
                     const char *on = pt.overridename.get();
                     if (on&&*on&&!isAbsolutePath(on)&&!directory.isEmpty())
@@ -1328,16 +1338,19 @@ class CFileDescriptor:  public CFileDescriptorBase, implements ISuperFileDescrip
                     splitDirTail(pt.overridename,tmp1);
                 if (directory.isEmpty()||(isAbsolutePath(tmp1.str())||(stdIoHandle(tmp1.str())>=0)))
                     fullpath.swapWith(tmp1);
-                else {
+                else
+                {
                     fullpath.append(directory);
                     if (fullpath.length())
                         addPathSepChar(fullpath);
                     fullpath.append(tmp1);
                 }
             }
-            else if (!partmask.isEmpty()) {
+            else if (!partmask.isEmpty())
+            {
                 fullpath.append(directory);
-                if (containsPathSepChar(partmask)) {
+                if (containsPathSepChar(partmask))
+                {
                     if (fullpath.length())
                         addPathSepChar(fullpath);
                     splitDirTail(partmask,fullpath);
@@ -1356,7 +1369,11 @@ class CFileDescriptor:  public CFileDescriptorBase, implements ISuperFileDescrip
                 cluster->getBaseDir(baseDir, os);
                 cluster->getReplicateDir(repDir, os);
                 setReplicateFilename(fullpath,queryDrive(idx,copy),baseDir.str(),repDir.str());
+            }
 
+            // Adding striping and/or aliasing to path already done if part overridename set
+            if (pt.overridename.isEmpty())
+            {
                 // The following code manipulates the directory for striping and aliasing if necessary.
                 // To do so, it needs the plane details.
                 // Normally, the plane name is obtained from IClusterInfo, however, if this file is foreign,
@@ -1366,7 +1383,7 @@ class CFileDescriptor:  public CFileDescriptorBase, implements ISuperFileDescrip
                 Owned<IStoragePlane> plane;
                 if (remoteStoragePlane)
                     plane.set(remoteStoragePlane);
-                else
+                else if (cluster)
                 {
                     const char *planeName = cluster->queryGroupName();
                     if (!isEmptyString(planeName))
@@ -1399,8 +1416,13 @@ class CFileDescriptor:  public CFileDescriptorBase, implements ISuperFileDescrip
                 buf.append(fullpath);
             else
                 buf.swapWith(fullpath);
-            if (FileDescriptorFlags::none != (fileFlags & FileDescriptorFlags::dirperpart))
-                addPathSepChar(buf).append(idx+1); // part subdir 1 based
+
+            // Adding dir-per-part directory to path already done if part overridename set
+            if (pt.overridename.isEmpty())
+            {
+                if (FileDescriptorFlags::none != (fileFlags & FileDescriptorFlags::dirperpart))
+                    addPathSepChar(buf).append(idx+1); // part subdir 1 based
+            }
         }
         return buf;
     }
@@ -2320,10 +2342,11 @@ public:
     {
     }
 
-    CSuperFileDescriptor(IPropertyTree *attr)
+    CSuperFileDescriptor(IPropertyTree *attr, FileDescriptorFlags _fileFlags)
         : CFileDescriptor(attr,NULL,IFDSF_ATTR_ONLY)    // only support attr here
     {
         subfilecounts = NULL;
+        fileFlags = _fileFlags;
     }
 
     virtual ~CSuperFileDescriptor()
@@ -2460,9 +2483,9 @@ IFileDescriptor *createFileDescriptor(IPropertyTree *tree)
     return new CFileDescriptor(tree,NULL,IFDSF_ATTR_ONLY);
 }
 
-ISuperFileDescriptor *createSuperFileDescriptor(IPropertyTree *tree)
+ISuperFileDescriptor *createSuperFileDescriptor(IPropertyTree *tree, FileDescriptorFlags fileFlags)
 {
-    return new CSuperFileDescriptor(tree);
+    return new CSuperFileDescriptor(tree, fileFlags);
 }
 
 

--- a/dali/base/dafdesc.hpp
+++ b/dali/base/dafdesc.hpp
@@ -423,7 +423,7 @@ extern da_decl IFileDescriptor *createFileDescriptor(IPropertyTree *attr);      
 extern da_decl IFileDescriptor *createFileDescriptor(const char *lname, const char *clusterType, const char *groupName, IGroup *grp);
 extern da_decl IFileDescriptor *createExternalFileDescriptor(const char *logicalname);
 extern da_decl IFileDescriptor *getExternalFileDescriptor(const char *logicalname);
-extern da_decl ISuperFileDescriptor *createSuperFileDescriptor(IPropertyTree *attr);        // ownership of attr tree is taken
+extern da_decl ISuperFileDescriptor *createSuperFileDescriptor(IPropertyTree *attr, FileDescriptorFlags fileFlags);        // ownership of attr tree is taken
 extern da_decl IFileDescriptor *deserializeFileDescriptor(MemoryBuffer &mb);
 extern da_decl IFileDescriptor *deserializeFileDescriptorTree(IPropertyTree *tree, INamedGroupStore *resolver=NULL, unsigned flags=0);  // flags IFDSF_*
 extern da_decl IPartDescriptor *deserializePartFileDescriptor(MemoryBuffer &mb);


### PR DESCRIPTION
1) Never stripe or add dir-per-part dirs, if parts have override
2) Do not remove dir-per-part meta flags when creating super file descriptor (was done to avoid workers re-adding, but now done via [1]). 
3) Ensure CDistributedFilePart::getPartDirectory stripes consistently. It was not doing so in general, and relied on the workers doing so (now not done due to [1]). This had the effect of when used of the directory being wrong, and when used to build a super IFileDescriptor the overridenames were wrong, but were patched by the worker code.
Now with the fixes, CDistributedFilePart::getPartDirectory will return a fully striped/dir-per-part dir, and the workers will not manipulate further if used as part of an overridename.
4) Tighen up the cluster/group lookups when a foreign file is involved. Avoid situations where the client environment lookup a group name from a foreign environment and spuriously matched a local group.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
