### PR TITLE
HPCC-35507 Extend jptree streaming tests for malformed content and parallel testing

### DIFF
--- a/testing/unittests/jlibtests.cpp
+++ b/testing/unittests/jlibtests.cpp
@@ -3624,6 +3624,14 @@ IPropertyTree *createBinaryDataCompressionTestPTree(const char *testXml)
  *
  * Tests PTree serialization/deserialization format consistency between MemoryBuffer and IBufferedSerialInputStream
  * and measures performance of both operations
+ *
+ * testRoundTripForRootOnlyPTree                              - Tests round-trip serialization/deserialization for a PTree with only a root node
+ * testRoundTripForCompatibilityConfigPropertyTree            - Tests round-trip serialization/deserialization for a complex compatibility config PTree
+ * testRoundTripForBinaryDataCompressionTestPTree             - Tests round-trip serialization/deserialization for a PTree with various binary data sizes
+ * testMalformedStreamMissingAttributeListTerminators         - Tests deserialization error handling for missing attribute list terminators
+ * testMalformedStreamMissingAttributeValue                   - Tests deserialization error handling for missing attribute values
+ * testMalformedStreamTruncatedName                           - Tests deserialization error handling for truncated names
+ * testMultiThreadedSerializationAndDeserializationOfAtomTree - Tests thread safety of Atom Tree serialization/deserialization with multiple threads
  */
 
 class PTreeSerializationDeserializationTest : public CppUnit::TestFixture
@@ -3633,6 +3641,10 @@ class PTreeSerializationDeserializationTest : public CppUnit::TestFixture
     CPPUNIT_TEST(testRoundTripForRootOnlyPTree);
     CPPUNIT_TEST(testRoundTripForCompatibilityConfigPropertyTree);
     CPPUNIT_TEST(testRoundTripForBinaryDataCompressionTestPTree);
+    CPPUNIT_TEST(testMalformedStreamMissingAttributeListTerminators);
+    CPPUNIT_TEST(testMalformedStreamMissingAttributeValue);
+    CPPUNIT_TEST(testMalformedStreamTruncatedName);
+    CPPUNIT_TEST(testMultiThreadedSerializationAndDeserializationOfAtomTree);
     CPPUNIT_TEST_SUITE_END();
 
 protected:
@@ -3652,6 +3664,8 @@ protected:
         "    </Policies>"
         "  </Cache>"
         "</Configuration>"};
+    static constexpr const char *treeRootName{"Root"};
+    static constexpr unsigned int treeRootNameLength{4};
 
     // Complete round-trip test method that performs serialization, deserialization, and validation
     void performRoundTripTest(const char *testName, IPropertyTree *tree)
@@ -3694,7 +3708,7 @@ protected:
             deserializeElapsedNs = timer.elapsedNs();
             CPPUNIT_ASSERT(areMatchingPTrees(originalTree, memoryBufferDeserialized));
         }
-        
+
         // Time deserializeFromStream() method
         __uint64 deserializeFromStreamElapsedNs = 0;
         {
@@ -3757,6 +3771,51 @@ protected:
         DBGLOG("=== ROUND-TRIP TEST COMPLETED SUCCESSFULLY");
     }
 
+    void expectTruncatedStreamFailure(IPropertyTree &tree, size32_t truncationOffset, const char *expectedSubstring, const char *contextDescription)
+    {
+        MemoryBuffer fullySerialized;
+        Owned<IBufferedSerialOutputStream> out{createBufferedSerialOutputStream(fullySerialized)};
+        tree.serializeToStream(*out);
+        out->flush();
+
+        {
+            size32_t totalLength{fullySerialized.length()};
+            VStringBuffer assertMsg("Serialized stream shorter than truncation offset for %s", contextDescription);
+            CPPUNIT_ASSERT_MESSAGE(assertMsg.str(), truncationOffset < totalLength);
+        }
+
+        MemoryBuffer truncated;
+        truncated.append(truncationOffset, fullySerialized.toByteArray());
+        Owned<IBufferedSerialInputStream> in{createBufferedSerialInputStream(truncated)};
+        bool hitExpectedException{false};
+        try
+        {
+            createPTreeFromBinary(*in, ipt_none);
+        }
+        catch (IException *e)
+        {
+            StringBuffer actualMsg;
+            e->errorMessage(actualMsg);
+            e->Release();
+            const char *actualMsgChars{actualMsg.str()};
+            if (actualMsgChars && strstr(actualMsgChars, expectedSubstring))
+            {
+                hitExpectedException = true;
+            }
+            else
+            {
+                VStringBuffer detail("Caught unexpected exception during %s: %s", contextDescription, actualMsgChars ? actualMsgChars : "<null>");
+                CPPUNIT_FAIL(detail.str());
+            }
+        }
+
+        if (!hitExpectedException)
+        {
+            VStringBuffer detail("Did not hit expected exception substring '%s' during %s", expectedSubstring, contextDescription);
+            CPPUNIT_FAIL(detail.str());
+        }
+    }
+
 public:
     // Complete round-trip test methods - perform serialization and deserialization in one test
     void testRoundTripForRootOnlyPTree()
