### PR TITLE
HPCC-35353 Add root node offset in index parts meta data

### DIFF
--- a/dali/dfu/dfuutil.cpp
+++ b/dali/dfu/dfuutil.cpp
@@ -545,6 +545,7 @@ public:
             copyProp(dstProps, srcProps, "@uncompressedSize");
             copyProp(dstProps, srcProps, "@recordCount");
             copyProp(dstProps, srcProps, "@offsetBranches");
+            copyProp(dstProps, srcProps, "@offsetRoot");
         }
 
         if (!copyphysical) //cloneFrom tells roxie where to copy from.. it's unnecessary if we already did the copy

--- a/ecl/hthor/hthor.cpp
+++ b/ecl/hthor/hthor.cpp
@@ -1248,6 +1248,7 @@ void CHThorIndexWriteActivity::execute()
     unsigned __int64 reccount = 0;
     unsigned int fileCrc = -1;
     offset_t offsetBranches = 0;
+    offset_t offsetRoot = 0;
     offset_t uncompressedSize = 0;
     unsigned __int64 numLeafNodes = 0;
     unsigned __int64 numBlobNodes = 0;
@@ -1362,6 +1363,7 @@ void CHThorIndexWriteActivity::execute()
         totalBlobNodes += numBlobNodes;
         numDiskWrites = io->getStatistic(StNumDiskWrites);
         offsetBranches = builder->getStatistic(StSizeOffsetBranches);
+        offsetRoot = builder->getStatistic(StSizeOffsetRoot);
         out->flush();
         out.clear();
         io->close();
@@ -1415,6 +1417,7 @@ void CHThorIndexWriteActivity::execute()
     attrs->setPropInt64("@size", indexFileSize);
     attrs->setPropInt64("@recordCount", reccount);
     attrs->setPropInt64("@offsetBranches", offsetBranches);
+    attrs->setPropInt64("@offsetRoot", offsetRoot);
 
     CDateTime createTime, modifiedTime, accessedTime;
     file->getTime(&createTime, &modifiedTime, &accessedTime);

--- a/roxie/ccd/ccdserver.cpp
+++ b/roxie/ccd/ccdserver.cpp
@@ -12628,6 +12628,7 @@ class CRoxieServerIndexWriteActivity : public CRoxieServerInternalSinkActivity, 
     unsigned __int64 numBlobNodes = 0;
     unsigned __int64 numBranchNodes = 0;
     offset_t offsetBranches = 0;
+    offset_t offsetRoot = 0;
     offset_t uncompressedSize = 0;
     offset_t originalBlobSize = 0;
     offset_t branchMemorySize = 0;
@@ -12840,6 +12841,7 @@ public:
             numBranchNodes = builder->getStatistic(StNumNodeCacheAdds);
             numBlobNodes = builder->getStatistic(StNumBlobCacheAdds);
             offsetBranches = builder->getStatistic(StSizeOffsetBranches);
+            offsetRoot = builder->getStatistic(StSizeOffsetRoot);
             originalBlobSize = bc.queryTotalSize();
             branchMemorySize = builder->getStatistic(StSizeBranchMemory);
             leafMemorySize = builder->getStatistic(StSizeLeafMemory);
@@ -12883,6 +12885,7 @@ public:
         numBlobNodes = 0;
         numBranchNodes = 0;
         offsetBranches = 0;
+        offsetRoot = 0;
         uncompressedSize = 0;
         originalBlobSize = 0;
         noteStatistic(StNumDuplicateKeys, cummulativeDuplicateKeyCount);
@@ -12904,6 +12907,7 @@ public:
         attrs->setPropInt64("@size", compressedFileSize);
         attrs->setPropInt64("@recordCount", reccount);
         attrs->setPropInt64("@offsetBranches", offsetBranches);
