### PR TITLE
HPCC-35671 Support remote/foreign superfile query operations

### DIFF
--- a/plugins/fileservices/fileservices.cpp
+++ b/plugins/fileservices/fileservices.cpp
@@ -1686,6 +1686,22 @@ static void CheckNotInTransaction(ICodeContext *ctx, const char *fn)
     }
 }
 
+static IDistributedSuperFile *lookupRemoteOrForeignSuper(ICodeContext *ctx, const char *caller, const char *superfn)
+{
+    CDfsLogicalFileName slfn;
+    slfn.set(superfn);
+    if (ctx->querySuperFileTransaction()->active())
+        throw makeStringExceptionV(0, "%s: Cannot access %s superfile %s within a transaction", caller, slfn.isRemote() ? "remote" : "foreign", superfn);
+    Owned<IDistributedFile> df = wsdfs::lookup(slfn, ctx->queryUserDescriptor(), AccessMode::readMeta, false, false, nullptr, defaultPrivilegedUser, INFINITE);
+    if (!df)
+        throw makeStringExceptionV(0, "%s: Could not locate superfile: %s", caller, slfn.get());
+    IDistributedSuperFile *superFile = df->querySuperFile();
+    if (!superFile)
+        throw makeStringExceptionV(0, "%s: File is not a superfile: %s", caller, slfn.get());
+    return LINK(superFile);
+}
+
+
 FILESERVICES_API void FILESERVICES_CALL fsCreateSuperFile(ICodeContext *ctx, const char *lsuperfn, bool sequentialparts, bool ifdoesnotexist)
 {
     IDistributedFileTransaction *transaction = ctx->querySuperFileTransaction();
@@ -1733,14 +1749,22 @@ FILESERVICES_API void FILESERVICES_CALL fsDeleteSuperFile(ICodeContext *ctx, con
 
 FILESERVICES_API unsigned FILESERVICES_CALL fsGetSuperFileSubCount(ICodeContext *ctx, const char *lsuperfn)
 {
-    Owned<ISimpleSuperFileEnquiry> enq = getSimpleSuperFileEnquiry(ctx, lsuperfn);
-    if (enq)
-        return enq->numSubFiles();
-    CImplicitSuperTransaction implicitTransaction(ctx->querySuperFileTransaction());
-    Owned<IDistributedSuperFile> file;
-    StringBuffer lsfn;
-    lookupSuperFile(ctx, lsuperfn, AccessMode::readMeta, file, true, lsfn, true);
-    return file->numSubFiles();
+    CDfsLogicalFileName slfn;
+    slfn.set(lsuperfn);
+    std::unique_ptr<CImplicitSuperTransaction> implicitTransaction;
+    Owned<IDistributedSuperFile> superFile;
+    if (slfn.isRemote() || slfn.isForeign())
+        superFile.setown(lookupRemoteOrForeignSuper(ctx, "fsGetSuperFileSubCount", lsuperfn));
+    else
+    {
+        Owned<ISimpleSuperFileEnquiry> enq = getSimpleSuperFileEnquiry(ctx, lsuperfn);
+        if (enq)
+            return enq->numSubFiles();
+        implicitTransaction = std::make_unique<CImplicitSuperTransaction>(ctx->querySuperFileTransaction());
+        StringBuffer lsfn;
+        lookupSuperFile(ctx, lsuperfn, AccessMode::readMeta, superFile, true, lsfn, true);
+    }
+    return superFile->numSubFiles();
 }
 
 FILESERVICES_API char *  FILESERVICES_CALL fsGetSuperFileSubName(ICodeContext *ctx, const char *lsuperfn,unsigned filenum, bool abspath)
@@ -1748,39 +1772,58 @@ FILESERVICES_API char *  FILESERVICES_CALL fsGetSuperFileSubName(ICodeContext *c
     StringBuffer ret;
     if (abspath)
         ret.append('~');
-    Owned<ISimpleSuperFileEnquiry> enq = getSimpleSuperFileEnquiry(ctx, lsuperfn);
-    if (enq) {
-        if (!filenum||!enq->getSubFileName(filenum-1,ret))
-            return CTXSTRDUP(parentCtx, "");
-        return ret.detach();
+    Owned<IDistributedSuperFile> superFile;
+    std::unique_ptr<CImplicitSuperTransaction> implicitTransaction;
+    CDfsLogicalFileName slfn;
+    slfn.set(lsuperfn);
+    if (slfn.isRemote() || slfn.isForeign())
+        superFile.setown(lookupRemoteOrForeignSuper(ctx, "GetSuperFileSubName", lsuperfn));
+    else
+    {
+        Owned<ISimpleSuperFileEnquiry> enq = getSimpleSuperFileEnquiry(ctx, lsuperfn);
+        if (enq)
+        {
+            if (!filenum||!enq->getSubFileName(filenum-1,ret))
+                return CTXSTRDUP(parentCtx, "");
+            return ret.detach();
+        }
+        implicitTransaction = std::make_unique<CImplicitSuperTransaction>(ctx->querySuperFileTransaction());
+        StringBuffer lsfn;
+        lookupSuperFile(ctx, lsuperfn, AccessMode::readMeta, superFile, true, lsfn, true);
     }
-    CImplicitSuperTransaction implicitTransaction(ctx->querySuperFileTransaction());
-    Owned<IDistributedSuperFile> file;
-    StringBuffer lsfn;
-    lookupSuperFile(ctx, lsuperfn, AccessMode::readMeta, file, true, lsfn, true);
-    if (!filenum||filenum>file->numSubFiles())
+    if (!filenum||filenum>superFile->numSubFiles())
         return CTXSTRDUP(parentCtx, "");
-    ret.append(file->querySubFile(filenum-1).queryLogicalName());
+    ret.append(superFile->querySubFile(filenum-1).queryLogicalName());
     return ret.detach();
 }
 
-FILESERVICES_API unsigned FILESERVICES_CALL fsFindSuperFileSubName(ICodeContext *ctx, const char *lsuperfn,const char *_lfn)
+FILESERVICES_API unsigned FILESERVICES_CALL fsFindSuperFileSubName(ICodeContext *ctx, const char *lsuperfn, const char *_lfn)
 {
+    std::unique_ptr<CImplicitSuperTransaction> implicitTransaction;
+    Owned<IDistributedSuperFile> superFile;
+    CDfsLogicalFileName slfn;
+    slfn.set(lsuperfn);
     StringBuffer lfn;
     constructLogicalName(ctx, _lfn, lfn);
-    Owned<ISimpleSuperFileEnquiry> enq = getSimpleSuperFileEnquiry(ctx, lsuperfn);
-    if (enq) {
-        unsigned n = enq->findSubName(lfn.str());
-        return (n==NotFound)?0:n+1;
+    if (slfn.isRemote() || slfn.isForeign())
+        superFile.setown(lookupRemoteOrForeignSuper(ctx, "GetSuperFileSubName", lsuperfn));
+    else
+    {
+        Owned<ISimpleSuperFileEnquiry> enq = getSimpleSuperFileEnquiry(ctx, lsuperfn);
+        if (enq)
+        {
+            unsigned n = enq->findSubName(lfn.str());
+            return (n==NotFound)?0:n+1;
+        }
+        implicitTransaction = std::make_unique<CImplicitSuperTransaction>(ctx->querySuperFileTransaction());
+        StringBuffer lsfn;
+        lookupSuperFile(ctx, lsuperfn, AccessMode::readMeta, superFile, true, lsfn, true);
     }
-    CImplicitSuperTransaction implicitTransaction(ctx->querySuperFileTransaction());
-    Owned<IDistributedSuperFile> file;
-    StringBuffer lsfn;
-    lookupSuperFile(ctx, lsuperfn, AccessMode::readMeta, file, true, lsfn, true);
     unsigned n = 0;
     // could do with better version of this TBD
-    Owned<IDistributedFileIterator> iter = file->getSubFileIterator();
-    ForEach(*iter) {
+    Owned<IDistributedFileIterator> iter = superFile->getSubFileIterator();
+    ForEach(*iter)
+    {
         n++;
         if (stricmp(iter->query().queryLogicalName(),lfn.str())==0)
             return n;
@@ -2330,10 +2373,12 @@ FILESERVICES_API void FILESERVICES_CALL fsSuperFileContents(ICodeContext *ctx, s
     Owned<ISimpleSuperFileEnquiry> enq;
     if (!recurse)
         enq.setown(getSimpleSuperFileEnquiry(ctx, lsuperfn));
-    if (enq) {
+    if (enq)
+    {
         StringArray subs;
         enq->getContents(subs);
-        ForEachItemIn(i,subs) {
+        ForEachItemIn(i,subs)
+        {
             const char *name = subs.item(i);
             size32_t sz = strlen(name);
             if (!sz)
@@ -2341,14 +2386,25 @@ FILESERVICES_API void FILESERVICES_CALL fsSuperFileContents(ICodeContext *ctx, s
             mb.append(sz).append(sz,name);
         }
     }
-    else {
-        CImplicitSuperTransaction implicitTransaction(ctx->querySuperFileTransaction());
-        Owned<IDistributedSuperFile> file;
-        StringBuffer lsfn;
-        lookupSuperFile(ctx, lsuperfn, AccessMode::readMeta, file, true, lsfn, true);
-        Owned<IDistributedFileIterator> iter = file->getSubFileIterator(recurse);
+    else
+    {
+        Owned<IDistributedSuperFile> superFile;
+
+        CDfsLogicalFileName slfn;
+        slfn.set(lsuperfn);
+        std::unique_ptr<CImplicitSuperTransaction> implicitTransaction;
+        if (slfn.isRemote() || slfn.isForeign())
+            superFile.setown(lookupRemoteOrForeignSuper(ctx, "SuperFileContents", lsuperfn));
+        else
+        {
+            implicitTransaction.reset(new CImplicitSuperTransaction(ctx->querySuperFileTransaction()));
+            StringBuffer lsfn;
+            lookupSuperFile(ctx, lsuperfn, AccessMode::readMeta, superFile, true, lsfn, true);
+        }
+        Owned<IDistributedFileIterator> iter = superFile->getSubFileIterator(recurse);
         StringBuffer name;
-        ForEach(*iter) {
+        ForEach(*iter)
+        {
             iter->getName(name.clear());
             size32_t sz = name.length();
             if (!sz)


### PR DESCRIPTION
This change extends FileServices superfile query operations to support remote and foreign superfiles when not in a transaction.

- Added lookupRemoteOrForeignSuper() helper function in fileservices.cpp to handle remote/foreign superfile lookups using wsdfs::lookup
- Updated fsGetSuperFileSubCount() to detect and handle remote/foreign files
- Updated fsGetSuperFileSubName() to support remote/foreign superfile lookups
- Updated fsFindSuperFileSubName() to work with remote/foreign superfiles
- Updated fsSuperFileContents() to support remote/foreign superfiles

The implementation checks if a superfile is remote or foreign (via CDfsLogicalFileName) and if so, uses wsdfs::lookup instead of the standard distributed file directory, while enforcing that such operations cannot be performed within a transaction.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
