### PR TITLE
HPCC-34234: Refactor event filter to use simplified visitor interface

### DIFF
--- a/common/eventconsumption/eventfilter.h
+++ b/common/eventconsumption/eventfilter.h
@@ -30,7 +30,7 @@
 //
 // An event blocked by an attribute constraint must not be forwarded to the decorated visitor.
 // Events that do not include a constrained attribute are not blocked.
-interface IEventFilter : extends IEventAttributeVisitor
+interface IEventFilter : extends IEventVisitorDecorator
 {
     // Filter on a single event type. All events are accepted by default.
     virtual bool acceptEvent(EventType type) = 0;
@@ -56,10 +56,6 @@ interface IEventFilter : extends IEventAttributeVisitor
     // - A filter for the integral EvAttrFileId may include string tokens that will be applied to
     //   a corresponding EvAttrPath attribute previously observed in a MetaFileInformation event.
     virtual bool acceptAttribute(EventAttr attr, const char* values) = 0;
-
-    // Install the recipient of unfiltered visits. `readEvents` will call this method before
-    // beginning visitation.
-    virtual void setTarget(IEventAttributeVisitor& visitor) = 0;
 };
 
 // Obtain a new instance of a standard event filter.

--- a/common/eventconsumption/eventoperation.cpp
+++ b/common/eventconsumption/eventoperation.cpp
@@ -50,11 +50,11 @@ IEventFilter* CEventConsumingOp::ensureFilter()
     return filter;
 }
 
-bool CEventConsumingOp::traverseEvents(const char* path, IEventAttributeVisitor& visitor)
+bool CEventConsumingOp::traverseEvents(const char* path, IEventVisitor& visitor)
 {
     if (filter)
     {
-        filter->setTarget(visitor);
+        filter->decorate(visitor);
         return readEvents(path, *filter);
     }
     return readEvents(path, visitor);

--- a/common/eventconsumption/eventoperation.h
+++ b/common/eventconsumption/eventoperation.h
@@ -37,7 +37,7 @@ public:
     bool acceptAttribute(EventAttr attr, const char* values);
 protected:
     IEventFilter* ensureFilter();
-    bool traverseEvents(const char* path, IEventAttributeVisitor& visitor);
+    bool traverseEvents(const char* path, IEventVisitor& visitor);
 protected:
     StringAttr inputPath;
     Linked<IBufferedSerialOutputStream> out;

--- a/common/eventconsumption/eventvisitor.h
+++ b/common/eventconsumption/eventvisitor.h
@@ -23,6 +23,30 @@
 // interface and the adapter to convert pulled events into visisted events.
 #include "jevent.hpp"
 
+// Abstract extension of IEventVisitor that supports decorating another visitor. Decorators may:
+// - prevent the decorated visitor from seeing data
+// - change the data seen by a decorated visitor
+// - simulate new data for the decorated visitor to process
+// - act on data without affecting the decorated visitor
+//
+// Implementations may use the IMPLEMENT_IEVENTVISITORDECORATOR macro to limit implementation
+// to only cisitEvent.
+interface IEventVisitorDecorator : extends IEventVisitor
+{
+    // Establshes the decorated-decorator relationship.
+    virtual void decorate(IEventVisitor& visitor) = 0;
+};
+
+// Shortcut to stantart implementations of visitFile and departFile in a decorator implementation.
+// All decorator implementations must still implement visitEvent.
+#define IMPLEMENT_IEVENTVISITORDECORATOR \
+protected: \
+    Linked<IEventVisitor> decorated; \
+public: \
+    void decorate(IEventVisitor& visitor) override { decorated.set(&visitor); } \
+    bool visitFile(const char* filename, uint32_t version) override { if (!decorated) return false; return decorated->visitFile(filename, version); } \
+    void departFile(uint32_t bytesRead) override { if (!decorated) return; decorated->departFile(bytesRead); }
+
 // Abstraction of the visitor pattern for "reading" binary event data files. The `readEvents`
 // function will pass each byte of data contained within a file throwgh exactly one method of
 // this interface.


### PR DESCRIPTION
- Define IEventVisitor extension for decorating a visitor. This will be reused by model classes.
- Change IEventFilter to extend the decorating interface.
- Streamline filter terms to act on event and attribute objects.
- Apply filters in visitEvent.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [x] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
