### PR TITLE
HPCC-35380: Improve event consumption use of nodeKind

### DIFF
--- a/common/eventconsumption/README.md
+++ b/common/eventconsumption/README.md
@@ -225,6 +225,7 @@ Optional storage plane name identifies the storage device on which the file is s
         file/
             @branchPlane
             @leafPlane
+            @blobPlane
 
 Optional storage plane names associating all nodes of a given kind to a storage plane. When present, the value must match one of the configured storage plane names. Omission, or empty, with the default plane for the file.
 
@@ -244,7 +245,9 @@ The optional configuration of memory expansion modeling for each index node kind
         node/
             @kind
 
-A value of zero for branch nodes or one for leaf nodes. Required to specify a leaf node, and optional to specify a branch node. A `node` without `kind` is ignored.
+One of zero or "branch" for branch nodes. One of one or "leaf" for leaf nodes. One of two or "blob" for blob nodes.
+
+In all cases, the numeric value takes precedence over the text equivalent. A `node` without `@kind` is ignored.
 
     memory/
         node/

--- a/common/eventconsumption/eventindex.hpp
+++ b/common/eventconsumption/eventindex.hpp
@@ -17,9 +17,64 @@
 
 #pragma once
 
+#include "jevent.hpp"
+
 enum NodeKind : unsigned
 {
     BranchNode,
     LeafNode,
+    BlobNode,
     NumNodeKinds
 };
+
+constexpr const char* nodeKindText[NumNodeKinds] = { "branch", "leaf", "blob" };
+
+inline bool isNodeKind(__uint64 kind)
+{
+    return kind < NumNodeKinds;
+}
+
+inline bool isNodeKind(unsigned kind)
+{
+    return kind < NumNodeKinds;
+}
+
+inline const char* mapNodeKind(NodeKind kind)
+{
+    if (isNodeKind(kind))
+        return nodeKindText[kind];
+    throw makeStringExceptionV(0, "unknown node kind %u", kind);
+}
+
+inline NodeKind mapNodeKind(const char* kindText)
+{
+    if (kindText)
+    {
+        static_assert(NumNodeKinds <= 10); // require a single digit node kind value
+        char number[2] = { '0', '\0' };
+        for (unsigned i = 0; i < NumNodeKinds; i++)
+        {
+            number[0] = '0' + i;
+            if (streq(kindText, number) || strieq(kindText, nodeKindText[i]))
+                return (NodeKind)i;
+        }
+    }
+    throw makeStringExceptionV(0, "unknown node kind '%s'", (kindText ? kindText : "<null>"));
+}
+
+// Determine the logical NodeKind value for the given event. Applies only to events of the
+// EventCtxIndex event context. Exceptions are thrown for any index event with an unknown node
+// kind and for all non-index events.
+inline NodeKind queryIndexNodeKind(const CEvent& evt)
+{
+    if (evt.hasAttribute(EvAttrNodeKind))
+    {
+        __uint64 nodeKind = evt.queryNumericValue(EvAttrNodeKind);
+        if (!isNodeKind(nodeKind))
+            throw makeStringExceptionV(0, "unknown node kind %llu", nodeKind);
+        return static_cast<NodeKind>(nodeKind);
+    }
+    if (queryEventContext(evt.queryType()) == EventCtxIndex)
+        return LeafNode;
+    throw makeStringExceptionV(0, "event %s does not use NodeKind", queryEventName(evt.queryType()));
+}

--- a/common/eventconsumption/eventindexhotspot.hpp
+++ b/common/eventconsumption/eventindexhotspot.hpp
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "eventconsumption.h"
+#include "eventindex.hpp"
 #include "eventvisitor.h"
 #include <set>
 
@@ -55,15 +56,6 @@ inline offset_t page2Offset(page_type page, byte pageBits)
     return page << pageBits;
 }
 
-// Index node kind(s) found in a bucket.
-enum BucketKind
-{
-    BucketBranch, // correlates to nodeKind in the event recorder interface
-    BucketLeaf, // correlates to nodeKind in the event recorder interface
-    BucketAmbiguous, // inactive between leaves and branches, or both leaf and branch activity
-    BucketKindMax
-};
-
 // Interface of an observer of index file activity.
 interface IBucketVisitor : IInterface
 {
@@ -72,14 +64,11 @@ interface IBucketVisitor : IInterface
     // Perform any setup required before visiting hotspot activity buckets for one file.
     virtual void arrive(unsigned id, const char* path) = 0;
     // Observe a hotspot activity bucket.
-    virtual void visitBucket(bucket_type bucket, BucketKind bucketKind, stat_type stat) = 0;
+    virtual void visitBucket(bucket_type bucket, NodeKind nodeKind, stat_type stat) = 0;
     // Perform any cleanup, or other post-processing, after visting all hotspot activity buckets.
     virtual void depart() = 0;
     // End a hotspot analysis activity.
     virtual void end() = 0;
-    // Does the visitor want ambiguous buckets, where a single bucket represents both leaves and
-    // branches? If not, the bucket will be reported twice, once as a leaf and once as a branch.
-    virtual bool wantAmbiguous() const = 0;
 };
 
 extern IBucketVisitor* createTopBucketVisitor(IBufferedSerialOutputStream& out, byte limit);

