### PR TITLE
HPCC-35110 Restore IsCompressed DFUQuery response for flat files

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -2182,6 +2182,9 @@ public:
 // "includeAll" is a special field values that are used by field filtering on the server side,
 // but are only sent to a server version that supports them. NB: it can be negated, i.e. : -includeAll
 // These fields are used to specify sort order, and to specify which fields are to be returned.
+//
+// New fields must be added to this array, if they are not, they will be ignored and will not be serialized to
+// the client in serializeFileAttributes.
 
 struct DFUQFieldInfo
 {
@@ -2230,6 +2233,8 @@ static const DFUQFieldInfo dfuqFieldInfos[] =
     {DFUQResultField::writeCost,       "@writeCost",        DFUQResultFieldType::floatType},
     {DFUQResultField::expireDays,      "@expireDays",       DFUQResultFieldType::numericType},
     {DFUQResultField::subfilenames,    "@subfilenames",     DFUQResultFieldType::stringType},
+    {DFUQResultField::blockCompressed, "@blockCompressed",  DFUQResultFieldType::boolType},
+    {DFUQResultField::rowCompressed,   "@rowCompressed",    DFUQResultFieldType::boolType},
     {DFUQResultField::includeAll,      "includeAll",        DFUQResultFieldType::unknown}
 };
 const size_t dfuqFieldInfosCount = sizeof(dfuqFieldInfos)/sizeof(dfuqFieldInfos[0]);

--- a/dali/base/dadfs.hpp
+++ b/dali/base/dadfs.hpp
@@ -307,6 +307,8 @@ enum class DFUQResultField : unsigned
     writeCost,
     expireDays,
     subfilenames,
+    blockCompressed,    // blockCompressed and rowCompressed need to be included for use
+    rowCompressed,      // by the dafdesc.cpp isCompressed function
     includeAll,
     term,               // NB: only used by client code, not passed to server. Signifies end of a list of fields
     fieldMask = 0xff,


### PR DESCRIPTION
Ensure that compressed flat files are marked as compressed. Restore the return of the @rowCompressed and @blockCompressed attributes from dali that are needed to set the IsCompressed flag.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [x] All new and existing tests passed.
  - [x] I have checked that this change does not introduce memory leaks.
  - [x] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [x] Scalability
  - [x] Performance
  - [x] Security
  - [x] Thread-safety
  - [x] Cloud-compatibility
  - [x] Premature optimization
  - [x] Existing deployed queries will not be broken
  - [x] This change fixes the problem, not just the symptom
  - [x] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
