### PR TITLE
HPCC-34940 HThor - Index Exists should stop as soon as it has found a match.

### DIFF
--- a/ecl/hthor/hthorkey.cpp
+++ b/ecl/hthor/hthorkey.cpp
@@ -36,7 +36,7 @@ using roxiemem::OwnedRoxieRow;
 using roxiemem::OwnedConstRoxieRow;
 using roxiemem::OwnedRoxieString;
 
-class TransformCallback : public CInterface, implements IThorIndexCallback 
+class TransformCallback : public CInterface, implements IThorIndexCallback
 {
 public:
     TransformCallback() { keyManager = NULL; };
@@ -44,9 +44,9 @@ public:
 
 //IThorIndexCallback
     virtual const byte * lookupBlob(unsigned __int64 id) override
-    { 
-        size32_t dummy; 
-        return (byte *) keyManager->loadBlob(id, dummy, ctx); 
+    {
+        size32_t dummy;
+        return (byte *) keyManager->loadBlob(id, dummy, ctx);
     }
 
 public:
@@ -60,7 +60,7 @@ public:
     void finishedRow()
     {
         if (keyManager)
-            keyManager->releaseBlobs(); 
+            keyManager->releaseBlobs();
     }
 
 protected:
@@ -196,7 +196,7 @@ public:
     //interface IHThorInput
     virtual bool isGrouped()                { return false; }
     virtual const char *getFileName()       { return NULL; }
-    virtual bool outputToFile(const char *) { return false; } 
+    virtual bool outputToFile(const char *) { return false; }
     virtual IOutputMetaData * queryOutputMeta() const { return outputMeta; }
 
     virtual void gatherActiveStats(IStatisticGatherer &progress) const
@@ -367,9 +367,9 @@ void CHThorIndexReadActivityBase::resolveIndexFilename()
 }
 
 void CHThorIndexReadActivityBase::stop()
-{ 
-    killPart(); 
-    CHThorActivityBase::stop(); 
+{
+    killPart();
+    CHThorActivityBase::stop();
 }
 
 bool CHThorIndexReadActivityBase::doPreopenLimit(unsigned __int64 limit)
@@ -630,7 +630,7 @@ bool CHThorIndexReadActivityBase::doNextSuper()
 {
     do
     {
-        clearTlk(); 
+        clearTlk();
         df.set(&superIterator->query());
         unsigned numParts = df->numParts();
         if (numParts==1)
@@ -866,7 +866,7 @@ bool CHThorIndexReadActivity::nextPart()
 }
 
 void CHThorIndexReadActivity::initPart()
-{ 
+{
     CHThorIndexReadActivityBase::initPart();
 }
 
@@ -1445,6 +1445,7 @@ const void *CHThorIndexCountActivity::nextRow()
         unsigned __int64 keyedProcessed = 0;
         unsigned __int64 rowsProcessed = 0;
         bool limitSkipped = false;
+        const bool wantsAggregateExists = (helper.getFlags() & TIRaggregateexists);
         for (;;)
         {
             if (helper.hasFilter())
@@ -1473,6 +1474,8 @@ const void *CHThorIndexCountActivity::nextRow()
                             helper.onLimitExceeded();
                     }
 
+                    if (wantsAggregateExists && totalCount) // EXISTS only needs to count one row
+                        break;
                     if ((totalCount > choosenLimit))
                         break;
                 }
@@ -1480,7 +1483,7 @@ const void *CHThorIndexCountActivity::nextRow()
             else
                 totalCount += klManager->getCount();
 
-            if (limitSkipped || (totalCount > choosenLimit) || !nextPart())
+            if (limitSkipped || (wantsAggregateExists && totalCount) || (totalCount > choosenLimit) || !nextPart())
                 break;
         }
     }
@@ -1523,7 +1526,7 @@ public:
     //interface IHThorInput
     virtual void ready();
     virtual const void *nextRow();
-    virtual bool needsAllocator() const { return true; }        
+    virtual bool needsAllocator() const { return true; }
     virtual void processRow(const void * next);
 
 protected:
@@ -1573,7 +1576,7 @@ void CHThorIndexGroupAggregateActivity::gather()
             if (!nextPart())
                 return;
         }
