### PR TITLE
HPCC-34558 Remove linking of userDesc in CDFSFile::queryUserDescriptor

### DIFF
--- a/esp/clients/ws_dfsclient/ws_dfsclient.cpp
+++ b/esp/clients/ws_dfsclient/ws_dfsclient.cpp
@@ -589,7 +589,7 @@ public:
     }
     virtual IUserDescriptor *queryUserDescriptor() const override
     {
-        return userDesc.getLink();
+        return userDesc;
     }
     virtual unsigned queryTimeoutSecs() const override
     {


### PR DESCRIPTION
The only place that CDFSFile::queryUserDescriptor() is used is in CServiceDistributedFileBase::CDistributedSuperFileIterator::setCurrent member function. This function uses source->queryUserDescriptor() as an argument in the call to lookupDFSFile:

    void setCurrent(unsigned w)
    {
        VStringBuffer lfn("~remote::%s::%s", source->queryRemoteName(), owners[w].c_str());
        Owned<IDFSFile> dfsFile = lookupDFSFile(lfn, accessMode, source->queryTimeoutSecs(), keepAliveExpiryFrequency, source->queryUserDescriptor());
	...

In lookupDFSFile, the userDesc is used as follows,
- calls getDfsClient(.., userDesc):  getDfsClient queries username and password from userDesc.  It doesn't doesn't own or link userDesc or pass it to any function or object.
- calls ensureClientLease(.., .., .., userDesc): ensureClient doesn't use userDesc at all.
- calls createDFSFile(.., .., .., .., userDesc): createDFSFile creates a CDFSFile object using userDesc as an argument in the constructor. The constructor initializes the member variable userDesc.  The member variable userDesc is Linked<IUserDescriptor>.  Linked will mean that userDesc  link counted.

CDFSFile::queryUserDescriptor() is not used in any other place.  CDFSFile::queryUserDescriptor() shouldn't return a linked pointer.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [ ] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [x] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
