### PR TITLE
HPCC-34225: Simplify IEventVisitor

### DIFF
--- a/common/eventconsumption/CMakeLists.txt
+++ b/common/eventconsumption/CMakeLists.txt
@@ -31,6 +31,7 @@ set (
     ${CMAKE_CURRENT_SOURCE_DIR}/eventindexhotspot.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/eventindexsummarize.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/eventoperation.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/eventvisitor.cpp
 )
 
 ADD_DEFINITIONS( -D_USRDLL -DEVENTCONSUMPTION_EXPORTS )

--- a/common/eventconsumption/eventdump.cpp
+++ b/common/eventconsumption/eventdump.cpp
@@ -24,7 +24,7 @@ void CDumpEventsOp::setFormat(OutputFormat _format)
 
 bool CDumpEventsOp::doOp()
 {
-    Owned<IEventVisitor> visitor;
+    Owned<IEventAttributeVisitor> visitor;
     switch (format)
     {
     case OutputFormat::json:

--- a/common/eventconsumption/eventdump.h
+++ b/common/eventconsumption/eventdump.h
@@ -22,25 +22,25 @@
 #include "eventoperation.h"
 
 // Get a visitor that streams visited event data in JSON format.
-extern event_decl IEventVisitor* createDumpJSONEventVisitor(IBufferedSerialOutputStream& out);
+extern event_decl IEventAttributeVisitor* createDumpJSONEventVisitor(IBufferedSerialOutputStream& out);
 
 // Get a visitor that streams visited event data in a flat text format.
-extern event_decl IEventVisitor* createDumpTextEventVisitor(IBufferedSerialOutputStream& out);
+extern event_decl IEventAttributeVisitor* createDumpTextEventVisitor(IBufferedSerialOutputStream& out);
 
 // Get a visitor that streams visited event data in XML format.
-extern event_decl IEventVisitor* createDumpXMLEventVisitor(IBufferedSerialOutputStream& out);
+extern event_decl IEventAttributeVisitor* createDumpXMLEventVisitor(IBufferedSerialOutputStream& out);
 
 // Get a visitor that streams visited event data in YAML format.
-extern event_decl IEventVisitor* createDumpYAMLEventVisitor(IBufferedSerialOutputStream& out);
+extern event_decl IEventAttributeVisitor* createDumpYAMLEventVisitor(IBufferedSerialOutputStream& out);
 
 // Get a visitor that streams visited event data in CSV format.
-extern event_decl IEventVisitor* createDumpCSVEventVisitor(IBufferedSerialOutputStream& out);
+extern event_decl IEventAttributeVisitor* createDumpCSVEventVisitor(IBufferedSerialOutputStream& out);
 
 // Encapsulation of a visitor that stores visited event data in a property tree and
 // access to the tree.
 interface IEventPTreeCreator : extends IInterface
 {
-    virtual IEventVisitor& queryVisitor() = 0;
+    virtual IEventAttributeVisitor& queryVisitor() = 0;
     virtual IPTree* queryTree() const = 0;
 };
 

--- a/common/eventconsumption/eventdump.hpp
+++ b/common/eventconsumption/eventdump.hpp
@@ -55,10 +55,15 @@ constexpr static const char* DUMP_STRUCTURE_FILE_BYTES_READ = "bytesRead";
 //  `virtual bool departEvent() = 0;`
 //  `virtual void departFile(uint32_t bytesRead) = 0;`
 //  `virtual void recordAttribute(EventAttr id, const char* name, const char* value, bool quoted) = 0;`
-class CDumpEventVisitor : public CInterfaceOf<IEventVisitor>
+class CDumpEventVisitor : public CInterfaceOf<IEventAttributeVisitor>
 {
 public:
-    using Continuation = IEventVisitor::Continuation;
+    using Continuation = IEventAttributeVisitor::Continuation;
+
+    virtual bool visitEvent(IEvent& event) override
+    {
+        return eventDistributor(event, *this);
+    }
 
     virtual Continuation visitAttribute(EventAttr id, const char* value) override
     {

--- a/common/eventconsumption/eventdumpptree.cpp
+++ b/common/eventconsumption/eventdumpptree.cpp
@@ -22,7 +22,7 @@
 // after visitation.
 class CPTreeEventVisitor : public CDumpEventVisitor
 {
-public: // IEventVisitor
+public: // IEventAttributeVisitor
     virtual bool visitFile(const char* filename, uint32_t version) override
     {
         tree.setown(createPTree(DUMP_STRUCTURE_ROOT));
@@ -72,7 +72,7 @@ IEventPTreeCreator* createEventPTreeCreator()
     class Creator : public CInterfaceOf<IEventPTreeCreator>
     {
     public:
-        virtual IEventVisitor& queryVisitor() override
+        virtual IEventAttributeVisitor& queryVisitor() override
         {
             return *visitor;
         }

--- a/common/eventconsumption/eventdumpstream.cpp
+++ b/common/eventconsumption/eventdumpstream.cpp
@@ -123,7 +123,7 @@ protected:
     }
 };
 
-IEventVisitor* createDumpTextEventVisitor(IBufferedSerialOutputStream& out)
+IEventAttributeVisitor* createDumpTextEventVisitor(IBufferedSerialOutputStream& out)
 {
     return new CDumpTextEventVisitor(out);
 }
@@ -207,7 +207,7 @@ private:
     unsigned indentLevel{0};
 };
 
-IEventVisitor* createDumpXMLEventVisitor(IBufferedSerialOutputStream& out)
+IEventAttributeVisitor* createDumpXMLEventVisitor(IBufferedSerialOutputStream& out)
 {
     return new CDumpXMLEventVisitor(out);
 }
@@ -341,7 +341,7 @@ private:
     bool firstEvent{true};
 };
 
-IEventVisitor* createDumpJSONEventVisitor(IBufferedSerialOutputStream& out)
+IEventAttributeVisitor* createDumpJSONEventVisitor(IBufferedSerialOutputStream& out)
 {
     return new CDumpJSONEventVisitor(out);
 }
@@ -437,7 +437,7 @@ protected:
     uint8_t indentLevel{0};
 };
 
-IEventVisitor* createDumpYAMLEventVisitor(IBufferedSerialOutputStream& out)
+IEventAttributeVisitor* createDumpYAMLEventVisitor(IBufferedSerialOutputStream& out)
 {
     return new CDumpYAMLEventVisitor(out);
 }
@@ -509,7 +509,7 @@ private:
     std::set<EventAttr> headerAttrs;
 };
 
-IEventVisitor* createDumpCSVEventVisitor(IBufferedSerialOutputStream& out)
+IEventAttributeVisitor* createDumpCSVEventVisitor(IBufferedSerialOutputStream& out)
 {
     return new CDumpCSVEventVisitor(out);
 }

--- a/common/eventconsumption/eventfilter.cpp
+++ b/common/eventconsumption/eventfilter.cpp
@@ -257,10 +257,15 @@ protected:
         bool b{false};
     };
 
