### PR TITLE
HPCC-35061 Step 1 PTree coverage unit tests

### DIFF
--- a/testing/unittests/CMakeLists.txt
+++ b/testing/unittests/CMakeLists.txt
@@ -84,6 +84,7 @@ include_directories (
          ./../../common/thorhelper
          ./../../dali/base
          ./../../system/security/shared
+         ./../../system/security/zcrypt
          ./../../common/deftype
          ./../../common/workunit
          ./../../system/security/cryptohelper
@@ -131,6 +132,7 @@ target_link_libraries ( unittests
          logginglib
          workunit
          eventconsumption
+         zcrypt
          ${CppUnit_LIBRARIES}
     )
 

--- a/testing/unittests/jlibtests.cpp
+++ b/testing/unittests/jlibtests.cpp
@@ -3405,16 +3405,10 @@ CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(JlibIPTTest, "JlibIPTTest");
  *
  */
 
-#include "platform.h"
-#include "jfile.ipp"
-#include "jptree.hpp"
-#include "jiface.hpp"
-#include "jio.hpp"
-#include "jstring.hpp"
-#include <string>
-#include "jstats.h"
-#include <thread>
 #include <atomic>
+#include <limits>
+#include <thread>
+#include "jptree.ipp"
 
 IPropertyTree *createCompatibilityConfigPropertyTree()
 {
@@ -3623,16 +3617,26 @@ IPropertyTree *createBinaryDataCompressionTestPTree(const char *testXml)
  * Combined PTree serialization and deserialization tests
  *
  * Tests PTree serialization/deserialization format consistency between MemoryBuffer and IBufferedSerialInputStream
- * and measures performance of both operations
+ *
+ * testRoundTripForRootOnlyPTree - Tests round-trip serialization/deserialization for a PTree with only a root node
+ * testRoundTripForCompatibilityConfigPropertyTree - Tests round-trip for a complex compatibility config PTree
+ * testRoundTripForBinaryDataCompressionTestPTree - Tests round-trip for a PTree with various binary data sizes
+ * testMalformedStreamMissingAttributeListTerminators - Tests deserialization error handling for missing attribute list terminators
+ * testMalformedStreamMissingAttributeValue - Tests deserialization error handling for missing attribute values
+ * testMalformedStreamTruncatedName - Tests deserialization error handling for truncated names
+ * testMultiThreadedSerializationAndDeserializationOfAtomTree - Tests thread safety of serialization/deserialization with multiple threads
  */
 
 class PTreeSerializationDeserializationTest : public CppUnit::TestFixture
 {
     CPPUNIT_TEST_SUITE(PTreeSerializationDeserializationTest);
-    // Complete round-trip tests - serialization followed by deserialization with validation
     CPPUNIT_TEST(testRoundTripForRootOnlyPTree);
     CPPUNIT_TEST(testRoundTripForCompatibilityConfigPropertyTree);
     CPPUNIT_TEST(testRoundTripForBinaryDataCompressionTestPTree);
+    CPPUNIT_TEST(testMalformedStreamMissingAttributeListTerminators);
+    CPPUNIT_TEST(testMalformedStreamMissingAttributeValue);
+    CPPUNIT_TEST(testMalformedStreamTruncatedName);
+    CPPUNIT_TEST(testMultiThreadedSerializationAndDeserializationOfAtomTree);
     CPPUNIT_TEST_SUITE_END();
 
 protected:
@@ -3660,83 +3664,58 @@ protected:
         originalTree.setown(tree);
         CCycleTimer timer;
 
-        MemoryBuffer memoryBuffer;
+        MemoryBuffer memoryBuffer, streamBuffer;
 
-        // Time serialize() method
-        __uint64 serializeElapsedNs = 0;
-        {
-            timer.reset();
-            originalTree->serialize(memoryBuffer);
-            serializeElapsedNs = timer.elapsedNs();
-        }
+        timer.reset();
+        originalTree->serialize(memoryBuffer);
+        __uint64 serializeElapsedNs = timer.elapsedNs();
+        size_t memoryBufferSize = memoryBuffer.length();
 
-        // Time serializeToStream() method
-        __uint64 serializeToStreamElapsedNs = 0;
-        {
-            MemoryBuffer streamBuffer;
-            Owned<IBufferedSerialOutputStream> out = createBufferedSerialOutputStream(streamBuffer);
-            timer.reset();
-            originalTree->serializeToStream(*out);
-            out->flush();
-            serializeToStreamElapsedNs = timer.elapsedNs();
+        Owned<IBufferedSerialOutputStream> out = createBufferedSerialOutputStream(streamBuffer);
+        timer.reset();
+        originalTree->serializeToStream(*out);
+        out->flush();
+        __uint64 serializeToStreamElapsedNs = timer.elapsedNs();
+        size_t streamBufferSize = streamBuffer.length();
 
-            // Validation - serialized data matches
-            CPPUNIT_ASSERT_EQUAL(memoryBuffer.length(), streamBuffer.length());
-            CPPUNIT_ASSERT(memcmp(memoryBuffer.toByteArray(), streamBuffer.toByteArray(), memoryBuffer.length()) == 0);
-        }
+        CPPUNIT_ASSERT_EQUAL(memoryBufferSize, streamBufferSize);
+        CPPUNIT_ASSERT(memcmp(memoryBuffer.toByteArray(), streamBuffer.toByteArray(), memoryBufferSize) == 0);
 
-        // Time deserialize() method
-        __uint64 deserializeElapsedNs = 0;
-        {
-            Owned<IPropertyTree> memoryBufferDeserialized = createPTree();
-            timer.reset();
-            memoryBufferDeserialized->deserialize(memoryBuffer);
-            deserializeElapsedNs = timer.elapsedNs();
-            CPPUNIT_ASSERT(areMatchingPTrees(originalTree, memoryBufferDeserialized));
-        }
-        
-        // Time deserializeFromStream() method
-        __uint64 deserializeFromStreamElapsedNs = 0;
-        {
-            MemoryBuffer clone(memoryBuffer.length(), memoryBuffer.toByteArray());
-            Owned<IBufferedSerialInputStream> in = createBufferedSerialInputStreamFillMemory(clone);
-            timer.reset();
-            Owned<IPropertyTree> streamDeserialized = createPTreeFromBinary(*in, ipt_none);
-            deserializeFromStreamElapsedNs = timer.elapsedNs();
-            CPPUNIT_ASSERT(areMatchingPTrees(originalTree, streamDeserialized));
-        }
+        timer.reset();
+        Owned<IPropertyTree> memoryBufferDeserialized = createPTree(memoryBuffer);
+        __uint64 deserializeElapsedNs = timer.elapsedNs();
 
-        // Create PTree from Binary tests
-        //
-        // Test 1: Call with null nodeCreator (should fall back to createPTree(src, ipt_none))
-        {
-            MemoryBuffer clone(memoryBuffer.length(), memoryBuffer.toByteArray());
-            Owned<IBufferedSerialInputStream> in2 = createBufferedSerialInputStreamFillMemory(clone);
-            Owned<IPropertyTree> deserializedCreatePTreeFromBinaryWithNull = createPTreeFromBinary(*in2, nullptr);
-            CPPUNIT_ASSERT(areMatchingPTrees(originalTree, deserializedCreatePTreeFromBinaryWithNull));
-        }
+        Owned<IBufferedSerialInputStream> in = createBufferedSerialInputStream(streamBuffer);
+        timer.reset();
+        Owned<IPropertyTree> streamDeserialized = createPTreeFromBinary(*in, ipt_none);
+        __uint64 deserializeFromStreamElapsedNs = timer.elapsedNs();
 
-        // Test 2: Call with custom nodeCreator
+        streamBuffer.reset();
+        Owned<IBufferedSerialInputStream> in2 = createBufferedSerialInputStream(streamBuffer);
+        Owned<IPropertyTree> deserializedCreatePTreeFromBinaryWithNull = createPTreeFromBinary(*in2, nullptr);
+        CPPUNIT_ASSERT(areMatchingPTrees(originalTree, deserializedCreatePTreeFromBinaryWithNull));
+
+        class TestNodeCreator : public CSimpleInterfaceOf<IPTreeNodeCreator>
         {
-            class TestNodeCreator : public CSimpleInterfaceOf<IPTreeNodeCreator>
+        public:
+            bool wasCalled = false;
+
+            virtual IPropertyTree *create(const char *tag) override
             {
-            public:
-                bool wasCalled = false;
+                wasCalled = true;
+                return createPTree(tag);
+            }
+        };
 
-                virtual IPropertyTree *create(const char *tag) override
-                {
-                    wasCalled = true;
-                    return createPTree(tag);
-                }
-            };
+        Owned<TestNodeCreator> nodeCreator = new TestNodeCreator();
+        streamBuffer.reset();
+        Owned<IBufferedSerialInputStream> in3 = createBufferedSerialInputStream(streamBuffer);
+        Owned<IPropertyTree> deserializedCreatePTreeFromBinaryWithCreator = createPTreeFromBinary(*in3, nodeCreator);
 
-            MemoryBuffer clone(memoryBuffer.length(), memoryBuffer.toByteArray());
-            Owned<TestNodeCreator> nodeCreator = new TestNodeCreator();
-            Owned<IBufferedSerialInputStream> in3 = createBufferedSerialInputStreamFillMemory(clone);
-            Owned<IPropertyTree> deserializedCreatePTreeFromBinaryWithCreator = createPTreeFromBinary(*in3, nodeCreator);
-            CPPUNIT_ASSERT(nodeCreator->wasCalled); // Verify nodeCreator was called
-            CPPUNIT_ASSERT(areMatchingPTrees(originalTree, deserializedCreatePTreeFromBinaryWithCreator));
-        }
+        CPPUNIT_ASSERT(areMatchingPTrees(originalTree, memoryBufferDeserialized));
+        CPPUNIT_ASSERT(areMatchingPTrees(originalTree, streamDeserialized));
+        CPPUNIT_ASSERT(nodeCreator->wasCalled); // Verify nodeCreator was called
+        CPPUNIT_ASSERT(areMatchingPTrees(originalTree, deserializedCreatePTreeFromBinaryWithCreator));
 
         double serializeTimeMs = serializeElapsedNs / 1e6;
         double serializeToStreamTimeMs = serializeToStreamElapsedNs / 1e6;
@@ -3757,6 +3736,52 @@ protected:
         DBGLOG("=== ROUND-TRIP TEST COMPLETED SUCCESSFULLY");
     }
 
