### PR TITLE
HPCC-35144 Make ws_smc unittests insensitive to element order

### DIFF
--- a/esp/services/ws_smc/ws_smcService.cpp
+++ b/esp/services/ws_smc/ws_smcService.cpp
@@ -3084,6 +3084,16 @@ public:
         CPPUNIT_ASSERT_MESSAGE("Response object type unexpected", impl != nullptr); 
         CGetGlobalMetricsResponse::serializer(nullptr, *impl, out, true); 
     }
+
+    void assertResponseMatchesExpected(IEspGetGlobalMetricsResponse &resp, const char * expected) {
+        StringBuffer out;
+        serializeResponse(resp, out);
+        Owned<IPropertyTree> responseTree = createPTreeFromXMLString(out.str());
+        Owned<IPropertyTree> expectedTree = createPTreeFromXMLString(expected);
+        VStringBuffer message("Response XML does not match expected. \nExpected:\n%s\nActual:\n%s", expected, out.str());
+        CPPUNIT_ASSERT_MESSAGE(message.str(), areMatchingPTrees(responseTree, expectedTree));
+    }
+
     static constexpr const char * expectedAllCategories = "<GetGlobalMetricsResponse><GlobalMetrics>" 
         "<GlobalMetric><Category>categoryTwo</Category><DateTimeRange><Start>1999070112</Start><End>1999070112</End></DateTimeRange><Stats><Stat><Name>TimeLocalExecute</Name><Value>444</Value></Stat></Stats></GlobalMetric>" 
         "<GlobalMetric><Category>categoryTwo</Category><Dimensions><Dimension><Name>user</Name><Value>alice</Value></Dimension></Dimensions><DateTimeRange><Start>1999070112</Start><End>1999070112</End></DateTimeRange><Stats><Stat><Name>TimeLocalExecute</Name><Value>555</Value></Stat><Stat><Name>CostExecute</Name><Value>7</Value></Stat></Stats></GlobalMetric>" 
@@ -3097,38 +3107,30 @@ public:
         Owned<IEspGetGlobalMetricsRequest> req = createRequestFromXML(requestXML); 
         Owned<IEspGetGlobalMetricsResponse> resp = createGetGlobalMetricsResponse(); 
         handleGetGlobalMetrics(*req, *resp); 
-        StringBuffer out; 
-        serializeResponse(*resp, out); 
-        CPPUNIT_ASSERT_EQUAL(std::string(expectedAllCategories), std::string(out.str())); 
+        assertResponseMatchesExpected(*resp, expectedAllCategories);
     }
     void testAllCategoriesImplicit() { 
         static const char * requestXML = "<GetGlobalMetricsRequest><DateTimeRange><Start>1999-01-01T00:00:00</Start><End>2099-01-01T00:00:00</End></DateTimeRange></GetGlobalMetricsRequest>"; 
         Owned<IEspGetGlobalMetricsRequest> req = createRequestFromXML(requestXML); 
         Owned<IEspGetGlobalMetricsResponse> resp = createGetGlobalMetricsResponse(); 
-        handleGetGlobalMetrics(*req, *resp); 
-        StringBuffer out; 
-        serializeResponse(*resp, out); 
-        CPPUNIT_ASSERT_EQUAL(std::string(expectedAllCategories), std::string(out.str())); 
+        handleGetGlobalMetrics(*req, *resp);
+        assertResponseMatchesExpected(*resp, expectedAllCategories);
     }
     void testSingleCategoryAndDimensions() { 
         static const char * requestXML = "<GetGlobalMetricsRequest><Category>categoryOne</Category><Dimensions><Dimension><Name>user</Name><Value>bob</Value></Dimension></Dimensions><DateTimeRange><Start>1999-01-01T00:00:00</Start><End>2099-01-01T00:00:00</End></DateTimeRange></GetGlobalMetricsRequest>"; 
         Owned<IEspGetGlobalMetricsRequest> req = createRequestFromXML(requestXML); 
         Owned<IEspGetGlobalMetricsResponse> resp = createGetGlobalMetricsResponse(); 
         handleGetGlobalMetrics(*req, *resp); 
-        StringBuffer out; 
-        serializeResponse(*resp, out); 
         static const char * expected = "<GetGlobalMetricsResponse><GlobalMetrics><GlobalMetric><Category>categoryOne</Category><Dimensions><Dimension><Name>user</Name><Value>bob</Value></Dimension><Dimension><Name>cluster</Name><Value>thor1</Value></Dimension></Dimensions><DateTimeRange><Start>1999070112</Start><End>1999070112</End></DateTimeRange><Stats><Stat><Name>TimeLocalExecute</Name><Value>333</Value></Stat></Stats></GlobalMetric></GlobalMetrics></GetGlobalMetricsResponse>"; 
-        CPPUNIT_ASSERT_EQUAL(std::string(expected), std::string(out.str())); 
+        assertResponseMatchesExpected(*resp, expected);
     }
     void testDimensionAcrossCategories() { 
         static const char * requestXML = "<GetGlobalMetricsRequest><Dimensions><Dimension><Name>user</Name><Value>alice</Value></Dimension></Dimensions><DateTimeRange><Start>1999-01-01T00:00:00</Start><End>2099-01-01T00:00:00</End></DateTimeRange></GetGlobalMetricsRequest>"; 
         Owned<IEspGetGlobalMetricsRequest> req = createRequestFromXML(requestXML); 
         Owned<IEspGetGlobalMetricsResponse> resp = createGetGlobalMetricsResponse(); 
         handleGetGlobalMetrics(*req, *resp); 
-        StringBuffer out; 
-        serializeResponse(*resp, out); 
         static const char * expected = "<GetGlobalMetricsResponse><GlobalMetrics><GlobalMetric><Category>categoryTwo</Category><Dimensions><Dimension><Name>user</Name><Value>alice</Value></Dimension></Dimensions><DateTimeRange><Start>1999070112</Start><End>1999070112</End></DateTimeRange><Stats><Stat><Name>TimeLocalExecute</Name><Value>555</Value></Stat><Stat><Name>CostExecute</Name><Value>7</Value></Stat></Stats></GlobalMetric><GlobalMetric><Category>categoryOne</Category><Dimensions><Dimension><Name>user</Name><Value>alice</Value></Dimension></Dimensions><DateTimeRange><Start>1999070112</Start><End>1999070112</End></DateTimeRange><Stats><Stat><Name>TimeLocalExecute</Name><Value>222</Value></Stat><Stat><Name>CostExecute</Name><Value>5</Value></Stat></Stats></GlobalMetric></GlobalMetrics></GetGlobalMetricsResponse>"; 
-        CPPUNIT_ASSERT_EQUAL(std::string(expected), std::string(out.str())); 
+        assertResponseMatchesExpected(*resp, expected);
     }
 };
 CPPUNIT_TEST_SUITE_REGISTRATION(DaliWsSMCGlobalMetricsTest);


### PR DESCRIPTION
Test results were correct but with elements in a different order. Serialized results and/or global metrics pulled from dali don't have stable element ordering. Read values to PTrees and use areMatchingPTrees() function to compare.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [x] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [x] Scalability
  - [x] Performance
  - [x] Security
  - [x] Thread-safety
  - [x] Cloud-compatibility
  - [x] Premature optimization
  - [x] Existing deployed queries will not be broken
  - [x] This change fixes the problem, not just the symptom
  - [x] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