@@ -3772,6 +3831,343 @@ public:
     void testRoundTripForBinaryDataCompressionTestPTree()
     {
         performRoundTripTest(__func__, createBinaryDataCompressionTestPTree(testXml));
+    }
+
+    class AtomTreeSerializationTestThread : public Thread
+    {
+    public:
+        AtomTreeSerializationTestThread(unsigned _index,
+                                        Semaphore &_startSem,
+                                        CriticalSection &_errorCs,
+                                        StringBuffer &_errorMessages,
+                                        IPropertyTree &_originalTree)
+            : Thread("AtomTreeSerializationTestThread"),
+              threadIndex(_index),
+              startSem(_startSem),
+              errorCs(_errorCs),
+              errorMessages(_errorMessages),
+              originalTree(_originalTree)
+        {
+        }
+
+        // Clone the shared template originalTree, apply per-thread mutations, then serialize/deserialize and verify equality
+        virtual int run() override
+        {
+            // Wait for the coordinated start gate so all threads begin together
+            startSem.wait();
+            try
+            {
+                // Duplicate the shared template using low-memory mode so that isolate per-thread mutations can be applied
+                Owned<IPropertyTree> expected{createPTreeFromIPT(&originalTree, ipt_lowmem)};
+
+                VStringBuffer threadTag("worker_%u", threadIndex);
+                expected->setProp("@threadId", threadTag.str());
+                IPropertyTree *settings{expected->queryPropTree("settings")};
+                if (settings)
+                {
+                    // Stamp per-thread identifiers and thresholds onto the settings subtree
+                    settings->setProp("@worker", threadTag.str());
+                    settings->setProp("threshold", VStringBuffer("%u", 42 + threadIndex).str());
+
+                    IPropertyTree *alpha{settings->queryPropTree("option[@name=\"alpha\"]")};
+                    if (alpha)
+                        alpha->setProp("value", VStringBuffer("alpha_value_%u", threadIndex).str());
+                    IPropertyTree *beta{settings->queryPropTree("option[@name=\"beta\"]")};
+                    if (beta)
+                        beta->setProp("value", VStringBuffer("beta_value_%u", threadIndex).str());
+                }
+                // Build a binary payload to exercise binary serialization
+                MemoryBuffer payload;
+                for (unsigned idx{0}; idx < 2048; ++idx)
+                    payload.append((byte)((idx + threadIndex) % 256));
+                expected->setPropBin("binaryPayload", payload.length(), payload.toByteArray());
+                IPropertyTree *clusters{expected->queryPropTree("clusters")};
+                if (clusters)
+                {
+                    unsigned clusterIndex{0};
+                    Owned<IPropertyTreeIterator> iter{clusters->getElements("cluster")};
+                    ForEach(*iter)
+                    {
+                        // Stamp per-cluster descriptions and attach binary payload variants
+                        IPropertyTree &cluster{iter->query()};
+                        cluster.setProp("description", VStringBuffer("Example cluster entry thread %u index %u", threadIndex, clusterIndex).str());
+                        cluster.setPropInt("@threadId", threadIndex);
+
+                        MemoryBuffer clusterPayload;
+                        clusterPayload.append(sizeof(threadIndex), &threadIndex);
+                        clusterPayload.append(sizeof(clusterIndex), &clusterIndex);
+                        cluster.setPropBin("payload", clusterPayload.length(), clusterPayload.toByteArray());
+                        ++clusterIndex;
+                    }
+                }
+                IPropertyTree *metrics{expected->queryPropTree("metrics")};
+                if (metrics)
+                {
+                    // Flip metrics attributes based on the thread id to vary content
+                    metrics->setProp("@enabled", (threadIndex % 2 == 0) ? "true" : "false");
+                    metrics->setProp("@thread", threadTag.str());
+                    metrics->setProp("sampleInterval", VStringBuffer("%u.%02u", threadIndex + 1, threadIndex).str());
+                }
+
+                MemoryBuffer serialized;
+                {
+                    Owned<IBufferedSerialOutputStream> out{createBufferedSerialOutputStream(serialized)};
+                    expected->serializeToStream(*out);
+                    out->flush();
+                }
+
+                {
+                    size32_t serializedLength{serialized.length()};
+                    if (!serializedLength)
+                    {
+                        CriticalBlock block(errorCs);
+                        errorMessages.appendf("Thread %u: serialization produced empty buffer\n", threadIndex);
+                        return 0;
+                    }
+                }
+
+                // Deserialize and verify the resulting tree matches the expected structure
+                Owned<IBufferedSerialInputStream> in{createBufferedSerialInputStream(serialized)};
+                Owned<IPropertyTree> deserialized{createPTreeFromBinary(*in, ipt_lowmem)};
+                if (!areMatchingPTrees(expected, deserialized))
+                {
+                    CriticalBlock block(errorCs);
+                    errorMessages.appendf("Thread %u: deserialized tree mismatch for root %s\n", threadIndex, expected->queryName());
+                }
+            }
+            catch (IException *e)
+            {
+                StringBuffer msg;
+                e->errorMessage(msg);
+                e->Release();
+                CriticalBlock block(errorCs);
+                errorMessages.appendf("Thread %u: %s\n", threadIndex, msg.str());
+            }
+            catch (...)
+            {
+                CriticalBlock block(errorCs);
+                errorMessages.appendf("Thread %u: unknown exception\n", threadIndex);
+            }
+
+            return 0;
+        }
+
+    private:
+        unsigned threadIndex{0};
+        Semaphore &startSem;
+        CriticalSection &errorCs;
+        StringBuffer &errorMessages;
+        IPropertyTree &originalTree;
+    };
+
+private:
+    static Owned<IPropertyTree> createSeededAtomTreeTemplate()
+    {
+        Owned<IPropertyTree> originalTree{createPTree("MultiThreadRoot", ipt_lowmem)};
+        CPPUNIT_ASSERT(originalTree != nullptr);
+
+        // Seed shared tree with structures to be exercised in per-thread mutations
+        IPropertyTree *settings{originalTree->addPropTree("settings")};
+        settings->setProp("@profile", "default");
+        settings->setProp("@worker", "seed");
+        settings->setProp("threshold", "42");
+
+        IPropertyTree *alpha{settings->addPropTree("option")};
+        alpha->setProp("@name", "alpha");
+        alpha->setProp("value", "alpha_value_seed");
+
+        IPropertyTree *beta{settings->addPropTree("option")};
+        beta->setProp("@name", "beta");
+        beta->setProp("value", "beta_value_seed");
+
+        IPropertyTree *clusters{originalTree->addPropTree("clusters")};
+        for (unsigned i{0}; i < 3; ++i)
+        {
+            IPropertyTree *cluster{clusters->addPropTree("cluster")};
+            cluster->setProp("@id", VStringBuffer("cluster_%u", i).str());
+            cluster->setProp("description", "initial cluster entry");
+        }
+
+        IPropertyTree *metrics{originalTree->addPropTree("metrics")};
+        metrics->setProp("@enabled", "true");
+        metrics->setProp("@thread", "seed");
+        metrics->setProp("sampleInterval", "1.00");
+
+        return originalTree.getClear();
+    }
+
+    static unsigned joinAllWorkersWithTimeout(IArrayOf<AtomTreeSerializationTestThread> &workers, unsigned totalTimeoutMs, StringBuffer &timeoutMessages)
+    {
+        using Clock = std::chrono::steady_clock;
+        Clock::time_point deadline{Clock::now() + std::chrono::milliseconds(totalTimeoutMs)};
+        unsigned timedOut{0};
+        for (unsigned i{0}; i < workers.ordinality(); ++i)
+        {
+            Clock::time_point now{Clock::now()};
+            if (now >= deadline)
+            {
+                ++timedOut;
+                timeoutMessages.appendf("Thread %u did not finish before total timeout of %u ms\n", i, totalTimeoutMs);
+                continue;
+            }
+
+            auto remainingMs64bit{std::chrono::duration_cast<std::chrono::milliseconds>(deadline - now).count()};
+            unsigned remainingMs{remainingMs64bit > 0 ? static_cast<unsigned>(remainingMs64bit) : 0U};
+
+            if (!workers.item(i).join(remainingMs))
+            {
+                ++timedOut;
+                timeoutMessages.appendf("Thread %u did not finish within total timeout (remaining %u ms of %u ms)\n", i, remainingMs, totalTimeoutMs);
+            }
+        }
+        return timedOut;
+    }
+
+    static void startAtomTreeWorkers(IArrayOf<AtomTreeSerializationTestThread> &workers,
+                                     unsigned numThreads,
+                                     Semaphore &startSem,
+                                     CriticalSection &errorCs,
+                                     StringBuffer &errorMessages,
+                                     IPropertyTree &originalTree)
+    {
+        for (unsigned i{0}; i < numThreads; ++i)
+        {
+            // All threads share the same originalTree, but each creates its own modified copy
+            // After deserialization, each thread compares its own expected vs actual trees
+            AtomTreeSerializationTestThread *worker{new AtomTreeSerializationTestThread(i, startSem, errorCs, errorMessages, originalTree)};
+            workers.append(*worker);
+            worker->start(false);
+        }
+        startSem.signal(numThreads);
+    }
+
+    struct WorkerCompletionGuard
+    {
+        IArrayOf<AtomTreeSerializationTestThread> &workers;
+        unsigned cleanupTimeoutMs;
+
+        WorkerCompletionGuard(IArrayOf<AtomTreeSerializationTestThread> &_workers, unsigned _cleanupTimeoutMs)
+            : workers(_workers), cleanupTimeoutMs(_cleanupTimeoutMs)
+        {
+        }
+
+        ~WorkerCompletionGuard()
+        {
+            StringBuffer cleanupTimeoutMessages;
+            unsigned timedOut{PTreeSerializationDeserializationTest::joinAllWorkersWithTimeout(workers, cleanupTimeoutMs, cleanupTimeoutMessages)};
+            if (timedOut)
+                DBGLOG("Cleanup wait detected %u stalled threads; waiting indefinitely for teardown\n%s", timedOut, cleanupTimeoutMessages.str());
+            for (unsigned i{0}; i < workers.ordinality(); ++i)
+                workers.item(i).join(INFINITE);
+        }
+    };
+
+public:
+
+    // Multi-threaded serialization/deserialization tests to ensure thread safety with unique Atom trees per thread
+    void testMultiThreadedSerializationAndDeserializationOfAtomTree()
+    {
+        try
+        {
+            constexpr unsigned numThreads{50};
+            constexpr unsigned fiveSeconds{5000};
+            constexpr unsigned joinTimeoutMs{fiveSeconds};
+            constexpr unsigned tenSeconds{10000};
+            constexpr unsigned cleanupTimeoutMs{tenSeconds};
+            IArrayOf<AtomTreeSerializationTestThread> workers;
+
+            CriticalSection errorCs;
+            StringBuffer errorMessages;
+            Semaphore startSem; // zero-initialized; used as a start gate
+
+            Owned<IPropertyTree> originalTree{createSeededAtomTreeTemplate()};
+
+            // Ensure worker threads cannot outlive stack locals even when the test fails
+            WorkerCompletionGuard workerCompletionGuard{workers, cleanupTimeoutMs};
+
+            try
+            {
+                startAtomTreeWorkers(workers, numThreads, startSem, errorCs, errorMessages, *originalTree);
+            }
+            catch (const std::exception &e)
+            {
+                startSem.signal(numThreads);
+                StringBuffer joinTimeoutMessages;
+                joinAllWorkersWithTimeout(workers, joinTimeoutMs, joinTimeoutMessages); // We have a specific exception so ignore any join timeouts here
+                CPPUNIT_FAIL(VStringBuffer("Exception while creating worker threads: %s", e.what()).str());
+            }
+            catch (...)
+            {
+                startSem.signal(numThreads);
+                StringBuffer joinTimeoutMessages;
+                unsigned timedOut{joinAllWorkersWithTimeout(workers, joinTimeoutMs, joinTimeoutMessages)}; // no specific exception so report any join timeouts
+                if (timedOut)
+                    DBGLOG("joinAllWorkersWithTimeout detected %u stalled threads during worker creation failure\n%s", timedOut, joinTimeoutMessages.str());
+                CPPUNIT_FAIL("Unknown exception while creating worker threads");
+            }
+
+            StringBuffer joinTimeoutMessages;
+            unsigned timedOut{joinAllWorkersWithTimeout(workers, joinTimeoutMs, joinTimeoutMessages)};
+            if (timedOut)
+            {
+                DBGLOG("joinAllWorkersWithTimeout detected %u stalled threads after normal completion\n%s", timedOut, joinTimeoutMessages.str());
+                VStringBuffer timeoutMsg("Timed out waiting for %u worker threads\n%s", timedOut, joinTimeoutMessages.str());
+                CPPUNIT_FAIL(timeoutMsg.str());
+            }
+
+            CPPUNIT_ASSERT_MESSAGE(errorMessages.length() ? errorMessages.str() : "Multi-threaded AtomTree ipt_lowmem deserialization failed", (errorMessages.length() == 0));
+        }
+        catch (IException *e)
+        {
+            StringBuffer msg;
+            e->errorMessage(msg);
+            e->Release();
+            CPPUNIT_FAIL(VStringBuffer("Unexpected IException in testMultiThreadedSerializationAndDeserializationOfAtomTree: %s", msg.str()).str());
+        }
+        catch (const std::exception &e)
+        {
+            CPPUNIT_FAIL(VStringBuffer("Unexpected std::exception in testMultiThreadedSerializationAndDeserializationOfAtomTree: %s", e.what()).str());
+        }
+        catch (...)
+        {
+            CPPUNIT_FAIL("Unexpected unknown exception in testMultiThreadedSerializationAndDeserializationOfAtomTree");
+        }
+    }
+
+    // Malformed buffered-serial stream with missing attribute list terminators: ensure exception thrown from PTree::deserializeSelf(IBufferedSerialInputStream)
+    void testMalformedStreamMissingAttributeListTerminators()
+    {
+        Owned<IPropertyTree> original{createPTree(treeRootName)};
+        original->setProp("child", "value");
+        constexpr unsigned int nullTerminatorSize{1};
+        constexpr unsigned int flagsSize{1};
+        size32_t flagsEnd{treeRootNameLength + nullTerminatorSize + flagsSize};
+
+        expectTruncatedStreamFailure(*original, flagsEnd, "PTree deserialization error: end of stream, expected attribute name", "attribute name test");
+    }
+
+    // Malformed buffered-serial stream with missing Value attribute: ensure exception thrown from PTree::deserializeSelf(IBufferedSerialInputStream)
+    void testMalformedStreamMissingAttributeValue()
+    {
+        constexpr const char *attrName{"@incomplete"};
+        constexpr unsigned int attrNameLength{11};
+        constexpr const char *attrValue{"value"};
+        Owned<IPropertyTree> original{createPTree(treeRootName)};
+        original->setProp(attrName, attrValue);
+        constexpr size32_t nullTerminatorSize{1};
+        constexpr size32_t flagsSize{1};
+        constexpr size32_t attributeSectionOffset{treeRootNameLength + nullTerminatorSize + flagsSize};
+        constexpr size32_t truncationPoint{attributeSectionOffset + attrNameLength + nullTerminatorSize};
+
+        expectTruncatedStreamFailure(*original, truncationPoint, "PTree deserialization error: end of stream, expected attribute value", "attribute value test");
+    }
+
+    // Malformed buffered-serial stream with missing tree Name: ensure exception thrown from PTree::deserializeSelf(IBufferedSerialInputStream)
+    void testMalformedStreamTruncatedName()
+    {
+        Owned<IPropertyTree> original{createPTree(treeRootName)};
+
+        expectTruncatedStreamFailure(*original, 0, "PTree deserialization error: end of stream, expected name", "name read test");
     }
 };
 