+    void expectTruncatedStreamFailure(IPropertyTree &tree, size32_t truncationOffset, const char *expectedSubstring, const char *contextDescription)
+    {
+        MemoryBuffer full;
+        Owned<IBufferedSerialOutputStream> out = createBufferedSerialOutputStream(full);
+        tree.serializeToStream(*out);
+        out->flush();
+
+        const byte *bytes = reinterpret_cast<const byte *>(full.toByteArray());
+        size32_t totalLength = full.length();
+
+        VStringBuffer assertMsg("Serialized stream shorter than truncation offset for %s", contextDescription);
+        CPPUNIT_ASSERT_MESSAGE(assertMsg.str(), truncationOffset <= totalLength);
+
+        MemoryBuffer truncated;
+        truncated.append(truncationOffset, bytes);
+
+        Owned<IBufferedSerialInputStream> in = createBufferedSerialInputStream(truncated);
+        bool hitExpectedThrow = false;
+        try
+        {
+            createPTreeFromBinary(*in, ipt_none);
+        }
+        catch (IException *e)
+        {
+            StringBuffer msg;
+            e->errorMessage(msg);
+            e->Release();
+            const char *mChars = msg.str();
+            if (mChars && strstr(mChars, expectedSubstring))
+            {
+                hitExpectedThrow = true;
+            }
+            else
+            {
+                VStringBuffer detail("Caught unexpected exception during %s: %s", contextDescription, mChars ? mChars : "<null>");
+                CPPUNIT_FAIL(detail.str());
+            }
+        }
+
+        if (!hitExpectedThrow)
+        {
+            VStringBuffer detail("Did not hit expected exception substring '%s' during %s", expectedSubstring, contextDescription);
+            CPPUNIT_FAIL(detail.str());
+        }
+    }
+
 public:
     // Complete round-trip test methods - perform serialization and deserialization in one test
     void testRoundTripForRootOnlyPTree()
