### PR TITLE
HPCC-35061 Step 1 Use peekStringList when reading attributes

### DIFF
--- a/system/jlib/jptree.cpp
+++ b/system/jlib/jptree.cpp
@@ -3047,7 +3047,7 @@ void PTree::serializeToStream(IBufferedSerialOutputStream &tgt) const
 
 void PTree::deserializeFromStream(IBufferedSerialInputStream &src, PTreeDeserializeContext &ctx)
 {
-    deserializeSelf(src);
+    deserializeSelf(src, ctx);
 
     for (;;)
     {
@@ -3070,39 +3070,36 @@ void PTree::deserializeFromStream(IBufferedSerialInputStream &src, PTreeDeserial
     }
 }
 
-void PTree::deserializeSelf(IBufferedSerialInputStream &src)
+void PTree::deserializeSelf(IBufferedSerialInputStream &src, PTreeDeserializeContext &ctx)
 {
-    size32_t len{0};
-    const char *name = queryZeroTerminatedString(src, len);
-    if (len == 0)
+    size32_t skipLen{0};
+    const char *name = queryZeroTerminatedString(src, skipLen);
+    if (unlikely(skipLen == 0))
         throwUnexpectedX("PTree deserialization error: end of stream, expected name");
     setName(name);
-    src.skip(len + 1); // Skip over name and null terminator
+    src.skip(skipLen + 1); // Skip over name and null terminator
 
     read(src, flags);
 
-    // Read attributes until we encounter a zero byte (attribute list terminator)
-    for (;;)
+    // Peek the attribute name/value string list (paired entries) and record offsets until the terminator
+    ctx.matchOffsets.clear();
+    constexpr unsigned pairedNameAndValueStringGrouping = 2;
+    const char * base = peekStringList(ctx.matchOffsets, src, skipLen, pairedNameAndValueStringGrouping);
+    if (unlikely(!base))
+        throwUnexpectedX("PTree deserialization error: end of stream, expected attribute name");
+
+    size_t numStringOffsets = ctx.matchOffsets.size();
+    if (unlikely(numStringOffsets % 2 != 0))
+        throwUnexpectedX("PTree deserialization error: end of stream, expected attribute value");
+    constexpr bool attributeNameNotEncoded = false; // Deserialized attribute name is in its original unencoded form
+    for (size_t i = 0; i < numStringOffsets; i += 2)
     {
-        NextByteStatus status = isNextByteZero(src);
-        if (status == NextByteStatus::nextByteIsZero)
-        {
-            src.skip(1); // Skip over null terminator.
-            break;
-        }
-        if (status == NextByteStatus::endOfStream)
-            throwUnexpectedX("PTree deserialization error: end of stream, expected attribute name");
-
-        // NextByteStatus::nextByteIsNonZero - read the attribute key-value pair
-        std::pair<const char *, const char *> attrPair = peekKeyValuePair(src, len);
-        if (attrPair.second == nullptr)
-            throwUnexpectedX("PTree deserialization error: end of stream, expected attribute value");
-
-        constexpr bool attributeNameNotEncoded = false; // Deserialized attribute name is in its original unencoded form
-        setAttribute(attrPair.first, attrPair.second, attributeNameNotEncoded);
-
-        src.skip(len + 1); // +1 to skip over second null terminator.
+        const char *attrName = base + ctx.matchOffsets[i];
+        const char *attrValue = base + ctx.matchOffsets[i + 1];
+        setAttribute(attrName, attrValue, attributeNameNotEncoded);
     }
+
+    src.skip(skipLen); // Skip over all attributes and the terminator
 
     if (value)
         delete value;
@@ -4527,8 +4524,8 @@ IPropertyTree *createPTree(MemoryBuffer &src, byte flags)
 
 IPropertyTree *createPTreeFromBinary(IBufferedSerialInputStream &src, byte flags)
 {
-    PTreeDeserializeContext ctx;
     IPropertyTree *tree = createPTree(nullptr, flags);
+    PTreeDeserializeContext ctx;
     tree->deserializeFromStream(src, ctx);
     return tree;
 }
@@ -4538,8 +4535,8 @@ IPropertyTree *createPTreeFromBinary(IBufferedSerialInputStream &src, IPTreeNode
     if (!nodeCreator)
         return createPTreeFromBinary(src, ipt_none);
 
-    PTreeDeserializeContext ctx;
     IPropertyTree *tree = nodeCreator->create(nullptr); // The nullptr is a dummy name value, it will be overwritten by deserializeFromStream
+    PTreeDeserializeContext ctx;
     tree->deserializeFromStream(src, ctx);
     return tree;
 }

--- a/system/jlib/jptree.ipp
+++ b/system/jlib/jptree.ipp
@@ -34,12 +34,20 @@
 #define ANE_APPEND -1
 #define ANE_SET -2
 
-// PTree deserialization context class
-class jlib_decl PTreeDeserializeContext
+// Context object for property tree deserialization
+// To be used to avoid repeated allocations during deserialization
+class PTreeDeserializeContext
 {
 public:
-    // This class can be extended in the future to hold state during deserialization
-    // For now, it serves as a placeholder for the context parameter
+    std::vector<size32_t> matchOffsets;
+
+    PTreeDeserializeContext()
+    {
+        // Since most nodes have <= 15 attribute name/value pairs;
+        // reserve space up front to avoid reallocations.
+        static constexpr size32_t expectedMaximumAttributeOffsetCount = 15 * 2;
+        matchOffsets.reserve(expectedMaximumAttributeOffsetCount);
+    }
 };
 
 ///////////////////
@@ -658,7 +666,7 @@ public:
     void serializeAttributes(MemoryBuffer &tgt);
 
     void serializeCutOff(IBufferedSerialOutputStream &tgt, int cutoff=-1, int depth=0) const;
-    void deserializeSelf(IBufferedSerialInputStream &src);
+    void deserializeSelf(IBufferedSerialInputStream &src, PTreeDeserializeContext &ctx);
     void serializeAttributes(IBufferedSerialOutputStream &tgt) const;
 
     void cloneIntoSelf(const IPropertyTree &srcTree, bool sub);     // clone the name and contents of srcTree into "this" tree
@@ -858,7 +866,6 @@ public:
     }
 };
 
