### PR TITLE
HPCC-35652: Unify event iteration between IEventReader and IEventIter…

### DIFF
--- a/common/eventconsumption/eventiterator.cpp
+++ b/common/eventconsumption/eventiterator.cpp
@@ -92,24 +92,15 @@ bool CPropertyTreeEvents::nextEvent(CEvent& event)
     return true;
 }
 
-const char* CPropertyTreeEvents::queryFilename() const
+const EventFileProperties& CPropertyTreeEvents::queryFileProperties() const
 {
-    return events->queryProp("@filename");
-}
-
-uint32_t CPropertyTreeEvents::queryVersion() const
-{
-    return uint32_t(events->getPropInt64("@version"));
-}
-
-uint32_t CPropertyTreeEvents::queryBytesRead() const
-{
-    return uint32_t(events->getPropInt64("@bytesRead"));
+    return properties;
 }
 
 CPropertyTreeEvents::CPropertyTreeEvents(const IPropertyTree& _events)
     : CPropertyTreeEvents(_events, true)
 {
+    // delegating constructor
 }
 
 CPropertyTreeEvents::CPropertyTreeEvents(const IPropertyTree& _events, bool _strictParsing)
@@ -119,15 +110,19 @@ CPropertyTreeEvents::CPropertyTreeEvents(const IPropertyTree& _events, bool _str
 {
     // enable the "next" event to populate from the first matching node
     (void)eventsIt->first();
+    properties.path.set(events->queryProp("@filename"));
+    properties.version = uint32_t(events->getPropInt64("@version"));
+    properties.bytesRead = uint32_t(events->getPropInt("@bytesRead"));
 }
 
 void visitIterableEvents(IEventIterator& iter, IEventVisitor& visitor)
 {
     CEvent event;
-    visitor.visitFile(iter.queryFilename(), iter.queryVersion());
+    const EventFileProperties& props = iter.queryFileProperties();
+    visitor.visitFile(props.path, props.version);
     while (iter.nextEvent(event))
         visitor.visitEvent(event);
-    visitor.departFile(iter.queryBytesRead());
+    visitor.departFile(props.bytesRead);
 }
 
 #ifdef _USE_CPPUNIT

--- a/common/eventconsumption/eventiterator.h
+++ b/common/eventconsumption/eventiterator.h
@@ -21,22 +21,6 @@
 #include "jevent.hpp"
 #include "jptree.hpp"
 
-// An abstraction enabling an event pulling model. Consumers control the pace of event
-// production by calling nextEvent() as needed.
-//
-// The interface is more simplistic than other iterators. A binary event file reader is considered
-// to be a potential event source.
-//
-// The query* methods are used to identify a source of events. The queried values coincide with
-// `IEventVisitor::visitFile` and `IEventVisitor::departFile` parameters.
-interface IEventIterator : extends IInterface
-{
-    virtual bool nextEvent(CEvent& event) = 0;
-    virtual const char* queryFilename() const = 0;
-    virtual uint32_t queryVersion() const = 0;
-    virtual uint32_t queryBytesRead() const = 0;
-};
-
 // Implementation of IEventIterator that extracts event data from a property tree whose contents
 // conform to this format (shown here as YAML):
 //
@@ -62,15 +46,14 @@ class event_decl CPropertyTreeEvents : public CInterfaceOf<IEventIterator>
 {
 public:
     virtual bool nextEvent(CEvent& event) override;
-    virtual const char* queryFilename() const override;
-    virtual uint32_t queryVersion() const override;
-    virtual uint32_t queryBytesRead() const override;
+    virtual const EventFileProperties& queryFileProperties() const override;
 public:
     CPropertyTreeEvents(const IPropertyTree& events);
     CPropertyTreeEvents(const IPropertyTree& events, bool strictParsing);
 protected:
     Linked<const IPropertyTree> events;
     Owned<IPropertyTreeIterator> eventsIt;
+    EventFileProperties properties;
     bool strictParsing{true};
 };
 

--- a/system/jlib/jevent.cpp
+++ b/system/jlib/jevent.cpp
@@ -1828,7 +1828,7 @@ bool readEvents(const char* filename, IEventVisitor& visitor)
     return reader.traverse(filename, visitor);
 }
 
