### PR TITLE
HPCC-34809 Improve XRef status updates during long running scans

### DIFF
--- a/dali/sasha/saxref.cpp
+++ b/dali/sasha/saxref.cpp
@@ -571,6 +571,57 @@ static void mergeDirPerPartDirs(cDirDesc *parent, cDirDesc *dir, const char *cur
     }
 }
 
+constexpr int64_t oneSecondNS = 1000 * 1000 * 1000; // 1 second in nanoseconds
+constexpr int64_t oneHourNS = 60 * 60 * oneSecondNS; // 1 hour in nanoseconds
+class XRefPeriodicTimer : public PeriodicTimer
+{
+public:
+    XRefPeriodicTimer() = default;
+    XRefPeriodicTimer(unsigned seconds, bool suppressFirst, const char *_clustname)
+    : clustname(_clustname) { reset(seconds, suppressFirst, clustname); }
+
+    unsigned calcElapsedMinutes() const
+    {
+        int64_t elapsedNS = cycle_to_nanosec(lastElapsedCycles - startCycles);
+        return elapsedNS / oneSecondNS / 60;
+    }
+
+    bool hasElapsed()
+    {
+        // MORE: Could make PeriodicTimer::hasElapsed thread safe and remove CriticalBlock
+        CriticalBlock block(timerSect);
+        return PeriodicTimer::hasElapsed();
+    }
+
+    void reset(unsigned seconds, bool suppressFirst, const char *_clustname)
+    {
+        clustname = _clustname;
+        PeriodicTimer::reset(seconds*1000, suppressFirst);
+        startCycles = lastElapsedCycles;
+    }
+
+    // Double the time period until it reaches 1 hour
+    void updatePeriod()
+    {
+        int64_t timePeriodNS = cycle_to_nanosec(timePeriodCycles) + 1; // 1 second is lost converting to nanoseconds
+        if (timePeriodNS < oneHourNS)
+        {
+            int64_t newTimePeriodNS = timePeriodNS >= oneHourNS / 2 ? oneHourNS : timePeriodNS * 2;
+            timePeriodCycles = nanosec_to_cycle(newTimePeriodNS);
+
+            unsigned intervalMinutes = newTimePeriodNS / oneSecondNS / 60;
+            if (clustname)
+                DBGLOG(LOGPFX "[%s] Heartbeat interval increased to %u minutes", clustname, intervalMinutes);
+            else
+                DBGLOG(LOGPFX "Heartbeat interval increased to %u minutes", intervalMinutes);
+        }
+    }
+
+private:
+    CriticalSection timerSect;
+    const char *clustname = nullptr; // Cluster name for logging
+    cycle_t startCycles = 0;
+};
 
 class CNewXRefManagerBase
 {
@@ -585,40 +636,30 @@ public:
     unsigned lastlog;
     unsigned sfnum;
     unsigned fnum;
+    XRefPeriodicTimer heartbeatTimer;
+
     Owned<IPropertyTree> foundbranch;
     Owned<IPropertyTree> lostbranch;
     Owned<IPropertyTree> orphansbranch;
     Owned<IPropertyTree> dirbranch;
 
-    void log(const char * format, ...) __attribute__((format(printf, 2, 3)))
+    void log(bool forceStatusUpdate, const char * format, ...) __attribute__((format(printf, 3, 4)))
     {
-        CriticalBlock block(logsect);
+        StringBuffer line;
         va_list args;
         va_start(args, format);
-        StringBuffer line;
         line.valist_appendf(format, args);
         va_end(args);
+
         if (clustname.get())
             PROGLOG(LOGPFX "[%s] %s",clustname.get(),line.str());
         else
             PROGLOG(LOGPFX "%s",line.str());
-        if (logconn) {
-            logcache.set(line.str());
-            updateStatus(false);
-        }
-    }
 
-    void statlog(const char * format, ...) __attribute__((format(printf, 2, 3)))
-    {
-        CriticalBlock block(logsect);
-        va_list args;
-        va_start(args, format);
-        StringBuffer line;
-        line.valist_appendf(format, args);
-        va_end(args);
         if (logconn) {
+            CriticalBlock block(logsect);
             logcache.set(line.str());
-            updateStatus(false);
+            updateStatus(forceStatusUpdate);
         }
     }
 
@@ -670,6 +711,34 @@ public:
 
     }
 