-public: // IEventVisitor
+public: // IEventAttributeVisitor
     virtual bool visitFile(const char* filename, uint32_t version) override
     {
         return target->visitFile(filename, version);
+    }
+
+    virtual bool visitEvent(IEvent& event) override
+    {
+        return eventDistributor(event, *this);
     }
 
     virtual Continuation visitEvent(EventType type) override
@@ -461,7 +466,7 @@ public:
         }
     }
 
-    virtual void setTarget(IEventVisitor& visitor) override
+    virtual void setTarget(IEventAttributeVisitor& visitor) override
     {
         target.set(&visitor);
     }
@@ -488,7 +493,7 @@ protected:
 
 protected:
     using AcceptedEvents = std::unordered_set<EventType>;
-    Linked<IEventVisitor> target;
+    Linked<IEventAttributeVisitor> target;
     Owned<FilterTerm> terms[EvAttrMax];
     CachedAttrValue cachedAttrValues[EvAttrMax];
     using CacheSequence = std::vector<EventAttr>;

--- a/common/eventconsumption/eventfilter.h
+++ b/common/eventconsumption/eventfilter.h
@@ -20,7 +20,7 @@
 #include "eventconsumption.h"
 #include "eventvisitor.h"
 
-// Extension of IEventVisitor that supports filtering of visited files and events. Implementations
+// Extension of IEventAttributeVisitor that supports filtering of visited files and events. Implementations
 // will decorate another visitor, forwarding all visits not blocked by the specified constraints to
 // the decorated visitor.
 //
@@ -30,7 +30,7 @@
 //
 // An event blocked by an attribute constraint must not be forwarded to the decorated visitor.
 // Events that do not include a constrained attribute are not blocked.
-interface IEventFilter : extends IEventVisitor
+interface IEventFilter : extends IEventAttributeVisitor
 {
     // Filter on a single event type. All events are accepted by default.
     virtual bool acceptEvent(EventType type) = 0;
@@ -59,7 +59,7 @@ interface IEventFilter : extends IEventVisitor
 
     // Install the recipient of unfiltered visits. `readEvents` will call this method before
     // beginning visitation.
-    virtual void setTarget(IEventVisitor& visitor) = 0;
+    virtual void setTarget(IEventAttributeVisitor& visitor) = 0;
 };
 
 // Obtain a new instance of a standard event filter.

--- a/common/eventconsumption/eventindexhotspot.cpp
+++ b/common/eventconsumption/eventindexhotspot.cpp
@@ -197,7 +197,7 @@ private:
     byte limit;
 };
 
