### PR TITLE
HPCC-35061 Step 1 PTree unit tests

### DIFF
--- a/testing/unittests/CMakeLists.txt
+++ b/testing/unittests/CMakeLists.txt
@@ -82,6 +82,7 @@ include_directories (
          ./../../common/thorhelper
          ./../../dali/base
          ./../../system/security/shared
+         ./../../system/security/zcrypt
          ./../../common/deftype
          ./../../common/workunit
          ./../../system/security/cryptohelper
@@ -128,6 +129,7 @@ target_link_libraries ( unittests
          logginglib
          workunit
          eventconsumption
+         zcrypt
          ${CppUnit_LIBRARIES}
     )
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [x] Send notifications about my Pull Request position in Smoketest queue.
- [x] Test my draft Pull Request.

## Testing:
- The unit test PTreeSerializationDeserializationTest tests the PTree::deserializeSelf
- The unit test PTreeXmlTimingStressTest counts CPU cycles used for ipt_none and ipt_lowmem XML tree serialization and deserialization, across a user defined number of iterations and user defined tree, giving a table of results for average, minimum, maximum and standard deviation
- The unit test PTreeBinaryTimingStressTest counts CPU cycles used for ipt_none and ipt_lowmembinary tree serialization and deserialization, across a user defined number of iterations and user defined tree, giving a table of results for average, minimum, maximum and standard deviation
- The unit test PTreeCombinedTimingStressTest counts CPU cycles used for ipt_none and ipt_lowmem XML and binary tree serialization and deserialization, across a user defined number of iterations and user defined tree, giving a table of results for average, minimum, maximum and standard deviation
- The unit test PTreeBinaryDeserializationProfilingStressTest counts CPU cycles used for ipt_lowmem binary tree deserialization, across a user defined number of iterations and user defined tree, giving a table of results for average, minimum, maximum and standard deviation. This test enables callgrind profiling.

### Running the unit tests
The following tests use the following environment variables with defaults:

PTREE_TEST_ITERATIONS defaulted to 10
PTREE_TEST_BINARY_FILE defaulted to ~/HPCC-Platform/testing/unittests/ptree.bin.gz
PTREE_TEST_XML_FILE defaulted to ~/HPCC-Platform/testing/unittests/ptree.xml.gz
Tests:

PTreeXmlTimingStressTest counts CPU cycles used for ipt_none and ipt_lowmem XML tree serialization and deserialization, across a user defined number of iterations and user defined tree, giving a table of results for average, minimum, maximum and standard deviation.
PTreeBinaryTimingStressTest counts CPU cycles used for ipt_none and ipt_lowmembinary tree serialization and deserialization, across a user defined number of iterations and user defined tree, giving a table of results for average, minimum, maximum and standard deviation
PTreeCombinedTimingStressTest counts CPU cycles used for ipt_none and ipt_lowmem XML and binary tree serialization and deserialization, across a user defined number of iterations and user defined tree, giving a table of results for average, minimum, maximum and standard deviation
PTreeBinaryDeserializationProfilingStressTest counts CPU cycles used for ipt_lowmem binary tree deserialization, across a user defined number of iterations and user defined tree, giving a table of results for average, minimum, maximum and standard deviation. This test enables callgrind profiling.
I ran a release build of PTreeBinaryTimingStressTest:

```
=== BINARY TIMING COMPARISON TEST ===
Binary data size: 103499268 bytes
Iterations: 10
┌────────────────────────┬─────────────────────────────────────────────────────────────────┬─────────────────────────────────────────────────────────────────┐
│ Mode                   │ Deserialize (cycles)                                            │ Serialize (cycles)                                              │
│                        │             Avg             Min             Max          Stddev │             Avg             Min             Max          Stddev │
├────────────────────────┼─────────────────────────────────────────────────────────────────┼─────────────────────────────────────────────────────────────────┤
│ Binary Normal          │      1332169001      1258273949      1434154617     52934157.47 │       419273323       380038411       569100794     61303419.57 │
│ Binary Low Memory      │      1657194675      1575849314      1784215731     63152684.94 │       440752308       384334817       550500719     48212310.36 │
├────────────────────────┼─────────────────────────────────────────────────────────────────┼─────────────────────────────────────────────────────────────────┤
│ Binary LowMem Diff     │         +24.40%         +25.24%         +24.41%         +19.30% │          +5.12%          +1.13%          -3.27%         -21.35% │
└────────────────────────┴─────────────────────────────────────────────────────────────────┴─────────────────────────────────────────────────────────────────┘

```
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
