### PR TITLE
HPCC-35520 Support remote superfile copy operations

### DIFF
--- a/dali/base/dautils.hpp
+++ b/dali/base/dautils.hpp
@@ -56,7 +56,7 @@ class da_decl CDfsLogicalFileName
 {
     StringAttr lfn;
     unsigned tailpos;
-    unsigned localpos; // if 0 not foreign
+    unsigned localpos; // if 0 not foreign or remote
     StringAttr cluster; 
     CMultiDLFN *multi;   // for temp superfile
     bool external;
@@ -95,6 +95,7 @@ public:
     void setExternal(const char *location,const char *path);
     void setExternal(const SocketEndpoint &dafsip,const char *path);
     void setExternal(const RemoteFilename &rfn);
+    void setRemote(const char *remoteName, const char *logicalName);
     void setPlaneExternal(const char *planeName,const char *path);
     bool isExternal() const { return external; }
     bool isExternalPlane() const;
@@ -119,14 +120,14 @@ public:
     void setCluster(const char *cname); 
     StringBuffer &getCluster(StringBuffer &cname) const { return cname.append(cluster); }
 
-    const char *get(bool removeforeign=false) const;
-    StringBuffer &get(StringBuffer &str,bool removeforeign=false, bool withCluster=false) const;
+    const char *get(bool removeForeignOrRemote=false) const;
+    StringBuffer &get(StringBuffer &str,bool removeForeignOrRemote=false, bool withCluster=false) const;
     const char *queryTail() const;
     StringBuffer &getTail(StringBuffer &buf) const;
 
-    StringBuffer &getScopes(StringBuffer &buf,bool removeforeign=false) const;
-    unsigned numScopes(bool removeforeign=false) const; // not including tail
-    StringBuffer &getScope(StringBuffer &buf,unsigned idx,bool removeforeign=false) const;
+    StringBuffer &getScopes(StringBuffer &buf,bool removeForeignOrRemote=false) const;
+    unsigned numScopes(bool removeForeignOrRemote=false) const; // not including tail
+    StringBuffer &getScope(StringBuffer &buf,unsigned idx,bool removeForeignOrRemote=false) const;
 
     StringBuffer &makeScopeQuery(StringBuffer &query, bool absolute=true) const; // returns xpath for containing scope
     StringBuffer &makeFullnameQuery(StringBuffer &query, DfsXmlBranchKind kind, bool absolute=true) const; // return xpath for branch
@@ -155,7 +156,7 @@ public:
     void expand(IUserDescriptor *user);
 
 protected:
-    void normalizeName(const char * name, StringAttr &res, bool strict, bool nameIsRoot);
+    void normalizeName(const char * name, StringAttr &res, bool strict, bool nameIsRoot, bool stripLeadingSelfScope);
     bool normalizeExternal(const char * name, StringAttr &res, bool strict);
 };
 

--- a/esp/clients/ws_dfsclient/ws_dfsclient.cpp
+++ b/esp/clients/ws_dfsclient/ws_dfsclient.cpp
@@ -139,7 +139,14 @@ protected:
 public:
     CServiceDistributedFileBase(IDFSFile *_dfsFile) : dfsFile(_dfsFile)
     {
-        logicalName.set(dfsFile->queryFileMeta()->queryProp("@name"));
+        const char *remoteName = dfsFile->queryRemoteName();
+        const char *remoteLfnName = dfsFile->queryFileMeta()->queryProp("@name");
+        CDfsLogicalFileName dlfn;
+        if (!isEmptyString(remoteName))
+            dlfn.setRemote(remoteName, remoteLfnName);
+        else
+            dlfn.set(remoteLfnName);
+        logicalName.set(dlfn.get());
     }
 
     virtual unsigned numParts() override { return legacyDFSFile->numParts(); }

--- a/testing/unittests/dalitests.cpp
+++ b/testing/unittests/dalitests.cpp
@@ -3296,7 +3296,7 @@ public:
             try
             {
                 ASSERT(internalFile == normalizeExternal(lfn, res, false));
-                normalizeName(lfn, res, false, true);
+                normalizeName(lfn, res, false, true, false);
                 PROGLOG("res = '%s'", res.str());
                 ASSERT(fileNameMatch == streq(res.str(), validInternalLfns[nlfn][normalizedFileName]))
             }


### PR DESCRIPTION
This change enables FileServices.Copy to support copying remote and foriegn superfiles by using wsdfs:: lookup functions and properly walking the superfile structure.

Key changes:
- Added CDfsLogicalFileName::setRemote() method to construct remote file names
- Fixed isForeign() to check both localpos and foreignep to properly detect foreign files
- Added stripLeadingSelfScope parameter to normalizeName() to handle self-scope translation for remote files
- Renamed removeForeign parameter to removeForeignOrRemote throughout for clarity
- Updated doSuperForeignCopy in dfurun.cpp to use wsdfs::lookup instead of getFileTree
- Modified superfile iteration to use IDistributedFile and IDistributedFileIterator
- Updated ws_dfsclient to properly construct remote logical file names using setRemote()

The implementation now correctly handles both regular files and superfiles when copying from remote or foreign systems.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [ ] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
