### PR TITLE
HPCC-34108: Remove unused synthetic event attributes

### DIFF
--- a/common/eventconsumption/eventdumpstream.cpp
+++ b/common/eventconsumption/eventdumpstream.cpp
@@ -493,16 +493,10 @@ public:
     }
 
 protected:
+    // No attributes to be skipped at this time. Retain for possible future use.
     bool skipAttribute(unsigned id) const
     {
-        switch (id)
-        {
-        case EvAttrRecordedTimestamp:
-        case EvAttrRecordedOption:
-            return true;
-        default:
-            return false;
-        }
+       return false;
     }
 
     virtual void recordAttribute(EventAttr id, const char*, const char* value, bool) override

--- a/system/jlib/jevent.cpp
+++ b/system/jlib/jevent.cpp
@@ -168,8 +168,6 @@ static constexpr EventAttrInformation attrInformation[] = {
     DEFINE_ATTR(ConnectId, u8),
     DEFINE_ATTR(Enabled, bool),
     DEFINE_ATTR(FileSize, u8),
-    DEFINE_ATTR(RecordedTimestamp, timestamp),
-    DEFINE_ATTR(RecordedOption, string),
     DEFINE_ATTR(EventTimestamp, timestamp),
     DEFINE_ATTR(EventTraceId, string),
     DEFINE_ATTR(EventThreadId, u8),

--- a/system/jlib/jevent.hpp
+++ b/system/jlib/jevent.hpp
@@ -77,8 +77,6 @@ enum EventAttr : byte
     EvAttrConnectId,
     EvAttrEnabled,
     EvAttrFileSize,
-    EvAttrRecordedTimestamp,
-    EvAttrRecordedOption,
     EvAttrEventTimestamp,
     EvAttrEventTraceId,
     EvAttrEventThreadId,

--- a/tools/evtool/evtool.hpp
+++ b/tools/evtool/evtool.hpp
@@ -124,8 +124,6 @@ protected:
             {
             case EvAttrNone: // not an attribute
             case EvAttrMax: // not an attribute
-            case EvAttrRecordedOption: // not an event attribute
-            case EvAttrRecordedTimestamp: // not an event attribute
                 return false;
             default:
                 if (attr > EvAttrMax) // should never happen
@@ -260,11 +258,6 @@ Filters:
                                 - EventThreadId: numeric
                                 - EventStackTrace: string
                                 - DataSize: numeric
-                              A limited number of attributes are unfilterable
-                              because they represent file header information
-                              and are not recorded with an event. These include:
-                                - RecordedTimestamp
-                                - RecordedOption
 )!!!";
         size32_t usageStrLength = size32_t(strlen(usageStr));
         out.put(usageStrLength, usageStr);


### PR DESCRIPTION
RecordedTimestamp and RecordedOption were defined as synthetic attributes used to pass file header values to event visitors. They were never recorded. They have not been visited attributes for some time. Consumers only references to them were to ignore them.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [x] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