--- a/testing/unittests/jlibtests.cpp
+++ b/testing/unittests/jlibtests.cpp
@@ -3628,10 +3628,7 @@ IPropertyTree *createBinaryDataCompressionTestPTree(const char *testXml)
  * testRoundTripForRootOnlyPTree                              - Tests round-trip serialization/deserialization for a PTree with only a root node
  * testRoundTripForCompatibilityConfigPropertyTree            - Tests round-trip serialization/deserialization for a complex compatibility config PTree
  * testRoundTripForBinaryDataCompressionTestPTree             - Tests round-trip serialization/deserialization for a PTree with various binary data sizes
- * testMalformedStreamMissingAttributeListTerminators         - Tests deserialization error handling for missing attribute list terminators
- * testMalformedStreamMissingAttributeValue                   - Tests deserialization error handling for missing attribute values
- * testMalformedStreamTruncatedName                           - Tests deserialization error handling for truncated names
- * testMultiThreadedSerializationAndDeserializationOfAtomTree - Tests thread safety of Atom Tree serialization/deserialization with multiple threads
+ * testMalformedStreamTruncations                             - Tests deserialization error handling for deterministic truncation offsets
  */
 
 class PTreeSerializationDeserializationTest : public CppUnit::TestFixture
@@ -3641,10 +3638,7 @@ class PTreeSerializationDeserializationTest : public CppUnit::TestFixture
     CPPUNIT_TEST(testRoundTripForRootOnlyPTree);
     CPPUNIT_TEST(testRoundTripForCompatibilityConfigPropertyTree);
     CPPUNIT_TEST(testRoundTripForBinaryDataCompressionTestPTree);
-    CPPUNIT_TEST(testMalformedStreamMissingAttributeListTerminators);
-    CPPUNIT_TEST(testMalformedStreamMissingAttributeValue);
-    CPPUNIT_TEST(testMalformedStreamTruncatedName);
-    CPPUNIT_TEST(testMultiThreadedSerializationAndDeserializationOfAtomTree);
+    CPPUNIT_TEST(testMalformedStreamTruncations);
     CPPUNIT_TEST_SUITE_END();
 
 protected:
@@ -3664,8 +3658,7 @@ protected:
         "    </Policies>"
         "  </Cache>"
         "</Configuration>"};
-    static constexpr const char *treeRootName{"Root"};
-    static constexpr unsigned int treeRootNameLength{4};
+    static const std::string treeRootName;
 
     // Complete round-trip test method that performs serialization, deserialization, and validation
     void performRoundTripTest(const char *testName, IPropertyTree *tree)
@@ -3771,48 +3764,30 @@ protected:
         DBGLOG("=== ROUND-TRIP TEST COMPLETED SUCCESSFULLY");
     }
 
