### PR TITLE
HPCC-35486 Wait for core dump completion before gdb analysis

### DIFF
--- a/initfiles/bin/collect_postmortem.sh
+++ b/initfiles/bin/collect_postmortem.sh
@@ -101,10 +101,49 @@ POST_MORTEM_DIR=${POST_MORTEM_DIR}/$(date -Iseconds)/$(hostname)/${container}/${
 mkdir -p ${POST_MORTEM_DIR}
 echo "Post-mortem info gathered in $POST_MORTEM_DIR"
 
-readarray -t core_files < <(find . -maxdepth 1 -type f -name 'core*' -print)
+# Function to wait for core file to be fully written
+wait_for_core_completion() {
+  local file=$1
+  local max_wait_decisecs=600  # 60 seconds
+  local wait_interval=1
+  local elapsed_decisecs=0
+  
+  echo "Waiting for core file $file to be fully written..."
+  
+  # Use lsof to check if file is still open for writing
+  while lsof "$file" >/dev/null 2>&1; do
+    if [[ $elapsed_decisecs -ge $max_wait_decisecs ]]; then
+      echo "Warning: Timeout waiting for core file completion" | tee -a $POST_MORTEM_DIR/info.log
+      return 1
+    fi
+    sleep $wait_interval
+    elapsed_decisecs=$((elapsed_decisecs + 10))
+  done
+  
+  local size=$(stat -c %s "$file" 2>/dev/null || echo 0)
+  echo "Core file $file is ready ($size bytes)"
+  return 0
+}
+
+# Wait for core files to appear (using deciseconds for integer arithmetic)
+max_wait_decisecs=100  # 10 seconds
+wait_interval=1
+elapsed_decisecs=0
+
+# Wait up to 10 seconds for core files to appear
+while true; do
+  readarray -t core_files < <(find . -maxdepth 1 -type f -name 'core*' -print)
+  [[ ${#core_files[@]} -gt 0 || $elapsed_decisecs -ge $max_wait_decisecs ]] && break
+  sleep $wait_interval
+  elapsed_decisecs=$((elapsed_decisecs + 10))
+done
+
 # we only expect one, but cater for multiple
 if [[ ${#core_files[@]} -gt 0 ]]; then
   for file in "${core_files[@]}"; do
+    # Wait for core file to be fully written before analyzing
+    wait_for_core_completion "$file"
+    
     echo "Generating info from core file($file) to $POST_MORTEM_DIR/info.log" | tee -a $POST_MORTEM_DIR/info.log
     gdb -batch -ix /opt/HPCCSystems/bin/.gdbinit -x /opt/HPCCSystems/bin/post-mortem-gdb /opt/HPCCSystems/bin/${process} $file 2>$POST_MORTEM_DIR/info.err >>$POST_MORTEM_DIR/info.log
     echo "Generated info from core file($file)" | tee -a $POST_MORTEM_DIR/info.log


### PR DESCRIPTION
Added synchronization to ensure core files are fully written before attempting to analyze them with gdb. Uses lsof to detect when the kernel has closed the core file, preventing race conditions that could cause incomplete or failed postmortem analysis.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