+    void startHeartbeat(const char * op)
+    {
+        heartbeatTimer.reset(60, true, clustname.get()); // 1 minute interval
+        log(true, "%s heartbeat started (interval: 1 minute)", op);
+    }
+
+    void checkHeartbeat(const char * op)
+    {
+        time_t now = time(NULL);
+        if (!heartbeatTimer.hasElapsed())
+            return;
+
+        unsigned elapsedMinutes = heartbeatTimer.calcElapsedMinutes();
+        unsigned elapsedHours = elapsedMinutes / 60;
+        unsigned remainingMinutes = elapsedMinutes % 60;
+
+        struct tm *utc_tm = gmtime(&now);
+        char timestamp[32];
+        strftime(timestamp, sizeof(timestamp), "%Y-%m-%d %H:%M:%S", utc_tm);
+
+        if (elapsedHours > 0)
+            log(true, "%s - elapsed: %uh %um (%s UTC)", op, elapsedHours, remainingMinutes, timestamp);
+        else
+            log(true, "%s - elapsed: %um (%s UTC)", op, elapsedMinutes, timestamp);
+
+        heartbeatTimer.updatePeriod();
+    }
+
     void addBranch(IPropertyTree *root,const char *name,IPropertyTree *branch)
     {
         if (!branch)
@@ -702,13 +771,13 @@ public:
             xpath.insert(0,"/DFU/XREF/");
             logconn.setown(querySDS().connect(xpath.str(),myProcessSession(),0 ,INFINITE));
         }
-        log("Starting");
+        log(false, "Starting");
     }
 
     void finish(bool aborted)
     {
         if (aborted)
-            log("Aborted");
+            log(false, "Aborted");
         logconn.clear(); // final message done by save to eclwatch
     }
 