@@ -3772,6 +3797,234 @@ public:
     void testRoundTripForBinaryDataCompressionTestPTree()
     {
         performRoundTripTest(__func__, createBinaryDataCompressionTestPTree(testXml));
+    }
+
+    class AtomTreeSerializationTestThread : public Thread
+    {
+    public:
+        AtomTreeSerializationTestThread(unsigned _index,
+                             Semaphore &_startSem,
+                             CriticalSection &_errorCs,
+                             bool &_encounteredError,
+                             StringBuffer &_errorMessages,
+                             IPropertyTree &_originalTree)
+            : Thread("AtomTreeSerializationTestThread"),
+              threadIndex(_index),
+              startSem(_startSem),
+              errorCs(_errorCs),
+              encounteredError(_encounteredError),
+              errorMessages(_errorMessages),
+              originalTree(_originalTree)
+        {
+        }
+
+        virtual int run() override
+        {
+            startSem.wait();
+            try
+            {
+                Owned<IPropertyTree> expected = createPTreeFromIPT(&originalTree, ipt_lowmem);
+
+                VStringBuffer threadTag("worker_%u", threadIndex);
+                expected->setProp("@threadId", threadTag.str());
+
+                IPropertyTree *settings = expected->queryPropTree("settings");
+                if (settings)
+                {
+                    settings->setProp("@worker", threadTag.str());
+                    settings->setProp("threshold", VStringBuffer("%u", 42 + threadIndex).str());
+
+                    if (IPropertyTree *alpha = settings->queryPropTree("option[@name=\"alpha\"]"))
+                        alpha->setProp("value", VStringBuffer("alpha_value_%u", threadIndex).str());
+                    if (IPropertyTree *beta = settings->queryPropTree("option[@name=\"beta\"]"))
+                        beta->setProp("value", VStringBuffer("beta_value_%u", threadIndex).str());
+                }
+
+                MemoryBuffer payload;
+                for (unsigned idx = 0; idx < 2048; ++idx)
+                    payload.append((byte)((idx + threadIndex) % 256));
+                expected->setPropBin("binaryPayload", payload.length(), payload.toByteArray());
+
+                if (IPropertyTree *clusters = expected->queryPropTree("clusters"))
+                {
+                    unsigned clusterIndex = 0;
+                    Owned<IPropertyTreeIterator> iter = clusters->getElements("cluster");
+                    ForEach(*iter)
+                    {
+                        IPropertyTree &cluster = iter->query();
+                        cluster.setProp("description", VStringBuffer("Example cluster entry thread %u index %u", threadIndex, clusterIndex).str());
+                        cluster.setPropInt("@threadId", threadIndex);
+
+                        MemoryBuffer clusterPayload;
+                        clusterPayload.append(sizeof(threadIndex), &threadIndex);
+                        clusterPayload.append(sizeof(clusterIndex), &clusterIndex);
+                        cluster.setPropBin("payload", clusterPayload.length(), clusterPayload.toByteArray());
+                        ++clusterIndex;
+                    }
+                }
+
+                if (IPropertyTree *metrics = expected->queryPropTree("metrics"))
+                {
+                    metrics->setProp("@enabled", (threadIndex % 2 == 0) ? "true" : "false");
+                    metrics->setProp("@thread", threadTag.str());
+                    metrics->setProp("sampleInterval", VStringBuffer("%u.%02u", threadIndex + 1, threadIndex).str());
+                }
+
+                MemoryBuffer serialized;
+                {
+                    Owned<IBufferedSerialOutputStream> out = createBufferedSerialOutputStream(serialized);
+                    expected->serializeToStream(*out);
+                    out->flush();
+                }
+
+                size32_t serializedLength = (size32_t)serialized.length();
+                if (!serializedLength)
+                {
+                    CriticalBlock block(errorCs);
+                    encounteredError = true;
+                    errorMessages.appendf("Thread %u: serialization produced empty buffer\n", threadIndex);
+                    return 0;
+                }
+
+                Owned<IBufferedSerialInputStream> in = createBufferedSerialInputStream(serialized);
+                Owned<IPropertyTree> deserialized = createPTreeFromBinary(*in, ipt_lowmem);
+                if (!areMatchingPTrees(expected, deserialized))
+                {
+                    CriticalBlock block(errorCs);
+                    encounteredError = true;
+                    errorMessages.appendf("Thread %u: deserialized tree mismatch for root %s\n", threadIndex, expected->queryName());
+                }
+            }
+            catch (IException *e)
+            {
+                StringBuffer msg;
+                e->errorMessage(msg);
+                e->Release();
+                CriticalBlock block(errorCs);
+                encounteredError = true;
+                errorMessages.appendf("Thread %u: %s\n", threadIndex, msg.str());
+            }
+            catch (...)
+            {
+                CriticalBlock block(errorCs);
+                encounteredError = true;
+                errorMessages.appendf("Thread %u: unknown exception\n", threadIndex);
+            }
+
+            return 0;
+        }
+
+    private:
+        unsigned threadIndex{0};
+        Semaphore &startSem;
+        CriticalSection &errorCs;
+        bool &encounteredError;
+        StringBuffer &errorMessages;
+        IPropertyTree &originalTree;
+    };
+
+    // Multi-threaded serialization/deserialization tests to ensure thread safety with unique Atom trees per thread
+    void testMultiThreadedSerializationAndDeserializationOfAtomTree()
+    {
+        try
+        {
+            constexpr unsigned numThreads = 50;
+            IArrayOf<AtomTreeSerializationTestThread> workers;
+
+            CriticalSection errorCs;
+            bool encounteredError = false;
+            StringBuffer errorMessages;
+            Semaphore startSem; // zero-initialized; used as a start gate
+
+            Owned<IPropertyTree> originalTree = createPTree("MultiThreadRoot", ipt_lowmem);
+            CPPUNIT_ASSERT(originalTree != nullptr);
+
+            auto joinAll = [&workers]()
+            {
+                for (unsigned i = 0; i < workers.ordinality(); ++i)
+                    workers.item(i).join();
+            };
+
+            try
+            {
+                for (unsigned i = 0; i < numThreads; ++i)
+                {
+                    // All threads share the same originalTree, but each creates its own modified copy
+                    // After deserialization, each thread compares its own expected vs actual trees
+                    AtomTreeSerializationTestThread *worker = new AtomTreeSerializationTestThread(i, startSem, errorCs, encounteredError, errorMessages, *originalTree);
+                    workers.append(*worker);
+                    worker->start(false);
+                }
+                startSem.signal(numThreads);
+            }
+            catch (const std::exception &e)
+            {
+                startSem.signal(numThreads);
+                joinAll();
+                CPPUNIT_FAIL(VStringBuffer("Exception while creating worker threads: %s", e.what()).str());
+            }
+            catch (...)
+            {
+                startSem.signal(numThreads);
+                joinAll();
+                CPPUNIT_FAIL("Unknown exception while creating worker threads");
+            }
+
+            joinAll();
+            CPPUNIT_ASSERT_MESSAGE(errorMessages.length() ? errorMessages.str() : "Multi-threaded AtomTree ipt_lowmem deserialization failed", !encounteredError);
+        }
+        catch (IException *e)
+        {
+            StringBuffer msg;
+            e->errorMessage(msg);
+            e->Release();
+            CPPUNIT_FAIL(VStringBuffer("Unexpected IException in testMultiThreadedSerializationAndDeserializationOfAtomTree: %s", msg.str()).str());
+        }
+        catch (const std::exception &e)
+        {
+            CPPUNIT_FAIL(VStringBuffer("Unexpected std::exception in testMultiThreadedSerializationAndDeserializationOfAtomTree: %s", e.what()).str());
+        }
+        catch (...)
+        {
+            CPPUNIT_FAIL("Unexpected unknown exception in testMultiThreadedSerializationAndDeserializationOfAtomTree");
+        }
+    }
+
+    // Malformed buffered-serial stream: ensure exception at jptree.cpp:3089 is thrown
+    void testMalformedStreamMissingAttributeListTerminators()
+    {
+        constexpr const char *rootName = "Root";
+        constexpr unsigned int rootNameLength = (unsigned int)strlen(rootName);
+        Owned<IPropertyTree> original = createPTree(rootName);
+        original->setProp("child", "value");
+        constexpr unsigned int nullTerminatorSize = 1;
+        constexpr unsigned int flagsSize = 1;
+        size32_t flagsEnd = rootNameLength + nullTerminatorSize + flagsSize;
+
+        expectTruncatedStreamFailure(*original, flagsEnd, "PTree deserialization error: end of stream, expected attribute name", "attribute name test");
+    }
+
+    void testMalformedStreamMissingAttributeValue()
+    {
+        constexpr const char *rootName = "Root";
+        constexpr unsigned int rootNameLength = (unsigned int)strlen(rootName);
+        constexpr const char *attrName = "@incomplete";
+        constexpr unsigned int attrNameLength = (unsigned int)strlen(attrName);
+        constexpr const char *attrValue = "value";
+        Owned<IPropertyTree> original = createPTree(rootName);
+        original->setProp(attrName, attrValue);
+        constexpr size32_t nullTerminatorSize = 1;
+        constexpr size32_t flagsSize = 1;
+        constexpr size32_t attributeSectionOffset = rootNameLength + nullTerminatorSize + flagsSize;
+        constexpr size32_t truncationPoint = attributeSectionOffset + attrNameLength + nullTerminatorSize;
+
+        expectTruncatedStreamFailure(*original, truncationPoint, "PTree deserialization error: end of stream, expected attribute value", "attribute value test");
+    }
+
+    void testMalformedStreamTruncatedName()
+    {
+        Owned<IPropertyTree> original = createPTree("Root");
+        expectTruncatedStreamFailure(*original, 0, "PTree deserialization error: end of stream, expected name", "name read test");
     }
 };
 