-    void expectTruncatedStreamFailure(IPropertyTree &tree, size32_t truncationOffset, const char *expectedSubstring, const char *contextDescription)
+    void expectTruncatedStreamFailure(const MemoryBuffer &serialized, size32_t truncationOffset, const char *contextDescription)
     {
-        MemoryBuffer fullySerialized;
-        Owned<IBufferedSerialOutputStream> out{createBufferedSerialOutputStream(fullySerialized)};
-        tree.serializeToStream(*out);
-        out->flush();
-
         {
-            size32_t totalLength{fullySerialized.length()};
             VStringBuffer assertMsg("Serialized stream shorter than truncation offset for %s", contextDescription);
-            CPPUNIT_ASSERT_MESSAGE(assertMsg.str(), truncationOffset < totalLength);
+            CPPUNIT_ASSERT_MESSAGE(assertMsg.str(), truncationOffset < serialized.length());
         }
 
         MemoryBuffer truncated;
-        truncated.append(truncationOffset, fullySerialized.toByteArray());
+        truncated.append(truncationOffset, serialized.toByteArray());
         Owned<IBufferedSerialInputStream> in{createBufferedSerialInputStream(truncated)};
-        bool hitExpectedException{false};
         try
         {
             createPTreeFromBinary(*in, ipt_none);
+            CPPUNIT_FAIL(VStringBuffer("Expected createPTreeFromBinary to fail for %s", contextDescription).str());
         }
         catch (IException *e)
         {
             StringBuffer actualMsg;
             e->errorMessage(actualMsg);
             e->Release();
-            const char *actualMsgChars{actualMsg.str()};
-            if (actualMsgChars && strstr(actualMsgChars, expectedSubstring))
-            {
-                hitExpectedException = true;
-            }
-            else
-            {
-                VStringBuffer detail("Caught unexpected exception during %s: %s", contextDescription, actualMsgChars ? actualMsgChars : "<null>");
-                CPPUNIT_FAIL(detail.str());
-            }
-        }
-
-        if (!hitExpectedException)
-        {
-            VStringBuffer detail("Did not hit expected exception substring '%s' during %s", expectedSubstring, contextDescription);
-            CPPUNIT_FAIL(detail.str());
+            const char *actualMsgChars = actualMsg.str();
+            bool isExpectedDeserializationFailure = (strstr(actualMsgChars, "PTree deserialization error") != nullptr) || (strstr(actualMsgChars, "Failed to read the expected number of bytes") != nullptr);
+            if (!isExpectedDeserializationFailure)
+                CPPUNIT_FAIL(VStringBuffer("Caught unexpected error during %s: %s", contextDescription, nullText(actualMsgChars)).str());
         }
     }
 
@@ -3833,343 +3808,46 @@ public:
         performRoundTripTest(__func__, createBinaryDataCompressionTestPTree(testXml));
     }
 
