### PR TITLE
HPCC-34375 ECL Watch v9 change useFIle hook return type

### DIFF
--- a/esp/src/src-react/components/DataPatterns.tsx
+++ b/esp/src/src-react/components/DataPatterns.tsx
@@ -30,7 +30,7 @@ export const DataPatterns: React.FunctionComponent<DataPatternsProps> = ({
     logicalFile
 }) => {
 
-    const [file] = useFile(cluster, logicalFile);
+    const { file } = useFile(cluster, logicalFile);
     const dpWu = React.useMemo(() => {
         if (file) {
             return new DPWorkunit(cluster, logicalFile, file?.Modified);

--- a/esp/src/src-react/components/FileBlooms.tsx
+++ b/esp/src/src-react/components/FileBlooms.tsx
@@ -20,7 +20,7 @@ export const FileBlooms: React.FunctionComponent<FileBloomsProps> = ({
     sort = defaultSort
 }) => {
 
-    const [file, , , refreshData] = useFile(cluster, logicalFile);
+    const { file, refreshData } = useFile(cluster, logicalFile);
     const [data, setData] = React.useState<any[]>([]);
     const {
         selection, setSelection,

--- a/esp/src/src-react/components/FileDetails.tsx
+++ b/esp/src/src-react/components/FileDetails.tsx
@@ -42,7 +42,7 @@ export const FileDetails: React.FunctionComponent<FileDetailsProps> = ({
     sort = {},
     queryParams = {}
 }) => {
-    const [file] = useFile(cluster, logicalFile);
+    const { file } = useFile(cluster, logicalFile);
     React.useEffect(() => {
         if (file?.NodeGroup && cluster === undefined && !file?.isSuperfile) {
             replaceUrl(`/files/${file.NodeGroup}/${logicalFile}`);

--- a/esp/src/src-react/components/FileDetailsGraph.tsx
+++ b/esp/src/src-react/components/FileDetailsGraph.tsx
@@ -37,7 +37,7 @@ export const FileDetailsGraph: React.FunctionComponent<FileDetailsGraphProps> = 
     sort = defaultSort
 }) => {
 
-    const [file, , , refreshData] = useFile(cluster, logicalFile);
+    const { file, refreshData } = useFile(cluster, logicalFile);
     const [uiState, setUIState] = React.useState({ ...defaultUIState });
     const [data, setData] = React.useState<any[]>([]);
     const {

--- a/esp/src/src-react/components/FileParts.tsx
+++ b/esp/src/src-react/components/FileParts.tsx
@@ -21,7 +21,7 @@ export const FileParts: React.FunctionComponent<FilePartsProps> = ({
     sort = defaultSort
 }) => {
 
-    const [file, , , refreshData] = useFile(cluster, logicalFile);
+    const { file, refreshData } = useFile(cluster, logicalFile);
     const [data, setData] = React.useState<any[]>([]);
     const {
         selection, setSelection,

--- a/esp/src/src-react/components/IndexFileSummary.tsx
+++ b/esp/src/src-react/components/IndexFileSummary.tsx
@@ -34,7 +34,7 @@ export const IndexFileSummary: React.FunctionComponent<IndexFileSummaryProps> = 
     tab = "summary"
 }) => {
 
-    const [file, isProtected, , refresh] = useFile(cluster, logicalFile);
+    const { file, isProtected, refreshData } = useFile(cluster, logicalFile);
     const [description, setDescription] = React.useState("");
     const [_protected, setProtected] = React.useState(false);
     const [restricted, setRestricted] = React.useState(false);
@@ -91,7 +91,7 @@ export const IndexFileSummary: React.FunctionComponent<IndexFileSummaryProps> = 
     const buttons = React.useMemo((): ICommandBarItemProps[] => [
         {
             key: "refresh", text: nlsHPCC.Refresh, iconProps: { iconName: "Refresh" },
-            onClick: () => refresh()
+            onClick: () => refreshData()
         },
         {
             key: "copyFilename", text: nlsHPCC.CopyLogicalFilename, iconProps: { iconName: "Copy" },
@@ -131,7 +131,7 @@ export const IndexFileSummary: React.FunctionComponent<IndexFileSummaryProps> = 
             key: "replicate", text: nlsHPCC.Replicate, disabled: !canReplicateFlag || !replicateFlag,
             onClick: () => setShowReplicateFile(true)
         },
-    ], [_protected, canReplicateFlag, canSave, description, file, logicalFile, refresh, replicateFlag, restricted, setShowDeleteConfirm]);
+    ], [_protected, canReplicateFlag, canSave, description, file, logicalFile, refreshData, replicateFlag, restricted, setShowDeleteConfirm]);
 
     const protectedImage = _protected ? Utility.getImageURL("locked.png") : Utility.getImageURL("unlocked.png");
     const stateImage = Utility.getImageURL(getStateImageName(file as unknown as IFile));

--- a/esp/src/src-react/components/LogicalFileSummary.tsx
+++ b/esp/src/src-react/components/LogicalFileSummary.tsx
@@ -34,7 +34,7 @@ export const LogicalFileSummary: React.FunctionComponent<LogicalFileSummaryProps
     tab = "summary"
 }) => {
 
-    const [file, isProtected, , refresh] = useFile(cluster, logicalFile);
+    const { file, isProtected, refreshData } = useFile(cluster, logicalFile);
     const [description, setDescription] = React.useState("");
     const [_protected, setProtected] = React.useState(false);
     const [restricted, setRestricted] = React.useState(false);
@@ -96,7 +96,7 @@ export const LogicalFileSummary: React.FunctionComponent<LogicalFileSummaryProps
     const buttons = React.useMemo((): ICommandBarItemProps[] => [
         {
             key: "refresh", text: nlsHPCC.Refresh, iconProps: { iconName: "Refresh" },
-            onClick: () => refresh()
+            onClick: () => refreshData()
         },
         {
             key: "copyFilename", text: nlsHPCC.CopyLogicalFilename, iconProps: { iconName: "Copy" },
@@ -142,7 +142,7 @@ export const LogicalFileSummary: React.FunctionComponent<LogicalFileSummaryProps
             key: "replicate", text: nlsHPCC.Replicate, disabled: !canReplicateFlag || !replicateFlag,
             onClick: () => setShowReplicateFile(true)
         },
-    ], [canReplicateFlag, canSave, description, file, logicalFile, refresh, replicateFlag, setShowDeleteConfirm]);
+    ], [canReplicateFlag, canSave, description, file, logicalFile, refreshData, replicateFlag, setShowDeleteConfirm]);
 
     const protectedImage = _protected ? Utility.getImageURL("locked.png") : Utility.getImageURL("unlocked.png");
     const stateImage = Utility.getImageURL(getStateImageName(file as unknown as IFile));

--- a/esp/src/src-react/components/ProtectedBy.tsx
+++ b/esp/src/src-react/components/ProtectedBy.tsx
@@ -20,7 +20,7 @@ export const ProtectedBy: React.FunctionComponent<ProtectedByProps> = ({
     sort = defaultSort
 }) => {
 
-    const [file, , , refreshData] = useFile(cluster, logicalFile);
+    const { file, refreshData } = useFile(cluster, logicalFile);
     const [data, setData] = React.useState<any[]>([]);
     const {
         selection, setSelection,

--- a/esp/src/src-react/components/SubFiles.tsx
+++ b/esp/src/src-react/components/SubFiles.tsx
@@ -29,7 +29,7 @@ export const SubFiles: React.FunctionComponent<SubFilesProps> = ({
     sort = defaultSort
 }) => {
 
-    const [file] = useFile(cluster, logicalFile);
+    const { file } = useFile(cluster, logicalFile);
     const [subfiles, refreshSubfiles] = useSubfiles(cluster, logicalFile);
     const [uiState, setUIState] = React.useState({ ...defaultUIState });
     const [data, setData] = React.useState<any[]>([]);

--- a/esp/src/src-react/components/SuperFileSummary.tsx
+++ b/esp/src/src-react/components/SuperFileSummary.tsx
@@ -25,7 +25,7 @@ export const SuperFileSummary: React.FunctionComponent<SuperFileSummaryProps> = 
     logicalFile
 }) => {
 
-    const [file, isProtected, , refresh] = useFile(cluster, logicalFile);
+    const { file, isProtected, refreshData } = useFile(cluster, logicalFile);
     const [description, setDescription] = React.useState("");
     const [_protected, setProtected] = React.useState(false);
     const [restricted, setRestricted] = React.useState(false);
@@ -65,7 +65,7 @@ export const SuperFileSummary: React.FunctionComponent<SuperFileSummaryProps> = 
     const buttons = React.useMemo((): ICommandBarItemProps[] => [
         {
             key: "refresh", text: nlsHPCC.Refresh, iconProps: { iconName: "Refresh" },
-            onClick: () => refresh()
+            onClick: () => refreshData()
         },
         { key: "divider_1", itemType: ContextualMenuItemType.Divider, onRender: () => <ShortVerticalDivider /> },
         {
@@ -90,7 +90,7 @@ export const SuperFileSummary: React.FunctionComponent<SuperFileSummaryProps> = 
             key: "copyFile", text: nlsHPCC.Copy, disabled: !file,
             onClick: () => setShowCopyFile(true)
         }
-    ], [_protected, canSave, description, file, refresh, restricted, setShowDeleteConfirm]);
+    ], [_protected, canSave, description, file, refreshData, restricted, setShowDeleteConfirm]);
 
     const protectedImage = _protected ? Utility.getImageURL("locked.png") : Utility.getImageURL("unlocked.png");
     const compressedImage = file?.IsCompressed ? Utility.getImageURL("compressed.png") : "";

--- a/esp/src/src-react/components/SuperFiles.tsx
+++ b/esp/src/src-react/components/SuperFiles.tsx
@@ -25,7 +25,7 @@ export const SuperFiles: React.FunctionComponent<SuperFilesProps> = ({
     sort = defaultSort
 }) => {
 
-    const [file, , , refreshData] = useFile(cluster, logicalFile);
+    const { file, refreshData } = useFile(cluster, logicalFile);
     const [uiState, setUIState] = React.useState({ ...defaultUIState });
     const [data, setData] = React.useState<any[]>([]);
     const {

--- a/esp/src/src-react/components/forms/ReplicateFile.tsx
+++ b/esp/src/src-react/components/forms/ReplicateFile.tsx
@@ -35,7 +35,7 @@ export const ReplicateFile: React.FunctionComponent<ReplicateFileProps> = ({
     setShowForm
 }) => {
 
-    const [file] = useFile(cluster, logicalFile);
+    const { file } = useFile(cluster, logicalFile);
     const { handleSubmit, control, reset } = useForm<ReplicateFileFormValues>({ defaultValues });
     const [submitDisabled, setSubmitDisabled] = React.useState(false);
     const [spinnerHidden, setSpinnerHidden] = React.useState(true);


### PR DESCRIPTION
fixes an issue where the ProtectList property of a logical file was not updating the state in the UI.

changes the shape of the return type of the useFIle hook to an object instead of an array, and adds a protectedBy state variable to that returned object.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [x] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
