### PR TITLE
HPCC-31368 Fix containerized issue with KJ and out-of-cluster parts

### DIFF
--- a/thorlcr/activities/keyedjoin/thkeyedjoinslave.cpp
+++ b/thorlcr/activities/keyedjoin/thkeyedjoinslave.cpp
@@ -1572,8 +1572,12 @@ class CKeyedJoinSlave : public CSlaveActivity, implements IJoinProcessor, implem
                     crc = 0;
                 RemoteFilename rfn;
                 part.getFilename(copy, rfn);
+
+                // NB: getPath will return a URL if filename is a non local (localhost) file part (e.g. off-cluster, foreign..)
+                // which the remote side needs to access the index part.
                 StringBuffer fname;
-                rfn.getLocalPath(fname);
+                rfn.getPath(fname);
+
                 msg.append(activity.queryId()).append(fname).append(crc); // lookup key
                 // serialize onCreate context
                 DelayedSizeMarker sizeMark(msg);
@@ -1940,8 +1944,12 @@ class CKeyedJoinSlave : public CSlaveActivity, implements IJoinProcessor, implem
                 IPartDescriptor &part = activity.allDataParts.item(partNo);
                 RemoteFilename rfn;
                 part.getFilename(copy, rfn);
+
+                // NB: getPath will return a URL if filename is a non local (localhost) file part (e.g. off-cluster, foreign..)
+                // which the remote side needs to access the index part.
                 StringBuffer fname;
-                rfn.getLocalPath(fname);
+                rfn.getPath(fname);
+
                 msg.append(fname);
                 msg.append(activity.messageCompression);
 

--- a/thorlcr/thorutil/thormisc.hpp
+++ b/thorlcr/thorutil/thormisc.hpp
@@ -128,6 +128,7 @@
 #define THOROPT_LOOKAHEAD_TEMPFILE_GRANULARITY "readAheadTempFileGranularity"     // Splitter temp file granularity (default = 1GB)
 #define THOROPT_ROXIEMEM_GLOBALSORT_PARTITION "useRoxieMemGlobalSortPartition"    // Use roxiemem for global sort partitioning (default = true)
 #define THOROPT_JOBINFO_CAPTURE_BEHAVIOUR "jobInfoCaptureBehaviour"               // controls behaviour of job info collection (default = 0)
+#define THOROPT_KJ_STRIPE_OUT_OF_CLUSTER_LOOKUPS "keyedJoinStripeOutOfClusterLookups" // Stripe out of cluster keyed lookups (default = false)
 #define INITIAL_SELFJOIN_MATCH_WARNING_LEVEL 20000 // max of row matches before selfjoin emits warning
 
 #define THOR_SEM_RETRY_TIMEOUT 2


### PR DESCRIPTION
(see when using ~foreign).

Containerized versions treated all file parts as being 'local to the cluster', which meant they were striped across workers, each dealing with a slice of them. Each worker would send requests to parts in other slices using remote handlers.
However, the remote handler code assumed the index parts were local (as most parts are in a containerized setup), this assumption broke down for out-of-cluster files, e.g. foreign indexes used in a KJ. The consequence was that KJ would fail with: "Failed to open index file".

The fix is 3 fold:
1) Add logic to check if parts are on localhost (mounted), and stripe if they are (this mirrors the previous behaviour where all were, and mirrors what BM is trying to acheive where 'local' parts are striped across their corresponding cluster hosts).

2) Add an option 'keyedJoinStripeOutOfClusterLookups' that forces all parts to be striped (default off for now). i.e. this will cause out-of-cluster parts to be striped across workers too. t sm
3) Change the remote handlers to send the full path in the remote requests (not just local path). Previously remote handlers were only intended to be used when parts were local to the remote lookup service. Now with keyedJoinStripeOutOfClusterLookups=true, that might not be the case.
e.g. if striped and foreign, remote handler requests will be sent to other workers to lookup parts which are non local. Therefore the full remote path is needed not just the local path.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