-
 class jlib_decl CAtomPTree : public PTree
 {
     AttrValue *newAttrArray(unsigned n);
@@ -866,6 +873,12 @@ class jlib_decl CAtomPTree : public PTree
     PtrStrUnion<HashKeyElement> name;
 protected:
     virtual bool removeAttribute(const char *k) override;
+    virtual IPropertyTree *create(IBufferedSerialInputStream &in, PTreeDeserializeContext &ctx) override
+    {
+        IPropertyTree *tree = new CAtomPTree();
+        tree->deserializeFromStream(in, ctx);
+        return tree;
+    }
 public:
     CAtomPTree(const char *name=nullptr, byte flags=ipt_none, IPTArrayValue *value=nullptr, ChildMap *children=nullptr);
     ~CAtomPTree();
@@ -884,12 +897,6 @@ public:
         tree->deserialize(mb);
         return tree;
     }
-    virtual IPropertyTree *create(IBufferedSerialInputStream &in, PTreeDeserializeContext &ctx) override
-    {
-        IPropertyTree *tree = new CAtomPTree();
-        tree->deserializeFromStream(in, ctx);
-        return tree;
-    }
 };
 
 
@@ -899,6 +906,12 @@ class jlib_decl LocalPTree : public PTree
 {
 protected:
     virtual bool removeAttribute(const char *k) override;
+    virtual IPropertyTree *create(IBufferedSerialInputStream &in, PTreeDeserializeContext &ctx) override
+    {
+        IPropertyTree *tree = new LocalPTree();
+        tree->deserializeFromStream(in, ctx);
+        return tree;
+    }
     AttrStrUnion name;
 public:
     LocalPTree(const char *name=nullptr, byte flags=ipt_none, IPTArrayValue *value=nullptr, ChildMap *children=nullptr);
@@ -923,12 +936,6 @@ public:
     {
         IPropertyTree *tree = new LocalPTree();
         tree->deserialize(mb);
-        return tree;
-    }
-    virtual IPropertyTree *create(IBufferedSerialInputStream &in, PTreeDeserializeContext &ctx) override
-    {
-        IPropertyTree *tree = new LocalPTree();
-        tree->deserializeFromStream(in, ctx);
         return tree;
     }
 

--- a/system/jlib/jstream.cpp
+++ b/system/jlib/jstream.cpp
@@ -543,8 +543,9 @@ extern jlib_decl std::pair<const char *, const char *> peekKeyValuePair(IBuffere
     }
 }
 
