### PR TITLE
HPCC-35508 Add jptree deserialize performance unittests (focus on binary deserialization)

### DIFF
--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -25,4 +25,5 @@ Install ( DIRECTORY regress DESTINATION "./testing" COMPONENT Runtime
 configure_file("regress/environment.xml.in" "regress/environment.xml")
 
 Install ( FILES ${CMAKE_CURRENT_BINARY_DIR}/regress/environment.xml DESTINATION "./testing/regress" COMPONENT Runtime )
+Install ( FILES ${CMAKE_CURRENT_SOURCE_DIR}/unittests/data/dalisds100mb.bin.zst DESTINATION "./testing/data" COMPONENT Runtime )
 


### PR DESCRIPTION
### Change

1.Add a new unittest `PTreeBinaryTimingStressTest` for jptree binary deserialization performance.
2.Add parameters to unittests for the binary file path and number of iterations.
3.A zstd compressed binary will be used if a binary file is not specified as a parameter

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [x] Send notifications about my Pull Request position in Smoketest queue.
- [x] Test my draft Pull Request.

## Testing:
launch.json

```
        {
            "name": "(gdb) Launch unittests PTreeBinaryTimingStressTest",
            "type": "cppdbg",
            "request": "launch",
            "program": "${workspaceFolder}/../build/Debug-install/Debug/bin/unittests",
            "args": [
                "-v",
                "-e",
                "-i",
                "10",
                "PTreeBinaryTimingStressTest"
            ],
            "stopAtEntry": false,
            "cwd": "${workspaceFolder}",
            "environment": [],
            "externalConsole": false,
            "MIMode": "gdb",
            "setupCommands": [
                {
                    "description": "Enable pretty-printing for gdb",
                    "text": "-enable-pretty-printing",
                    "ignoreFailures": true
                }
            ]
        },
```
Test output:
```
.16:56:32.980275 56036 UNK UNK === BINARY TIMING COMPARISON TEST ===
16:56:32.980598 56036 UNK UNK Binary data size: 103499268 bytes
16:56:32.980605 56036 UNK UNK Iterations: 10
16:56:32.980608 56036 UNK UNK ┌──────────────────────┬─────────────────┐
16:56:32.980623 56036 UNK UNK │ Mode                 │ Avg Deserialize │
16:56:32.980629 56036 UNK UNK │                      │ (cycles)        │
16:56:32.980632 56036 UNK UNK ├──────────────────────┼─────────────────┤
16:56:32.980636 56036 UNK UNK │ Binary Normal        │      6130745072 │
16:56:32.980639 56036 UNK UNK │ Binary Low Memory    │      7608132506 │
16:56:32.980642 56036 UNK UNK │ Binary LowMem Diff   │         +24.10% │
16:56:32.980649 56036 UNK UNK └──────────────────────┴─────────────────┘
```