### PR TITLE
HPCC-35674 Add adaptive time-windowed paging to Sasha file expiry

### DIFF
--- a/dali/base/dadfs.hpp
+++ b/dali/base/dadfs.hpp
@@ -663,7 +663,7 @@ interface IDistributedFileDirectory: extends IInterface
     // NB: getDFAttributesIterator is just a wrapper onto of getDFAttributesFilteredIterator
     virtual IPropertyTreeIterator *getDFAttributesIterator(const char *wildname, IUserDescriptor *user, bool recursive=true, bool includesuper=false, INode *foreigndali=nullptr, unsigned foreigndalitimeout=FOREIGN_DALI_TIMEOUT) = 0;
     virtual IPropertyTreeIterator *getDFAttributesFilteredIterator(const char *filters, const char *localFilters, const DFUQResultField *fields,
-        IUserDescriptor *user, bool recursive, bool& allMatchingFilesReceived, INode *foreigndali=nullptr, unsigned foreigndalitimeout=FOREIGN_DALI_TIMEOUT) = 0;
+        IUserDescriptor *user, bool recursive, bool& allMatchingFilesReceived, unsigned *total, INode *foreigndali=nullptr, unsigned foreigndalitimeout=FOREIGN_DALI_TIMEOUT) = 0;
 
     virtual IDFScopeIterator *getScopeIterator(IUserDescriptor *user, const char *subscope=NULL,bool recursive=true,bool includeempty=false)=0;
 

--- a/dali/base/dautils.cpp
+++ b/dali/base/dautils.cpp
@@ -2853,7 +2853,7 @@ void getLogicalFileSuperSubList(MemoryBuffer &mb, IUserDescriptor *user)
 
     bool allMatchingFilesReceived;
     Owned<IPropertyTreeIterator> iter = queryDistributedFileDirectory().getDFAttributesFilteredIterator(filterBuf,
-        nullptr, selectiveFields.data(), user, true, allMatchingFilesReceived);
+        nullptr, selectiveFields.data(), user, true, allMatchingFilesReceived, nullptr);
     ForEach(*iter)
     {
         IPropertyTree &attr = iter->query();

--- a/helm/hpcc/values.schema.json
+++ b/helm/hpcc/values.schema.json
@@ -3176,6 +3176,11 @@
           "description": "Default number of days to delete unused standard files that are flagged with EXPIRY",
           "default": "14"
         },
+        "maxFileLimit": {
+          "type": "integer",
+          "description": "Override of server limit of maximum files that can be retrieved",
+          "default": 100000
+        },
         "disabled": {},
         "interval": {},
         "user": {},

--- a/initfiles/componentfiles/configxml/sasha.xsd
+++ b/initfiles/componentfiles/configxml/sasha.xsd
@@ -504,6 +504,13 @@
                 </xs:appinfo>
             </xs:annotation>
         </xs:attribute>
+        <xs:attribute name="MaxFileLimit" type="xs:nonNegativeInteger" use="optional" default="100000">
+            <xs:annotation>
+                <xs:appinfo>
+                    <tooltip>Maximum number of files that can be retrieved</tooltip>
+                </xs:appinfo>
+            </xs:annotation>
+        </xs:attribute>
     </xs:attributeGroup>
     <xs:attributeGroup name="ThorQMon">
      <!--DOC-Autobuild-code-->

--- a/initfiles/componentfiles/configxml/sasha.xsl
+++ b/initfiles/componentfiles/configxml/sasha.xsl
@@ -248,6 +248,11 @@
                        <xsl:value-of select="@ExpiryDefault"/>
                     </xsl:attribute>
                 </xsl:if>
+                <xsl:if test="string(@MaxFileLimit) != ''">
+                    <xsl:attribute name="maxFileLimit">
+                       <xsl:value-of select="@MaxFileLimit"/>
+                    </xsl:attribute>
+                </xsl:if>
             </xsl:element>
             <xsl:element name="ThorQMon">
                 <xsl:attribute name="queues">

--- a/testing/unittests/dalitests.cpp
+++ b/testing/unittests/dalitests.cpp
@@ -2715,7 +2715,8 @@ public:
             nullptr,                      // no fields specified (default all)
             user,                         // user context
             true,                         // recursive
-            allReceived                   // output parameter
+            allReceived,                  // output parameter
+            nullptr                       // pointer to receive total count
         );
         CPPUNIT_ASSERT(allReceived);
 
@@ -2746,7 +2747,8 @@ public:
             nullptr,                      // no fields specified (default all)
             user,                         // user context
             true,                         // recursive
-            allReceived                   // output parameter
+            allReceived,                  // output parameter
+            nullptr                       // pointer to receive total count
         ));
         CPPUNIT_ASSERT(allReceived);
 
@@ -2774,7 +2776,8 @@ public:
             fields.data(),                // select fields
             user,                         // user context
             true,                         // recursive
-            allReceived                   // output parameter
+            allReceived,                  // output parameter
+            nullptr                       // pointer to receive total count
         );
         CPPUNIT_ASSERT(allReceived);
 
@@ -2801,7 +2804,8 @@ public:
                 fields.data(),                // select fields
                 user,                         // user context
                 true,                         // recursive
-                allReceived                   // output parameter
+                allReceived,                  // output parameter
+                nullptr                       // pointer to receive total count
             ));
             CPPUNIT_ASSERT(allReceived);
             count = 0;


### PR DESCRIPTION
The server (Dali) imposes a limit on the number of files returned by getDFAttributesTreeIterator. This change adds a maxFileLimit configuration option to allow the limit to be increased for sasha fileexpiry, which heavily filters both files and attributes, reducing data volume.

Key feature: Adaptive time-windowed paging mechanism When the initial query exceeds the limit, automatically switches to a paging approach that uses time windows to partition the file space. Works backwards from 'now' using bounded time ranges (windowStart <= modified < windowEnd), with window size adapting dynamically based on file density:
- Halves window when exceeding limit
- Doubles window when file count is low
- Switches to unbounded query when no files found or at maximum window
- Prevents duplicate processing between windows through bounded ranges

The approach accepts incomplete coverage at minimum window size, relying on successive expiry runs to eventually process all files as expired files are deleted over time.

NB: Primarily intended for systems with millions of files having @expireDays attributes.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
