### PR TITLE
HPCC-35771 Sasha Colescer trying to load a non-existent binary dali store file

### DIFF
--- a/dali/base/dasds.cpp
+++ b/dali/base/dasds.cpp
@@ -5453,7 +5453,12 @@ class CStoreHelper : implements IStoreHelper, public CInterface
             OwnedIFile iFileStore = createIFile(storeFilename);
             OwnedIFileIO iFileIOStore = iFileStore->open(IFOread);
             if (!iFileIOStore)
-                throw MakeSDSException(SDSExcpt_OpenStoreFailed, "%s", storeFilename.str());
+            {
+                if (isBinary)
+                    return nullptr;
+                else
+                    throw MakeSDSException((SDSExcpt_OpenStoreFailed), "xml file: %s", storeFilename.str());
+            }
 
             offset_t fSize = iFileIOStore->size();
             PROGLOG("Loading %s store %u (size=%.2f MB, storedCrc=%x)", isBinary ? "Binary" : "XML", queryCurrentEdition(), ((double)fSize) / 0x100000, storedCrc);

--- a/dali/base/dasds.ipp
+++ b/dali/base/dasds.ipp
@@ -389,7 +389,7 @@ public:
             case SDSExcpt_AmbiguousXpath:
                 return out.append("Invalid ambiguous xpath detected ");
             case SDSExcpt_OpenStoreFailed:
-                return out.append("Failed to open sds xml store file ");
+                return out.append("Failed to open sds store ");
             case SDSExcpt_OrphanedNode:
                 return out.append("Transaction to orphaned server node ");
             case SDSExcpt_ServerStoppedLockAborted:


### PR DESCRIPTION
The log entry for failing to load a binary store file now correctly reports the file type as xml or binary.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [x] Send notifications about my Pull Request position in Smoketest queue.
- [x] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->
After running Dali to create an initial store which saved in both binary and xml format, I then deleted the binary store.
After starting Dali again I verified the log to did not show the binary failure to open the file:

```
dave@RISKAZ-06905526:~/hpccDebug/etc/init.d$ ls -la /home/dave/hpccDebug/var/lib/HPCCSystems/hpcc-data/dali/
total 120
drwxr-xr-x 2 dave dave  4096 Feb  3 14:12 .
drwxr-xr-x 3 dave dave  4096 Feb  3 14:12 ..
-rw-r--r-- 1 dave dave   179 Feb  3 14:12 dalicoven.xml
-rw-r--r-- 1 dave dave  1351 Feb  3 14:12 daliinc.xml
-rw-r--r-- 1 dave dave 38055 Feb  3 14:12 dalisds1.bin
-rw-r--r-- 1 dave dave 60416 Feb  3 14:12 dalisds1.xml
-rw-r--r-- 1 dave dave     8 Feb  3 14:12 store.1
dave@RISKAZ-06905526:~/hpccDebug/etc/init.d$ rm /home/dave/hpccDebug/var/lib/HPCCSystems/hpcc-data/dali/dalisds1.bin
dave@RISKAZ-06905526:~/hpccDebug/etc/init.d$ ~/hpccDebug/etc/init.d/hpcc-init start -c mydali
Starting mydali ...            [   OK    ]
dave@RISKAZ-06905526:~/hpccDebug/etc/init.d$ tail -n 50 ~/hpccDebug/var/log/HPCCSystems/mydali/server/DaServer.log
...
00000006 PRG 2026-02-03 14:13:36.152 17175 17175 "Server Version = 3.20, required minimum client version 3.6"
00000007 USR 2026-02-03 14:13:36.152 17175 17175 "DFS Server: numThreads=100"
00000008 USR 2026-02-03 14:13:36.171 17175 17175 "externalSizeThreshold = 10240"
00000009 USR 2026-02-03 14:13:36.171 17175 17175 "Loading XML store 1 (size=0.06 MB, storedCrc=27647994)"
0000000A USR 2026-02-03 14:13:36.176 17175 17175 "Load progress - 100.00% complete"
0000000B PRG 2026-02-03 14:13:36.176 17175 17175 "store and deltas loaded"
0000000C PRG 2026-02-03 14:13:36.176 17175 17175 "loading external Environment from: /home/dave/hpccDebug/etc/HPCCSystems/environment.xml"...
```

After running Dali start and stop I deleted all the binary and xml stores.
The log only shows the store file is message:

```
dave@RISKAZ-06905526:~/hpccDebug/etc/init.d$ ~/hpccDebug/etc/init.d/hpcc-init start -c mydali
Starting mydali ...            [   OK    ]
dave@RISKAZ-06905526:~/hpccDebug/etc/init.d$ ~/hpccDebug/etc/init.d/hpcc-init stop -c mydali
Stopping mydali...             [   OK    ]
dave@RISKAZ-06905526:~/hpccDebug/etc/init.d$ ls -la /home/dave/hpccDebug/var/lib/HPCCSystems/hpcc-data/dali/
total 184
drwxr-xr-x 2 dave dave  4096 Feb  3 14:17 .
drwxr-xr-x 3 dave dave  4096 Feb  3 14:12 ..
-rw-r--r-- 1 dave dave   179 Feb  3 14:17 dalicoven.xml
-rw-r--r-- 1 dave dave  1351 Feb  3 14:12 daliinc.xml
-rw-r--r-- 1 dave dave   854 Feb  3 14:13 daliinc1.xml
-rw-r--r-- 1 dave dave 60416 Feb  3 14:12 dalisds1.xml
-rw-r--r-- 1 dave dave 38033 Feb  3 14:17 dalisds2.bin
-rw-r--r-- 1 dave dave 60392 Feb  3 14:17 dalisds2.xml
-rw-r--r-- 1 dave dave     8 Feb  3 14:17 store.2
dave@RISKAZ-06905526:~/hpccDebug/etc/init.d$ rm /home/dave/hpccDebug/var/lib/HPCCSystems/hpcc-data/dali/dalisds*
dave@RISKAZ-06905526:~/hpccDebug/etc/init.d$ ~/hpccDebug/etc/init.d/hpcc-init start -c mydali
Starting mydali ...            [   OK    ]
dave@RISKAZ-06905526:~/hpccDebug/etc/init.d$ tail -n 50 ~/hpccDebug/var/log/HPCCSystems/mydali/server/DaServer.log
...
00000006 PRG 2026-02-03 14:17:54.934 25537 25537 "Server Version = 3.20, required minimum client version 3.6"
00000007 USR 2026-02-03 14:17:54.934 25537 25537 "DFS Server: numThreads=100"
00000008 USR 2026-02-03 14:17:54.953 25537 25537 "externalSizeThreshold = 10240"
00000009 PRG 2026-02-03 14:17:54.953 25537 25537 "Store 2 does not exist, creating new store"
0000000A PRG 2026-02-03 14:17:54.954 25537 25537 "store and deltas loaded"
0000000B PRG 2026-02-03 14:17:54.954 25537 25537 "loading external Environment from: /home/dave/hpccDebug/etc/HPCCSystems/environment.xml"
```

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
