### PR TITLE
HPCC-34315 Reduce costly log chatter

### DIFF
--- a/esp/bindings/http/platform/httpservice.cpp
+++ b/esp/bindings/http/platform/httpservice.cpp
@@ -471,11 +471,13 @@ int CEspHttpServer::processRequest()
 
         StringBuffer peerStr, pathStr;
         const char *userid=ctx->queryUserId();
-        if (isEmptyString(userid))
-            ESPLOG(LogMin, "%s %s, from %s", method.str(), m_request->getPath(pathStr).str(), m_request->getPeer(peerStr).str());
-        else //user ID is in HTTP header
-            ESPLOG(LogMin, "%s %s, from %s@%s", method.str(), m_request->getPath(pathStr).str(), userid, m_request->getPeer(peerStr).str());
-
+        if (doTrace(traceHttp))
+        {
+            if (isEmptyString(userid))
+                ESPLOG(LogMin, "%s %s, from %s", method.str(), m_request->getPath(pathStr).str(), m_request->getPeer(peerStr).str());
+            else //user ID is in HTTP header
+                ESPLOG(LogMin, "%s %s, from %s@%s", method.str(), m_request->getPath(pathStr).str(), userid, m_request->getPeer(peerStr).str());
+        }
         authState = checkUserAuth();
         if ((authState == authTaskDone) || (authState == authFailed))
             return 0;
@@ -2389,7 +2391,7 @@ EspAuthState CEspHttpServer::authExistingSession(EspAuthRequest& authReq, unsign
     {
         time_t timeoutAt = createTime + authReq.authBinding->getServerSessionTimeoutSeconds();
         sessionTree->setPropInt64(PropSessionTimeoutAt, timeoutAt);
-        ESPLOG(LogMin, "Updated %s for (/%s/%s) : %" PRId64 "", PropSessionTimeoutAt, authReq.serviceName.isEmpty() ? "" : authReq.serviceName.str(),
+        ESPLOG(LogMax, "Updated %s for (/%s/%s) : %" PRId64 "", PropSessionTimeoutAt, authReq.serviceName.isEmpty() ? "" : authReq.serviceName.str(),
             authReq.methodName.isEmpty() ? "" : authReq.methodName.str(), (int64_t)timeoutAt);
     }
     ///authReq.ctx->setAuthorized(true);

--- a/esp/bindings/http/platform/httptransport.cpp
+++ b/esp/bindings/http/platform/httptransport.cpp
@@ -1446,7 +1446,8 @@ int CHttpRequest::parseFirstLine(char* oneline)
 {
     //if (getEspLogLevel()>LogNormal)
     //  DBGLOG("First Line of request=%s", oneline);
-    DBGLOG("HTTP First Line: %s", oneline);
+    if (doTrace(traceHttp))
+        DBGLOG("HTTP First Line: %s", oneline);
 
     if(*oneline == 0)
         return -1;

--- a/esp/platform/esptrace.h
+++ b/esp/platform/esptrace.h
@@ -25,12 +25,14 @@
 constexpr const char* propTraceFlags = "traceFlags";
 
 // Trace option list fragment for jtrace-defined options used by ESPs
-#define PLATFORM_OPTIONS_FRAGMENT
+#define PLATFORM_OPTIONS_FRAGMENT \
+    TRACEOPT(traceAll), \
+    TRACEOPT(traceDetail), \
+    TRACEOPT(traceHttp),
 
 // Trace option list fragment for options used by most ESPs
 #define ESP_OPTIONS_FRAGMENT \
-    PLATFORM_OPTIONS_FRAGMENT \
-    TRACEOPT(traceDetail),
+    PLATFORM_OPTIONS_FRAGMENT
 
 // Trace option initializer list for ESPs that do not define their own options.
 constexpr std::initializer_list<TraceOption> espTraceOptions

--- a/helm/hpcc/values.schema.json
+++ b/helm/hpcc/values.schema.json
@@ -1715,6 +1715,10 @@
         },
         "terminationGracePeriodSeconds": {
           "$ref": "#/definitions/terminationGracePeriodSeconds"
+        },
+        "traceFlags": {
+          "type": "object",
+          "additionalProperties": { "type": ["integer", "boolean"] }
         }
       }
     },

--- a/helm/hpcc/values.yaml
+++ b/helm/hpcc/values.yaml
@@ -643,6 +643,36 @@ esp:
 #  trustClients:
 #  - commonName: rabc.example.com
 
+  # Logging output can be controlled in three main ways.
+  #
+  # First are the platform standard settings explained in helm/examples/logging
+  # The example below shows the format with the default ESP filter settings.
+  # logging:
+  #   detail: 80        # includes all detail <= 80, debug message threshold
+  #   classes: "ALL"    # all message classes included
+  #   audiences: "ALL"  # all message audiences included
+  #
+  # Second are tracing and feature tracing settings. These allow you to set a simplified detail
+  # filter in addition to toggling messages about specific kinds of activity like HTTP transactions.
+  # They are explained in detail in helm/examples/esp. The example below shows how to enable
+  # detailed HTTP messages.
+  # traceFlags:
+  #   traceHTTP: true
+  #
+  # Third are legacy ESP settings for messages that haven't yet been migrated to use the preferred
+  # settings in the first two categories.
+  #   * logLevel - Filters messages before sending to standard logging. Only applies to `ESPLOG` messages.
+  #   * logRequests - Specifies when to log incoming HTTP request payloads. Accepted values are:
+  #       "all"/"true" : logs all requests
+  #       "never" : does not log any requests
+  #       "only-ones-with-issues" : logs requests when an exception is thrown or the processing time
+  #          exceeds the configurable `slowProcessingTime` property (which defaults to 30 seconds).
+  #   * logResponses - Toggles logging of HTTP response payloads
+  # Following are examples showing the default values.
+  # logLevel: 8 # 1-10, 8 is the default.
+  # logRequests: "never" # default is never
+  # logResponses: false # default is false
+
   service:
     ## port can be used to change the local port used by the pod. If omitted, the default port (8880) is used
     port: 8888


### PR DESCRIPTION
Reclassify several log messages to reduce logging costs.

These messages now require `traceHttp` traceFlag enabled:
- "HTTP First Line: ..."
- "POST <path> from <peer> ..."

These messages require `logLevel: 10`:
- "Updated @timeoutAt for ..."
- "Authentication Failed: send BasicAuth ..." (Other auth failed messages remain at logMin, but this was high-volume and an `auth=Fail` entry still appears in the TxSummary for these cases)

Fixed values.schema.json to allow `traceFlags` object in esp section, and added logging configuration explanation to values.yaml. Updated esptrace.h to allow `traceHttp` and follow jtrace conventions.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [x] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [x] Scalability
  - [x] Performance
  - [x] Security
  - [x] Thread-safety
  - [x] Cloud-compatibility
  - [x] Premature optimization
  - [x] Existing deployed queries will not be broken
  - [x] This change fixes the problem, not just the symptom
  - [x] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->
Tested locally with a containerized deployment. Ensured that the HTTP messages can be enabled by setting `traceHttp: true`.
<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