-    class AtomTreeSerializationTestThread : public Thread
+    // Malformed buffered-serial stream truncations test: ensure deserialize errors are reported without relying on specific format offsets
+    void testMalformedStreamTruncations()
     {
-    public:
-        AtomTreeSerializationTestThread(unsigned _index,
-                                        Semaphore &_startSem,
-                                        CriticalSection &_errorCs,
-                                        StringBuffer &_errorMessages,
-                                        IPropertyTree &_originalTree)
-            : Thread("AtomTreeSerializationTestThread"),
-              threadIndex(_index),
-              startSem(_startSem),
-              errorCs(_errorCs),
-              errorMessages(_errorMessages),
-              originalTree(_originalTree)
-        {
-        }
-
-        // Clone the shared template originalTree, apply per-thread mutations, then serialize/deserialize and verify equality
-        virtual int run() override
-        {
-            // Wait for the coordinated start gate so all threads begin together
-            startSem.wait();
-            try
-            {
-                // Duplicate the shared template using low-memory mode so that isolate per-thread mutations can be applied
-                Owned<IPropertyTree> expected{createPTreeFromIPT(&originalTree, ipt_lowmem)};
-
-                VStringBuffer threadTag("worker_%u", threadIndex);
-                expected->setProp("@threadId", threadTag.str());
-                IPropertyTree *settings{expected->queryPropTree("settings")};
-                if (settings)
-                {
-                    // Stamp per-thread identifiers and thresholds onto the settings subtree
-                    settings->setProp("@worker", threadTag.str());
-                    settings->setProp("threshold", VStringBuffer("%u", 42 + threadIndex).str());
-
-                    IPropertyTree *alpha{settings->queryPropTree("option[@name=\"alpha\"]")};
-                    if (alpha)
-                        alpha->setProp("value", VStringBuffer("alpha_value_%u", threadIndex).str());
-                    IPropertyTree *beta{settings->queryPropTree("option[@name=\"beta\"]")};
-                    if (beta)
-                        beta->setProp("value", VStringBuffer("beta_value_%u", threadIndex).str());
-                }
-                // Build a binary payload to exercise binary serialization
-                MemoryBuffer payload;
-                for (unsigned idx{0}; idx < 2048; ++idx)
-                    payload.append((byte)((idx + threadIndex) % 256));
-                expected->setPropBin("binaryPayload", payload.length(), payload.toByteArray());
-                IPropertyTree *clusters{expected->queryPropTree("clusters")};
-                if (clusters)
-                {
-                    unsigned clusterIndex{0};
-                    Owned<IPropertyTreeIterator> iter{clusters->getElements("cluster")};
-                    ForEach(*iter)
-                    {
-                        // Stamp per-cluster descriptions and attach binary payload variants
-                        IPropertyTree &cluster{iter->query()};
-                        cluster.setProp("description", VStringBuffer("Example cluster entry thread %u index %u", threadIndex, clusterIndex).str());
-                        cluster.setPropInt("@threadId", threadIndex);
-
-                        MemoryBuffer clusterPayload;
-                        clusterPayload.append(sizeof(threadIndex), &threadIndex);
-                        clusterPayload.append(sizeof(clusterIndex), &clusterIndex);
-                        cluster.setPropBin("payload", clusterPayload.length(), clusterPayload.toByteArray());
-                        ++clusterIndex;
-                    }
-                }
-                IPropertyTree *metrics{expected->queryPropTree("metrics")};
-                if (metrics)
-                {
-                    // Flip metrics attributes based on the thread id to vary content
-                    metrics->setProp("@enabled", (threadIndex % 2 == 0) ? "true" : "false");
-                    metrics->setProp("@thread", threadTag.str());
-                    metrics->setProp("sampleInterval", VStringBuffer("%u.%02u", threadIndex + 1, threadIndex).str());
-                }
-
-                MemoryBuffer serialized;
-                {
-                    Owned<IBufferedSerialOutputStream> out{createBufferedSerialOutputStream(serialized)};
-                    expected->serializeToStream(*out);
-                    out->flush();
-                }
-
-                {
-                    size32_t serializedLength{serialized.length()};
-                    if (!serializedLength)
-                    {
-                        CriticalBlock block(errorCs);
-                        errorMessages.appendf("Thread %u: serialization produced empty buffer\n", threadIndex);
-                        return 0;
-                    }
-                }
-
-                // Deserialize and verify the resulting tree matches the expected structure
-                Owned<IBufferedSerialInputStream> in{createBufferedSerialInputStream(serialized)};
-                Owned<IPropertyTree> deserialized{createPTreeFromBinary(*in, ipt_lowmem)};
-                if (!areMatchingPTrees(expected, deserialized))
-                {
-                    CriticalBlock block(errorCs);
-                    errorMessages.appendf("Thread %u: deserialized tree mismatch for root %s\n", threadIndex, expected->queryName());
-                }
-            }
-            catch (IException *e)
-            {
-                StringBuffer msg;
-                e->errorMessage(msg);
-                e->Release();
-                CriticalBlock block(errorCs);
-                errorMessages.appendf("Thread %u: %s\n", threadIndex, msg.str());
-            }
-            catch (...)
-            {
-                CriticalBlock block(errorCs);
-                errorMessages.appendf("Thread %u: unknown exception\n", threadIndex);
-            }
-
-            return 0;
-        }
-
-    private:
-        unsigned threadIndex{0};
-        Semaphore &startSem;
-        CriticalSection &errorCs;
-        StringBuffer &errorMessages;
-        IPropertyTree &originalTree;
-    };
-
-private:
-    static Owned<IPropertyTree> createSeededAtomTreeTemplate()
-    {
-        Owned<IPropertyTree> originalTree{createPTree("MultiThreadRoot", ipt_lowmem)};
-        CPPUNIT_ASSERT(originalTree != nullptr);
-
-        // Seed shared tree with structures to be exercised in per-thread mutations
-        IPropertyTree *settings{originalTree->addPropTree("settings")};
-        settings->setProp("@profile", "default");
-        settings->setProp("@worker", "seed");
-        settings->setProp("threshold", "42");
-
-        IPropertyTree *alpha{settings->addPropTree("option")};
-        alpha->setProp("@name", "alpha");
-        alpha->setProp("value", "alpha_value_seed");
-
-        IPropertyTree *beta{settings->addPropTree("option")};
-        beta->setProp("@name", "beta");
-        beta->setProp("value", "beta_value_seed");
-
-        IPropertyTree *clusters{originalTree->addPropTree("clusters")};
-        for (unsigned i{0}; i < 3; ++i)
-        {
-            IPropertyTree *cluster{clusters->addPropTree("cluster")};
-            cluster->setProp("@id", VStringBuffer("cluster_%u", i).str());
-            cluster->setProp("description", "initial cluster entry");
-        }
-
-        IPropertyTree *metrics{originalTree->addPropTree("metrics")};
-        metrics->setProp("@enabled", "true");
-        metrics->setProp("@thread", "seed");
-        metrics->setProp("sampleInterval", "1.00");
-
-        return originalTree.getClear();
-    }
-
-    static unsigned joinAllWorkersWithTimeout(IArrayOf<AtomTreeSerializationTestThread> &workers, unsigned totalTimeoutMs, StringBuffer &timeoutMessages)
-    {
-        using Clock = std::chrono::steady_clock;
-        Clock::time_point deadline{Clock::now() + std::chrono::milliseconds(totalTimeoutMs)};
-        unsigned timedOut{0};
-        for (unsigned i{0}; i < workers.ordinality(); ++i)
-        {
-            Clock::time_point now{Clock::now()};
-            if (now >= deadline)
-            {
-                ++timedOut;
-                timeoutMessages.appendf("Thread %u did not finish before total timeout of %u ms\n", i, totalTimeoutMs);
-                continue;
-            }
-
-            auto remainingMs64bit{std::chrono::duration_cast<std::chrono::milliseconds>(deadline - now).count()};
-            unsigned remainingMs{remainingMs64bit > 0 ? static_cast<unsigned>(remainingMs64bit) : 0U};
-
-            if (!workers.item(i).join(remainingMs))
-            {
-                ++timedOut;
-                timeoutMessages.appendf("Thread %u did not finish within total timeout (remaining %u ms of %u ms)\n", i, remainingMs, totalTimeoutMs);
-            }
-        }
-        return timedOut;
-    }
-
-    static void startAtomTreeWorkers(IArrayOf<AtomTreeSerializationTestThread> &workers,
-                                     unsigned numThreads,
-                                     Semaphore &startSem,
-                                     CriticalSection &errorCs,
-                                     StringBuffer &errorMessages,
-                                     IPropertyTree &originalTree)
-    {
-        for (unsigned i{0}; i < numThreads; ++i)
-        {
-            // All threads share the same originalTree, but each creates its own modified copy
-            // After deserialization, each thread compares its own expected vs actual trees
-            AtomTreeSerializationTestThread *worker{new AtomTreeSerializationTestThread(i, startSem, errorCs, errorMessages, originalTree)};
-            workers.append(*worker);
-            worker->start(false);
-        }
-        startSem.signal(numThreads);
-    }
-
-    struct WorkerCompletionGuard
-    {
-        IArrayOf<AtomTreeSerializationTestThread> &workers;
-        unsigned cleanupTimeoutMs;
-
-        WorkerCompletionGuard(IArrayOf<AtomTreeSerializationTestThread> &_workers, unsigned _cleanupTimeoutMs)
-            : workers(_workers), cleanupTimeoutMs(_cleanupTimeoutMs)
-        {
-        }
-
-        ~WorkerCompletionGuard()
-        {
-            StringBuffer cleanupTimeoutMessages;
-            unsigned timedOut{PTreeSerializationDeserializationTest::joinAllWorkersWithTimeout(workers, cleanupTimeoutMs, cleanupTimeoutMessages)};
-            if (timedOut)
-                DBGLOG("Cleanup wait detected %u stalled threads; waiting indefinitely for teardown\n%s", timedOut, cleanupTimeoutMessages.str());
-            for (unsigned i{0}; i < workers.ordinality(); ++i)
-                workers.item(i).join(INFINITE);
-        }
-    };
-
-public:
-
-    // Multi-threaded serialization/deserialization tests to ensure thread safety with unique Atom trees per thread
-    void testMultiThreadedSerializationAndDeserializationOfAtomTree()
-    {
-        try
-        {
-            constexpr unsigned numThreads{50};
-            constexpr unsigned fiveSeconds{5000};
-            constexpr unsigned joinTimeoutMs{fiveSeconds};
-            constexpr unsigned tenSeconds{10000};
-            constexpr unsigned cleanupTimeoutMs{tenSeconds};
-            IArrayOf<AtomTreeSerializationTestThread> workers;
-
-            CriticalSection errorCs;
-            StringBuffer errorMessages;
-            Semaphore startSem; // zero-initialized; used as a start gate
-
-            Owned<IPropertyTree> originalTree{createSeededAtomTreeTemplate()};
-
-            // Ensure worker threads cannot outlive stack locals even when the test fails
-            WorkerCompletionGuard workerCompletionGuard{workers, cleanupTimeoutMs};
-
-            try
-            {
-                startAtomTreeWorkers(workers, numThreads, startSem, errorCs, errorMessages, *originalTree);
-            }
-            catch (const std::exception &e)
-            {
-                startSem.signal(numThreads);
-                StringBuffer joinTimeoutMessages;
-                joinAllWorkersWithTimeout(workers, joinTimeoutMs, joinTimeoutMessages); // We have a specific exception so ignore any join timeouts here
-                CPPUNIT_FAIL(VStringBuffer("Exception while creating worker threads: %s", e.what()).str());
-            }
-            catch (...)
-            {
-                startSem.signal(numThreads);
-                StringBuffer joinTimeoutMessages;
-                unsigned timedOut{joinAllWorkersWithTimeout(workers, joinTimeoutMs, joinTimeoutMessages)}; // no specific exception so report any join timeouts
-                if (timedOut)
-                    DBGLOG("joinAllWorkersWithTimeout detected %u stalled threads during worker creation failure\n%s", timedOut, joinTimeoutMessages.str());
-                CPPUNIT_FAIL("Unknown exception while creating worker threads");
-            }
-
-            StringBuffer joinTimeoutMessages;
-            unsigned timedOut{joinAllWorkersWithTimeout(workers, joinTimeoutMs, joinTimeoutMessages)};
-            if (timedOut)
-            {
-                DBGLOG("joinAllWorkersWithTimeout detected %u stalled threads after normal completion\n%s", timedOut, joinTimeoutMessages.str());
-                VStringBuffer timeoutMsg("Timed out waiting for %u worker threads\n%s", timedOut, joinTimeoutMessages.str());
-                CPPUNIT_FAIL(timeoutMsg.str());
-            }
-
-            CPPUNIT_ASSERT_MESSAGE(errorMessages.length() ? errorMessages.str() : "Multi-threaded AtomTree ipt_lowmem deserialization failed", (errorMessages.length() == 0));
-        }
-        catch (IException *e)
-        {
-            StringBuffer msg;
-            e->errorMessage(msg);
-            e->Release();
-            CPPUNIT_FAIL(VStringBuffer("Unexpected IException in testMultiThreadedSerializationAndDeserializationOfAtomTree: %s", msg.str()).str());
-        }
-        catch (const std::exception &e)
-        {
-            CPPUNIT_FAIL(VStringBuffer("Unexpected std::exception in testMultiThreadedSerializationAndDeserializationOfAtomTree: %s", e.what()).str());
-        }
-        catch (...)
-        {
-            CPPUNIT_FAIL("Unexpected unknown exception in testMultiThreadedSerializationAndDeserializationOfAtomTree");
-        }
-    }
-
-    // Malformed buffered-serial stream with missing attribute list terminators: ensure exception thrown from PTree::deserializeSelf(IBufferedSerialInputStream)
-    void testMalformedStreamMissingAttributeListTerminators()
-    {
-        Owned<IPropertyTree> original{createPTree(treeRootName)};
+        Owned<IPropertyTree> original{createPTree(treeRootName.c_str())};
+        original->setProp("@scenario", "truncation-test");
         original->setProp("child", "value");
-        constexpr unsigned int nullTerminatorSize{1};
-        constexpr unsigned int flagsSize{1};
-        size32_t flagsEnd{treeRootNameLength + nullTerminatorSize + flagsSize};
 
-        expectTruncatedStreamFailure(*original, flagsEnd, "PTree deserialization error: end of stream, expected attribute name", "attribute name test");
-    }
+        MemoryBuffer payload;
+        for (unsigned i = 0; i < 32; ++i)
+            payload.append((byte)i);
+        original->setPropBin("binaryPayload", payload.length(), payload.toByteArray());
 
