### PR TITLE
HPCC-33889 Catch XRef errors on single files

### DIFF
--- a/dali/base/dautils.cpp
+++ b/dali/base/dautils.cpp
@@ -2686,11 +2686,17 @@ void CSDSFileScanner::processFiles(IRemoteConnection *conn,IPropertyTree &root,S
             if (!fn||!*fn)
                 continue;
             name.append(fn);
-            if (checkFileOk(file,name.str())) {
-                processFile(file,name);
+            try {
+                if (checkFileOk(file,name.str())) {
+                    processFile(file,name);
+                }
             }
-            else
-                ; // DBGLOG("ignoreFile %s",name.str());
+            catch (IException *e) {
+                StringBuffer tmp("CSDSFileScanner::processFiles ");
+                tmp.appendf("(%s)", name.str());
+                EXCLOG(e, tmp.str());
+                e->Release();
+            }
 
             name.setLength(ns);
             conn->rollbackChildren(&file,true);

--- a/dali/sasha/saxref.cpp
+++ b/dali/sasha/saxref.cpp
@@ -957,7 +957,7 @@ public:
             rootdir.set(basedir);
             iswin = getPathSepChar(rootdir.get())=='\\';
         }
-        assert(!rootdir.isEmpty());
+        assertex(!rootdir.isEmpty());
         return true;
     }
 
@@ -1086,7 +1086,15 @@ public:
                 nsz += fsz;
                 iter->getModifiedTime(dt);
                 if (!fileFiltered(path.str(),dt)) {
-                    pdir->addFile(drv,fname.str(),fsz,dt,node,ep,*grp,numnodes,&mem);
+                    try {
+                        pdir->addFile(drv,fname.str(),fsz,dt,node,ep,*grp,numnodes,&mem);
+                    }
+                    catch (IException *e) {
+                        StringBuffer tmp(LOGPFX "scanDirectory: Error adding file ");
+                        addPathSepChar(rfn.getRemotePath(tmp)).append(fname);
+                        EXCLOG(e,tmp.str());
+                        e->Release();
+                    }
                 }
             }
             path.setLength(dsz);
@@ -1138,7 +1146,7 @@ public:
                 // A hosted plane will never be striped, so for striped planes, use local host
                 if (parent.isPlaneStriped)
                 {
-                    assert(!parent.storagePlane->hasProp("@hostGroup"));
+                    assertex(!parent.storagePlane->hasProp("@hostGroup"));
                     SocketEndpoint localEP;
                     localEP.setLocalHost(0);
                     addPathSepChar(path).append('d').append(i+1);
@@ -1642,7 +1650,15 @@ public:
         i = 0;
         cFileDesc *file = d->files.first(i);
         while (file) {
-            listOrphans(file,basedir,scope,abort,recentCutoffDays);
+            try {
+                listOrphans(file,basedir,scope,abort,recentCutoffDays);
+            }
+            catch (IException *e) {
+                StringBuffer tmp(LOGPFX "listOrphans: Error processing file ");
+                file->getNameMask(addPathSepChar(tmp.append(basedir.str())));
+                EXCLOG(e,tmp.str());
+                e->Release();
+            }
             if (abort)
                 return;
             file = d->files.next(i);


### PR DESCRIPTION
- Add try/catch to scanLogicalFiles where it tries to get filename from IFileDescriptor.
- Add try/catch around processFile call to catch unknown errors
- Add try/catch around listOrphans(cFileDesc to prevent single file from ending file processing
- Add try/catch around addFile call in scanDirectories to prevent scan from ending early
- Change two cases of assert to assertex so they can be caught by the try/catch

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [x] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