### PR DESCRIPTION
### Changes:
New unit tests to cover ptree serialization and deserialization exceptions and thread safety:
- testMalformedStreamMissingAttributeListTerminators - Tests deserialization error handling for missing attribute list terminators
- testMalformedStreamMissingAttributeValue - Tests deserialization error handling for missing attribute values
- testMalformedStreamTruncatedName - Tests deserialization error handling for truncated names
- testMultiThreadedSerializationAndDeserializationOfAtomTree - Tests thread safety of serialization/deserialization with multiple threads

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [ ] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [x] Send notifications about my Pull Request position in Smoketest queue.
- [x] Test my draft Pull Request.

## Testing:
Running the unit test `PTreeSerializationDeserializationTest` generates:
```
15:04:14.715241  1769 UNK UNK Adding default library location /home/dave/build/Release-install/Release/lib/
15:04:14.717177  1769 UNK UNK Including test PTreeSerializationDeserializationTest
.15:04:14.717276  1769 UNK UNK === ROUND-TRIP TEST STARTED FOR: testRoundTripForRootOnlyPTree ===
15:04:14.717293  1769 UNK UNK === SERIALIZATION TEST RESULTS:
15:04:14.717297  1769 UNK UNK   serialize() time: 0.008818 ms
15:04:14.717314  1769 UNK UNK   serializeToStream() time: 0.002689 ms
15:04:14.717319  1769 UNK UNK   Performance ratio (serializeToStream/serialize): 0.304944
15:04:14.717321  1769 UNK UNK   serialize()/serializeToStream() data size: 17 bytes
15:04:14.717324  1769 UNK UNK === DESERIALIZATION TEST RESULTS:
15:04:14.717325  1769 UNK UNK   deserialize() time: 0.003500 ms
15:04:14.717339  1769 UNK UNK   deserializeFromStream() time: 0.005208 ms
15:04:14.717344  1769 UNK UNK   Performance ratio (deserializeFromStream/deserialize): 1.488000
15:04:14.717346  1769 UNK UNK === ROUND-TRIP TEST COMPLETED SUCCESSFULLY
.15:04:14.717707  1769 UNK UNK === ROUND-TRIP TEST STARTED FOR: testRoundTripForCompatibilityConfigPropertyTree ===
15:04:14.717728  1769 UNK UNK === SERIALIZATION TEST RESULTS:
15:04:14.717731  1769 UNK UNK   serialize() time: 0.020001 ms
15:04:14.717733  1769 UNK UNK   serializeToStream() time: 0.013537 ms
15:04:14.717735  1769 UNK UNK   Performance ratio (serializeToStream/serialize): 0.676816
15:04:14.717737  1769 UNK UNK   serialize()/serializeToStream() data size: 3330 bytes
15:04:14.717739  1769 UNK UNK === DESERIALIZATION TEST RESULTS:
15:04:14.717740  1769 UNK UNK   deserialize() time: 0.050559 ms
15:04:14.717742  1769 UNK UNK   deserializeFromStream() time: 0.036709 ms
15:04:14.717744  1769 UNK UNK   Performance ratio (deserializeFromStream/deserialize): 0.726063
15:04:14.717747  1769 UNK UNK === ROUND-TRIP TEST COMPLETED SUCCESSFULLY
.15:04:14.718228  1769 UNK UNK === ROUND-TRIP TEST STARTED FOR: testRoundTripForBinaryDataCompressionTestPTree ===
15:04:14.718250  1769 UNK UNK === SERIALIZATION TEST RESULTS:
15:04:14.718254  1769 UNK UNK   serialize() time: 0.004555 ms
15:04:14.718272  1769 UNK UNK   serializeToStream() time: 0.003485 ms
15:04:14.718295  1769 UNK UNK   Performance ratio (serializeToStream/serialize): 0.765093
15:04:14.718328  1769 UNK UNK   serialize()/serializeToStream() data size: 4447 bytes
15:04:14.718344  1769 UNK UNK === DESERIALIZATION TEST RESULTS:
15:04:14.718360  1769 UNK UNK   deserialize() time: 0.023062 ms
15:04:14.718376  1769 UNK UNK   deserializeFromStream() time: 0.005469 ms
15:04:14.718393  1769 UNK UNK   Performance ratio (deserializeFromStream/deserialize): 0.237143
15:04:14.718409  1769 UNK UNK === ROUND-TRIP TEST COMPLETED SUCCESSFULLY
.15:04:14.718446  1769 UNK UNK Backtrace:
15:04:14.720359  1769 UNK UNK   /home/dave/build/Release-install/Release/libs/libjlib.so(_Z16printStackReportx+0x5c) [0x7ffff6f0dffc]
15:04:14.720384  1769 UNK UNK   /home/dave/build/Release-install/Release/libs/libjlib.so(_Z24throwUnexpectedExceptionPKcS0_S0_j+0x1e) [0x7ffff6f0e1ae]
15:04:14.720388  1769 UNK UNK   /home/dave/build/Release-install/Release/libs/libjlib.so(_ZN5PTree15deserializeSelfER26IBufferedSerialInputStream+0x120) [0x7ffff6f90060]
15:04:14.720390  1769 UNK UNK   /home/dave/build/Release-install/Release/libs/libjlib.so(_ZN5PTree21deserializeFromStreamER26IBufferedSerialInputStreamR23PTreeDeserializeContext+0x35) [0x7ffff6f90225]
15:04:14.720392  1769 UNK UNK   /home/dave/build/Release-install/Release/libs/libjlib.so(_Z21createPTreeFromBinaryR26IBufferedSerialInputStreamh+0x40) [0x7ffff6f96600]
15:04:14.720394  1769 UNK UNK   /home/dave/build/Release-install/Release/bin/unittests(+0xd9ac5) [0x55555562dac5]
15:04:14.720395  1769 UNK UNK   /home/dave/build/Release-install/Release/bin/unittests(+0x16ce8e) [0x5555556c0e8e]
15:04:14.720397  1769 UNK UNK   /home/dave/build/Release-install/vcpkg_installed/x64-linux-dynamic/lib/libcppunit-1.15.so.1(_ZNK7CppUnit21TestCaseMethodFunctorclEv+0x26) [0x7ffff7e84126]
15:04:14.720399  1769 UNK UNK   /home/dave/build/Release-install/vcpkg_installed/x64-linux-dynamic/lib/libcppunit-1.15.so.1(_ZN7CppUnit16DefaultProtector7protectERKNS_7FunctorERKNS_16ProtectorContextE+0x35) [0x7ffff7e795c5]
15:04:14.720401  1769 UNK UNK   /home/dave/build/Release-install/vcpkg_installed/x64-linux-dynamic/lib/libcppunit-1.15.so.1(_ZN7CppUnit14ProtectorChain7protectERKNS_7FunctorERKNS_16ProtectorContextE+0x318) [0x7ffff7e81038]
15:04:14.720403  1769 UNK UNK   /home/dave/build/Release-install/vcpkg_installed/x64-linux-dynamic/lib/libcppunit-1.15.so.1(_ZN7CppUnit10TestResult7protectERKNS_7FunctorEPNS_4TestERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE+0x94) [0x7ffff7e8bd64]
15:04:14.720405  1769 UNK UNK   /home/dave/build/Release-install/vcpkg_installed/x64-linux-dynamic/lib/libcppunit-1.15.so.1(_ZN7CppUnit8TestCase3runEPNS_10TestResultE+0x130) [0x7ffff7e83d80]
15:04:14.720407  1769 UNK UNK   /home/dave/build/Release-install/vcpkg_installed/x64-linux-dynamic/lib/libcppunit-1.15.so.1(_ZN7CppUnit13TestComposite15doRunChildTestsEPNS_10TestResultE+0x43) [0x7ffff7e84453]
15:04:14.720409  1769 UNK UNK   /home/dave/build/Release-install/vcpkg_installed/x64-linux-dynamic/lib/libcppunit-1.15.so.1(_ZN7CppUnit13TestComposite3runEPNS_10TestResultE+0x3d) [0x7ffff7e844dd]
15:04:14.720425  1769 UNK UNK   /home/dave/build/Release-install/vcpkg_installed/x64-linux-dynamic/lib/libcppunit-1.15.so.1(_ZN7CppUnit10TestResult7runTestEPNS_4TestE+0x27) [0x7ffff7e8bc87]
15:04:14.720429  1769 UNK UNK   /home/dave/build/Release-install/vcpkg_installed/x64-linux-dynamic/lib/libcppunit-1.15.so.1(_ZN7CppUnit10TestRunner3runERNS_10TestResultERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE+0x43) [0x7ffff7e8e803]
15:04:14.720432  1769 UNK UNK   /home/dave/build/Release-install/vcpkg_installed/x64-linux-dynamic/lib/libcppunit-1.15.so.1(_ZN7CppUnit14TextTestRunner3runENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEbbb+0x74) [0x7ffff7e90b04]
15:04:14.720448  1769 UNK UNK   /home/dave/build/Release-install/Release/bin/unittests(+0x73de9) [0x5555555c7de9]
15:04:14.720451  1769 UNK UNK   /lib/x86_64-linux-gnu/libc.so.6(+0x29d90) [0x7ffff6629d90]
15:04:14.720453  1769 UNK UNK   /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0x80) [0x7ffff6629e40]
15:04:14.720455  1769 UNK UNK   /home/dave/build/Release-install/Release/bin/unittests(+0x77d85) [0x5555555cbd85]
.15:04:14.720536  1769 UNK UNK Backtrace:
15:04:14.720751  1769 UNK UNK   /home/dave/build/Release-install/Release/libs/libjlib.so(_Z16printStackReportx+0x5c) [0x7ffff6f0dffc]
15:04:14.720768  1769 UNK UNK   /home/dave/build/Release-install/Release/libs/libjlib.so(_Z24throwUnexpectedExceptionPKcS0_S0_j+0x1e) [0x7ffff6f0e1ae]
15:04:14.720772  1769 UNK UNK   /home/dave/build/Release-install/Release/libs/libjlib.so(_ZN5PTree15deserializeSelfER26IBufferedSerialInputStream+0x26b) [0x7ffff6f901ab]
15:04:14.720774  1769 UNK UNK   /home/dave/build/Release-install/Release/libs/libjlib.so(_ZN5PTree21deserializeFromStreamER26IBufferedSerialInputStreamR23PTreeDeserializeContext+0x35) [0x7ffff6f90225]
15:04:14.720777  1769 UNK UNK   /home/dave/build/Release-install/Release/libs/libjlib.so(_Z21createPTreeFromBinaryR26IBufferedSerialInputStreamh+0x40) [0x7ffff6f96600]
15:04:14.720779  1769 UNK UNK   /home/dave/build/Release-install/Release/bin/unittests(+0xd9ac5) [0x55555562dac5]
15:04:14.720794  1769 UNK UNK   /home/dave/build/Release-install/Release/bin/unittests(+0x16cf0e) [0x5555556c0f0e]
15:04:14.720797  1769 UNK UNK   /home/dave/build/Release-install/vcpkg_installed/x64-linux-dynamic/lib/libcppunit-1.15.so.1(_ZNK7CppUnit21TestCaseMethodFunctorclEv+0x26) [0x7ffff7e84126]
15:04:14.720800  1769 UNK UNK   /home/dave/build/Release-install/vcpkg_installed/x64-linux-dynamic/lib/libcppunit-1.15.so.1(_ZN7CppUnit16DefaultProtector7protectERKNS_7FunctorERKNS_16ProtectorContextE+0x35) [0x7ffff7e795c5]
15:04:14.720803  1769 UNK UNK   /home/dave/build/Release-install/vcpkg_installed/x64-linux-dynamic/lib/libcppunit-1.15.so.1(_ZN7CppUnit14ProtectorChain7protectERKNS_7FunctorERKNS_16ProtectorContextE+0x318) [0x7ffff7e81038]
15:04:14.720805  1769 UNK UNK   /home/dave/build/Release-install/vcpkg_installed/x64-linux-dynamic/lib/libcppunit-1.15.so.1(_ZN7CppUnit10TestResult7protectERKNS_7FunctorEPNS_4TestERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE+0x94) [0x7ffff7e8bd64]
15:04:14.720820  1769 UNK UNK   /home/dave/build/Release-install/vcpkg_installed/x64-linux-dynamic/lib/libcppunit-1.15.so.1(_ZN7CppUnit8TestCase3runEPNS_10TestResultE+0x130) [0x7ffff7e83d80]
15:04:14.720824  1769 UNK UNK   /home/dave/build/Release-install/vcpkg_installed/x64-linux-dynamic/lib/libcppunit-1.15.so.1(_ZN7CppUnit13TestComposite15doRunChildTestsEPNS_10TestResultE+0x43) [0x7ffff7e84453]
15:04:14.720826  1769 UNK UNK   /home/dave/build/Release-install/vcpkg_installed/x64-linux-dynamic/lib/libcppunit-1.15.so.1(_ZN7CppUnit13TestComposite3runEPNS_10TestResultE+0x3d) [0x7ffff7e844dd]
15:04:14.720844  1769 UNK UNK   /home/dave/build/Release-install/vcpkg_installed/x64-linux-dynamic/lib/libcppunit-1.15.so.1(_ZN7CppUnit10TestResult7runTestEPNS_4TestE+0x27) [0x7ffff7e8bc87]
15:04:14.720860  1769 UNK UNK   /home/dave/build/Release-install/vcpkg_installed/x64-linux-dynamic/lib/libcppunit-1.15.so.1(_ZN7CppUnit10TestRunner3runERNS_10TestResultERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE+0x43) [0x7ffff7e8e803]
15:04:14.720863  1769 UNK UNK   /home/dave/build/Release-install/vcpkg_installed/x64-linux-dynamic/lib/libcppunit-1.15.so.1(_ZN7CppUnit14TextTestRunner3runENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEbbb+0x74) [0x7ffff7e90b04]
15:04:14.720865  1769 UNK UNK   /home/dave/build/Release-install/Release/bin/unittests(+0x73de9) [0x5555555c7de9]
15:04:14.720868  1769 UNK UNK   /lib/x86_64-linux-gnu/libc.so.6(+0x29d90) [0x7ffff6629d90]
15:04:14.720883  1769 UNK UNK   /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0x80) [0x7ffff6629e40]
15:04:14.720899  1769 UNK UNK   /home/dave/build/Release-install/Release/bin/unittests(+0x77d85) [0x5555555cbd85]
.15:04:14.720943  1769 UNK UNK Backtrace:
15:04:14.721141  1769 UNK UNK   /home/dave/build/Release-install/Release/libs/libjlib.so(_Z16printStackReportx+0x5c) [0x7ffff6f0dffc]
15:04:14.721155  1769 UNK UNK   /home/dave/build/Release-install/Release/libs/libjlib.so(_Z24throwUnexpectedExceptionPKcS0_S0_j+0x1e) [0x7ffff6f0e1ae]
15:04:14.721159  1769 UNK UNK   /home/dave/build/Release-install/Release/libs/libjlib.so(_ZN5PTree15deserializeSelfER26IBufferedSerialInputStream+0x297) [0x7ffff6f901d7]
15:04:14.721161  1769 UNK UNK   /home/dave/build/Release-install/Release/libs/libjlib.so(_ZN5PTree21deserializeFromStreamER26IBufferedSerialInputStreamR23PTreeDeserializeContext+0x35) [0x7ffff6f90225]
15:04:14.721177  1769 UNK UNK   /home/dave/build/Release-install/Release/libs/libjlib.so(_Z21createPTreeFromBinaryR26IBufferedSerialInputStreamh+0x40) [0x7ffff6f96600]
15:04:14.721193  1769 UNK UNK   /home/dave/build/Release-install/Release/bin/unittests(+0xd9ac5) [0x55555562dac5]
15:04:14.721209  1769 UNK UNK   /home/dave/build/Release-install/Release/bin/unittests(+0x16cf74) [0x5555556c0f74]
15:04:14.721225  1769 UNK UNK   /home/dave/build/Release-install/vcpkg_installed/x64-linux-dynamic/lib/libcppunit-1.15.so.1(_ZNK7CppUnit21TestCaseMethodFunctorclEv+0x26) [0x7ffff7e84126]
15:04:14.721243  1769 UNK UNK   /home/dave/build/Release-install/vcpkg_installed/x64-linux-dynamic/lib/libcppunit-1.15.so.1(_ZN7CppUnit16DefaultProtector7protectERKNS_7FunctorERKNS_16ProtectorContextE+0x35) [0x7ffff7e795c5]
15:04:14.721259  1769 UNK UNK   /home/dave/build/Release-install/vcpkg_installed/x64-linux-dynamic/lib/libcppunit-1.15.so.1(_ZN7CppUnit14ProtectorChain7protectERKNS_7FunctorERKNS_16ProtectorContextE+0x318) [0x7ffff7e81038]
15:04:14.721275  1769 UNK UNK   /home/dave/build/Release-install/vcpkg_installed/x64-linux-dynamic/lib/libcppunit-1.15.so.1(_ZN7CppUnit10TestResult7protectERKNS_7FunctorEPNS_4TestERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE+0x94) [0x7ffff7e8bd64]
15:04:14.721292  1769 UNK UNK   /home/dave/build/Release-install/vcpkg_installed/x64-linux-dynamic/lib/libcppunit-1.15.so.1(_ZN7CppUnit8TestCase3runEPNS_10TestResultE+0x130) [0x7ffff7e83d80]
15:04:14.721308  1769 UNK UNK   /home/dave/build/Release-install/vcpkg_installed/x64-linux-dynamic/lib/libcppunit-1.15.so.1(_ZN7CppUnit13TestComposite15doRunChildTestsEPNS_10TestResultE+0x43) [0x7ffff7e84453]
15:04:14.721324  1769 UNK UNK   /home/dave/build/Release-install/vcpkg_installed/x64-linux-dynamic/lib/libcppunit-1.15.so.1(_ZN7CppUnit13TestComposite3runEPNS_10TestResultE+0x3d) [0x7ffff7e844dd]
15:04:14.721340  1769 UNK UNK   /home/dave/build/Release-install/vcpkg_installed/x64-linux-dynamic/lib/libcppunit-1.15.so.1(_ZN7CppUnit10TestResult7runTestEPNS_4TestE+0x27) [0x7ffff7e8bc87]
15:04:14.721357  1769 UNK UNK   /home/dave/build/Release-install/vcpkg_installed/x64-linux-dynamic/lib/libcppunit-1.15.so.1(_ZN7CppUnit10TestRunner3runERNS_10TestResultERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE+0x43) [0x7ffff7e8e803]
15:04:14.721373  1769 UNK UNK   /home/dave/build/Release-install/vcpkg_installed/x64-linux-dynamic/lib/libcppunit-1.15.so.1(_ZN7CppUnit14TextTestRunner3runENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEbbb+0x74) [0x7ffff7e90b04]
15:04:14.721377  1769 UNK UNK   /home/dave/build/Release-install/Release/bin/unittests(+0x73de9) [0x5555555c7de9]
15:04:14.721379  1769 UNK UNK   /lib/x86_64-linux-gnu/libc.so.6(+0x29d90) [0x7ffff6629d90]
15:04:14.721382  1769 UNK UNK   /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0x80) [0x7ffff6629e40]
15:04:14.721385  1769 UNK UNK   /home/dave/build/Release-install/Release/bin/unittests(+0x77d85) [0x5555555cbd85]
.


OK (7 tests)
```
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
