### PR TITLE
HPCC-34260 Fix XRef constructing external file names incorrectly

### DIFF
--- a/dali/sasha/saxref.cpp
+++ b/dali/sasha/saxref.cpp
@@ -192,6 +192,11 @@ struct cFileDesc // no virtuals
         return memcmp(key,name+1,sl)==0;
     }
 
+    bool isHPCCFile() const
+    {
+        return filenameLen > 0;
+    }
+
     bool getName(StringBuffer &buf) const
     {
         // Check mask exists
@@ -345,11 +350,20 @@ struct cDirDesc
         else {  // didn't match mask so use straight name
             //PROGLOG("**unmatched(%d,%d,%d) %s",drv,node,numnodes,name);
             pf = (node+numnodes-drv)%numnodes;
-            nf = numnodes;
+            nf = NotFound;
         }
         return fn;
     }
 
+    bool isMisplaced(unsigned partNum, unsigned numParts, const SocketEndpoint &ep, IGroup &grp)
+    {
+        // MORE: Add better check for misplaced in Containerized
+        // If plane being scanned is host based (i.e. not locally mounted), misplaced could still make sense
+        if (isContainerized())
+            return false;
+
+        return numParts!=grp.ordinality() || partNum>=grp.ordinality() || !grp.queryNode(partNum).endpoint().equals(ep);
+    }
 
     cFileDesc *addFile(unsigned drv,const char *name,__int64 sz,CDateTime &dt,unsigned node, const SocketEndpoint &ep, IGroup &grp, unsigned numnodes, CLargeMemoryAllocator *mem)
     {
@@ -359,9 +373,7 @@ struct cDirDesc
         unsigned filenameLen; // length of file name excluding extension i.e. ._$P$_of_$N$
         StringAttr mask;
         const char *fn = decodeName(drv,name,node,numnodes,mask,pf,nf,filenameLen);
-        // TODO: Add better check for misplaced in isContainerized
-        // If plane being scanned is host based (i.e. not locally mounted), misplaced could still make sense
-        bool misplaced = !isContainerized() && (nf!=grp.ordinality() || pf>=grp.ordinality() || !grp.queryNode(pf).endpoint().equals(ep));
+        bool misplaced = isMisplaced(pf, nf, ep, grp);
         cFileDesc *file = files.find(fn,false);
         if (!file) {
             if (!mem)
@@ -1326,6 +1338,7 @@ public:
             StringBuffer tmp(LOGPFX "listOrphans reading ");
             rfn.getRemotePath(tmp);
             EXCLOG(e,tmp.str());
+            e->Release();
         }
         return false;
     }
@@ -1344,8 +1357,54 @@ public:
             pb = branch->addPropTree("Part",pb);
         }
         pb->setProp(rep?"RNode":"Node",ep.getEndpointHostText(tmp.clear()).str());
-    }   
+    }
 
+    void addExternalFoundFile(cFileDesc *file, const char *currentPath, unsigned int recentCutoffDays)
+    {
+        // Treat external files as a single file because without a partmask there is no way
+        // to determine the number of parts or the part number
+        StringBuffer filePath(currentPath);
+        file->getNameMask(addPathSepChar(filePath));
+
+        // Files that are non-conforming will be marked as misplaced in the directory scan
+        unsigned node = 0;
+        assertex(file->misplaced);
+        node = file->misplaced->nn;
+
+        SocketEndpoint ep = grp->queryNode(node).endpoint();
+        RemoteFilename rfn;
+        rfn.setPath(ep, filePath.str());
+        offset_t sz;
+        CDateTime dt;
+        bool found;
+        {
+            CheckTime ct("checkOrphanPhysicalFile ");
+            found = checkOrphanPhysicalFile(rfn,sz,dt);
+            if (ct.slow())
+                ct.appendMsg(filePath.str());
+        }
+        if (found)
+        {
+            CDateTime now;
+            now.setNow();
+            CDateTime co(dt);
+            co.adjustTime(recentCutoffDays*60*24);
+            if (co.compare(now)>=0) {
+                warn(filePath.str(),"Recent external file ignored");
+                return;
+            }
+
+            StringBuffer tmp;
+            Owned<IPropertyTree> branch;
+            addOrphanPartNode(branch,rfn.queryEndpoint(),0,false);
+            branch->setPropInt64("Size",sz);
+            branch->setProp("Partmask",filePath.str());
+            branch->setProp("Modified",dt.getString(tmp.clear()));
+            branch->setPropInt("Numparts",1);
+            branch->setPropInt("Partsfound",1);
+            foundbranch->addPropTree("File",branch.getClear());
+        }
+    }
 
     void listOrphans(cFileDesc *f,const char *currentPath,const char *currentScope,bool &abort,unsigned int recentCutoffDays)
     {
@@ -1359,6 +1418,12 @@ public:
         f->getNameMask(dbgname);
         PROGLOG("listOrphans TEST FILE(%s)",dbgname.str());
 #endif
+
+        // Non-conforming files won't have a part mask and should be treated as single files
+        if (!f->isHPCCFile()) {
+            addExternalFoundFile(f,currentPath,recentCutoffDays);
+            return;
+        }
 
         unsigned drv;
         unsigned drvs = isContainerized() ? 1 : 2;
@@ -1376,17 +1441,18 @@ public:
         StringBuffer scopeBuf(currentScope);
         scopeBuf.append("::");
         f->getNameMask(mask);
-        if (f->getName(scopeBuf)) { // orphans are only orphans if there doesn't exist a valid file
-            try {
-                if (queryDistributedFileDirectory().exists(scopeBuf.str(),udesc,true,false)) {
-                    warn(mask.str(),"Orphans ignored as %s exists",scopeBuf.str());
-                    return;
-                }
-            }
-            catch (IException *e) {
-                EXCLOG(e,"CNewXRefManager::listOrphans");
+        assertex(f->getName(scopeBuf)); // Should always return true for HPCC files
+        // orphans are only orphans if there doesn't exist a valid file
+        try {
+            if (queryDistributedFileDirectory().exists(scopeBuf.str(),udesc,true,false)) {
+                warn(mask.str(),"Orphans ignored as %s exists",scopeBuf.str());
                 return;
             }
+        }
+        catch (IException *e) {
+            EXCLOG(e,"CNewXRefManager::listOrphans");
+            e->Release();
+            return;
         }
         // treat drive differently for orphans (bit silly but bward compatible
         MemoryAttr buf;
@@ -1757,6 +1823,7 @@ public:
                         StringBuffer tmp(LOGPFX "Checking file ");
                         rfn.getRemotePath(tmp);
                         EXCLOG(e, tmp.str());
+                        e->Release();
                         ok = false;
                     }
                     if (!ok)


### PR DESCRIPTION
- Add call to getNameMask if getName returns false
- Add parameter to constructPartFileName and makePhysicalPartName to prevent logical file suffix from being appended to external files
- Update calls to constructPartFileName and makePhysicalPartName to include additional parameter
- If filenameLen is 0, set 1 as the max part number since there is no way to know if multiple parts. Otherwise, external files will always be marked as orphans rather than found.

@jakesmith Is adding an additional parameter the best choice? I don't think there is a definitive way to tell from the information that makePhysicalPartName has already.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [ ] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