+        attrs->setPropInt64("@offsetRoot", offsetRoot);
 
         CDateTime createTime, modifiedTime, accessedTime;
         writer->queryFile()->getTime(&createTime, &modifiedTime, &accessedTime);

--- a/system/jhtree/keybuild.cpp
+++ b/system/jhtree/keybuild.cpp
@@ -151,6 +151,7 @@ protected:
     unsigned levels;
     offset_t nextPos;
     offset_t offsetBranches = 0;
+    offset_t offsetRoot = 0;
     Owned<CWriteKeyHdr> keyHdr;
     CWriteNode *prevLeafNode;
     NodeInfoArray leafInfo;
@@ -509,6 +510,7 @@ protected:
         }
         offsetBranches = nextPos;
         buildTree(leafInfo);
+        offsetRoot = keyHdr->getHdrStruct()->root;
         if(metadata)
         {
             assertex(strcmp(metadata->queryName(), "metadata") == 0);
@@ -663,6 +665,8 @@ protected:
             return duplicateCount;
         case StSizeOffsetBranches:
             return offsetBranches;
+        case StSizeOffsetRoot:
+            return offsetRoot;
         case StSizeBranchMemory:
             return indexCompressor->queryBranchMemorySize();
         case StSizeLeafMemory:

--- a/system/jlib/jptree-attrs.hpp
+++ b/system/jlib/jptree-attrs.hpp
@@ -58,6 +58,7 @@
     "@numLeafNodes"
     "@offset",
     "@offsetBranches",
+    "@offsetRoot",
     "@originalBlobSize",
     "@partmask",
     "@persistent",

--- a/system/jlib/jstatcodes.h
+++ b/system/jlib/jstatcodes.h
@@ -365,6 +365,7 @@ enum StatisticKind
     StCycleQueryPreparationCycles,
     StCostSavingPotential,
     StCostFailed,
+    StSizeOffsetRoot,
     StMax,
 
     //For any quantity there is potentially the following variants.

--- a/system/jlib/jstats.cpp
+++ b/system/jlib/jstats.cpp
@@ -792,7 +792,7 @@ public:
 constexpr const char * UNUSED = "<unused>";
 
 //The order of entries in this table must match the order in the enumeration
-static const constexpr StatisticMeta statsMetaData[StMax] = {
+static const constexpr StatisticMeta statsMetaData[] = {
     { StKindNone, SMeasureNone, StatsMergeSum, StKindNone, StKindNone, { "none" }, { "@none" }, nullptr },
     { StKindAll, SMeasureAll, StatsMergeSum, StKindAll, StKindAll, { "all" }, { "@all" }, nullptr },
     { WHENFIRSTSTAT(GraphStarted), "The time when a graph started./nDeprecated" }, // Deprecated - use WhenStart
@@ -1032,9 +1032,12 @@ static const constexpr StatisticMeta statsMetaData[StMax] = {
     { CYCLESTAT(QueryPreparation) },
     { COSTSTAT(SavingPotential), "The potential cost savings from optimizations" },
     { COSTSTAT(Failed), "The cost associated with failed jobs" },
+    { SIZESTAT(OffsetRoot), "The offset of the root branch in an index" },
 };
 
 static MapStringTo<StatisticKind, StatisticKind> statisticNameMap(true);
+
+static_assert(StMax == sizeof(statsMetaData) / sizeof(StatisticMeta), "statsMetaData table out of sync with StatisticKind enumeration");
 
 MODULE_INIT(INIT_PRIORITY_STANDARD)
 {

--- a/thorlcr/activities/indexwrite/thindexwrite.cpp
+++ b/thorlcr/activities/indexwrite/thindexwrite.cpp
@@ -343,9 +343,11 @@ public:
                 offset_t slaveUncompressedSize;
                 offset_t slaveOriginalBlobSize;
                 offset_t offsetBranches;
+                offset_t offsetRoot;
                 mb.read(slaveUncompressedSize);
                 mb.read(slaveOriginalBlobSize);
                 mb.read(offsetBranches);
+                mb.read(offsetRoot);
 
                 compressedFileSize += size;
                 uncompressedSize += slaveUncompressedSize;
@@ -353,6 +355,7 @@ public:
 
                 props.setPropInt64("@uncompressedSize", slaveUncompressedSize);
                 props.setPropInt64("@offsetBranches", offsetBranches);
+                props.setPropInt64("@offsetRoot", offsetRoot);
 
                 //Read details for the TLK if it has been generated
                 if (!singlePartKey && 0 == slaveIdx && buildTlk)

--- a/thorlcr/activities/indexwrite/thindexwriteslave.cpp
+++ b/thorlcr/activities/indexwrite/thindexwriteslave.cpp
@@ -616,6 +616,7 @@ public:
             mb.append(uncompressedSize);
             mb.append(originalBlobSize);
             mb.append(inactiveStats.getStatisticValue(StSizeOffsetBranches));
+            mb.append(inactiveStats.getStatisticValue(StSizeOffsetRoot));
             if (!singlePartKey && firstNode() && buildTlk)
             {
                 mb.append(tlkCrc);

--- a/thorlcr/thorutil/thormisc.cpp
+++ b/thorlcr/thorutil/thormisc.cpp
@@ -85,7 +85,7 @@ const StatisticsMapping basicActivityStatistics({StNumParallelExecute, StTimeLoo
 const StatisticsMapping groupActivityStatistics({StNumGroups, StNumGroupMax}, basicActivityStatistics);
 const StatisticsMapping indexReadFileStatistics({}, diskReadRemoteStatistics, jhtreeCacheStatistics);
 const StatisticsMapping indexReadActivityStatistics({StNumRowsProcessed}, indexReadFileStatistics, basicActivityStatistics);
-const StatisticsMapping indexWriteActivityStatistics({StPerReplicated, StNumLeafCacheAdds, StNumNodeCacheAdds, StNumBlobCacheAdds, StNumDuplicateKeys, StSizeOffsetBranches, StSizeBranchMemory, StSizeLeafMemory, StSizeLargestExpandedLeaf}, basicActivityStatistics, diskWriteRemoteStatistics);
+const StatisticsMapping indexWriteActivityStatistics({StPerReplicated, StNumLeafCacheAdds, StNumNodeCacheAdds, StNumBlobCacheAdds, StNumDuplicateKeys, StSizeOffsetBranches, StSizeOffsetRoot, StSizeBranchMemory, StSizeLeafMemory, StSizeLargestExpandedLeaf}, basicActivityStatistics, diskWriteRemoteStatistics);
 const StatisticsMapping keyedJoinActivityStatistics({ StNumIndexAccepted, StNumPreFiltered, StNumDiskSeeks, StNumDiskAccepted, StNumDiskRejected}, basicActivityStatistics, indexReadFileStatistics);
 const StatisticsMapping commonJoinActivityStatistics({StNumMatchLeftRowsMax, StNumMatchRightRowsMax, StNumMatchCandidates, StNumMatchCandidatesMax}, basicActivityStatistics);
 const StatisticsMapping hashJoinActivityStatistics({StNumLeftRows, StNumRightRows}, commonJoinActivityStatistics);


### PR DESCRIPTION
- Added StSizeOffsetRoot enum to jstatcodes.h
- Added @offsetRoot attribute to jptree-attrs.hpp
- Updated keybuild.cpp to capture and return root offset after buildTree
- Updated roxie (ccdserver.cpp) to handle root offset
- Updated hthor (hthor.cpp) to handle root offset
- Updated thor slave (thindexwriteslave.cpp) to handle root offset
- Updated thor master (thindexwrite.cpp) to handle root offset
- Added StSizeOffsetRoot to thormisc.cpp indexWriteActivityStatistics
- Updated dfuutil.cpp to copy offsetRoot property

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