--- a/common/eventconsumption/eventindexmodel.hpp
+++ b/common/eventconsumption/eventindexmodel.hpp
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "eventmodeling.h"
+#include "eventindex.hpp"
 #include "jqueue.hpp"
 #include <memory>
 #include <set>
@@ -45,71 +46,6 @@ enum class ExpansionMode
     OnDemand
 };
 
-// The index event model configuration conforms to this structure:
-//   kind: index-event
-//   storage:
-//     cacheReadTime: nanosecond time to read one page
-//     cacheCapacity: maximum bytes to use for the cache
-//     plane:
-//     - name: unique, non-empty, identifier
-//       readTime: nanosecond time to read one page
-//     file:
-//     - path: empty or unique index file path
-//       plane: name of place in which the file resides, if different from the default
-//       branchPlane: name of place in which index branches reside, if different from the default
-//       leafPlane: name of place in which index leaves reside, if different from the default
-//   memory:
-//     node:
-//     - kind: node kind
-//       sizeFactor: floating point multiplier for estimated node size
-//       sizeToTimeFactor: floating point multiplier for estimated node expansionMode time
-//       expansionMode: choice of `ll`, `ld`, or `dd`
-//       cacheCapacity: maximum bytes to use for the cache
-//     observed:
-//     - FileId: unique index file identifier
-//       FileOffset: index page offset
-//       NodeKind: node kind
-//       InMemorySize: size of the node in bytes
-//       ExpandTime: time in nanoseconds to expand the node
-//
-// - `kind` is optional; as the first model the value is implied.
-// - `cacheReadTime` is optional; if zero, empty, or omitted, the cache is disabled.
-// - `cacheCapacity` is optional; if zero, empty, or omitted, the cache is unlimited.
-// - The first `plane` declared is assumed to be the default plane for files not explicitly assigned
-//   an alternate choice.
-// - `file` is optional; omission implies all files exist in the default plane.
-// - `file/path` is optional; omission, or empty, assigns the storage plane for all files not
-//   explicitly configured.
-// - `file/plane` is optional; omission, or empty, implies the file resides in the default storage
-//   plane.
-// - `file/branchPlane` is optional; omission, or empty, implies the file's index branches reside in
-//   the file's default storage plane.
-// - `file/leafPlane` is optional; omission, or empty, implies the file's index leaves reside in the
-//   file's default storage plane.
-// - `memory` is optional; omission prevents any memory modeling.
-// - `memory/node` is optional; omission prevents estimating algorithm performance. If present,
-//   one instance for each type of index node is required.
-// - `memory/node/kind` is a required choice of `branch` or `leaf`.
-// - `memory/node/sizeFactor` is a required positive floating point multiplier for algorithm
-//   performance estimation. The on disk page size is multiplied by this value.
-// - `memory/node/sizeToTimeFactor` is a required positive floating point multiplier for
-//   algorithm performance estimation. The estimated size is multipled by this factor to estimate
-//   the expansion time.
-// - `expansion/node/mode` is optional; omission and empty are equivalent to `ll`. The value is
-//   ignored for branch nodes, which are always treated as `ll`. Accepted options are:
-//   - `ll`: model input and output are both on-load
-//   - `ld`: model input is on-load and output is on-demand
-//   - `dd`: model input and output are both on-demand
-// - `memory/observed` is an optional mechanism to pre-populate the memory caches. It enables
-//   unit test case scenarios to be set up without requiring explicit events to be visited.
-// - `memory/observed/NodeKind` is expected and corresponds to input event NodeKind values.
-// - `memory/observed/FileId` is expected only when history is used for the node kind.
-// - `memory/observed/FileOffset` is expected only when history is used for the node kind.
-// - `memory/observed/InMemorySize` is expected only when the node cache for the node kind is
-//   enabled, which implies that history is also used for the node kind.
-// - `memory/observed/ExpandTime` is expected only when the node cache for the node kind is
-//   enabled, which implies that history is also used for the node kind.
-
 // Encapsulation of all modeled information about given file page. Note that the file path is not
 // included as the model does not retain that information.
 struct ModeledPage
@@ -121,7 +57,7 @@ struct ModeledPage
     };
     __uint64 fileId{0};
     __uint64 offset{0};
-    __uint64 nodeKind{1};
+    __uint64 nodeKind{LeafNode};
     __uint64 readTime{0};
     Size compressed;
     Size expanded;