-class CEventFilePuller : implements IEventReader, public CEventFileConsumer
+class CEventFileIterator : implements IEventIterator, public CEventFileConsumer
 {
 public:
     IMPLEMENT_IINTERFACE_USING(CEventFileConsumer);
@@ -1844,13 +1844,13 @@ public:
     }
 };
 
-IEventReader* createEventReader(const char* path)
+IEventIterator* createEventFileIterator(const char* path)
 {
-    Owned<CEventFilePuller> reader = new CEventFilePuller;
-    if (reader->openFile(path))
+    Owned<CEventFileIterator> it = new CEventFileIterator;
+    if (it->openFile(path))
     {
-        reader->readHeader();
-        return reader.getClear();
+        it->readHeader();
+        return it.getClear();
     }
     return nullptr;
 }

--- a/system/jlib/jevent.hpp
+++ b/system/jlib/jevent.hpp
@@ -587,9 +587,9 @@ struct jlib_decl EventFileProperties
 
 // Pull-based interface for reading events from a binary event data file.
 //
-// An IEventReader provides an iterator-like API over the events contained in a single file.
+// An IEventIterator provides an iterator-like API over the events contained in a single file.
 // It is the counterpart to the push-based readEvents() helper:
-//   - Use IEventReader when the caller wants explicit control over when the next event is read,
+//   - Use IEventIterator when the caller wants explicit control over when the next event is read,
 //     for example to integrate with existing loops, apply back-pressure, or stop after a
 //     partial read.
 //   - Use readEvents() when all events should be processed in one pass via an IEventVisitor
@@ -600,7 +600,7 @@ struct jlib_decl EventFileProperties
 //   - Populate queryFileProperties() as information becomes available (see EventFileProperties
 //     for details of which fields are set when).
 //   - Throw an IException-derived exception on I/O or format errors.
-interface IEventReader : extends IInterface
+interface IEventIterator : extends IInterface
 {
     // Reads the next event from the file.
     //
@@ -611,7 +611,7 @@ interface IEventReader : extends IInterface
 
     // Returns the current properties of the underlying event file.
     //
-    // The returned reference remains valid for the lifetime of the reader. Fields are populated
+    // The returned reference remains valid for the lifetime of the iterator. Fields are populated
     // as they become known:
     //   - path and version are set once the file is opened and its header parsed;
     //   - options are derived from the header;
@@ -621,20 +621,20 @@ interface IEventReader : extends IInterface
     virtual const EventFileProperties& queryFileProperties() const = 0;
 };
 
-// Creates an IEventReader for the specified event data file.
+// Creates an IEventIterator for the specified event data file.
 //
 // The path identifies a single binary event file previously produced by the event recording
-// infrastructure. The returned reader exposes a pull-based API via nextEvent(), allowing
+// infrastructure. The returned iterator exposes a pull-based API via nextEvent(), allowing
 // callers to iterate over events at their own pace. This is functionally equivalent to
 // readEvents(), but gives the caller more control over iteration and lifetime.
 //
-// On success, returns a new IEventReader instance. The caller is responsible for releasing
+// On success, returns a new IEventIterator instance. The caller is responsible for releasing
 // the interface when it is no longer needed, using the standard IInterface reference-counting
 // conventions.
 //
 // Throws an IException-derived exception if the file cannot be opened, the header cannot be
 // parsed, or the contents are not a supported event file format.
-extern jlib_decl IEventReader* createEventReader(const char* path);
+extern jlib_decl IEventIterator* createEventFileIterator(const char* path);
 
 // Opens and parses a single binary event data file. Parsed data is passed to the given visitor
 // until parsing completes or the visitor requests it to stop.


### PR DESCRIPTION
…ator

- Rename IEventReader to IEventIterator
- Rename CEventFilePuller to CEventFileIterator.
- Remove IEventIterator from the eventconsumption library.
- Adapt CPropertyTreeEvents to conform to the updated iterator interface.
- Update visitIterableEvents to use the updated iterator interface.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [x] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