-    // Malformed buffered-serial stream with missing Value attribute: ensure exception thrown from PTree::deserializeSelf(IBufferedSerialInputStream)
-    void testMalformedStreamMissingAttributeValue()
-    {
-        constexpr const char *attrName{"@incomplete"};
-        constexpr unsigned int attrNameLength{11};
-        constexpr const char *attrValue{"value"};
-        Owned<IPropertyTree> original{createPTree(treeRootName)};
-        original->setProp(attrName, attrValue);
-        constexpr size32_t nullTerminatorSize{1};
-        constexpr size32_t flagsSize{1};
-        constexpr size32_t attributeSectionOffset{treeRootNameLength + nullTerminatorSize + flagsSize};
-        constexpr size32_t truncationPoint{attributeSectionOffset + attrNameLength + nullTerminatorSize};
+        MemoryBuffer serialized;
+        Owned<IBufferedSerialOutputStream> out{createBufferedSerialOutputStream(serialized)};
+        original->serializeToStream(*out);
+        out->flush();
 
-        expectTruncatedStreamFailure(*original, truncationPoint, "PTree deserialization error: end of stream, expected attribute value", "attribute value test");
-    }
+        size32_t totalLength = serialized.length();
+        CPPUNIT_ASSERT_MESSAGE("Serialized stream unexpectedly short for truncation test", totalLength > 1);
 
-    // Malformed buffered-serial stream with missing tree Name: ensure exception thrown from PTree::deserializeSelf(IBufferedSerialInputStream)
-    void testMalformedStreamTruncatedName()
-    {
-        Owned<IPropertyTree> original{createPTree(treeRootName)};
+        size32_t step = totalLength / 11; // Test 11 truncation points across the stream
+        if (step == 0)
+            step = 1;
 
-        expectTruncatedStreamFailure(*original, 0, "PTree deserialization error: end of stream, expected name", "name read test");
+        for (size32_t truncationOffset = 0; truncationOffset < totalLength; truncationOffset += step)
+        {
+            VStringBuffer context("truncation test at offset %u of %u", truncationOffset, totalLength);
+            expectTruncatedStreamFailure(serialized, truncationOffset, context.str());
+        }
+
+        size32_t lastOffset = totalLength - 1;
+        if ((lastOffset % step) != 0)
+        {
+            VStringBuffer context("truncation test final offset %u of %u", lastOffset, totalLength);
+            expectTruncatedStreamFailure(serialized, lastOffset, context.str());
+        }
     }
 };
+
+const std::string PTreeSerializationDeserializationTest::treeRootName{"Root"};
 
 CPPUNIT_TEST_SUITE_REGISTRATION(PTreeSerializationDeserializationTest);
 CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(PTreeSerializationDeserializationTest, "PTreeSerializationDeserializationTest");

--- a/testing/unittests/jlibtests.cpp
+++ b/testing/unittests/jlibtests.cpp
@@ -3658,7 +3658,6 @@ protected:
         "    </Policies>"
         "  </Cache>"
         "</Configuration>"};
-    static const std::string treeRootName;
 
     // Complete round-trip test method that performs serialization, deserialization, and validation
     void performRoundTripTest(const char *testName, IPropertyTree *tree)
@@ -3766,17 +3765,15 @@ protected:
 
     void expectTruncatedStreamFailure(const MemoryBuffer &serialized, size32_t truncationOffset, const char *contextDescription)
     {
-        {
-            VStringBuffer assertMsg("Serialized stream shorter than truncation offset for %s", contextDescription);
-            CPPUNIT_ASSERT_MESSAGE(assertMsg.str(), truncationOffset < serialized.length());
-        }
+        VStringBuffer assertMsg("Serialized stream shorter than truncation offset for %s", contextDescription);
+        CPPUNIT_ASSERT_MESSAGE(assertMsg.str(), truncationOffset < serialized.length());
 
         MemoryBuffer truncated;
         truncated.append(truncationOffset, serialized.toByteArray());
         Owned<IBufferedSerialInputStream> in{createBufferedSerialInputStream(truncated)};
         try
         {
-            createPTreeFromBinary(*in, ipt_none);
+            Owned<IPropertyTree> unexpected{createPTreeFromBinary(*in, ipt_none)};
             CPPUNIT_FAIL(VStringBuffer("Expected createPTreeFromBinary to fail for %s", contextDescription).str());
         }
         catch (IException *e)
@@ -3811,7 +3808,7 @@ public:
     // Malformed buffered-serial stream truncations test: ensure deserialize errors are reported without relying on specific format offsets
     void testMalformedStreamTruncations()
     {
-        Owned<IPropertyTree> original{createPTree(treeRootName.c_str())};
+        Owned<IPropertyTree> original{createPTree("root")};
         original->setProp("@scenario", "truncation-test");
         original->setProp("child", "value");
 
@@ -3846,8 +3843,6 @@ public:
         }
     }
 };
-
-const std::string PTreeSerializationDeserializationTest::treeRootName{"Root"};
 
 CPPUNIT_TEST_SUITE_REGISTRATION(PTreeSerializationDeserializationTest);
 CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(PTreeSerializationDeserializationTest, "PTreeSerializationDeserializationTest");


### PR DESCRIPTION
Add unit tests for jptree malformed content and parallel access testing.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [x] Send notifications about my Pull Request position in Smoketest queue.
- [x] Test my draft Pull Request.

## Testing:
Running `PTreeSerializationDeserializationTest` in release produces the following output:

