### PR TITLE
HPCC-34172 owner costs, avoid super lookup for every sub

### DIFF
--- a/dali/base/dautils.cpp
+++ b/dali/base/dautils.cpp
@@ -3819,15 +3819,15 @@ class FileReadPropertiesUpdater : public CSimpleInterfaceOf<IFileReadPropertiesU
     // Update the readCost and numDiskReads for owning superfiles
     // - this will recurse up the superfiles tree updating the owning superfiles
     // n.b. fileStatItem.file must be set to a valid IDistributedFile
-    void updateOwnersStats(FileStatMap & ownerStats, const FileStatItem & fileStatItem)
+    void updateOwnersStats(FileStatMap & ownerStats, const FileStatItem & fileStatItem, IDistributedFileTransaction &transaction)
     {
         // getOwningSuperFiles iterator is slow, so only call it once (say at the end of graph)
-        Owned<IDistributedSuperFileIterator> iter = fileStatItem.file->getOwningSuperFiles();
+        Owned<IDistributedSuperFileIterator> iter = fileStatItem.file->getOwningSuperFiles(&transaction);
         ForEach(*iter)
         {
             IDistributedSuperFile & cur = iter->query();
             const FileStatItem & owningFileStatItem = appendOwnersCostAndNumReads(ownerStats, &cur, fileStatItem.numDiskReads, fileStatItem.readCost);
-            updateOwnersStats(ownerStats, owningFileStatItem);
+            updateOwnersStats(ownerStats, owningFileStatItem, transaction);
         }
     }
 
@@ -3860,16 +3860,18 @@ public:
         FileStatMap ownerStats;
         // Iterate through files, updating the ownerStats
         // (Also, set FileStatItem::file to a valid IDistributedFile, if possible)
+
+        Owned<IDistributedFileTransaction> transaction = createDistributedFileTransaction(udesc);
         for (auto & [logicalName, curStatItem] : stats)
         {
-            curStatItem.file.setown(queryDistributedFileDirectory().lookup(logicalName.c_str(), udesc, AccessMode::tbdRead,false,false,nullptr,defaultNonPrivilegedUser));
+            curStatItem.file.setown(transaction->lookupFile(logicalName.c_str(), AccessMode::tbdRead));
             if (!curStatItem.file) // File may have been deleted
             {
                 if (curStatItem.readCost)
                     OERRLOG("FileReadPropertiesUpdater: file has read cost but file not found: %s", logicalName.c_str());
                 continue;
             }
-            updateOwnersStats(ownerStats, curStatItem);
+            updateOwnersStats(ownerStats, curStatItem, *transaction);
         }
         // Update the file properties with the new stats
         for (auto & [logicalName, curStatItem] : stats)


### PR DESCRIPTION
Use a IDistributedFileTransaction in
FileReadPropertiesUpdater::publish(), to avoid pathological cost of re-looking up the owning super file for every subfile read.

In practice this meant that when iterating through owning supers, it looked the super up, and all the subfiles (include all locking).

i.e. if a super file with 10 subfiles was read, publish() would: 1) find the super (getOwningSuperFiles)
2) look them up each (just 1 in this example) super via DFS. This would involve lookup all (10) subfiles, including locking. 3) update cost in super
* Repeat for all other subfiles.

Employing a IDistributedFileTransaction, will cause the 2nd iteration to find any super that has previously been found as an owner, to be found within the transaction rather than re-looking up.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [x] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