-                
+
         agent.reportProgress(NULL);
         try
         {
@@ -1785,9 +1788,9 @@ protected:
     ISourceRowPrefetcher * prefetcher;
 public:
     FetchPartHandlerBase(offset_t _base, offset_t _size, bool _blockcompressed, MemoryAttr &_encryptionkey, unsigned _activityId, CachedOutputMetaData const & _outputMeta, ISourceRowPrefetcher * _prefetcher, IEngineRowAllocator *_rowAllocator)
-        : blockcompressed(_blockcompressed), 
-          encryptionkey(_encryptionkey), 
-          activityId(_activityId), 
+        : blockcompressed(_blockcompressed),
+          encryptionkey(_encryptionkey),
+          activityId(_activityId),
           outputMeta(_outputMeta),
           rowAllocator(_rowAllocator),
           prefetcher(_prefetcher)
@@ -1842,7 +1845,7 @@ public:
                     else
                         expectedSize = props.getPropInt64("@size", -1);
                     if(thissize != expectedSize && expectedSize != (unsigned __int64)-1)
-                        throw MakeStringException(0, "File size mismatch: file %s was supposed to be %" I64F "d bytes but appears to be %" I64F "d bytes", ifile->queryFilename(), expectedSize, thissize); 
+                        throw MakeStringException(0, "File size mismatch: file %s was supposed to be %" I64F "d bytes but appears to be %" I64F "d bytes", ifile->queryFilename(), expectedSize, thissize);
                     if(blockcompressed)
                         rawFile.setown(createCompressedFileReader(ifile, eexp, useDefaultIoBufferSize, false, IFEnone));
                     else
@@ -1964,7 +1967,7 @@ protected:
             }
         }
         if (partsize == (offset_t)-1)
-            throw MakeStringException(0, "Unable to determine size of filepart"); 
+            throw MakeStringException(0, "Unable to determine size of filepart");
         return partsize;
     }
 
@@ -2102,9 +2105,9 @@ public:
 
     virtual void fetchAll() = 0;
 
-    virtual void ready()        
-    { 
-        CHThorActivityBase::ready(); 
+    virtual void ready()
+    {
+        CHThorActivityBase::ready();
         started = false;
         stopped = false;
         aborting = false;
@@ -2128,7 +2131,7 @@ public:
         clearQueue();
         waitForThreads();
         avail.reinit(0);
-        CHThorActivityBase::stop(); 
+        CHThorActivityBase::stop();
     }
 
     virtual const void * getRow() = 0;
@@ -2139,7 +2142,7 @@ public:
     //interface IHThorInput
     virtual bool isGrouped()                { return false; }
     virtual const char *getFileName()       { return NULL; }
-    virtual bool outputToFile(const char *) { return false; } 
+    virtual bool outputToFile(const char *) { return false; }
     virtual IOutputMetaData * queryOutputMeta() const { return CHThorActivityBase::outputMeta; }
 
 protected:
@@ -2202,7 +2205,7 @@ public:
     }
 
     virtual void initParts(IDistributedFile * f) = 0;
-    
+
     virtual void stopParts() = 0;
 
     virtual void onLimitExceeded() = 0;
@@ -2374,7 +2377,7 @@ protected:
     Owned<IOutputMetaData> actualDiskMeta;
     Owned<const IDynamicTransform> translator;
 private:
-    PartHandlerThreadFactory<FetchRequest> threadFactory;   
+    PartHandlerThreadFactory<FetchRequest> threadFactory;
     Owned<DistributedFileFetchHandler<SimpleFetchPartHandlerBase, const void *, FetchRequest> > parts;
     offset_t pendingSeq, signalSeq, dequeuedSeq;
     QueueOf<const void *, true> pending;
@@ -2551,7 +2554,7 @@ public:
             buff.append("Skipping OPT fetch of nonexistent file ").append(lfn);
             agent.addWuExceptionEx(buff.str(), WRN_SkipMissingOptFile, SeverityInformation, MSGAUD_user, "hthor");
         }
-            
+
         csvSplitter.init(_arg.getMaxColumns(), csvInfo, quotes, separators, terminators, escapes);
     }
 
@@ -2606,7 +2609,7 @@ public:
     }
 
 protected:
-    CSVSplitter csvSplitter;    
+    CSVSplitter csvSplitter;
     CriticalSection transformCrit;
     IHThorCsvFetchArg & helper;
 };
@@ -2716,7 +2719,7 @@ public:
                 setRow(rowBuilder.finalizeRowClear(thisSize), fetch->seq);
             }
             else
-            {   
+            {
                 setRow(NULL, fetch->seq);
             }
         }
@@ -2834,7 +2837,7 @@ public:
         unsigned ms;
         unsigned idx;
     } matches;
-    
+
     CJoinGroup *prev;  // Doubly-linked list to allow us to keep track of ones that are still in use
     CJoinGroup *next;
 
@@ -3186,7 +3189,7 @@ public:
             IDistributedFile & f = keyFiles.item(idx);
             IDistributedFilePart &tlk = tlks.item(idx);
             Owned<IKeyIndex> index = openKeyFile(tlk);
-            //Owned<IRecordLayoutTranslator> 
+            //Owned<IRecordLayoutTranslator>
             trans.setown(owner.getLayoutTranslator(&f));
             owner.verifyIndex(&f, index, trans);
             const RtlRecord & actualRecInfo = trans ? trans->querySourceMeta() : owner.queryIndexRecord();
@@ -3379,11 +3382,11 @@ public:
     virtual IDistributedFilePart * queryPart() { return part; }
 
 private:
