### PR TITLE
HPCC-35269 Add unittests to XRef

### DIFF
--- a/dali/sasha/CMakeLists.txt
+++ b/dali/sasha/CMakeLists.txt
@@ -107,6 +107,10 @@ target_link_libraries ( saserver
          sashalib
     )
 
+if (USE_CPPUNIT)
+    target_link_libraries ( saserver ${CppUnit_LIBRARIES} )
+endif()
+
 set (    SRCS 
          sacmd.cpp 
          sasha.cpp 

--- a/dali/sasha/saxref.cpp
+++ b/dali/sasha/saxref.cpp
@@ -3425,3 +3425,502 @@ void runExpiryCLI()
     Owned<CSashaExpiryServer> sashaExpiryServer = new CSashaExpiryServer(config);
     sashaExpiryServer->runExpiry();
 }
+
+
+#ifdef _USE_CPPUNIT
+
+#include <cppunit/extensions/HelperMacros.h>
+#include <thread>
+#include <vector>
+
+class XRefAllocatorTest : public CppUnit::TestFixture
+{
+    CPPUNIT_TEST_SUITE(XRefAllocatorTest);
+        CPPUNIT_TEST(testBasicAllocation);
+        CPPUNIT_TEST(testDeallocation);
+        CPPUNIT_TEST(testMemoryLimit);
+    CPPUNIT_TEST_SUITE_END();
+
+public:
+    void testBasicAllocation()
+    {
+        const int numThreads = 10;
+        const size_t allocMBs = 1;
+        const size_t allocSize = allocMBs * 1024 * 1024;
+        XRefAllocator allocator(numThreads * allocMBs);
+        std::vector<std::thread> threads;
+        threads.reserve(numThreads);
+        std::vector<void*> allocatedPtrs(numThreads);
+        bool allAllocationsSucceeded = true;
+
+        // Lambda function for each thread to allocate memory
+        auto threadFunc = [&](int threadId)
+        {
+            try
+            {
+                void *ptr = allocator.alloc(allocSize);
+                if (ptr != nullptr)
+                    allocatedPtrs[threadId] = ptr;
+                else
+                    allAllocationsSucceeded = false;
+            }
+            catch (...)
+            {
+                allAllocationsSucceeded = false;
+            }
+        };
+
+        // Create and start 10 threads
+        for (int i = 0; i < numThreads; i++)
+            threads.emplace_back(threadFunc, i);
+
+        for (auto& thread : threads)
+            thread.join();
+
+        // Verify all allocations succeeded
+        CPPUNIT_ASSERT(allAllocationsSucceeded);
+
+        // Verify all pointers are non-null and unique using a set
+        std::set<void*> uniquePtrs;
+        for (void* ptr : allocatedPtrs)
+        {
+            CPPUNIT_ASSERT(ptr != nullptr);
+            auto result = uniquePtrs.insert(ptr);
+            CPPUNIT_ASSERT(result.second); // insertion should succeed, i.e., ptr is unique
+        }
+        // Deallocate memory
+        for (void* ptr : allocatedPtrs)
+            allocator.dealloc(ptr, allocSize);
+    }
+
+    void testDeallocation()
+    {
+        XRefAllocator allocator(1); // 1MB limit
+
+        void *ptr1 = allocator.alloc(512);
+        void *ptr2 = allocator.alloc(512);
+
+        CPPUNIT_ASSERT(ptr1 != nullptr);
+        CPPUNIT_ASSERT(ptr2 != nullptr);
+        CPPUNIT_ASSERT(ptr1 != ptr2);
+
+        allocator.dealloc(ptr1, 512);
+        allocator.dealloc(ptr2, 512);
+    }
+
+    void testMemoryLimit()
+    {
+        XRefAllocator allocator(1); // 1MB limit
+
+        // Try to allocate more than the limit
+        try
+        {
+            void *ptr = allocator.alloc(2 * 1024 * 1024); // 2MB
+            allocator.dealloc(ptr, 2 * 1024 * 1024); // cleanup in case test fails
+            CPPUNIT_FAIL("Should have thrown an exception for memory limit exceeded");
+        }
+        catch (...)
+        {
+            // Expected behavior
+        }
+    }
+};
+
+
+class XRefcMisplacedRecTest : public CppUnit::TestFixture
+{
+    CPPUNIT_TEST_SUITE(XRefcMisplacedRecTest);
+        CPPUNIT_TEST(testCreation);
+        CPPUNIT_TEST(testInitialization);
+        CPPUNIT_TEST(testEquality);
+        CPPUNIT_TEST(testGetters);
+    CPPUNIT_TEST_SUITE_END();
+
+public:
+    void testCreation()
+    {
+        XRefAllocator allocator(1); // 1MB limit
+        std::unique_ptr<cMisplacedRec> rec(cMisplacedRec::create(&allocator));
+
+        CPPUNIT_ASSERT(rec != nullptr);
+        CPPUNIT_ASSERT(rec->allocator == &allocator);
+    }
+
+    void testInitialization()
+    {
+        XRefAllocator allocator(1);
+        std::unique_ptr<cMisplacedRec> rec(cMisplacedRec::create(&allocator));
+
+        rec->init(0, 5, 2, 4); // drv=0, part=5, node=2, totalNodes=4
+
+        CPPUNIT_ASSERT_EQUAL((unsigned short)5, rec->pn);
+        CPPUNIT_ASSERT_EQUAL((unsigned short)2, rec->nn);
+        CPPUNIT_ASSERT_EQUAL(false, rec->marked);
+        CPPUNIT_ASSERT(rec->next == nullptr);
+    }
+
+    void testEquality()
+    {
+        XRefAllocator allocator(1);
+        std::unique_ptr<cMisplacedRec> rec(cMisplacedRec::create(&allocator));
+
+        rec->init(0, 5, 2, 4);
+
+        CPPUNIT_ASSERT(rec->eq(0, 5, 2, 4));
+        CPPUNIT_ASSERT(!rec->eq(0, 6, 2, 4)); // different part
+        CPPUNIT_ASSERT(!rec->eq(0, 5, 3, 4)); // different node
+    }
+
+    void testGetters()
+    {
+        XRefAllocator allocator(1);
+        std::unique_ptr<cMisplacedRec> rec(cMisplacedRec::create(&allocator));
+
+        rec->init(1, 5, 2, 4); // drv=1, part=5, node=2, totalNodes=4
+
+        CPPUNIT_ASSERT_EQUAL(1U, rec->getDrv(4));
+        CPPUNIT_ASSERT_EQUAL(2U, rec->getNode(4));
+    }
+};
+
+
+class XRefcFileDescTest : public CppUnit::TestFixture
+{
+    CPPUNIT_TEST_SUITE(XRefcFileDescTest);
+        CPPUNIT_TEST(testCreation);
+        CPPUNIT_TEST(testPresentBits);
+        CPPUNIT_TEST(testMarkedBits);
+        CPPUNIT_TEST(testHPCCFile);
+        CPPUNIT_TEST(testGetNameAndMask);
+        CPPUNIT_TEST(testGetPartName);
+    CPPUNIT_TEST_SUITE_END();
+
+public:
+    void testCreation()
+    {
+        XRefAllocator allocator(1);
+        const char *testName = "testfile.$N$_of_$P$";
+        std::unique_ptr<cFileDesc> file(cFileDesc::create(testName, 400, true, 8, &allocator));
+
+        CPPUNIT_ASSERT(file != nullptr);
+        CPPUNIT_ASSERT(file->eq(testName));
+        CPPUNIT_ASSERT_EQUAL((unsigned short)400, file->N);
+        CPPUNIT_ASSERT_EQUAL(true, file->isDirPerPart);
+        CPPUNIT_ASSERT_EQUAL((byte)8, file->filenameLen);
+        CPPUNIT_ASSERT(file->eq(testName));
+        CPPUNIT_ASSERT(!file->eq("differentfile.$N$_of_$P$"));
+    }
+
+    void testPresentBits()
+    {
+        XRefAllocator allocator(1);
+        std::unique_ptr<cFileDesc> file(cFileDesc::create("testfile.$N$_of_$P$", 400, true, 8, &allocator));
+
+        // Test setting and getting present bits
+        CPPUNIT_ASSERT_EQUAL(false, file->setpresent(0, 1));    // should return false (not previously set)
+        CPPUNIT_ASSERT_EQUAL(true, file->testpresent(0, 1));    // should now be set
+        CPPUNIT_ASSERT_EQUAL(true, file->setpresent(0, 1));     // should return true (previously set)
+        CPPUNIT_ASSERT_EQUAL(false, file->testpresent(0, 400)); // should be false (not set)
+        CPPUNIT_ASSERT_EQUAL(false, file->setpresent(0, 400));  // should return false (not previously set)
+        CPPUNIT_ASSERT_EQUAL(true, file->testpresent(0, 400));  // should now be set
+    }
+
+    void testMarkedBits()
+    {
+        XRefAllocator allocator(1);
+        std::unique_ptr<cFileDesc> file(cFileDesc::create("testfile.$N$_of_$P$", 400, true, 8, &allocator));
+
+        // Test setting and getting marked bits
+        CPPUNIT_ASSERT_EQUAL(false, file->setmarked(0, 1));    // should return false (not previously set)
+        CPPUNIT_ASSERT_EQUAL(true, file->testmarked(0, 1));    // should now be set
+        CPPUNIT_ASSERT_EQUAL(true, file->setmarked(0, 1));     // should return true (previously set)
+        CPPUNIT_ASSERT_EQUAL(false, file->testmarked(0, 400)); // should be false (not set)
+        CPPUNIT_ASSERT_EQUAL(false, file->setmarked(0, 400));  // should return false (not previously set)
+        CPPUNIT_ASSERT_EQUAL(true, file->testmarked(0, 400));  // should now be set
+    }
+
+    void testHPCCFile()
+    {
+        XRefAllocator allocator(1);
+
+        std::unique_ptr<cFileDesc> hpccFile(cFileDesc::create("testfile.$N$_of_$P$", 4, false, 8, &allocator));
+        CPPUNIT_ASSERT(hpccFile->isHPCCFile());
+
+        // For non-HPCC files, filenameLen will be 0 because deduceMask fails to find a partmask
+        std::unique_ptr<cFileDesc> nonHpccFile(cFileDesc::create("testfile.dat", 4, false, 0, &allocator));
+        CPPUNIT_ASSERT(!nonHpccFile->isHPCCFile());
+    }
+
+    void testGetNameAndMask()
+    {
+        XRefAllocator allocator(1);
+
+        // Test HPCC file with filename length
+        std::unique_ptr<cFileDesc> hpccFile(cFileDesc::create("testfile.$N$_of_$P$", 4, false, 8, &allocator));
+
+        StringBuffer nameBuf;
+        CPPUNIT_ASSERT(hpccFile->getName(nameBuf));
+        CPPUNIT_ASSERT_EQUAL(std::string("testfile"), std::string(nameBuf.str()));
+
+        StringBuffer maskBuf;
+        hpccFile->getNameMask(maskBuf);
+        CPPUNIT_ASSERT_EQUAL(std::string("testfile.$N$_of_$P$"), std::string(maskBuf.str()));
+        // Test non-HPCC file (no filename length)
+        std::unique_ptr<cFileDesc> nonHpccFile(cFileDesc::create("regularfile.dat", 1, false, 0, &allocator));
+
+        StringBuffer nameBuf2;
+        CPPUNIT_ASSERT(!nonHpccFile->getName(nameBuf2)); // Should return false
+    }
+
+    void testGetPartName()
+    {
+        XRefAllocator allocator(1);
+        std::unique_ptr<cFileDesc> file(cFileDesc::create("testfile.$N$_of_$P$", 4, false, 8, &allocator));
+
+        StringBuffer partName;
+        file->getPartName(partName, 1);
+
+        // Should expand the mask with part number
+        // Note: The exact expansion depends on expandMask implementation
+        CPPUNIT_ASSERT(partName.length() > 0);
+        CPPUNIT_ASSERT(strstr(partName.str(), "testfile") != nullptr);
+    }
+};
+
+
+class XRefcDirDescTest : public CppUnit::TestFixture
+{
+    CPPUNIT_TEST_SUITE(XRefcDirDescTest);
+        CPPUNIT_TEST(testCreation);
+        CPPUNIT_TEST(testEmpty);
+        CPPUNIT_TEST(testAddFile);
+        CPPUNIT_TEST(testIsMisplaced);
+        CPPUNIT_TEST(testSetMisplacedAndPresent);
+        CPPUNIT_TEST(testEnsureFile);
+        CPPUNIT_TEST(testSetMisplacedAndPresentMultipleMisplaced);
+        CPPUNIT_TEST(testGetFileNotExist);
+        CPPUNIT_TEST(testEnsureFileExternalFile);
+    CPPUNIT_TEST_SUITE_END();
+
+public:
+    void testCreation()
+    {
+        XRefAllocator allocator(1);
+        const char *testName = "directory";
+
+        std::unique_ptr<cDirDesc> dir(cDirDesc::create(testName, &allocator));
+
+        CPPUNIT_ASSERT(dir != nullptr);
+        CPPUNIT_ASSERT(dir->eq(testName));
+        CPPUNIT_ASSERT(!dir->eq("directory2"));
+    }
+
+    void testEmpty()
+    {
+        XRefAllocator allocator(1);
+        std::unique_ptr<cDirDesc> dir(cDirDesc::create("directory", &allocator));
+
+        // Initially, directory should be empty
+        CPPUNIT_ASSERT(dir->empty(0));
+        CPPUNIT_ASSERT(dir->empty(1));
+
+        // Add a file to the directory
+        const char *testName = "testfile.$N$_of_$P$";
+        std::unique_ptr<cFileDesc> file(cFileDesc::create(testName, 400, true, 8, &allocator));
+        dir->files.emplace(testName, file.release());
+        CPPUNIT_ASSERT(!dir->empty(0));
+        CPPUNIT_ASSERT(!dir->empty(1));
+    }
+
+    void testAddFile()
+    {
+        XRefAllocator allocator(1);
+        std::unique_ptr<cDirDesc> dir(cDirDesc::create("directory", &allocator));
+
+        // Simulate scanDirectory logic for adding a file
+        unsigned numNodes = 20;
+        unsigned nodeNum = 0;
+        unsigned drv = 0;
+        unsigned partNum = 122; // 0-based
+        unsigned numParts = 456; // logical part count
+        unsigned filenameLen = 8; // length of "testfile"
+        const char *fn = "testfile._$P$_of_456";
+        cFileDesc *file = dir->ensureFile(fn, numParts, false, filenameLen, &allocator);
+        dir->setMisplacedAndPresent(file, false, partNum, drv, "/home/test/testfile._123_of_456", nodeNum, numNodes);
+        CPPUNIT_ASSERT(!dir->empty(0));
+        CPPUNIT_ASSERT(!dir->empty(1));
+
+        // Check file was created properly
+        cFileDesc *found = dir->getFile(fn);
+        CPPUNIT_ASSERT(found != nullptr);
+        CPPUNIT_ASSERT(found->misplaced == nullptr);
+        CPPUNIT_ASSERT(found->N == numParts);
+        CPPUNIT_ASSERT(found->filenameLen == filenameLen);
+        CPPUNIT_ASSERT(found->eq(fn));
+
+        // Check present bit
+        CPPUNIT_ASSERT(found->testpresent(drv, partNum));
+    }
+
+    void testSetMisplacedAndPresent()
+    {
+        XRefAllocator allocator(1);
+        std::unique_ptr<cDirDesc> dir(cDirDesc::create("directory", &allocator));
+
+        unsigned numNodes = 20;
+        unsigned nodeNum = 0;
+        unsigned drv = 0;
+        unsigned partNum = 5;
+        unsigned numParts = 10;
+        unsigned filenameLen = 8;
+        const char *fn = "misplacedfile._$P$_of_10";
+        cFileDesc *file = dir->ensureFile(fn, numParts, false, filenameLen, &allocator);
+
+        // Mark as misplaced
+        dir->setMisplacedAndPresent(file, true, partNum, drv, "/home/test/misplacedfile._6_of_10", nodeNum, numNodes);
+        CPPUNIT_ASSERT(file->misplaced != nullptr);
+        CPPUNIT_ASSERT(file->misplaced->pn == partNum);
+        CPPUNIT_ASSERT(file->misplaced->nn == nodeNum);
+        CPPUNIT_ASSERT(file->misplaced->marked == false);
+
+        // Mark as present (not misplaced)
+        dir->setMisplacedAndPresent(file, false, partNum, drv, "/home/test/misplacedfile._6_of_10", nodeNum, numNodes);
+        CPPUNIT_ASSERT(file->testpresent(drv, partNum));
+    }
+
+    void testEnsureFile()
+    {
+        XRefAllocator allocator(1);
+        std::unique_ptr<cDirDesc> dir(cDirDesc::create("directory", &allocator));
+
+        unsigned numParts = 5;
+        unsigned filenameLen = 8;
+        const char *fn = "ensurefile._$P$_of_5";
+
+        // Ensure file creation
+        cFileDesc *file = dir->ensureFile(fn, numParts, false, filenameLen, &allocator);
+        CPPUNIT_ASSERT(file != nullptr);
+        CPPUNIT_ASSERT(file->N == numParts);
+        CPPUNIT_ASSERT(file->filenameLen == filenameLen);
+
+        // Ensure file lookup returns same pointer
+        cFileDesc *found = dir->getFile(fn);
+        CPPUNIT_ASSERT(found == file);
+
+        // EnsureFile should not create duplicate
+        cFileDesc *file2 = dir->ensureFile(fn, numParts, false, filenameLen, &allocator);
+        CPPUNIT_ASSERT(file2 == file);
+        CPPUNIT_ASSERT(dir->files.size() == 1);
+    }
+
+    void testIsMisplaced()
+    {
+        XRefAllocator allocator(1);
+        std::unique_ptr<cDirDesc> dir(cDirDesc::create("directory", &allocator));
+
+        // Test external files (numParts == NotFound) - should always return true
+        SocketEndpointArray emptyEpa;
+        Owned<IGroup> emptyGroup = createIGroup(emptyEpa);
+        CPPUNIT_ASSERT(dir->isMisplaced(0, NotFound, SocketEndpoint(), *emptyGroup, "/test/file.dat", 5, 1, 1));
+
+        if (isContainerized())
+        {
+            // Test stripe number validation - invalid stripe numbers should return true
+            CPPUNIT_ASSERT(dir->isMisplaced(0, 4, SocketEndpoint(), *emptyGroup, "/test/file._1_of_4", 5, 0, 2)); // stripeNum < 1
+            CPPUNIT_ASSERT(dir->isMisplaced(0, 4, SocketEndpoint(), *emptyGroup, "/test/file._1_of_4", 5, 3, 2)); // stripeNum > numStripedDevices
+
+            // Test dir-per-part detection
+
+            // Valid dir-per-part where part matches directory number
+            CPPUNIT_ASSERT(!dir->isMisplaced(41, 4, SocketEndpoint(), *emptyGroup, "/test/scope/42/file._42_of_45", 11, 1, 1));
+
+            // Invalid dir-per-part where part doesn't match directory number
+            CPPUNIT_ASSERT(dir->isMisplaced(19, 40, SocketEndpoint(), *emptyGroup, "/test/scope/21/file._20_of_40", 11, 1, 1));
+
+            // Directory number too large (beyond numParts) - should be ignored, not considered misplaced
+            CPPUNIT_ASSERT(!dir->isMisplaced(0, 4, SocketEndpoint(), *emptyGroup, "/test/scope/999/file._1_of_4", 11, 1, 1));
+            CPPUNIT_ASSERT(!dir->isMisplaced(0, 4, SocketEndpoint(), *emptyGroup, "/test/scope/20250101/file._1_of_4", 11, 1, 1));
+
+            // Test files in root directory (no dir-per-part to check)
+            CPPUNIT_ASSERT(!dir->isMisplaced(0, 4, SocketEndpoint(), *emptyGroup, "/file._1_of_4", 0, 1, 1));
+
+            // Test striped files
+            CPPUNIT_ASSERT(!dir->isMisplaced(0, 4, SocketEndpoint(), *emptyGroup, "/test/scope/subdir/file._1_of_4", 11, calcStripeNumber(0, "subdir::file", 20), 20));
+            CPPUNIT_ASSERT(!dir->isMisplaced(99, 4, SocketEndpoint(), *emptyGroup, "/test/scope/subdir/100/file._100_of_400", 11, calcStripeNumber(99, "subdir::file", 20), 20));
+
+            // Test edge case with single digit dir-per-part
+            CPPUNIT_ASSERT(!dir->isMisplaced(2, 4, SocketEndpoint(), *emptyGroup, "/test/scope/3/file._3_of_4", 11, 1, 1));
+
+            // Test leading zeros in directory names (should still parse correctly)
+            // MORE: I don't think an actual dir-per-part will have leading zeros. This may be an edge case to handle.
+            CPPUNIT_ASSERT(!dir->isMisplaced(0, 4, SocketEndpoint(), *emptyGroup, "/test/scope/01/file._1_of_4", 11, 1, 1));
+        }
+        else
+        {
+            // Test non-containerized paths
+            SocketEndpointArray epa;
+            for (unsigned i = 0; i < 4; i++)
+            {
+                SocketEndpoint ep;
+                ep.set("127.0.0.1", 7070 + i);
+                epa.append(ep);
+            }
+            Owned<IGroup> grp = createIGroup(epa);
+
+            // Test mismatched group size
+            CPPUNIT_ASSERT(dir->isMisplaced(0, 5, epa.item(0), *grp, "/test/file._1_of_5", 5, 1, 1)); // numParts != grp.ordinality()
+
+            // Test part number out of range
+            CPPUNIT_ASSERT(dir->isMisplaced(4, 4, epa.item(0), *grp, "/test/file._5_of_4", 5, 1, 1)); // partNum >= grp.ordinality()
+
+            // Test endpoint mismatch
+            SocketEndpoint wrongEp;
+            wrongEp.set("192.168.1.1", 8080);
+            CPPUNIT_ASSERT(dir->isMisplaced(0, 4, wrongEp, *grp, "/test/file._1_of_4", 5, 1, 1)); // endpoint not in group
+
+            // Test correct placement
+            CPPUNIT_ASSERT(!dir->isMisplaced(0, 4, epa.item(0), *grp, "/test/file._1_of_4", 5, 1, 1)); // correct placement
+            CPPUNIT_ASSERT(!dir->isMisplaced(1, 4, epa.item(1), *grp, "/test/file._2_of_4", 5, 1, 1)); // correct placement
+        }
+    }
+
+    void testSetMisplacedAndPresentMultipleMisplaced()
+    {
+        XRefAllocator allocator(1);
+        std::unique_ptr<cDirDesc> dir(cDirDesc::create("directory", &allocator));
+        const char *fn = "multi._$P$_of_10";
+        cFileDesc *file = dir->ensureFile(fn, 10, false, 8, &allocator);
+        dir->setMisplacedAndPresent(file, true, 1, 0, "/home/test/multi._2_of_10", 0, 20);
+        dir->setMisplacedAndPresent(file, true, 2, 0, "/home/test/multi._3_of_10", 0, 20);
+        CPPUNIT_ASSERT(file->misplaced != nullptr);
+        CPPUNIT_ASSERT(file->misplaced->next != nullptr);
+        CPPUNIT_ASSERT(file->misplaced->pn == 2 && file->misplaced->next->pn == 1);
+    }
+
+    void testGetFileNotExist()
+    {
+        XRefAllocator allocator(1);
+        std::unique_ptr<cDirDesc> dir(cDirDesc::create("directory", &allocator));
+        CPPUNIT_ASSERT(dir->getFile("doesnotexist._$P$_of_1") == nullptr);
+    }
+
+    void testEnsureFileExternalFile()
+    {
+        XRefAllocator allocator(1);
+        std::unique_ptr<cDirDesc> dir(cDirDesc::create("directory", &allocator));
+        const char *fn = "externalfile.dat";
+        cFileDesc *file = dir->ensureFile(fn, NotFound, false, 0, &allocator);
+        CPPUNIT_ASSERT(file != nullptr);
+        CPPUNIT_ASSERT(file->N == 1);
+        dir->setMisplacedAndPresent(file, true, 0, 0, "/home/test/externalfile.dat", 0, 1);
+        CPPUNIT_ASSERT(file->misplaced != nullptr);
+    }
+};
+
+
+CPPUNIT_TEST_SUITE_REGISTRATION(XRefAllocatorTest);
+CPPUNIT_TEST_SUITE_REGISTRATION(XRefcMisplacedRecTest);
+CPPUNIT_TEST_SUITE_REGISTRATION(XRefcFileDescTest);
+CPPUNIT_TEST_SUITE_REGISTRATION(XRefcDirDescTest);
+
+#endif // _USE_CPPUNIT