```
09:26:19.335430 11527 UNK UNK Adding default library location /home/dave/build/Release-install/Release/lib/
09:26:19.338606 11527 UNK UNK Including test PTreeSerializationDeserializationTest
.09:26:19.338735 11527 UNK UNK === ROUND-TRIP TEST STARTED FOR: testRoundTripForRootOnlyPTree ===
09:26:19.338753 11527 UNK UNK === SERIALIZATION TEST RESULTS:
09:26:19.338756 11527 UNK UNK   serialize() time: 0.010546 ms
09:26:19.338774 11527 UNK UNK   serializeToStream() time: 0.003249 ms
09:26:19.338778 11527 UNK UNK   Performance ratio (serializeToStream/serialize): 0.308079
09:26:19.338796 11527 UNK UNK   serialize()/serializeToStream() data size: 17 bytes
09:26:19.338812 11527 UNK UNK === DESERIALIZATION TEST RESULTS:
09:26:19.338816 11527 UNK UNK   deserialize() time: 0.003773 ms
09:26:19.338820 11527 UNK UNK   deserializeFromStream() time: 0.004051 ms
09:26:19.338822 11527 UNK UNK   Performance ratio (deserializeFromStream/deserialize): 1.073681
09:26:19.338825 11527 UNK UNK === ROUND-TRIP TEST COMPLETED SUCCESSFULLY
.09:26:19.339348 11527 UNK UNK === ROUND-TRIP TEST STARTED FOR: testRoundTripForCompatibilityConfigPropertyTree ===
09:26:19.339372 11527 UNK UNK === SERIALIZATION TEST RESULTS:
09:26:19.339375 11527 UNK UNK   serialize() time: 0.034097 ms
09:26:19.339378 11527 UNK UNK   serializeToStream() time: 0.035074 ms
09:26:19.339379 11527 UNK UNK   Performance ratio (serializeToStream/serialize): 1.028654
09:26:19.339381 11527 UNK UNK   serialize()/serializeToStream() data size: 3330 bytes
09:26:19.339383 11527 UNK UNK === DESERIALIZATION TEST RESULTS:
09:26:19.339385 11527 UNK UNK   deserialize() time: 0.102645 ms
09:26:19.339387 11527 UNK UNK   deserializeFromStream() time: 0.037287 ms
09:26:19.339388 11527 UNK UNK   Performance ratio (deserializeFromStream/deserialize): 0.363262
09:26:19.339390 11527 UNK UNK === ROUND-TRIP TEST COMPLETED SUCCESSFULLY
.09:26:19.340784 11527 UNK UNK === ROUND-TRIP TEST STARTED FOR: testRoundTripForBinaryDataCompressionTestPTree ===
09:26:19.340809 11527 UNK UNK === SERIALIZATION TEST RESULTS:
09:26:19.340813 11527 UNK UNK   serialize() time: 0.005657 ms
09:26:19.340816 11527 UNK UNK   serializeToStream() time: 0.002581 ms
09:26:19.340818 11527 UNK UNK   Performance ratio (serializeToStream/serialize): 0.456249
09:26:19.340819 11527 UNK UNK   serialize()/serializeToStream() data size: 4447 bytes
09:26:19.340821 11527 UNK UNK === DESERIALIZATION TEST RESULTS:
09:26:19.340823 11527 UNK UNK   deserialize() time: 0.006237 ms
09:26:19.340825 11527 UNK UNK   deserializeFromStream() time: 0.005432 ms
09:26:19.340827 11527 UNK UNK   Performance ratio (deserializeFromStream/deserialize): 0.870932
09:26:19.340829 11527 UNK UNK === ROUND-TRIP TEST COMPLETED SUCCESSFULLY
.09:26:19.340847 11527 UNK UNK Backtrace:
09:26:19.342881 11527 UNK UNK   /home/dave/build/Release-install/Release/libs/libjlib.so(_Z16printStackReportx+0x5c) [0x7ffff6f0dffc]
09:26:19.342910 11527 UNK UNK   /home/dave/build/Release-install/Release/libs/libjlib.so(_Z24throwUnexpectedExceptionPKcS0_S0_j+0x1e) [0x7ffff6f0e1ae]
09:26:19.342913 11527 UNK UNK   /home/dave/build/Release-install/Release/libs/libjlib.so(_ZN5PTree15deserializeSelfER26IBufferedSerialInputStream+0x120) [0x7ffff6f90060]
09:26:19.342928 11527 UNK UNK   /home/dave/build/Release-install/Release/libs/libjlib.so(_ZN5PTree21deserializeFromStreamER26IBufferedSerialInputStreamR23PTreeDeserializeContext+0x35) [0x7ffff6f90225]
09:26:19.342963 11527 UNK UNK   /home/dave/build/Release-install/Release/libs/libjlib.so(_Z21createPTreeFromBinaryR26IBufferedSerialInputStreamh+0x40) [0x7ffff6f96600]
09:26:19.342966 11527 UNK UNK   /home/dave/build/Release-install/Release/bin/unittests(+0xd91ed) [0x55555562d1ed]
09:26:19.342968 11527 UNK UNK   /home/dave/build/Release-install/Release/bin/unittests(+0x16cf6e) [0x5555556c0f6e]
09:26:19.342970 11527 UNK UNK   /home/dave/build/Release-install/vcpkg_installed/x64-linux-dynamic/lib/libcppunit-1.15.so.1(_ZNK7CppUnit21TestCaseMethodFunctorclEv+0x26) [0x7ffff7e84126]
09:26:19.342974 11527 UNK UNK   /home/dave/build/Release-install/vcpkg_installed/x64-linux-dynamic/lib/libcppunit-1.15.so.1(_ZN7CppUnit16DefaultProtector7protectERKNS_7FunctorERKNS_16ProtectorContextE+0x35) [0x7ffff7e795c5]
09:26:19.342992 11527 UNK UNK   /home/dave/build/Release-install/vcpkg_installed/x64-linux-dynamic/lib/libcppunit-1.15.so.1(_ZN7CppUnit14ProtectorChain7protectERKNS_7FunctorERKNS_16ProtectorContextE+0x318) [0x7ffff7e81038]
09:26:19.342997 11527 UNK UNK   /home/dave/build/Release-install/vcpkg_installed/x64-linux-dynamic/lib/libcppunit-1.15.so.1(_ZN7CppUnit10TestResult7protectERKNS_7FunctorEPNS_4TestERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE+0x94) [0x7ffff7e8bd64]
09:26:19.343001 11527 UNK UNK   /home/dave/build/Release-install/vcpkg_installed/x64-linux-dynamic/lib/libcppunit-1.15.so.1(_ZN7CppUnit8TestCase3runEPNS_10TestResultE+0x130) [0x7ffff7e83d80]
09:26:19.343005 11527 UNK UNK   /home/dave/build/Release-install/vcpkg_installed/x64-linux-dynamic/lib/libcppunit-1.15.so.1(_ZN7CppUnit13TestComposite15doRunChildTestsEPNS_10TestResultE+0x43) [0x7ffff7e84453]
09:26:19.343008 11527 UNK UNK   /home/dave/build/Release-install/vcpkg_installed/x64-linux-dynamic/lib/libcppunit-1.15.so.1(_ZN7CppUnit13TestComposite3runEPNS_10TestResultE+0x3d) [0x7ffff7e844dd]
09:26:19.343011 11527 UNK UNK   /home/dave/build/Release-install/vcpkg_installed/x64-linux-dynamic/lib/libcppunit-1.15.so.1(_ZN7CppUnit10TestResult7runTestEPNS_4TestE+0x27) [0x7ffff7e8bc87]
09:26:19.343014 11527 UNK UNK   /home/dave/build/Release-install/vcpkg_installed/x64-linux-dynamic/lib/libcppunit-1.15.so.1(_ZN7CppUnit10TestRunner3runERNS_10TestResultERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE+0x43) [0x7ffff7e8e803]
09:26:19.343016 11527 UNK UNK   /home/dave/build/Release-install/vcpkg_installed/x64-linux-dynamic/lib/libcppunit-1.15.so.1(_ZN7CppUnit14TextTestRunner3runENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEbbb+0x74) [0x7ffff7e90b04]
09:26:19.343019 11527 UNK UNK   /home/dave/build/Release-install/Release/bin/unittests(+0x73e39) [0x5555555c7e39]
09:26:19.343023 11527 UNK UNK   /lib/x86_64-linux-gnu/libc.so.6(+0x29d90) [0x7ffff6629d90]
09:26:19.343026 11527 UNK UNK   /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0x80) [0x7ffff6629e40]
09:26:19.343044 11527 UNK UNK   /home/dave/build/Release-install/Release/bin/unittests(+0x77dd5) [0x5555555cbdd5]
.09:26:19.343207 11527 UNK UNK Backtrace:
09:26:19.343512 11527 UNK UNK   /home/dave/build/Release-install/Release/libs/libjlib.so(_Z16printStackReportx+0x5c) [0x7ffff6f0dffc]
09:26:19.343529 11527 UNK UNK   /home/dave/build/Release-install/Release/libs/libjlib.so(_Z24throwUnexpectedExceptionPKcS0_S0_j+0x1e) [0x7ffff6f0e1ae]
09:26:19.343533 11527 UNK UNK   /home/dave/build/Release-install/Release/libs/libjlib.so(_ZN5PTree15deserializeSelfER26IBufferedSerialInputStream+0x26b) [0x7ffff6f901ab]
09:26:19.343535 11527 UNK UNK   /home/dave/build/Release-install/Release/libs/libjlib.so(_ZN5PTree21deserializeFromStreamER26IBufferedSerialInputStreamR23PTreeDeserializeContext+0x35) [0x7ffff6f90225]
09:26:19.343537 11527 UNK UNK   /home/dave/build/Release-install/Release/libs/libjlib.so(_Z21createPTreeFromBinaryR26IBufferedSerialInputStreamh+0x40) [0x7ffff6f96600]
09:26:19.343538 11527 UNK UNK   /home/dave/build/Release-install/Release/bin/unittests(+0xd91ed) [0x55555562d1ed]
09:26:19.343540 11527 UNK UNK   /home/dave/build/Release-install/Release/bin/unittests(+0x16cfee) [0x5555556c0fee]
09:26:19.343542 11527 UNK UNK   /home/dave/build/Release-install/vcpkg_installed/x64-linux-dynamic/lib/libcppunit-1.15.so.1(_ZNK7CppUnit21TestCaseMethodFunctorclEv+0x26) [0x7ffff7e84126]
09:26:19.343556 11527 UNK UNK   /home/dave/build/Release-install/vcpkg_installed/x64-linux-dynamic/lib/libcppunit-1.15.so.1(_ZN7CppUnit16DefaultProtector7protectERKNS_7FunctorERKNS_16ProtectorContextE+0x35) [0x7ffff7e795c5]
09:26:19.343562 11527 UNK UNK   /home/dave/build/Release-install/vcpkg_installed/x64-linux-dynamic/lib/libcppunit-1.15.so.1(_ZN7CppUnit14ProtectorChain7protectERKNS_7FunctorERKNS_16ProtectorContextE+0x318) [0x7ffff7e81038]
09:26:19.343565 11527 UNK UNK   /home/dave/build/Release-install/vcpkg_installed/x64-linux-dynamic/lib/libcppunit-1.15.so.1(_ZN7CppUnit10TestResult7protectERKNS_7FunctorEPNS_4TestERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE+0x94) [0x7ffff7e8bd64]
09:26:19.343568 11527 UNK UNK   /home/dave/build/Release-install/vcpkg_installed/x64-linux-dynamic/lib/libcppunit-1.15.so.1(_ZN7CppUnit8TestCase3runEPNS_10TestResultE+0x130) [0x7ffff7e83d80]
09:26:19.343570 11527 UNK UNK   /home/dave/build/Release-install/vcpkg_installed/x64-linux-dynamic/lib/libcppunit-1.15.so.1(_ZN7CppUnit13TestComposite15doRunChildTestsEPNS_10TestResultE+0x43) [0x7ffff7e84453]
09:26:19.343573 11527 UNK UNK   /home/dave/build/Release-install/vcpkg_installed/x64-linux-dynamic/lib/libcppunit-1.15.so.1(_ZN7CppUnit13TestComposite3runEPNS_10TestResultE+0x3d) [0x7ffff7e844dd]
09:26:19.343601 11527 UNK UNK   /home/dave/build/Release-install/vcpkg_installed/x64-linux-dynamic/lib/libcppunit-1.15.so.1(_ZN7CppUnit10TestResult7runTestEPNS_4TestE+0x27) [0x7ffff7e8bc87]
09:26:19.343630 11527 UNK UNK   /home/dave/build/Release-install/vcpkg_installed/x64-linux-dynamic/lib/libcppunit-1.15.so.1(_ZN7CppUnit10TestRunner3runERNS_10TestResultERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE+0x43) [0x7ffff7e8e803]
09:26:19.343648 11527 UNK UNK   /home/dave/build/Release-install/vcpkg_installed/x64-linux-dynamic/lib/libcppunit-1.15.so.1(_ZN7CppUnit14TextTestRunner3runENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEbbb+0x74) [0x7ffff7e90b04]
09:26:19.343654 11527 UNK UNK   /home/dave/build/Release-install/Release/bin/unittests(+0x73e39) [0x5555555c7e39]
09:26:19.343660 11527 UNK UNK   /lib/x86_64-linux-gnu/libc.so.6(+0x29d90) [0x7ffff6629d90]
09:26:19.343678 11527 UNK UNK   /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0x80) [0x7ffff6629e40]
09:26:19.343682 11527 UNK UNK   /home/dave/build/Release-install/Release/bin/unittests(+0x77dd5) [0x5555555cbdd5]
.09:26:19.343711 11527 UNK UNK Backtrace:
09:26:19.343916 11527 UNK UNK   /home/dave/build/Release-install/Release/libs/libjlib.so(_Z16printStackReportx+0x5c) [0x7ffff6f0dffc]
09:26:19.343935 11527 UNK UNK   /home/dave/build/Release-install/Release/libs/libjlib.so(_Z24throwUnexpectedExceptionPKcS0_S0_j+0x1e) [0x7ffff6f0e1ae]
09:26:19.343939 11527 UNK UNK   /home/dave/build/Release-install/Release/libs/libjlib.so(_ZN5PTree15deserializeSelfER26IBufferedSerialInputStream+0x297) [0x7ffff6f901d7]
09:26:19.343943 11527 UNK UNK   /home/dave/build/Release-install/Release/libs/libjlib.so(_ZN5PTree21deserializeFromStreamER26IBufferedSerialInputStreamR23PTreeDeserializeContext+0x35) [0x7ffff6f90225]
09:26:19.343946 11527 UNK UNK   /home/dave/build/Release-install/Release/libs/libjlib.so(_Z21createPTreeFromBinaryR26IBufferedSerialInputStreamh+0x40) [0x7ffff6f96600]
09:26:19.343965 11527 UNK UNK   /home/dave/build/Release-install/Release/bin/unittests(+0xd91ed) [0x55555562d1ed]
09:26:19.343985 11527 UNK UNK   /home/dave/build/Release-install/Release/bin/unittests(+0x16d054) [0x5555556c1054]
09:26:19.344005 11527 UNK UNK   /home/dave/build/Release-install/vcpkg_installed/x64-linux-dynamic/lib/libcppunit-1.15.so.1(_ZNK7CppUnit21TestCaseMethodFunctorclEv+0x26) [0x7ffff7e84126]
09:26:19.344013 11527 UNK UNK   /home/dave/build/Release-install/vcpkg_installed/x64-linux-dynamic/lib/libcppunit-1.15.so.1(_ZN7CppUnit16DefaultProtector7protectERKNS_7FunctorERKNS_16ProtectorContextE+0x35) [0x7ffff7e795c5]
09:26:19.344032 11527 UNK UNK   /home/dave/build/Release-install/vcpkg_installed/x64-linux-dynamic/lib/libcppunit-1.15.so.1(_ZN7CppUnit14ProtectorChain7protectERKNS_7FunctorERKNS_16ProtectorContextE+0x318) [0x7ffff7e81038]
09:26:19.344052 11527 UNK UNK   /home/dave/build/Release-install/vcpkg_installed/x64-linux-dynamic/lib/libcppunit-1.15.so.1(_ZN7CppUnit10TestResult7protectERKNS_7FunctorEPNS_4TestERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE+0x94) [0x7ffff7e8bd64]
09:26:19.344077 11527 UNK UNK   /home/dave/build/Release-install/vcpkg_installed/x64-linux-dynamic/lib/libcppunit-1.15.so.1(_ZN7CppUnit8TestCase3runEPNS_10TestResultE+0x130) [0x7ffff7e83d80]
09:26:19.344112 11527 UNK UNK   /home/dave/build/Release-install/vcpkg_installed/x64-linux-dynamic/lib/libcppunit-1.15.so.1(_ZN7CppUnit13TestComposite15doRunChildTestsEPNS_10TestResultE+0x43) [0x7ffff7e84453]
09:26:19.344118 11527 UNK UNK   /home/dave/build/Release-install/vcpkg_installed/x64-linux-dynamic/lib/libcppunit-1.15.so.1(_ZN7CppUnit13TestComposite3runEPNS_10TestResultE+0x3d) [0x7ffff7e844dd]
09:26:19.344137 11527 UNK UNK   /home/dave/build/Release-install/vcpkg_installed/x64-linux-dynamic/lib/libcppunit-1.15.so.1(_ZN7CppUnit10TestResult7runTestEPNS_4TestE+0x27) [0x7ffff7e8bc87]
09:26:19.344156 11527 UNK UNK   /home/dave/build/Release-install/vcpkg_installed/x64-linux-dynamic/lib/libcppunit-1.15.so.1(_ZN7CppUnit10TestRunner3runERNS_10TestResultERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE+0x43) [0x7ffff7e8e803]
09:26:19.344174 11527 UNK UNK   /home/dave/build/Release-install/vcpkg_installed/x64-linux-dynamic/lib/libcppunit-1.15.so.1(_ZN7CppUnit14TextTestRunner3runENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEbbb+0x74) [0x7ffff7e90b04]
09:26:19.344178 11527 UNK UNK   /home/dave/build/Release-install/Release/bin/unittests(+0x73e39) [0x5555555c7e39]
09:26:19.344179 11527 UNK UNK   /lib/x86_64-linux-gnu/libc.so.6(+0x29d90) [0x7ffff6629d90]
09:26:19.344182 11527 UNK UNK   /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0x80) [0x7ffff6629e40]
09:26:19.344184 11527 UNK UNK   /home/dave/build/Release-install/Release/bin/unittests(+0x77dd5) [0x5555555cbdd5]
.


OK (7 tests)
```
<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