-    virtual void openPart() 
-    { 
-        FetchPartHandlerBase::openPart(); 
+    virtual void openPart()
+    {
+        FetchPartHandlerBase::openPart();
     }
-    
+
     virtual void doRequest(KeyedJoinFetchRequest * _fetch)
     {
         Owned<KeyedJoinFetchRequest> fetch(_fetch);
@@ -3399,7 +3402,7 @@ private:
 
 class CHThorKeyedJoinActivity  : public CHThorThreadedActivityBase, implements IJoinProcessor, public IKeyedJoinFetchHandlerCallback, public IFetchHandlerFactory<KeyedJoinFetchPartHandler>
 {
-    PartHandlerThreadFactory<FetchRequest> threadFactory;   
+    PartHandlerThreadFactory<FetchRequest> threadFactory;
     Owned<DistributedFileFetchHandler<KeyedJoinFetchPartHandler, MatchSet *, KeyedJoinFetchRequest> > parts;
     IHThorKeyedJoinArg &helper;
     Owned<IKeyLookupHandler> lookup;
@@ -3463,9 +3466,9 @@ public:
 
     virtual bool hasNewSegmentMonitors() { return helper.hasNewSegmentMonitors(); }
 
-    virtual void ready()        
-    { 
-        CHThorThreadedActivityBase::ready(); 
+    virtual void ready()
+    {
+        CHThorThreadedActivityBase::ready();
 
         preserveOrder = ((helper.getJoinFlags() & JFreorderable) == 0);
         preserveGroups = helper.queryOutputMeta()->isGrouped();
@@ -3513,7 +3516,7 @@ public:
         fetch.getFileEncryptKey(kl,k);
         MemoryAttr encryptionkey;
         encryptionkey.setOwn(kl,k);
-        Owned<IEngineRowAllocator> inputRowAllocator;   
+        Owned<IEngineRowAllocator> inputRowAllocator;
         if (needsDiskRead)
         {
             inputRowAllocator.setown(agent.queryCodeContext()->getRowAllocator(helper.queryDiskRecordSize(), activityId));
@@ -3528,7 +3531,7 @@ public:
             parts->stopThread();
     }
 
-    virtual bool isGrouped() { return preserveGroups; } 
+    virtual bool isGrouped() { return preserveGroups; }
 
     virtual void waitForThreads()
     {
@@ -3585,7 +3588,7 @@ public:
             {
                 if (eogSeen)
                     break;
-                else 
+                else
                     eogSeen = true;
                 pool->endGroup();
             }
@@ -3639,7 +3642,7 @@ public:
             }
             else
             {
-                RtlDynamicRowBuilder extractBuilder(queryRightRowAllocator()); 
+                RtlDynamicRowBuilder extractBuilder(queryRightRowAllocator());
                 size32_t size = helper.extractJoinFields(extractBuilder, row, NULL);
                 void * ret = (void *) extractBuilder.finalizeRowClear(size);
                 fetch->ms->setPendingRightMatch(fetch->seq, ret);
@@ -3823,8 +3826,8 @@ public:
                     }
                 case TAKkeyeddenormalize:
                     {
-                        LinkRoxieRow(left);     
-                        addRow((void *) left ); 
+                        LinkRoxieRow(left);
+                        addRow((void *) left );
                         added++;
                         break;
                     }
@@ -3937,7 +3940,7 @@ public:
                             LinkRoxieRow(row);
                             extractedRows.append(row);
                         } while(jg->matches.next());
-                    
+
                     size32_t transformedSize;
                     try
                     {
@@ -4053,7 +4056,7 @@ public:
                     ms->incRightMatchCount();
                 else
                 {
-                    RtlDynamicRowBuilder rowBuilder(queryRightRowAllocator()); 
+                    RtlDynamicRowBuilder rowBuilder(queryRightRowAllocator());
                     size32_t size = helper.extractJoinFields(rowBuilder, rhs, &adapter);
                     void * ret = (void *)rowBuilder.finalizeRowClear(size);
                     ms->addRightMatch(ret);


### PR DESCRIPTION
hthor optimization for EXISTS from O(n) to O(1)

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [x] Send notifications about my Pull Request position in Smoketest queue.
- [x] Test my draft Pull Request.

## Testing:
Using the following ECL:

```
IMPORT Std;

STRING ns       := '~temp::hpcc34940::existslog';
STRING dataLFN  := ns + '::data';
STRING indexLFN := ns + '::index';

LAYOUT := RECORD
    UNSIGNED8 id;
    STRING    value;
END;

seed := DATASET([
    {1, 'match'},
    {2, 'ignore'}
], LAYOUT);

diskDS := DATASET(dataLFN, LAYOUT, THOR);
idx    := INDEX(diskDS, { id }, { value }, indexLFN);

SEQUENTIAL(
    Std.File.DeleteLogicalFile(indexLFN, TRUE),
    Std.File.DeleteLogicalFile(dataLFN, TRUE),
    OUTPUT(seed,,dataLFN, OVERWRITE),
    BUILDINDEX(idx, OVERWRITE),
    OUTPUT(EXISTS(idx(KEYED(id = 1) AND value = 'match')), NAMED('ExistsResult'))
);

```
I was able to see that the new code exits early.
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
