### PR TITLE
HPCC-34105: Add evtool save-as command

### DIFF
--- a/common/eventconsumption/CMakeLists.txt
+++ b/common/eventconsumption/CMakeLists.txt
@@ -37,6 +37,7 @@ set (
     ${CMAKE_CURRENT_SOURCE_DIR}/eventiterator.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/eventmodeling.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/eventoperation.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/eventsaveas.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/eventunittests.cpp
 )
 

--- a/common/eventconsumption/eventsaveas.cpp
+++ b/common/eventconsumption/eventsaveas.cpp
@@ -1,0 +1,89 @@
+/*##############################################################################
+
+    Copyright (C) 2025 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include "eventsaveas.h"
+#include "jevent.hpp"
+
+class event_decl CEventSavingVisitor : public CInterfaceOf<IEventVisitor>
+{
+public:
+    virtual bool visitFile(const char* filename, uint32_t version) override
+    {
+        return true;
+    }
+    virtual bool visitEvent(CEvent& event) override
+    {
+        queryRecorder().recordEvent(event);
+        return true;
+    }
+    virtual void departFile(uint32_t bytesRead) override
+    {
+    }
+
+public:
+    CEventSavingVisitor(CEventSavingOp& _op)
+        : op(_op)
+    {
+    }
+
+private:
+    CEventSavingOp& op;
+};
+
+bool CEventSavingOp::ready() const
+{
+    return CEventConsumingOp::ready() && !outputPath.isEmpty();
+}
+
+bool CEventSavingOp::doOp()
+{
+    EventRecorder& recorder = queryRecorder();
+    if (!recorder.startRecording(options, outputPath, false))
+        return false;
+    Owned<IEventVisitor> terminalVisitor = new CEventSavingVisitor(*this);
+    try
+    {
+        traverseEvents(inputPath, *terminalVisitor);
+        recorder.stopRecording(&summary);
+    }
+    catch (...)
+    {
+        recorder.stopRecording(&summary);
+        throw;
+    }
+
+    return true;
+}
+
+void CEventSavingOp::setOutputPath(const char* path)
+{
+    outputPath = path;
+}
+
+void CEventSavingOp::setOutputOptions(const char* _options)
+{
+    options.set(_options);
+}
+
+StringBuffer& CEventSavingOp::getResults(StringBuffer& results) const
+{
+    results.set("Saved ")
+           .append(summary.numEvents)
+           .append(" events to ")
+           .append(summary.filename);
+    return results;
+}

--- a/common/eventconsumption/eventsaveas.h
+++ b/common/eventconsumption/eventsaveas.h
@@ -1,0 +1,39 @@
+/*##############################################################################
+
+    Copyright (C) 2025 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#pragma once
+
+#include "eventconsumption.h"
+#include "eventoperation.h"
+#include "jevent.hpp"
+
+class event_decl CEventSavingOp : public CEventConsumingOp
+{
+public:
+    virtual bool ready() const override;
+    virtual bool doOp() override;
+public:
+    void setOutputPath(const char* path);
+    const char* queryOutputPath() const { return outputPath; }
+    void setOutputOptions(const char* options);
+    const char* queryOptions() const { return options; }
+    StringBuffer& getResults(StringBuffer& results) const;
+protected:
+    StringBuffer outputPath;
+    StringBuffer options;
+    EventRecordingSummary summary;
+};

--- a/tools/evtool/CMakeLists.txt
+++ b/tools/evtool/CMakeLists.txt
@@ -37,6 +37,7 @@ set (  SRCS
        evtindex.cpp
        evtindex_summary.cpp
        evtindex_hotspot.cpp
+       evtsaveas.cpp
     )
 
 ADD_DEFINITIONS(-D_CONSOLE)

--- a/tools/evtool/evtmain.cpp
+++ b/tools/evtool/evtmain.cpp
@@ -32,6 +32,7 @@ int main(int argc, const char* argv[])
 
     CEvtCommandGroup evtool({
         { "dump", createDumpCommand },
+        { "save-as", createSaveAsCommand },
         { "sim", createSimCommand },
         { "index", createIndexCommand },
     });

--- a/tools/evtool/evtool.h
+++ b/tools/evtool/evtool.h
@@ -53,5 +53,6 @@ extern void cleanupConsole();
 
 // Command factory functions.
 extern IEvToolCommand* createDumpCommand();
+extern IEvToolCommand* createSaveAsCommand();
 extern IEvToolCommand* createSimCommand();
 extern IEvToolCommand* createIndexCommand();

--- a/tools/evtool/evtsaveas.cpp
+++ b/tools/evtool/evtsaveas.cpp
@@ -1,0 +1,114 @@
+/*##############################################################################
+
+    Copyright (C) 2025 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#include "evtool.hpp"
+#include "eventsaveas.h"
+
+class CEvtSaveAsCommand : public TEventConsumingCommand<CEventSavingOp>
+{
+public:
+    virtual int doRequest() override
+    {
+        try
+        {
+            if (op.doOp())
+            {
+                StringBuffer summary;
+                op.getResults(summary);
+                consoleOut().put(summary.length(), summary.str());
+                consoleOut().put(1, "\n");
+                return 0;
+            }
+            StringBuffer error("command execution failed\n");
+            consoleErr().put(error.length(), error.str());
+            return 1;
+        }
+        catch (IException* e)
+        {
+            StringBuffer msg("command execution exception: ");
+            e->errorMessage(msg);
+            e->Release();
+            msg.append('\n');
+            consoleErr().put(msg.length(), msg.str());
+            return 1;
+        }
+    }
+
+    virtual bool acceptKVOption(const char* key, const char* value) override
+    {
+        if (TEventConsumingCommand<CEventSavingOp>::acceptKVOption(key, value))
+            return true;
+        if (strieq(key, "output-path"))
+        {
+            op.setOutputPath(value);
+            return true;
+        }
+        if (strieq(key, "recording-options"))
+        {
+            op.setOutputOptions(value);
+            return true;
+        }
+        return false;
+    }
+
+    virtual void usageSyntax(int argc, const char* argv[], int pos, IBufferedSerialOutputStream& out) override
+    {
+        TEventConsumingCommand<CEventSavingOp>::usageSyntax(argc, argv, pos, out);
+        constexpr const char* usageStr =
+R"!!!([options] [filters] <filename>
+)!!!";
+        size32_t usageStrLength = size32_t(strlen(usageStr));
+        out.put(usageStrLength, usageStr);
+    }
+
+    virtual void usageSynopsis(IBufferedSerialOutputStream& out) override
+    {
+        constexpr const char* usageStr = R"!!!(
+Record visited events to a new binary event file. The output file path and
+recording options are specified by --output-path and --recording-options, respectively.
+)!!!";
+        size32_t usageStrLength = size32_t(strlen(usageStr));
+        out.put(usageStrLength, usageStr);
+    }
+
+    virtual void usageOptions(IBufferedSerialOutputStream& out) override
+    {
+        TEventConsumingCommand<CEventSavingOp>::usageOptions(out);
+        constexpr const char* usageStr =
+R"!!!(    --output-path             Output event file path.
+    --recording-options       Event recording options string.
+)!!!";
+        size32_t usageStrLength = size32_t(strlen(usageStr));
+        out.put(usageStrLength, usageStr);
+    }
+
+    virtual void usageDetails(IBufferedSerialOutputStream& out) override
+    {
+        constexpr const char* usageStr = R"!!!(
+Any input event stream, optionally constrained by filters modified
+by models, is saved into a new binary event file.
+)!!!";
+        size32_t usageStrLength = size32_t(strlen(usageStr));
+        out.put(usageStrLength, usageStr);
+    }
+};
+
+// Create a save-as command instance as needed.
+IEvToolCommand* createSaveAsCommand()
+{
+    return new CEvtSaveAsCommand();
+}


### PR DESCRIPTION
Extend the eventconsumption library with an operation and corresponding visitor that will record each visited event to a designated file using the designation recording options.

Add a tool command that saves events visited after applying filters and event modeling to an input event file.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