-class CHotspotEventVisitor : public CInterfaceOf<IEventVisitor>
+class CHotspotEventVisitor : public CInterfaceOf<IEventAttributeVisitor>
 {
     // Manages the event data for a single file.
     class CActivity
@@ -321,10 +321,15 @@ class CHotspotEventVisitor : public CInterfaceOf<IEventVisitor>
         Activity activity[BucketAmbiguous]; // incoming activity is never ambiguous, this storage is not ambiguous
     };
 
-public: // IEventVisitor
+public: // IEventAttributeVisitor
     virtual bool visitFile(const char* filename, uint32_t version) override
     {
         return true;
+    }
+
+    virtual bool visitEvent(IEvent& event) override
+    {
+        return eventDistributor(event, *this);
     }
 
     virtual Continuation visitEvent(EventType type) override

--- a/common/eventconsumption/eventindexsummarize.cpp
+++ b/common/eventconsumption/eventindexsummarize.cpp
@@ -22,7 +22,12 @@ bool CIndexFileSummary::visitFile(const char *filename, uint32_t version)
     return true;
 }
 
-IEventVisitor::Continuation CIndexFileSummary::visitEvent(EventType id)
+bool CIndexFileSummary::visitEvent(IEvent& event)
+{
+    return eventDistributor(event, *this);
+}
+
+IEventAttributeVisitor::Continuation CIndexFileSummary::visitEvent(EventType id)
 {
     switch (id)
     {
@@ -31,13 +36,13 @@ IEventVisitor::Continuation CIndexFileSummary::visitEvent(EventType id)
     case EventIndexEviction:
     case MetaFileInformation:
         currentEvent = id;
-        return IEventVisitor::visitContinue;
+        return IEventAttributeVisitor::visitContinue;
     default:
-        return IEventVisitor::visitSkipEvent;
+        return IEventAttributeVisitor::visitSkipEvent;
     }
 }
 