@@ -737,7 +806,7 @@ public:
     {
         if (abort)
             return;
-        log("Saving information");
+        log(false,"Saving information");
         Owned<IPropertyTree> croot = createPTree("Cluster");
         croot->setProp("@name",clustname);
         if (!rootdir.isEmpty()) 
@@ -812,7 +881,7 @@ public:
         lostbranch.setown(createPTree("Lost"));
         orphansbranch.setown(createPTree("Orphans"));
         dirbranch.setown(createPTree("Directories"));
-        log("Max memory = %d MB", maxMb);
+        log(false, "Max memory = %d MB", maxMb);
 
         StringBuffer userName;
         serverConfig->getProp("@sashaUser", userName);
@@ -1024,6 +1093,7 @@ public:
 
     bool scanDirectory(unsigned node,const SocketEndpoint &ep,StringBuffer &path, unsigned drv, cDirDesc *pdir, IFile *cachefile, unsigned level)
     {
+        checkHeartbeat("Directory scan");
         size32_t dsz = path.length();
         if (pdir==NULL) 
             pdir = root;
@@ -1162,7 +1232,7 @@ public:
                     SocketEndpoint localEP;
                     localEP.setLocalHost(0);
                     addPathSepChar(path).append('d').append(i+1);
-                    parent.log("Scanning %s directory %s",parent.storagePlane->queryProp("@name"),path.str());
+                    parent.log(false,"Scanning %s directory %s",parent.storagePlane->queryProp("@name"),path.str());
                     if (!parent.scanDirectory(0,localEP,path,0,parent.root,NULL,1))
                     {
                         ok = false;
@@ -1172,7 +1242,7 @@ public:
                 else
                 {
                     SocketEndpoint ep = parent.rawgrp->queryNode(i).endpoint();
-                    parent.log("Scanning %s directory %s",ep.getEndpointHostText(tmp).str(),path.str());
+                    parent.log(false,"Scanning %s directory %s",ep.getEndpointHostText(tmp).str(),path.str());
                     if (!parent.scanDirectory(i,ep,path,0,NULL,NULL,0)) {
                         ok = false;
                         return;
@@ -1181,7 +1251,7 @@ public:
                         i = (i+r)%n;
                         setReplicateFilename(path,1);
                         ep = parent.rawgrp->queryNode(i).endpoint();
-                        parent.log("Scanning %s directory %s",ep.getEndpointHostText(tmp.clear()).str(),path.str());
+                        parent.log(false,"Scanning %s directory %s",ep.getEndpointHostText(tmp.clear()).str(),path.str());
                         if (!parent.scanDirectory(i,ep,path,1,NULL,NULL,0)) {
                             ok = false;
                         }
@@ -1197,11 +1267,12 @@ public:
             numMaxThreads = numuniqnodes;
         if (numThreads > numMaxThreads)
             numThreads = numMaxThreads;
+        startHeartbeat("Directory scan"); // Initialize heartbeat mechanism
         afor.For(numMaxThreads,numThreads,true,numThreads>1);
         if (afor.ok)
-            log("Directory scan complete");
+            log(true,"Directory scan complete");
         else
-            log("Errors occurred during scan");
+            log(true,"Errors occurred during scan");
         return afor.ok;
     }
 
@@ -1247,7 +1318,7 @@ public:
             {
                 if (abort)
                     return;
-                parent.log("Process file %s",name.str());
+                parent.log(false,"Process file %s",name.str());
                 parent.fnum++;
 
                 Owned<IFileDescriptor> fdesc;
@@ -1348,7 +1419,7 @@ public:
         } filescan(*this,abort);
 
         filescan.scan();
-        log("File scan complete");
+        log(true,"File scan complete");
 
     }
 
@@ -1682,6 +1753,7 @@ public:
 
     void listOrphans(cDirDesc *d,StringBuffer &basedir,StringBuffer &scope,bool &abort,unsigned int recentCutoffDays)
     {
+        checkHeartbeat("Orphan scan");
         if (abort)
             return;
         if (!d) {
@@ -1749,23 +1821,24 @@ public:
     void listOrphans(bool &abort,unsigned int recentCutoffDays)
     {   
         // also does directories
-        log("Scanning for orphans");
+        log(true,"Scanning for orphans");
+        startHeartbeat("Orphan scan");
         StringBuffer basedir;
         StringBuffer scope;
         listOrphans(NULL,basedir,scope,abort,recentCutoffDays);
         if (abort)
             return;
-        log("Orphan scan complete");
+        log(true,"Orphan scan complete");
         sorteddirs.sort(compareDirs);   // NB sort reverse
         while (!abort&&sorteddirs.ordinality())
             dirbranch->addPropTree("Directory",&sorteddirs.popGet());
-        log("Directories sorted");
+        log(true,"Directories sorted");
     }
 
 
     void listLost(bool &abort,bool ignorelazylost,unsigned int recentCutoffDays)
     {
-        log("Scanning for lost files");
+        log(true,"Scanning for lost files");
         StringBuffer tmp;
         ForEachItemIn(i0,lostfiles) {
             if (abort)
@@ -1905,7 +1978,7 @@ public:
                 lostbranch->addPropTree("File",ft.getClear());
             }
         }
-        log("Lost scan complete");
+        log(true,"Lost scan complete");
     }
 
 
@@ -2042,7 +2115,7 @@ public:
             void processSuperFile(IPropertyTree &file,StringBuffer &name)
             {
                 parent.sfnum++;
-                parent.log("Scanning SuperFile %s",name.str());
+                parent.log(false,"Scanning SuperFile %s",name.str());
                 unsigned numsub = file.getPropInt("@numsubfiles");
                 unsigned n = 0;
                 Owned<IPropertyTreeIterator> iter = file.getElements("SubFile");
@@ -2098,7 +2171,7 @@ public:
 
         bool fix = false;
 
-        log("Crossreferencing %d SuperFiles",superowner.ordinality());
+        log(false,"Crossreferencing %d SuperFiles",superowner.ordinality());
         ForEachItemIn(i1,superowner) {
             const char *owner = superowner.item(i1);
             const char *owned = superowned.item(i1);
@@ -2141,8 +2214,8 @@ public:
                     }
                 }
             }
-        }       
-        log("Crossreferencing %d Files",fileowned.ordinality());
+        }
+        log(false,"Crossreferencing %d Files",fileowned.ordinality());
         ForEachItemIn(i3,fileowned) {
             const char *fowner = fileowner.item(i3);
             const char *fowned = fileowned.item(i3);


### PR DESCRIPTION
- Add a periodic heartbeat to XRef directory scan and listOrphans processing.
- Add exponential backoff to avoid spam for long running scans
- Add unconditional log update for forcing Start/Finish logs to show in ECL Watch

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [x] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [x] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [x] This change fixes the problem, not just the symptom
  - [x] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->
Tested with a long running XRef scan
```
0000000D USR PRO 2025-08-27 17:22:57.288     7    54 UNK     "XREF: [test-xref-20] Starting"
0000000E USR PRO 2025-08-27 17:22:57.288     7    54 UNK     "XREF: [test-xref-20] Directory scan heartbeat started (interval: 1 minute)"
0000000F USR PRO 2025-08-27 17:22:57.289     7   180 UNK     "XREF: [test-xref-20] Scanning test-xref-20 directory /var/lib/HPCCSystems/test-xref-20/d1"
00000010 USR PRO 2025-08-27 17:22:57.289     7   181 UNK     "XREF: [test-xref-20] Scanning test-xref-20 directory /var/lib/HPCCSystems/test-xref-20/d2"
00000011 USR PRO 2025-08-27 17:22:57.289     7   182 UNK     "XREF: [test-xref-20] Scanning test-xref-20 directory /var/lib/HPCCSystems/test-xref-20/d3"
00000012 USR PRO 2025-08-27 17:22:57.289     7   183 UNK     "XREF: [test-xref-20] Scanning test-xref-20 directory /var/lib/HPCCSystems/test-xref-20/d4"
00000013 USR PRO 2025-08-27 17:22:57.291     7   198 UNK     "XREF: [test-xref-20] Scanning test-xref-20 directory /var/lib/HPCCSystems/test-xref-20/d19"
00000014 USR PRO 2025-08-27 17:22:57.291     7   185 UNK     "XREF: [test-xref-20] Scanning test-xref-20 directory /var/lib/HPCCSystems/test-xref-20/d6"
00000015 USR PRO 2025-08-27 17:22:57.292     7   186 UNK     "XREF: [test-xref-20] Scanning test-xref-20 directory /var/lib/HPCCSystems/test-xref-20/d7"
00000016 USR PRO 2025-08-27 17:22:57.292     7   187 UNK     "XREF: [test-xref-20] Scanning test-xref-20 directory /var/lib/HPCCSystems/test-xref-20/d8"
00000017 USR PRO 2025-08-27 17:22:57.294     7   188 UNK     "XREF: [test-xref-20] Scanning test-xref-20 directory /var/lib/HPCCSystems/test-xref-20/d9"
00000018 USR PRO 2025-08-27 17:22:57.294     7   189 UNK     "XREF: [test-xref-20] Scanning test-xref-20 directory /var/lib/HPCCSystems/test-xref-20/d10"
00000019 USR PRO 2025-08-27 17:22:57.295     7   190 UNK     "XREF: [test-xref-20] Scanning test-xref-20 directory /var/lib/HPCCSystems/test-xref-20/d11"
0000001A USR PRO 2025-08-27 17:22:57.295     7   191 UNK     "XREF: [test-xref-20] Scanning test-xref-20 directory /var/lib/HPCCSystems/test-xref-20/d12"
0000001B USR PRO 2025-08-27 17:22:57.295     7   192 UNK     "XREF: [test-xref-20] Scanning test-xref-20 directory /var/lib/HPCCSystems/test-xref-20/d13"
0000001C USR PRO 2025-08-27 17:22:57.295     7   193 UNK     "XREF: [test-xref-20] Scanning test-xref-20 directory /var/lib/HPCCSystems/test-xref-20/d14"
0000001D USR PRO 2025-08-27 17:22:57.295     7   194 UNK     "XREF: [test-xref-20] Scanning test-xref-20 directory /var/lib/HPCCSystems/test-xref-20/d15"
0000001E USR PRO 2025-08-27 17:22:57.295     7   195 UNK     "XREF: [test-xref-20] Scanning test-xref-20 directory /var/lib/HPCCSystems/test-xref-20/d16"
0000001F USR PRO 2025-08-27 17:22:57.297     7   197 UNK     "XREF: [test-xref-20] Scanning test-xref-20 directory /var/lib/HPCCSystems/test-xref-20/d18"
00000020 USR PRO 2025-08-27 17:22:57.297     7    54 UNK     "XREF: [test-xref-20] Scanning test-xref-20 directory /var/lib/HPCCSystems/test-xref-20/d20"
00000021 USR PRO 2025-08-27 17:22:57.297     7   184 UNK     "XREF: [test-xref-20] Scanning test-xref-20 directory /var/lib/HPCCSystems/test-xref-20/d5"
00000022 USR PRO 2025-08-27 17:22:57.307     7   196 UNK     "XREF: [test-xref-20] Scanning test-xref-20 directory /var/lib/HPCCSystems/test-xref-20/d17"
00000023 USR PRO 2025-08-27 17:23:57.010     7   186 UNK     "XREF: [test-xref-20] Directory scan - elapsed: 1m (2025-08-27 17:23:57 UTC)"
00000024 PRG INF 2025-08-27 17:23:57.011     7   186 UNK     "XREF: [test-xref-20] Heartbeat interval increased to 2 minutes"
00000025 USR PRO 2025-08-27 17:25:57.011     7   190 UNK     "XREF: [test-xref-20] Directory scan - elapsed: 3m (2025-08-27 17:25:57 UTC)"
00000026 PRG INF 2025-08-27 17:25:57.012     7   190 UNK     "XREF: [test-xref-20] Heartbeat interval increased to 4 minutes"
00000027 USR PRO 2025-08-27 17:29:57.012     7   187 UNK     "XREF: [test-xref-20] Directory scan - elapsed: 7m (2025-08-27 17:29:57 UTC)"
00000028 PRG INF 2025-08-27 17:29:57.013     7   187 UNK     "XREF: [test-xref-20] Heartbeat interval increased to 8 minutes"
00000029 USR PRO 2025-08-27 17:37:57.016     7   189 UNK     "XREF: [test-xref-20] Directory scan - elapsed: 15m (2025-08-27 17:37:57 UTC)"
0000002A PRG INF 2025-08-27 17:37:57.017     7   189 UNK     "XREF: [test-xref-20] Heartbeat interval increased to 16 minutes"
0000002B USR PRO 2025-08-27 17:53:57.009     7   195 UNK     "XREF: [test-xref-20] Directory scan - elapsed: 31m (2025-08-27 17:53:57 UTC)"
0000002C PRG INF 2025-08-27 17:53:57.010     7   195 UNK     "XREF: [test-xref-20] Heartbeat interval increased to 32 minutes"
0000002D USR PRO 2025-08-27 18:25:57.006     7   182 UNK     "XREF: [test-xref-20] Directory scan - elapsed: 1h 3m (2025-08-27 18:25:57 UTC)"
0000002E PRG INF 2025-08-27 18:25:57.007     7   182 UNK     "XREF: [test-xref-20] Heartbeat interval increased to 60 minutes"
0000002F USR PRO 2025-08-27 19:11:25.612     7    54 UNK     "XREF: [test-xref-20] Directory scan complete"
```
<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
