### PR TITLE
HPCC-35594: Decouple meta state data from event visitation

### DIFF
--- a/common/eventconsumption/README.md
+++ b/common/eventconsumption/README.md
@@ -320,9 +320,13 @@ If algorithm estimation is enabled, the value is replaced. If the node will not 
 
 
 
-### CMetaInfoState
+### CMetaInfoState::CCollector
 
-A concrete implementation of `IEventVisitationLink` that observes all `FileInformation` and `QueryStart` events. The relationships between `FileId` and `Path` attributes, and also `EventTraceId` and `ServiceName` attributes, are retained and made available to operations and other event visitors. When visited before a filter, the state information is available to all operations and visitors even if the filter suppresses the observed events.
+`CMetaInfoState` provides a runtime repository of event-defined state information, including values from the `FileInformation` and `QueryStart` events. As a concrete implementation of `IEventVisitationLink`, `CCollector` is a companion class that extracts event data for the repository.
+
+To avoid data loss, this link must precede all other links. It is the responsibility of event iterating code to ensure this requirement is satisfied.
+
+The repository is available to all operations and all other visitors. The collector itself is not.
 
 # CEventVisitationLinkTester
 

--- a/common/eventconsumption/eventmetaparser.cpp
+++ b/common/eventconsumption/eventmetaparser.cpp
@@ -18,11 +18,11 @@
 #include "eventmetaparser.hpp"
 #include "jevent.hpp"
 
-void CMetaInfoState::configure(const IPropertyTree& config)
+void CMetaInfoState::CCollector::configure(const IPropertyTree& config)
 {
 }
 
-bool CMetaInfoState::visitEvent(CEvent& event)
+bool CMetaInfoState::CCollector::visitEvent(CEvent& event)
 {
     switch (event.queryType())
     {
@@ -32,8 +32,8 @@ bool CMetaInfoState::visitEvent(CEvent& event)
             const char* path = event.queryTextValue(EvAttrPath);
             if (!isEmptyString(path))
             {
-                fileIdToPath[fileId].set(path);
-                pathToFileId[path] = fileId;
+                metaState->fileIdToPath[fileId].set(path);
+                metaState->pathToFileId[path] = fileId;
             }
         }
         break;
@@ -44,7 +44,7 @@ bool CMetaInfoState::visitEvent(CEvent& event)
                 const char* traceId = event.queryTextValue(EvAttrEventTraceId);
                 const char* serviceName = event.queryTextValue(EvAttrServiceName);
                 if (!isEmptyString(traceId) && !isEmptyString(serviceName))
-                    traceIdToService.emplace(traceId, serviceName);
+                    metaState->traceIdToService.emplace(traceId, serviceName);
             }
         }
         break;
@@ -54,6 +54,16 @@ bool CMetaInfoState::visitEvent(CEvent& event)
     if (nextLink)
         return nextLink->visitEvent(event);
     return true;
+}
+
+CMetaInfoState::CCollector::CCollector(CMetaInfoState& _metaState)
+    : metaState(&_metaState)
+{
+}
+
+IEventVisitationLink* CMetaInfoState::getCollector()
+{
+    return new CCollector(*this);
 }
 
 const char* CMetaInfoState::queryFilePath(__uint64 fileId) const

--- a/common/eventconsumption/eventmetaparser.hpp
+++ b/common/eventconsumption/eventmetaparser.hpp
@@ -24,17 +24,23 @@
 #include <string>
 
 // Visitor that parses and caches file ID to path mappings and trace ID to service name mappings
-class event_decl CMetaInfoState : public CInterfaceOf<IEventVisitationLink>
+class event_decl CMetaInfoState : public CInterface
 {
+    class event_decl CCollector : public CInterfaceOf<IEventVisitationLink>
+    {
+    public: // IEventVisitor
+        virtual bool visitEvent(CEvent& event) override;
+    public: // IEventVisitationLink
+        IMPLEMENT_IEVENTVISITATIONLINK
+        virtual void configure(const IPropertyTree& config) override;
+    public:
+        CCollector(CMetaInfoState& _metaState);
+    private:
+        Linked<CMetaInfoState> metaState;
+    };
+
 public:
-    CMetaInfoState() = default;
-    ~CMetaInfoState() = default;
-
-    // IEventVisitationLink interface
-    IMPLEMENT_IEVENTVISITATIONLINK
-    virtual void configure(const IPropertyTree& config) override;
-    virtual bool visitEvent(CEvent& event) override;
-
+    IEventVisitationLink* getCollector();
     // Accessor functions for file ID to path mappings
     const char* queryFilePath(__uint64 fileId) const;
     bool hasFileMapping(__uint64 fileId) const;

--- a/common/eventconsumption/eventoperation.cpp
+++ b/common/eventconsumption/eventoperation.cpp
@@ -77,10 +77,8 @@ bool CEventConsumingOp::traverseEvents(const char* path, IEventVisitor& visitor)
         model->setNextLink(*actual);
         actual = model;
     }
+    Owned<IEventVisitationLink> metaCollector = metaState->getCollector();
+    metaCollector->setNextLink(*actual);
 
-    // Always include the meta information parser as the first link in the chain
-    // to ensure MetaFileInformation and EventQueryStart events are captured
-    metaState->setNextLink(*actual);
-
-    return readEvents(path, *metaState);
+    return readEvents(path, *metaCollector);
 }

--- a/common/eventconsumption/eventoperation.h
+++ b/common/eventconsumption/eventoperation.h
@@ -47,6 +47,7 @@ protected:
     Owned<CMetaInfoState> metaState;
     StringAttr inputPath;
     Linked<IBufferedSerialOutputStream> out;
+private:
     Owned<IEventFilter> filter;
     Owned<IEventModel> model;
 };

--- a/common/eventconsumption/eventunittests.cpp
+++ b/common/eventconsumption/eventunittests.cpp
@@ -186,8 +186,9 @@ void testEventVisitationLinks(const IPropertyTree& inputTree, const IPropertyTre
             }
 
             // Always include the meta information parser as the first link in the chain
-            metaState->setNextLink(*currentVisitor);
-            visitIterableEvents(*input, *metaState);
+            Owned<IEventVisitationLink> metaCollector = metaState->getCollector();
+            metaCollector->setNextLink(*currentVisitor);
+            visitIterableEvents(*input, *metaCollector);
             return true;
         }
 


### PR DESCRIPTION
- Changed CMetaInfoState to only be a state repository.
- Added CMetaInfoStateCollector as a visitation link with the ability to update the state repository.
- Updated event traversal logic to create ans use a state collector on- demand. No operation or visitor can depend on the collector.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [x] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