-IEventVisitor::Continuation CIndexFileSummary::visitAttribute(EventAttr id, const char *value)
+IEventAttributeVisitor::Continuation CIndexFileSummary::visitAttribute(EventAttr id, const char *value)
 {
     switch (id)
     {
@@ -48,10 +53,10 @@ IEventVisitor::Continuation CIndexFileSummary::visitAttribute(EventAttr id, cons
     default:
         break;
     }
-    return IEventVisitor::visitContinue;
+    return IEventAttributeVisitor::visitContinue;
 }
 
-IEventVisitor::Continuation CIndexFileSummary::visitAttribute(EventAttr id, bool value)
+IEventAttributeVisitor::Continuation CIndexFileSummary::visitAttribute(EventAttr id, bool value)
 {
     switch (id)
     {
@@ -62,10 +67,10 @@ IEventVisitor::Continuation CIndexFileSummary::visitAttribute(EventAttr id, bool
             nodeSummary().misses++;
         break;
     }
-    return IEventVisitor::visitContinue;
+    return IEventAttributeVisitor::visitContinue;
 }
 
-IEventVisitor::Continuation CIndexFileSummary::visitAttribute(EventAttr id, __uint64 value)
+IEventAttributeVisitor::Continuation CIndexFileSummary::visitAttribute(EventAttr id, __uint64 value)
 {
     switch (id)
     {
@@ -108,7 +113,7 @@ IEventVisitor::Continuation CIndexFileSummary::visitAttribute(EventAttr id, __ui
     default:
         break;
     }
-    return IEventVisitor::visitContinue;
+    return IEventAttributeVisitor::visitContinue;
 }
 
 bool CIndexFileSummary::departEvent()

--- a/common/eventconsumption/eventindexsummarize.h
+++ b/common/eventconsumption/eventindexsummarize.h
@@ -21,10 +21,11 @@
 #include "eventoperation.h"
 #include "eventvisitor.h"
 
-class event_decl CIndexFileSummary : public IEventVisitor, public CEventConsumingOp
+class event_decl CIndexFileSummary : public IEventAttributeVisitor, public CEventConsumingOp
 {
-public: // IEventVisitor
+public: // IEventAttributeVisitor
     virtual bool visitFile(const char *filename, uint32_t version) override;
+    virtual bool visitEvent(IEvent& event) override;
     virtual Continuation visitEvent(EventType id) override;
     virtual Continuation visitAttribute(EventAttr id, const char *value) override;
     virtual Continuation visitAttribute(EventAttr id, bool value) override;

--- a/common/eventconsumption/eventoperation.cpp
+++ b/common/eventconsumption/eventoperation.cpp
@@ -50,7 +50,7 @@ IEventFilter* CEventConsumingOp::ensureFilter()
     return filter;
 }
 
-bool CEventConsumingOp::traverseEvents(const char* path, IEventVisitor& visitor)
+bool CEventConsumingOp::traverseEvents(const char* path, IEventAttributeVisitor& visitor)
 {
     if (filter)
     {

--- a/common/eventconsumption/eventoperation.h
+++ b/common/eventconsumption/eventoperation.h
@@ -37,7 +37,7 @@ public:
     bool acceptAttribute(EventAttr attr, const char* values);
 protected:
     IEventFilter* ensureFilter();
-    bool traverseEvents(const char* path, IEventVisitor& visitor);
+    bool traverseEvents(const char* path, IEventAttributeVisitor& visitor);
 protected:
     StringAttr inputPath;
     Linked<IBufferedSerialOutputStream> out;

--- a/common/eventconsumption/eventvisitor.cpp
+++ b/common/eventconsumption/eventvisitor.cpp
@@ -1,0 +1,53 @@
+/*##############################################################################
+
+    Copyright (C) 2025 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include "eventvisitor.h"
+#include "jiface.hpp"
+#include "jexcept.hpp"
+
+bool eventDistributor(IEvent& event, IEventAttributeVisitor& visitor)
+{
+    IEventAttributeVisitor::Continuation result = visitor.visitEvent(event.queryType());
+    switch (result)
+    {
+    case IEventAttributeVisitor::visitSkipEvent:
+        return true;
+    case IEventAttributeVisitor::visitSkipFile:
+        return false;
+    }
+    Owned<IEventAttributeIterator> attributes = event.getAttributes();
+    ForEach(*attributes)
+    {
+        const IEventAttribute& attribute = attributes->query();
+        if (attribute.isNumeric())
+            result = visitor.visitAttribute(attribute.queryId(), attribute.queryNumericValue());
+        else if (attribute.isText())
+            result = visitor.visitAttribute(attribute.queryId(), attribute.queryTextValue());
+        else if (attribute.isBoolean())
+            result = visitor.visitAttribute(attribute.queryId(), attribute.queryBooleanValue());
+        else
+            throw makeStringException(-1, "unknown attribute type");
+        switch (result)
+        {
+        case IEventAttributeVisitor::visitSkipEvent:
+            return true;
+        case IEventAttributeVisitor::visitSkipFile:
+            return false;
+        }
+    }
+    return visitor.departEvent();
+}

--- a/common/eventconsumption/eventvisitor.h
+++ b/common/eventconsumption/eventvisitor.h
@@ -17,7 +17,49 @@
 
 #pragma once
 
+#include "eventconsumption.h"
 // MORE: If jevent.hpp replaces readEvents with a function that returns a reader instance, from
 // which events are pulled instead of visisted, then this file will declare the IEventVisisot
 // interface and the adapter to convert pulled events into visisted events.
 #include "jevent.hpp"
+
+// Abstraction of the visitor pattern for "reading" binary event data files. The `readEvents`
+// function will pass each byte of data contained within a file throwgh exactly one method of
+// this interface.
+//
+// For each compatibile file the visitor can expect:
+// 1. One call to visitFile
+// 2. Zero or more sequences of:
+//    a. One call to visitEvent
+//    b. Zero or more calls to visitAttribute
+//    c. One call to departEvent
+// 3. One call to departFile
+//
+// Implementations may implement limited filtering during visitation. All methods, except
+// `departFile`, may abort visitation. Both `visitEvent` and `visitAttribute` (in the context of
+// an event) may suppress visitation of the remainder of the current event.
+//
+// Reasons for aborting a file include:
+// - unrecognized file version; or
+// - (remaining) events out of a target date range; or
+// - trace IDs are required but are not present.
+//
+// Reasons for suppressing an event include:
+// - event type not required by current use case; or
+// - attribute value not out of range for current use case.
+interface IEventAttributeVisitor : extends IEventVisitor
+{
+    enum Continuation {
+        visitContinue,
+        visitSkipEvent,
+        visitSkipFile
+    };
+    using IEventVisitor::visitEvent;
+    virtual Continuation visitEvent(EventType id) = 0;
+    virtual Continuation visitAttribute(EventAttr id, const char * value) = 0;
+    virtual Continuation visitAttribute(EventAttr id, bool value) = 0;
+    virtual Continuation visitAttribute(EventAttr id, __uint64 value) = 0;
+    virtual bool departEvent() = 0;
+};
+
+extern event_decl bool eventDistributor(IEvent& event, IEventAttributeVisitor& visitor);


### PR DESCRIPTION
Update jevent:
- Define an event encapsulation.
- Remove visitEvent, visitAttribute, and departEvent.
- Add visitEvent that accepts an event encapsulation.

Update eventconsumption:
- Declare IEventVisitor extension that accepts the visits removed from IEventVisitor.
- Implement a utility function to distribute encapsulated event data to the visitor extension.
- Change all implementations of IEventVisitor to implement the extension.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [x] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
