### PR TITLE
HPCC-35590 In Thor disk/index write, use stat size vs IFile::size()

### DIFF
--- a/helm/hpcc/docs/expert.md
+++ b/helm/hpcc/docs/expert.md
@@ -116,6 +116,25 @@ thor:
 
 Note: This requires that libjemalloc is installed in the container image at /usr/lib/x86_64-linux-gnu/libjemalloc.so.2
 
+## fileSizeCheckMode (unsigned)
+
+Controls how Thor write activities verify expected disk file sizes against actual filesystem sizes.
+This setting currently applies to Thor index writes, disk writes
+
+Values:
+- 0 (default): Verify with retries. Compares expected size (from writer statistics) against IFile::size() with up to 5 retries and 200ms delays. Throws exception if mismatch persists.
+- 1: Trust expected size. Returns the expected size from writer statistics without calling IFile::size(), avoiding filesystem queries entirely.
+- 2: Call size() with warning. Always calls IFile::size() and returns the actual size, but logs a warning if it doesn't match the expected size (no error thrown).
+
+Default: 0
+
+Example:
+```
+global:
+  expert:
+    fileSizeCheckMode: 0
+```
+
 
 # Plane Expert Settings
 

--- a/thorlcr/activities/thactivityutil.cpp
+++ b/thorlcr/activities/thactivityutil.cpp
@@ -655,7 +655,7 @@ class CWriteHandler : implements IFileIO, public CInterface
             return;
         closed = true;
         primaryio->close();
-        primaryio.clear();
+        // NB: do not clear 'primaryio', keep around after close for this object's getStatistic calls.
         if (aborted && *aborted)
         {
             primary->remove(); // i.e. never completed, so remove partial (temp) primary

--- a/thorlcr/activities/thdiskbaseslave.ipp
+++ b/thorlcr/activities/thdiskbaseslave.ipp
@@ -120,6 +120,7 @@ protected:
     StringAttr fName;
     bool compress, grouped, rfsQueryParallel;
     offset_t uncompressedBytesWritten;
+    offset_t partDiskSize;
     unsigned replicateDone;
     Owned<ICompressor> ecomp;
     unsigned usageCount;

--- a/thorlcr/thorutil/thormisc.hpp
+++ b/thorlcr/thorutil/thormisc.hpp
@@ -741,4 +741,6 @@ extern graph_decl void saveWuidToFile(const char *wuid);
 
 extern graph_decl bool hasTLK(IDistributedFile &file, CActivityBase *activity);
 extern graph_decl std::vector<std::string> captureDebugInfo(const char *dir, const char *prefix, const char *suffix);
+
+extern graph_decl offset_t verifyFileSize(IFile *file, offset_t expectedSize, unsigned maxRetries=5, unsigned retryDelayMs=200);
 #endif


### PR DESCRIPTION
Rely on already accumulated disk write stat. size when serializing sizes back meta data to manager.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