@@ -235,10 +171,8 @@ private:
     class File
     {
     public:
-        static constexpr size_t NumPlanes = 2;
-    public:
         StringAttr path;
-        const Plane* planes[NumPlanes]{nullptr,};
+        const Plane* planes[NumNodeKinds]{nullptr,};
 
     public:
         File() = default;
@@ -315,7 +249,6 @@ private:
 class MemoryModel : public IIndexMRUCacheContainer
 {
 public:
-    static constexpr size_t NumKinds = 2;
     struct Estimate
     {
         __uint64 compressed{8'192}; // all nodes assumed to be 8K on disk
@@ -339,10 +272,10 @@ public:
         virtual __uint64 size(const IndexHashKey& key) override;
         virtual const char* description() const override;
     public:
-        NodeCache(MemoryModel& _parent, __uint64 _kind);
+        NodeCache(MemoryModel& _parent, NodeKind _kind);
     private:
         MemoryModel& parent;
-        __uint64 kind{0};
+        NodeKind kind;
     };
 
 public:
@@ -354,8 +287,8 @@ public:
     MemoryModel();
     void configure(const IPropertyTree& config);
 
-    inline bool caching(const CEvent& event) const { return caching(event.hasAttribute(EvAttrNodeKind) ? event.queryNumericValue(EvAttrNodeKind) : 1); }
-    bool caching(__uint64 nodeKind) const { assertex(nodeKind < NumKinds); return caches[nodeKind].enabled(); }
+    inline bool caching(const CEvent& event) const { return caching(queryIndexNodeKind(event)); }
+    bool caching(__uint64 nodeKind) const { assertex(isNodeKind(nodeKind)); return caches[nodeKind].enabled(); }
 
     // Record, if necessary, that indicated index node has been observed. Intended to be called only
     // for IndexCacheHit and IndexCacheMiss events, but not enforced.
@@ -380,15 +313,15 @@ public:
     void cachePage(ModeledPage& page, IndexMRUCacheReporter& reporter);
 
 protected:
-    inline bool usingHistory(const CEvent& event) const { return usingHistory(event.hasAttribute(EvAttrNodeKind) ? event.queryNumericValue(EvAttrNodeKind) : 1); }
-    inline bool usingHistory(__uint64 nodeKind) const { assertex(nodeKind < NumKinds); return ((ExpansionMode::OnLoadToOnDemand == modes[nodeKind] && !estimating) || caches[nodeKind].enabled()); }
+    inline bool usingHistory(const CEvent& event) const { return usingHistory(queryIndexNodeKind(event)); }
+    inline bool usingHistory(__uint64 nodeKind) const { assertex(isNodeKind(nodeKind)); return ((ExpansionMode::OnLoadToOnDemand == modes[nodeKind] && !estimating) || caches[nodeKind].enabled()); }
     void refreshPage(ActualHistory::iterator& it, const CEvent& event);
     __uint64 nodeEntrySize(const IndexHashKey& key, __uint64) const;
 public:
     ActualHistory actualHistory;
     EstimatedHistory estimatedHistory;
-    Estimate estimates[NumKinds];
-    ExpansionMode modes[NumKinds] = {ExpansionMode::OnLoad,};
+    Estimate estimates[NumNodeKinds];
+    ExpansionMode modes[NumNodeKinds] = {ExpansionMode::OnLoad,};
     bool estimating{false};
-    mutable NodeCache caches[NumKinds]; // testing presence in the cache can modify the cache
+    mutable NodeCache caches[NumNodeKinds]; // testing presence in the cache can modify the cache
 };

--- a/system/jlib/jevent.hpp
+++ b/system/jlib/jevent.hpp
@@ -351,6 +351,11 @@ public:
     bool setValue(EventAttr attr, const char* value);
     bool setValue(EventAttr attr, __uint64 value);
     bool setValue(EventAttr attr, bool value);
+    // Ambiguity resolution: ensures unsigned values are correctly cast to __uint64 and routed to the intended overload.
+    inline bool setValue(EventAttr attr, unsigned value)
+    {
+        return setValue(attr, __uint64(value));
+    }
 
 public:
     CEvent();

--- a/tools/evtool/evtool.hpp
+++ b/tools/evtool/evtool.hpp
@@ -251,7 +251,8 @@ Filters:
                                     of MetaFileInformation, by file ID, and
                                     applies the filter to the path.
                                 - FileOffset: numeric
-                                - NodeKind: numeric, 0 or 1
+                                - NodeKind: numeric, 0 (branch), 1 (leaf), or 2
+                                    (blob)
                                 - ReadTime: numeric
                                 - ExpandTime: numeric
                                 - InMemorySize: numeric


### PR DESCRIPTION
- Support value 2 for blob nodes.
- Accept text and numbers for NodeKind attributes.
- Accept text and numbers for node/@kind attributes.
- Replace hard-coded literals with common enumerated names.
- Standardize array dimensions with a common enumerated name.
- Standardize NodeKind extraction from CEvent.
- Standardize conversion between NodeKind number and text.
- Standardize numeric NodeKind validity checks.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [x] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