-const char * peekStringList(std::vector<size32_t> & matchOffsets, IBufferedSerialInputStream & in, size32_t & len)
+const char * peekStringList(std::vector<size32_t> & matchOffsets, IBufferedSerialInputStream & in, size32_t & len, unsigned tupleSize)
 {
+    dbgassertex(tupleSize != 0);
     size32_t scanned = 0;
     size32_t startNext = 0;
     for (;;)
@@ -557,6 +558,7 @@ const char * peekStringList(std::vector<size32_t> & matchOffsets, IBufferedSeria
             if (startNext == scanned)
             {
                 //End of file, but the last string was null terminated...
+                //NB: matchOffsets.size() may not be a multiple of tupleSize - caller should check.
                 return start;
             }
             return nullptr;
@@ -567,7 +569,9 @@ const char * peekStringList(std::vector<size32_t> & matchOffsets, IBufferedSeria
             char next = start[offset];
             if (!next)
             {
-                if (offset == startNext)
+                // Detect list terminator: empty string at current offset, aligned to a tuple boundary.
+                // Tuple boundary example (tupleSize == 2): ensure terminator after a name/value pair.
+                if ((offset == startNext) && (matchOffsets.size() % tupleSize == 0))
                 {
                     //A zero length string terminates the list - include the empty string in the length
                     len = offset + 1;

--- a/system/jlib/jstream.hpp
+++ b/system/jlib/jstream.hpp
@@ -71,8 +71,9 @@ extern jlib_decl const char * queryZeroTerminatedString(IBufferedSerialInputStre
 extern jlib_decl std::pair<const char *, const char *> peekKeyValuePair(IBufferedSerialInputStream & in, size32_t & len);
 
 //Return a vector of offsets of the starts of null terminated strings - terminated by a null string or end of file.
+// tupleSize allows empty strings within a tuple, but the list ends when a tuple starts with an empty string.
 //Returns a pointer to the base string if valid.
-extern jlib_decl const char * peekStringList(std::vector<size32_t> & matches, IBufferedSerialInputStream & in, size32_t & len);
+extern jlib_decl const char * peekStringList(std::vector<size32_t> & matches, IBufferedSerialInputStream & in, size32_t & len, unsigned tupleSize);
 
 
 interface ISerialOutputStream : extends IInterface

--- a/testing/unittests/jstreamtests.cpp
+++ b/testing/unittests/jstreamtests.cpp
@@ -1004,7 +1004,7 @@ public:
         offset_t offset = 0;
         std::vector<size32_t> matches;
         unsigned skipLen = 0;
-        const char * base = peekStringList(matches, in, skipLen);
+        const char * base = peekStringList(matches, in, skipLen, 1);
 
         unsigned delta = 0;
         for (size32_t next : matches)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [x] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [ ] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [x] Send notifications about my Pull Request position in Smoketest queue.
- [x] Test my draft Pull Request.

## Changes
- Use the `peekStringList` function in `deserializeSelf` to deserialize the Name and Value pairs; using the deserialization context vector to prevent unnecessary allocations.
- Ensure that the deserialization context is passed into functions `deserializeFromStream`, `deserializeSelf` and `create` where necessary in the binary deserialization process.

## Testing:
- Will be performed on separate PRs
- The unit tests `PtreeThreadingStressTest` and `PTreeSerializationDeserializationTest` were used to test this change.
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