--- a/dockerfiles/image.sh
+++ b/dockerfiles/image.sh
@@ -35,6 +35,9 @@ globals() {
     DOCKER_USERNAME="${DOCKER_USERNAME:-hpccbuilds}"
 
     CMAKE_OPTIONS="-G Ninja -DCPACK_THREADS=$(docker info --format '{{.NCPU}}') -DUSE_OPTIONAL=OFF -DCONTAINERIZED=ON -DINCLUDE_PLUGINS=ON -DSUPPRESS_V8EMBED=ON"
+    if [ "$USE_CPPUNIT" -eq 1 ]; then
+        CMAKE_OPTIONS="$CMAKE_OPTIONS -DUSE_CPPUNIT=ON"
+    fi
 
     if [ "$TAG_BUILD" -eq 1 ]; then
         HPCC_BUILD="hpcc_build_$MODE-$IMAGE_BRANCH_TAG"
@@ -410,6 +413,7 @@ status() {
     echo "HPCC_BUILD: $HPCC_BUILD"
     echo "ARCH: $ARCH"
     echo "NAME_TAG: $NAME_TAG"
+    echo "USE_CPPUNIT: $USE_CPPUNIT"
 }
 
 # Print usage information
@@ -428,6 +432,7 @@ usage() {
     echo "  -r, --reconfigure       reconfigure CMake before building"
     echo "  -a, --architecture      override default architecture (x64 or arm64)"
     echo "  -n, --name-tag          create an additional tag with the specified name for the final image"
+    echo "  -c, --cppunit           enable CppUnit tests (adds -DUSE_CPPUNIT=ON to CMake options)"
 }
 
 # Set default values
@@ -440,6 +445,7 @@ RELEASE_BASE_IMAGE="ubuntu:22.04" # Matches vcpkg base image (does not need to b
 TAG_BUILD=0
 ARCH=""
 NAME_TAG=""
+USE_CPPUNIT=0
 
 # Parse command line arguments
 while [[ $# -gt 0 ]]
@@ -491,6 +497,10 @@ case $key in
         NAME_TAG="$2"
         shift # past argument
         shift # past value
+        ;;
+    -c|--cppunit)
+        USE_CPPUNIT=1
+        shift # past argument
         ;;
     -h|--help)
         usage


### PR DESCRIPTION
- Refactor XRef to make it usable with the CPPUNIT framework. I wasn't sure of the best way to refactor or where to move the code. After some back and forth, I settled on removing all of the XRef classes from saxref.cpp and creating a subfolder under sasha with the XRef functionality.
- Add unittests in xrefunittests.cpp and export them as a library. I also export the XRef classes as a library to be used elsewhere.
- Add option to image.sh for allowing unittests to be built. I am not sure if this was the best way to add that functionality, but it works.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [x] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [x] I have added tests to cover my changes.
  - [x] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [x] This change fixes the problem, not just the symptom
  - [x] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
