### PR TITLE
HPCC-34935: Iterate events from multiple input files

### DIFF
--- a/common/eventconsumption/eventdump.cpp
+++ b/common/eventconsumption/eventdump.cpp
@@ -45,7 +45,7 @@ bool CDumpEventsOp::doOp()
     case OutputFormat::tree:
         {
             Owned<IEventPTreeCreator> creator = createEventPTreeCreator();
-            if (traverseEvents(inputPath.str(), creator->queryVisitor()))
+            if (traverseEvents(creator->queryVisitor()))
             {
                 StringBuffer yaml;
                 toYAML(creator->queryTree(), yaml, 2, 0);
@@ -58,5 +58,5 @@ bool CDumpEventsOp::doOp()
     default:
         throw makeStringExceptionV(-1, "unsupported output format: %d", (int)format);
     }
-    return traverseEvents(inputPath.str(), *visitor);
+    return traverseEvents(*visitor);
 }

--- a/common/eventconsumption/eventfilter.cpp
+++ b/common/eventconsumption/eventfilter.cpp
@@ -771,7 +771,7 @@ public:
                 </expect>
             </test>
         )!!!";
-        testEventVisitationLinks(testData, false);
+        testEventVisitationLinks(testData, PTEFlenientParsing);
     }
 
     void testFilterByEventsByContext()
@@ -809,7 +809,7 @@ public:
                 </expect>
             </test>
         )!!!";
-        testEventVisitationLinks(testData, false);
+        testEventVisitationLinks(testData, PTEFlenientParsing);
     }
 
     void testFilterByEventsByType()
@@ -844,7 +844,7 @@ public:
                 </expect>
             </test>
         )!!!";
-        testEventVisitationLinks(testData, false);
+        testEventVisitationLinks(testData, PTEFlenientParsing);
     }
 
     void testFilterByEventsByContextComplement()
@@ -883,7 +883,7 @@ public:
                 </expect>
             </test>
         )!!!";
-        testEventVisitationLinks(testData, false);
+        testEventVisitationLinks(testData, PTEFlenientParsing);
     }
 
     void testFilterByEventsByTypeComplement()
@@ -930,7 +930,7 @@ public:
                 </expect>
             </test>
         )!!!";
-        testEventVisitationLinks(testData, false);
+        testEventVisitationLinks(testData, PTEFlenientParsing);
     }
 
     void testFilterByEventsWithGoodException()
@@ -967,7 +967,7 @@ public:
                 </expect>
             </test>
         )!!!";
-        testEventVisitationLinks(testData, false);
+        testEventVisitationLinks(testData, PTEFlenientParsing);
     }
 
     void testFilterByEventsWithIrrelevantException()
@@ -1005,7 +1005,7 @@ public:
                 </expect>
             </test>
         )!!!";
-        testEventVisitationLinks(testData, false);
+        testEventVisitationLinks(testData, PTEFlenientParsing);
     }
 
     void testFilterByEventByCanceledTerms()
@@ -1055,7 +1055,7 @@ public:
                 </expect>
             </test>
         )!!!";
-        testEventVisitationLinks(testData, false);
+        testEventVisitationLinks(testData, PTEFlenientParsing);
     }
 
     void testFilterByEventByBadName()
@@ -1072,7 +1072,7 @@ public:
                 </expect>
             </test>
         )!!!";
-        CPPUNIT_ASSERT_THROW_MESSAGE("expected exception for bad event filter term name", testEventVisitationLinks(testData, false), std::exception);
+        CPPUNIT_ASSERT_THROW_MESSAGE("expected exception for bad event filter term name", testEventVisitationLinks(testData, PTEFlenientParsing), std::exception);
     }
 
     void testFilterByEventByBadComparison()
@@ -1089,7 +1089,7 @@ public:
                 </expect>
             </test>
         )!!!";
-        CPPUNIT_ASSERT_THROW_MESSAGE("expected exception for bad event filter term comparison", testEventVisitationLinks(testData, false), std::exception);
+        CPPUNIT_ASSERT_THROW_MESSAGE("expected exception for bad event filter term comparison", testEventVisitationLinks(testData, PTEFlenientParsing), std::exception);
     }
 
     void testFilterByAttributeByFileId()
@@ -1127,7 +1127,7 @@ public:
                 </expect>
             </test>
         )!!!";
-        testEventVisitationLinks(testData, false);
+        testEventVisitationLinks(testData, PTEFlenientParsing);
     }
 
     void testFilterByAttributeByPath1()
@@ -1155,7 +1155,7 @@ public:
                 </expect>
             </test>
         )!!!";
-        testEventVisitationLinks(testData, false);
+        testEventVisitationLinks(testData, PTEFlenientParsing);
     }
 
     void testFilterByAttributeByPath2()
@@ -1184,7 +1184,7 @@ public:
                 </expect>
             </test>
         )!!!";
-        testEventVisitationLinks(testData, false);
+        testEventVisitationLinks(testData, PTEFlenientParsing);
     }
 
     void testFilterByAttributeByPath3()
@@ -1215,7 +1215,7 @@ public:
                 </expect>
             </test>
         )!!!";
-        testEventVisitationLinks(testData, false);
+        testEventVisitationLinks(testData, PTEFlenientParsing);
     }
 
     void testFilterByAttributeByBool1()
@@ -1238,7 +1238,7 @@ public:
                 </expect>
             </test>
         )!!!";
-        testEventVisitationLinks(testData, false);
+        testEventVisitationLinks(testData, PTEFlenientParsing);
     }
 
     void testFilterByAttributeByBool2()
@@ -1263,7 +1263,7 @@ public:
                 </expect>
             </test>
         )!!!";
-        testEventVisitationLinks(testData, false);
+        testEventVisitationLinks(testData, PTEFlenientParsing);
     }
 
     void testFilterByAttributeByTimestamp1()
@@ -1303,7 +1303,7 @@ public:
                 </expect>
             </test>
         )!!!";
-        testEventVisitationLinks(testData, false);
+        testEventVisitationLinks(testData, PTEFlenientParsing);
     }
 
     void testFilterByAttributeByTimestamp2()
@@ -1343,7 +1343,7 @@ public:
                 </expect>
             </test>
         )!!!";
-        testEventVisitationLinks(testData, false);
+        testEventVisitationLinks(testData, PTEFlenientParsing);
     }
 
     void testFilterByAttributeByTimestamp3()
@@ -1378,7 +1378,7 @@ public:
                 </expect>
             </test>
         )!!!";
-        testEventVisitationLinks(testData, false);
+        testEventVisitationLinks(testData, PTEFlenientParsing);
     }
 
     void testFilterByAttributeByNodeKind()
@@ -1404,7 +1404,7 @@ public:
                 </expect>
             </test>
         )!!!";
-        testEventVisitationLinks(testData, false);
+        testEventVisitationLinks(testData, PTEFlenientParsing);
     }
 
     void testFilterByAttributeByTraceId()
@@ -1432,7 +1432,7 @@ public:
                 </expect>
             </test>
         )!!!";
-        testEventVisitationLinks(testData, false);
+        testEventVisitationLinks(testData, PTEFlenientParsing);
     }
 };
 

--- a/common/eventconsumption/eventindexhotspot.cpp
+++ b/common/eventconsumption/eventindexhotspot.cpp
@@ -188,7 +188,7 @@ bool CIndexHotspotOp::ready() const
 bool CIndexHotspotOp::doOp()
 {
     Owned<CHotspotEventVisitor> visitor = new CHotspotEventVisitor(*this, observedEvents, granularityBits);
-    if (traverseEvents(inputPath, *visitor))
+    if (traverseEvents(*visitor))
     {
         Owned<IBucketVisitor> analyzer;
         if (limit)

--- a/common/eventconsumption/eventindexsummarize.cpp
+++ b/common/eventconsumption/eventindexsummarize.cpp
@@ -935,7 +935,7 @@ bool CIndexFileSummary::doOp()
     default:
         return false;
     }
-    if (!traverseEvents(inputPath, *collector))
+    if (!traverseEvents(*collector))
         return false;
     collector->summarize();
     return true;

--- a/common/eventconsumption/eventiterator.cpp
+++ b/common/eventconsumption/eventiterator.cpp
@@ -17,26 +17,111 @@
 
 #include "eventiterator.h"
 #include "eventindex.hpp"
+#include <list>
+#include <map>
+#include <string>
+
+// Implementation of IEventIterator that distributes events extracted from a property tree.
+// Distribution occurs in the order that events appear in the tree. If event order is important,
+// such as when used with a multiplexer, the input used to create the property tree is responsible
+// for ensuring event order.
+class event_decl CPropertyTreeEvents : public CInterfaceOf<IEventIterator>
+{
+public:
+    virtual bool nextEvent(CEvent& event) override;
+    virtual const EventFileProperties& queryFileProperties() const override;
+public:
+    CPropertyTreeEvents(const IPropertyTree& events, unsigned flags);
+protected:
+    Linked<const IPropertyTree> events;
+    Owned<IPropertyTreeIterator> eventsIt;
+    EventFileProperties properties;
+    unsigned flags;
+    bool firstEvent{true};
+    bool firstRecordingSource{true};
+};
+
+IEventIterator* createPropertyTreeEvents(const IPropertyTree& events, unsigned flags)
+{
+    return new CPropertyTreeEvents(events, flags);
+}
 
 bool CPropertyTreeEvents::nextEvent(CEvent& event)
 {
-    if (!eventsIt->isValid())
-        return false;
-    const IPropertyTree& node = eventsIt->query();
-    const char* typeStr = node.queryProp("@type");
-    if (isEmptyString(typeStr))
-        throw makeStringException(-1, "missing event type");
-    EventType type = queryEventType(typeStr);
-    if (EventNone == type)
+    const IPropertyTree* node = nullptr;
+    const char* typeStr = nullptr;
+    EventType type = EventNone;
+    while (true)
     {
-        if (strictParsing)
+        if (!eventsIt->isValid())
+            return false;
+        node = &eventsIt->query();
+        typeStr = node->queryProp("@type");
+        if (isEmptyString(typeStr))
+            throw makeStringException(-1, "missing event type");
+        type = queryEventType(typeStr);
+        if (type != EventNone)
+            break;
+        if (!(flags & PTEFlenientParsing))
             throw makeStringExceptionV(-1, "unknown event type: %s", typeStr);
-        eventsIt->next();
-        return nextEvent(event);
+        firstEvent = false;
+        (void)eventsIt->next();
     }
+    if (EventRecordingSource == type)
+    {
+        if ((firstEvent && firstRecordingSource) || (flags & PTEFliteralParsing))
+        {
+            // Extract
+            if (node->hasProp("@ProcessDescriptor"))
+                properties.processDescriptor.set(node->queryProp("@ProcessDescriptor"));
+            if (node->hasProp("@ChannelId"))
+            {
+                __uint64 channelId = node->getPropInt64("@ChannelId");
+                if (channelId > UINT8_MAX)
+                    throw makeStringExceptionV(0, "ChannelId value %llu exceeds maximum allowed value %u", channelId, UINT8_MAX);
+                properties.channelId = static_cast<byte>(channelId);
+            }
+            if (node->hasProp("@ReplicaId"))
+            {
+                __uint64 replicaId = node->getPropInt64("@ReplicaId");
+                if (replicaId > UINT8_MAX)
+                    throw makeStringExceptionV(0, "ReplicaId value %llu exceeds maximum allowed value %u", replicaId, UINT8_MAX);
+                properties.replicaId = static_cast<byte>(replicaId);
+            }
+            if (node->hasProp("@InstanceId"))
+                properties.instanceId = node->getPropInt64("@InstanceId");
+
+            if (!(flags & PTEFliteralParsing))
+            {
+                // Non-literal parsing requires silent consumption of this event with automatic
+                // progression to the next event. The recursion will recurse exactly one time
+                // neither firtEvent nor firstRecordingSource remain set.
+                firstEvent = false;
+                firstRecordingSource = false;
+                (void)eventsIt->next();
+                return nextEvent(event);
+            }
+        }
+        else if (!firstRecordingSource)
+        {
+            // Non-literal parsing requires at most one RecordingSource event at the start of the
+            // stream. Strict parsing is not required for enforcement.
+            if (!(flags & PTEFliteralParsing))
+                throw makeStringException(-1, "multiple RecordingSource events encountered");
+        }
+        else if (!firstEvent)
+        {
+            // Non-literal parsing requires the RecordingSource event to be the first event in the
+            // stream. Strict parsing is not required for enforcement.
+            if (!(flags & PTEFliteralParsing))
+                throw makeStringException(-1, "RecordingSource event must be the first event in the stream");
+        }
+        firstRecordingSource = false;
+    }
+    firstEvent = false;
     event.reset(type);
 
-    Owned<IAttributeIterator> attrIt = node.getAttributes();
+    Owned<IAttributeIterator> attrIt = node->getAttributes();
     ForEach(*attrIt)
     {
         const char* name = attrIt->queryName();
@@ -47,13 +132,13 @@ bool CPropertyTreeEvents::nextEvent(CEvent& event)
         EventAttr attrId = queryEventAttribute(name);
         if (EvAttrNone == attrId)
         {
-            if (strictParsing)
+            if (!(flags & PTEFlenientParsing))
                 throw makeStringExceptionV(-1, "unknown attribute: %s", name);
             continue;
         }
         if (!event.isAttribute(attrId))
         {
-            if (strictParsing)
+            if (!(flags & PTEFlenientParsing))
                 throw makeStringExceptionV(-1, "unused attribute %s/%s", typeStr, name);
             continue;
         }
@@ -77,12 +162,14 @@ bool CPropertyTreeEvents::nextEvent(CEvent& event)
             attr.setValue(strToBool(valueStr));
             break;
         default:
-            if (strictParsing)
+            if (!(flags & PTEFlenientParsing))
                 throw makeStringExceptionV(-1, "unknown attribute type class %u for %s/%s", attr.queryTypeClass(), typeStr, name);
             break;
         }
     }
-    if (strictParsing && !event.isComplete())
+    if (!(flags & PTEFliteralParsing))
+        event.fixup(properties);
+    if (!(flags & PTEFlenientParsing) && !event.isComplete())
         throw makeStringExceptionV(-1, "incomplete event %s", typeStr);
 
     // advance to the next matching node
@@ -97,22 +184,184 @@ const EventFileProperties& CPropertyTreeEvents::queryFileProperties() const
     return properties;
 }
 
-CPropertyTreeEvents::CPropertyTreeEvents(const IPropertyTree& _events)
-    : CPropertyTreeEvents(_events, true)
-{
-    // delegating constructor
-}
-
-CPropertyTreeEvents::CPropertyTreeEvents(const IPropertyTree& _events, bool _strictParsing)
+CPropertyTreeEvents::CPropertyTreeEvents(const IPropertyTree& _events, unsigned _flags)
     : events(&_events)
     , eventsIt(_events.getElements("event"))
-    , strictParsing(_strictParsing)
+    , flags(_flags)
 {
     // enable the "next" event to populate from the first matching node
     (void)eventsIt->first();
     properties.path.set(events->queryProp("@filename"));
     properties.version = uint32_t(events->getPropInt64("@version"));
     properties.bytesRead = uint32_t(events->getPropInt("@bytesRead"));
+}
+
+// Implementation of IEventMultiplexer that merges events from multiple underlying event iterators.
+// Events should be distributed in chronological order according to the EventTimestamp attribute//
+// value. Events with timestamps are always distributed before events without.
+//
+// An event file iterator is guaranteed to provide events with timestamps and in chronological
+// order.
+//
+// A property tree event iterator provides events in the order they appear in the tree, with or
+// without timestamps. If a multiplexer source input provides events in non-chronological order,
+// this iterator will distribute those events in non-chronological order.
+class event_decl CEventMultiplexer : public CInterfaceOf<IEventMultiplexer>
+{
+public:
+    using Sources = std::list<std::pair<Linked<IEventIterator>, CEvent>>;
+public: // IEventMultiplexer
+    virtual bool nextEvent(CEvent& event) override;
+    virtual const EventFileProperties& queryFileProperties() const override;
+    virtual void addSource(IEventIterator& source) override;
+public:
+    CEventMultiplexer(CMetaInfoState& metaState);
+    bool hasSource(IEventIterator& source) const;
+protected:
+    CMetaInfoState& metaState;
+    Owned<IEventVisitor> metaStateCollector;
+    EventFileProperties properties;
+    Sources sources;
+    std::unordered_map<size_t, __uint64> idMap;
+    std::unordered_map<std::string, __uint64> pathMap;
+    bool acceptSources{true};
+};
+
+IEventMultiplexer* createEventMultiplexer(CMetaInfoState& metaState)
+{
+    return new CEventMultiplexer(metaState);
+}
+
+bool CEventMultiplexer::nextEvent(CEvent& event)
+{
+    // If at least one source has a next event with a timestamp, choose the timestamped event with
+    // the lowest chronological value.
+    Sources::iterator best = sources.end();
+    for (Sources::iterator it = sources.begin(); it != sources.end(); ++it)
+    {
+        if (it->second.queryType() == EventNone)
+            continue;
+        if (!it->second.hasAttribute(EvAttrEventTimestamp))
+            continue;
+        if (sources.end() == best)
+            best = it;
+        else if (it->second.queryNumericValue(EvAttrEventTimestamp) < best->second.queryNumericValue(EvAttrEventTimestamp))
+            best = it;
+    }
+    // If the loop terminated without a best candidate, all remaining sources have a next event
+    // without a timestamp. No secondary sort key exists. Choose the next event from the first
+    // source.
+    if (sources.end() == best)
+        best = sources.begin();
+    // If a best candidate has been identified, prepare for its use.
+    // If no best candidate has been found, no events remain.
+    if (best != sources.end())
+    {
+        event = best->second;
+        (void)metaStateCollector->visitEvent(event);
+        properties.eventsRead++;
+        acceptSources = false;
+        if (!best->first->nextEvent(best->second))
+        {
+            // Source completed - accumulate final stats
+            const EventFileProperties& sourceProps = best->first->queryFileProperties();
+            properties.bytesRead += sourceProps.bytesRead;
+            sources.erase(best);
+        }
+        return true;
+    }
+    else
+        return false;
+}
+
+const EventFileProperties& CEventMultiplexer::queryFileProperties() const
+{
+    return properties;
+}
+
+CEventMultiplexer::CEventMultiplexer(CMetaInfoState& _metaState)
+    : metaState(_metaState)
+{
+    metaStateCollector.setown(metaState.getCollector());
+    properties.path.set("multiplexed");
+}
+
+void CEventMultiplexer::addSource(IEventIterator& source)
+{
+    if (!acceptSources)
+        throw makeStringException(0, "event multiplexer cannot add a source after event consumption has started");
+    if (this == &source)
+        throw makeStringException(0, "event multiplexer cannot add itself as source");
+    if (hasSource(source))
+        throw makeStringException(0, "event multiplexer cannot add a source already in use");
+    CEvent next;
+    if (!source.nextEvent(next))
+        return;
+    const EventFileProperties& sourceProps = source.queryFileProperties();
+    if (sources.empty())
+    {
+        // First source - initialize properties
+        properties.processDescriptor.set(sourceProps.processDescriptor.get());
+        properties.version = sourceProps.version;
+        properties.channelId = sourceProps.channelId;
+        properties.replicaId = sourceProps.replicaId;
+        properties.instanceId = sourceProps.instanceId;
+        properties.options.includeTraceIds = sourceProps.options.includeTraceIds;
+        properties.options.includeThreadIds = sourceProps.options.includeThreadIds;
+        properties.options.includeStackTraces = sourceProps.options.includeStackTraces;
+    }
+    else
+    {
+        const char* actual = sourceProps.processDescriptor.str();
+        const char* expected = properties.processDescriptor.str();
+        if (!streq(expected, actual))
+            throw makeStringExceptionV(0, "file source mismatch - needed ProcessDescriptor '%s' but found '%s'", expected, actual);
+        for (const Sources::value_type& entry : sources)
+        {
+            if (&source == entry.first.get())
+                return;
+            const char* path = sourceProps.path.str();
+            if (!isEmptyString(path) && streq(path, entry.first->queryFileProperties().path.str()))
+                return;
+        }
+
+        // Aggregate properties - use ambiguous value when sources conflict
+        if (sourceProps.version != properties.version)
+            properties.version = AmbiguousVersion;
+        if (sourceProps.channelId != properties.channelId)
+            properties.channelId = AmbiguousChannelId;
+        if (sourceProps.replicaId != properties.replicaId)
+            properties.replicaId = AmbiguousReplicaId;
+        if (sourceProps.instanceId != properties.instanceId)
+            properties.instanceId = AmbiguousInstanceId;
+
+        // Update tri-state options
+        auto updateTriState = [](EventFileOption& current, EventFileOption source) {
+            if (EventFileOption::Ambiguous == current)
+                return; // already ambiguous
+            if (current == source)
+                return; // still the same
+            current = EventFileOption::Ambiguous;
+        };
+        updateTriState(properties.options.includeTraceIds, sourceProps.options.includeTraceIds);
+        updateTriState(properties.options.includeThreadIds, sourceProps.options.includeThreadIds);
+        updateTriState(properties.options.includeStackTraces, sourceProps.options.includeStackTraces);
+    }
+    sources.emplace_back(Linked(&source), next);
+    metaStateCollector->visitFile(sourceProps.path.str(), sourceProps.version);
+}
+
+bool CEventMultiplexer::hasSource(IEventIterator& source) const
+{
+    for (const Sources::value_type& entry : sources)
+    {
+        if (&source == entry.first.get())
+            return true;
+        CEventMultiplexer* nested = dynamic_cast<CEventMultiplexer*>(entry.first.get());
+        if (nested && nested->hasSource(source))
+            return true;
+    }
+    return false;
 }
 
 void visitIterableEvents(IEventIterator& iter, IEventVisitor& visitor)
@@ -138,6 +387,11 @@ class EventIteratorTests : public CppUnit::TestFixture
     CPPUNIT_TEST(testStrictEventParsingIncompleteEvent);
     CPPUNIT_TEST(testLenientEventParsing);
     CPPUNIT_TEST(testNodeKindMapping);
+    CPPUNIT_TEST(testPropertyTreeEventsPassThrough);
+    CPPUNIT_TEST(testMultiplexerNoSources);
+    CPPUNIT_TEST(testMultiplexerSingleSource);
+    CPPUNIT_TEST(testMultiplexerSingleSourceWithSiblings);
+    CPPUNIT_TEST(testMultiplexerMultipleSources);
     CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -216,7 +470,7 @@ public:
                 </expect>
             </test>
         )!!!";
-        testEventVisitationLinks(testData, false);
+        testEventVisitationLinks(testData, PTEFlenientParsing);
     }
 
     void testNodeKindMapping()
@@ -241,7 +495,376 @@ public:
                 </expect>
             </test>
         )!!!";
-        testEventVisitationLinks(testData, false);
+        testEventVisitationLinks(testData, PTEFlenientParsing);
+    }
+
+    // Test CPropertyTreeEvents pass-through mode (consumeRecordingSource = false)
+    // Events should be passed through exactly as specified in XML, including source attributes
+    void testPropertyTreeEventsPassThrough()
+    {
+        constexpr const char* testData = R"!!!(
+            <test>
+                <input>
+                    <event type="RecordingSource" ProcessDescriptor="should_not_be_consumed" ChannelId="99" ReplicaId="98" InstanceId="97"/>
+                    <event type="FileInformation" FileId="1" Path="/test/file.dat"/>
+                    <event type="IndexCacheMiss" EventTimestamp="2025-01-01T10:00:00.000000100" FileId="1" FileOffset="1024" NodeKind="0" ChannelId="5" ReplicaId="6" InstanceId="7"/>
+                    <event type="IndexLoad" EventTimestamp="2025-01-01T10:00:00.000000200" FileId="1" FileOffset="2048" NodeKind="1" InMemorySize="4096" ReadTime="50" ExpandTime="25" ChannelId="10" ReplicaId="11" InstanceId="12"/>
+                </input>
+                <expect>
+                    <event type="RecordingSource" ProcessDescriptor="should_not_be_consumed" ChannelId="99" ReplicaId="98" InstanceId="97"/>
+                    <event type="FileInformation" FileId="1" Path="/test/file.dat"/>
+                    <event type="IndexCacheMiss" EventTimestamp="2025-01-01T10:00:00.000000100" FileId="1" FileOffset="1024" NodeKind="0" ChannelId="5" ReplicaId="6" InstanceId="7"/>
+                    <event type="IndexLoad" EventTimestamp="2025-01-01T10:00:00.000000200" FileId="1" FileOffset="2048" NodeKind="1" InMemorySize="4096" ReadTime="50" ExpandTime="25" ChannelId="10" ReplicaId="11" InstanceId="12"/>
+                </expect>
+            </test>
+        )!!!";
+        testEventVisitationLinks(testData, PTEFlenientParsing | PTEFliteralParsing);
+    }
+
+    // Test CEventMultiplexer with no source elements (direct events)
+    void testMultiplexerNoSources()
+    {
+        const char* testData = R"!!!(
+input:
+  event:
+  - type: RecordingSource
+    ProcessDescriptor: myprocess
+    ChannelId: 5
+    ReplicaId: 10
+    InstanceId: 15
+  - type: FileInformation
+    FileId: 100
+    Path: /path/to/file1.dat
+  - type: IndexCacheMiss
+    EventTimestamp: '2025-01-01T10:00:00.000000100'
+    FileId: 100
+    FileOffset: 1024
+    NodeKind: 0
+  - type: IndexLoad
+    EventTimestamp: '2025-01-01T10:00:00.000000200'
+    FileId: 100
+    FileOffset: 1024
+    NodeKind: 0
+    InMemorySize: 8192
+    ReadTime: 50
+    ExpandTime: 25
+expect:
+  event:
+  - type: RecordingSource
+    ProcessDescriptor: myprocess
+    ChannelId: 5
+    ReplicaId: 10
+    InstanceId: 15
+  - type: FileInformation
+    FileId: 100
+    Path: /path/to/file1.dat
+  - type: IndexCacheMiss
+    EventTimestamp: '2025-01-01T10:00:00.000000100'
+    FileId: 100
+    FileOffset: 1024
+    NodeKind: 0
+  - type: IndexLoad
+    EventTimestamp: '2025-01-01T10:00:00.000000200'
+    FileId: 100
+    FileOffset: 1024
+    NodeKind: 0
+    InMemorySize: 8192
+    ReadTime: 50
+    ExpandTime: 25
+)!!!";
+        testEventVisitationLinks(testData, PTEFlenientParsing);
+    }
+
+    // Test CEventMultiplexer with a single source element
+    void testMultiplexerSingleSource()
+    {
+        const char* testData = R"!!!(
+input:
+  source:
+  - event:
+    - type: RecordingSource
+      ProcessDescriptor: process1
+      ChannelId: 1
+      ReplicaId: 2
+      InstanceId: 3
+    - type: FileInformation
+      FileId: 50
+      Path: /data/index.idx
+    - type: IndexCacheHit
+      EventTimestamp: '2025-01-01T12:00:00.000000500'
+      FileId: 50
+      FileOffset: 2048
+      NodeKind: 1
+      InMemorySize: 4096
+      ExpandTime: 75
+    - type: IndexCacheMiss
+      EventTimestamp: '2025-01-01T12:00:00.000000600'
+      FileId: 50
+      FileOffset: 4096
+      NodeKind: 0
+expect:
+  event:
+  - type: FileInformation
+    FileId: 50
+    Path: /data/index.idx
+    ChannelId: 1
+    ReplicaId: 2
+    InstanceId: 3
+  - type: IndexCacheHit
+    EventTimestamp: '2025-01-01T12:00:00.000000500'
+    FileId: 50
+    FileOffset: 2048
+    NodeKind: 1
+    InMemorySize: 4096
+    ExpandTime: 75
+    ChannelId: 1
+    ReplicaId: 2
+    InstanceId: 3
+  - type: IndexCacheMiss
+    EventTimestamp: '2025-01-01T12:00:00.000000600'
+    FileId: 50
+    FileOffset: 4096
+    NodeKind: 0
+    ChannelId: 1
+    ReplicaId: 2
+    InstanceId: 3
+)!!!";
+        testEventVisitationLinks(testData, PTEFlenientParsing);
+    }
+
+    // Test CEventMultiplexer with a single source and sibling events (siblings should be ignored)
+    void testMultiplexerSingleSourceWithSiblings()
+    {
+        const char* testData = R"!!!(
+input:
+  source:
+  - event:
+    - type: RecordingSource
+      ProcessDescriptor: process2
+      ChannelId: 7
+      ReplicaId: 8
+      InstanceId: 9
+    - type: FileInformation
+      FileId: 200
+      Path: /var/data/test.dat
+    - type: IndexLoad
+      EventTimestamp: '2025-01-02T08:30:00.000001000'
+      FileId: 200
+      FileOffset: 8192
+      NodeKind: 0
+      InMemorySize: 16384
+      ReadTime: 120
+      ExpandTime: 30
+  event:
+  - type: IndexCacheMiss
+    EventTimestamp: '2025-01-02T08:30:00.000002000'
+    FileId: 999
+    FileOffset: 12288
+    NodeKind: 0
+expect:
+  event:
+  - type: FileInformation
+    FileId: 200
+    Path: /var/data/test.dat
+    ChannelId: 7
+    ReplicaId: 8
+    InstanceId: 9
+  - type: IndexLoad
+    EventTimestamp: '2025-01-02T08:30:00.000001000'
+    FileId: 200
+    FileOffset: 8192
+    NodeKind: 0
+    InMemorySize: 16384
+    ReadTime: 120
+    ExpandTime: 30
+    ChannelId: 7
+    ReplicaId: 8
+    InstanceId: 9
+)!!!";
+        testEventVisitationLinks(testData, PTEFlenientParsing);
+    }
+
+    // Test CEventMultiplexer with multiple sources (chronological merging with file ID remapping)
+    // This test covers several scenarios:
+    // 1. Same path with different FileIds in different sources (deduplication)
+    // 2. Same FileId with same path in different sources (handled correctly)
+    // 3. Same FileId with different paths in different sources (requires remapping)
+    void testMultiplexerMultipleSources()
+    {
+        const char* testData = R"!!!(
+input:
+  source:
+    - event:
+      - type: RecordingSource
+        ProcessDescriptor: testproc
+        ChannelId: 1
+        ReplicaId: 1
+        InstanceId: 1
+      - type: FileInformation
+        EventTimestamp: '2025-01-03T10:00:00.000000020'
+        FileId: 10
+        Path: /shared/index.idx
+      - type: FileInformation
+        EventTimestamp: '2025-01-03T10:00:00.000000030'
+        FileId: 50
+        Path: /local/data1.dat
+      - type: FileInformation
+        EventTimestamp: '2025-01-03T10:00:00.000000040'
+        FileId: 100
+        Path: /unique/file1.idx
+      - type: IndexCacheMiss
+        EventTimestamp: '2025-01-03T10:00:00.000000100'
+        FileId: 10
+        FileOffset: 1024
+        NodeKind: 0
+      - type: IndexCacheMiss
+        EventTimestamp: '2025-01-03T10:00:00.000000150'
+        FileId: 50
+        FileOffset: 2048
+        NodeKind: 0
+      - type: IndexLoad
+        EventTimestamp: '2025-01-03T10:00:00.000000300'
+        FileId: 100
+        FileOffset: 3072
+        NodeKind: 0
+        InMemorySize: 4096
+        ReadTime: 50
+        ExpandTime: 10
+    - event:
+      - type: RecordingSource
+        ProcessDescriptor: testproc
+        ChannelId: 2
+        ReplicaId: 1
+        InstanceId: 1
+      - type: FileInformation
+        EventTimestamp: '2025-01-03T10:00:00.000000025'
+        FileId: 10
+        Path: /shared/index.idx
+      - type: FileInformation
+        EventTimestamp: '2025-01-03T10:00:00.000000035'
+        FileId: 50
+        Path: /other/data2.dat
+      - type: FileInformation
+        EventTimestamp: '2025-01-03T10:00:00.000000045'
+        FileId: 100
+        Path: /unique/file2.idx
+      - type: IndexCacheHit
+        EventTimestamp: '2025-01-03T10:00:00.000000200'
+        FileId: 10
+        FileOffset: 1024
+        NodeKind: 0
+        InMemorySize: 4096
+        ExpandTime: 60
+      - type: IndexCacheMiss
+        EventTimestamp: '2025-01-03T10:00:00.000000250'
+        FileId: 50
+        FileOffset: 4096
+        NodeKind: 0
+      - type: IndexCacheMiss
+        EventTimestamp: '2025-01-03T10:00:00.000000400'
+        FileId: 100
+        FileOffset: 5120
+        NodeKind: 0
+expect:
+  event:
+  - type: FileInformation
+    EventTimestamp: '2025-01-03T10:00:00.000000020'
+    FileId: 1
+    Path: /shared/index.idx
+    ChannelId: 1
+    ReplicaId: 1
+    InstanceId: 1
+  - type: FileInformation
+    EventTimestamp: '2025-01-03T10:00:00.000000025'
+    FileId: 1
+    Path: /shared/index.idx
+    ChannelId: 2
+    ReplicaId: 1
+    InstanceId: 1
+  - type: FileInformation
+    EventTimestamp: '2025-01-03T10:00:00.000000030'
+    FileId: 2
+    Path: /local/data1.dat
+    ChannelId: 1
+    ReplicaId: 1
+    InstanceId: 1
+  - type: FileInformation
+    EventTimestamp: '2025-01-03T10:00:00.000000035'
+    FileId: 3
+    Path: /other/data2.dat
+    ChannelId: 2
+    ReplicaId: 1
+    InstanceId: 1
+  - type: FileInformation
+    EventTimestamp: '2025-01-03T10:00:00.000000040'
+    FileId: 4
+    Path: /unique/file1.idx
+    ChannelId: 1
+    ReplicaId: 1
+    InstanceId: 1
+  - type: FileInformation
+    EventTimestamp: '2025-01-03T10:00:00.000000045'
+    FileId: 5
+    Path: /unique/file2.idx
+    ChannelId: 2
+    ReplicaId: 1
+    InstanceId: 1
+  - type: IndexCacheMiss
+    EventTimestamp: '2025-01-03T10:00:00.000000100'
+    ChannelId: 1
+    ReplicaId: 1
+    InstanceId: 1
+    FileId: 1
+    FileOffset: 1024
+    NodeKind: 0
+  - type: IndexCacheMiss
+    EventTimestamp: '2025-01-03T10:00:00.000000150'
+    ChannelId: 1
+    ReplicaId: 1
+    InstanceId: 1
+    FileId: 2
+    FileOffset: 2048
+    NodeKind: 0
+  - type: IndexCacheHit
+    EventTimestamp: '2025-01-03T10:00:00.000000200'
+    ChannelId: 2
+    ReplicaId: 1
+    InstanceId: 1
+    FileId: 1
+    FileOffset: 1024
+    NodeKind: 0
+    InMemorySize: 4096
+    ExpandTime: 60
+  - type: IndexCacheMiss
+    EventTimestamp: '2025-01-03T10:00:00.000000250'
+    ChannelId: 2
+    ReplicaId: 1
+    InstanceId: 1
+    FileId: 3
+    FileOffset: 4096
+    NodeKind: 0
+  - type: IndexLoad
+    EventTimestamp: '2025-01-03T10:00:00.000000300'
+    ChannelId: 1
+    ReplicaId: 1
+    InstanceId: 1
+    FileId: 4
+    FileOffset: 3072
+    NodeKind: 0
+    InMemorySize: 4096
+    ReadTime: 50
+    ExpandTime: 10
+  - type: IndexCacheMiss
+    EventTimestamp: '2025-01-03T10:00:00.000000400'
+    ChannelId: 2
+    ReplicaId: 1
+    InstanceId: 1
+    FileId: 5
+    FileOffset: 5120
+    NodeKind: 0
+
+)!!!";
+        testEventVisitationLinks(testData, PTEFlenientParsing);
     }
 };
 

--- a/common/eventconsumption/eventmetaparser.hpp
+++ b/common/eventconsumption/eventmetaparser.hpp
@@ -21,22 +21,36 @@
 #include "jstring.hpp"
 #include <map>
 #include <unordered_map>
+#include <set>
 #include <string>
 
 // Visitor that parses and caches file ID to path mappings and trace ID to service name mappings
 class event_decl CMetaInfoState : public CInterface
 {
+public:
+    struct IndexFileProperties
+    {
+        Owned<String> path;
+        uint32_t id;
+
+        IndexFileProperties(String* _path, uint32_t _id) : path(_path), id(_id) {}
+    };
+
+private:
     class event_decl CCollector : public CInterfaceOf<IEventVisitationLink>
     {
     public: // IEventVisitor
+        virtual bool visitFile(const char* filename, uint32_t version) override;
         virtual bool visitEvent(CEvent& event) override;
+        virtual void departFile(uint32_t bytesRead) override;
     public: // IEventVisitationLink
-        IMPLEMENT_IEVENTVISITATIONLINK
+        virtual void setNextLink(IEventVisitor& visitor) override;
         virtual void configure(const IPropertyTree& config) override;
     public:
         CCollector(CMetaInfoState& _metaState);
     private:
         Linked<CMetaInfoState> metaState;
+        Linked<IEventVisitor> nextLink;
     };
 
 public:
@@ -54,13 +68,19 @@ public:
     // Clear all mappings
     void clearAll();
 
-    // Reverse lookup functions for convenience
-    __uint64 queryFileIdByPath(const char* path) const;
+private:
+    void onFile(const char* filename, uint32_t version);
+    void onEvent(CEvent& event);
+    uint32_t generateSourceFileId(const CEvent& event);
+    uint32_t generateRuntimeFileId(const CEvent& event);
 
 private:
+    size_t sourceCount{0};
+
     // File ID to path mappings (from MetaFileInformation events)
-    std::unordered_map<__uint64, StringAttr> fileIdToPath;
-    std::unordered_map<std::string, __uint64> pathToFileId; // For reverse lookup optimization
+    std::set<IndexFileProperties, std::less<>> indexFiles;
+    std::unordered_map<size_t, const IndexFileProperties*> sourceToProps;
+    std::unordered_map<__uint64, Owned<String>> fileIdToPath;
 
     // Trace ID to service name mappings (from EventQueryStart events)
     std::unordered_map<std::string, std::string> traceIdToService;

--- a/common/eventconsumption/eventoperation.cpp
+++ b/common/eventconsumption/eventoperation.cpp
@@ -27,12 +27,13 @@ CEventConsumingOp::CEventConsumingOp()
 
 bool CEventConsumingOp::ready() const
 {
-    return !inputPath.isEmpty() && out.get();
+    return !inputPaths.empty() && out.get();
 }
 
 void CEventConsumingOp::setInputPath(const char* path)
 {
-    inputPath.set(path);
+    if (!isEmptyString(path))
+        inputPaths.insert(path);
 }
 
 void CEventConsumingOp::setOutput(IBufferedSerialOutputStream& _out)
@@ -65,25 +66,44 @@ IEventFilter* CEventConsumingOp::ensureFilter()
     return filter;
 }
 
-bool CEventConsumingOp::traverseEvents(const char* path, IEventVisitor& visitor)
+bool CEventConsumingOp::traverseEvents(IEventVisitor& visitor)
 {
-    IEventVisitor* actual = &visitor;
+    IEventVisitor* visitationHead = &visitor;
     if (filter)
     {
-        filter->setNextLink(*actual);
-        actual = filter;
+        filter->setNextLink(*visitationHead);
+        visitationHead = filter;
     }
     if (model)
     {
-        model->setNextLink(*actual);
-        actual = model;
+        model->setNextLink(*visitationHead);
+        visitationHead = model;
     }
-    Owned<IEventVisitationLink> metaCollector = metaState->getCollector();
-    metaCollector->setNextLink(*actual);
 
-    Owned<IEventIterator> source = createEventFileIterator(path);
-    if (!source)
-        return false;
-    visitIterableEvents(*source, *metaCollector);
+    Owned<IEventIterator> source;
+    Owned<IEventVisitationLink> metaCollector;
+    if (inputPaths.size() > 1)
+    {
+        Owned<IEventMultiplexer> multiplexer = createEventMultiplexer(*metaState);
+        source.set(multiplexer.get());
+        for (const std::string& path : inputPaths)
+        {
+            Owned<IEventIterator> input = createEventFileIterator(path.c_str());
+            if (!input)
+                throw makeStringExceptionV(0, "Failed to open event file: %s", path.c_str());
+            multiplexer->addSource(*input);
+        }
+    }
+    else
+    {
+        source.setown(createEventFileIterator(inputPaths.begin()->c_str()));
+        if (!source)
+            throw makeStringExceptionV(0, "Failed to open event file: %s", inputPaths.begin()->c_str());
+        metaCollector.setown(metaState->getCollector());
+        metaCollector->setNextLink(*visitationHead);
+        visitationHead = metaCollector;
+    }
+
+    visitIterableEvents(*source, *visitationHead);
     return true;
 }

--- a/common/eventconsumption/eventoperation.h
+++ b/common/eventconsumption/eventoperation.h
@@ -21,6 +21,8 @@
 #include "eventfilter.h"
 #include "eventmodeling.h"
 #include "eventmetaparser.hpp"
+#include <set>
+#include <string>
 
 // Base operation class that provides meta parser functionality and supports streaming output
 // and event filtering by event kind and attribute values. This satisfies the requirements
@@ -35,6 +37,7 @@ public:
     CEventConsumingOp();
     CMetaInfoState& queryMetaInfoState() { return *metaState; }
     virtual bool ready() const;
+    // Add unique and non-empty paths to the collection of input paths.
     void setInputPath(const char* path);
     void setOutput(IBufferedSerialOutputStream& _out);
     bool acceptEvents(const char* eventNames);
@@ -42,10 +45,10 @@ public:
     bool acceptModel(const IPropertyTree& config);
 protected:
     IEventFilter* ensureFilter();
-    bool traverseEvents(const char* path, IEventVisitor& visitor);
+    bool traverseEvents(IEventVisitor& visitor);
 protected:
     Owned<CMetaInfoState> metaState;
-    StringAttr inputPath;
+    std::set<std::string> inputPaths;
     Linked<IBufferedSerialOutputStream> out;
 private:
     Owned<IEventFilter> filter;

--- a/common/eventconsumption/eventsaveas.cpp
+++ b/common/eventconsumption/eventsaveas.cpp
@@ -57,7 +57,7 @@ bool CEventSavingOp::doOp()
     Owned<IEventVisitor> terminalVisitor = new CEventSavingVisitor(*this);
     try
     {
-        traverseEvents(inputPath, *terminalVisitor);
+        traverseEvents(*terminalVisitor);
         recorder.stopRecording(&summary);
     }
     catch (...)

--- a/common/eventconsumption/eventunittests.hpp
+++ b/common/eventconsumption/eventunittests.hpp
@@ -45,9 +45,9 @@ private:
 
 // Extracts `input`, `expect`, and `link` property tree sections from `testData`, passing them to
 // `testEventVisitationLinks(input, expect, links)` for processing. The markup may be XML, JSON,
-// or 'YAML' format.
-extern void testEventVisitationLinks(const char* testData, bool strictParsing);
-inline void testEventVisitationLinks(const char* testData) { testEventVisitationLinks(testData, true); }
+// or YAML format.
+extern void testEventVisitationLinks(const char* testData, unsigned flags);
+inline void testEventVisitationLinks(const char* testData) { testEventVisitationLinks(testData, PTEFnone); }
 
 // Uses a `CEventVisitationLinkTester` instance to iterate over the `input` events, verifying that
 // the events received by the tester match the `expected` events after modification by visitation
@@ -55,9 +55,7 @@ inline void testEventVisitationLinks(const char* testData) { testEventVisitation
 //
 // Multiple links may be configured. Within the iteration, the first link is closest to the tester
 // and the last link receives the input events.
-//
-// At this time, only model links are supported. Filters may be supported by a future update.
-extern void testEventVisitationLinks(const IPropertyTree& input, const IPropertyTree& expect, IPropertyTreeIterator& links, bool strictParsing);
+extern void testEventVisitationLinks(const IPropertyTree& input, const IPropertyTree& expect, IPropertyTreeIterator& links, unsigned flags);
 
 extern IPropertyTree* createTestConfiguration(const char* configText);
 

--- a/common/eventconsumption/eventvisitor.h
+++ b/common/eventconsumption/eventvisitor.h
@@ -44,6 +44,6 @@ interface IEventVisitationLink : extends IEventVisitor
 protected: \
     Linked<IEventVisitor> nextLink; \
 public: \
-    void setNextLink(IEventVisitor& visitor) override { nextLink.set(&visitor); } \
-    bool visitFile(const char* filename, uint32_t version) override { if (!nextLink) return false; return nextLink->visitFile(filename, version); } \
-    void departFile(uint32_t bytesRead) override { if (!nextLink) return; nextLink->departFile(bytesRead); }
+    virtual void setNextLink(IEventVisitor& visitor) override { nextLink.set(&visitor); } \
+    virtual bool visitFile(const char* filename, uint32_t version) override { if (!nextLink) return false; return nextLink->visitFile(filename, version); } \
+    virtual void departFile(uint32_t bytesRead) override { if (!nextLink) return; nextLink->departFile(bytesRead); }

--- a/testing/unittests/jlibtests2.cpp
+++ b/testing/unittests/jlibtests2.cpp
@@ -634,7 +634,8 @@ attribute: DataSize = 73
 
                     if (eventCount == 1)
                     {
-                        // First event should be IndexCacheMiss without ChannelId, ReplicaId, InstanceId assigned
+                        // First event should be IndexCacheMiss with ChannelId, ReplicaId, InstanceId
+                        // assigned from RecordingSource (even though not originally recorded with them)
                         CPPUNIT_ASSERT_EQUAL((int)EventIndexCacheMiss, (int)event.queryType());
                         CPPUNIT_ASSERT(event.hasAttribute(EvAttrFileId));
                         CPPUNIT_ASSERT_EQUAL(100ULL, event.queryNumericValue(EvAttrFileId));
@@ -642,13 +643,14 @@ attribute: DataSize = 73
                         CPPUNIT_ASSERT_EQUAL(200ULL, event.queryNumericValue(EvAttrFileOffset));
                         CPPUNIT_ASSERT(event.hasAttribute(EvAttrNodeKind));
                         CPPUNIT_ASSERT_EQUAL((int)NodeLeaf, (int)event.queryNumericValue(EvAttrNodeKind));
-                        // Verify ChannelId, ReplicaId, InstanceId are defined but not assigned
-                        CPPUNIT_ASSERT(event.isAttribute(EvAttrChannelId));
-                        CPPUNIT_ASSERT(!event.hasAttribute(EvAttrChannelId));
-                        CPPUNIT_ASSERT(event.isAttribute(EvAttrReplicaId));
-                        CPPUNIT_ASSERT(!event.hasAttribute(EvAttrReplicaId));
-                        CPPUNIT_ASSERT(event.isAttribute(EvAttrInstanceId));
-                        CPPUNIT_ASSERT(!event.hasAttribute(EvAttrInstanceId));
+                        // Verify ChannelId, ReplicaId, InstanceId are assigned with correct values
+                        // from RecordingSource by the iterator
+                        CPPUNIT_ASSERT(event.hasAttribute(EvAttrChannelId));
+                        CPPUNIT_ASSERT_EQUAL(1ULL, event.queryNumericValue(EvAttrChannelId));
+                        CPPUNIT_ASSERT(event.hasAttribute(EvAttrReplicaId));
+                        CPPUNIT_ASSERT_EQUAL(2ULL, event.queryNumericValue(EvAttrReplicaId));
+                        CPPUNIT_ASSERT(event.hasAttribute(EvAttrInstanceId));
+                        CPPUNIT_ASSERT_EQUAL(3ULL, event.queryNumericValue(EvAttrInstanceId));
                     }
                     else if (eventCount == 2)
                     {

--- a/tools/evtool/evtool.hpp
+++ b/tools/evtool/evtool.hpp
@@ -161,7 +161,9 @@ protected:
     {
         constexpr const char* usageStr = R"!!!(
 Parameters:
-    <filename>                Full path to an event data file.
+    <filename>                Full path to an event data file. One is required.
+                              Multiple are accepted, with the effect of merge-
+                              sorting the events from each by timestamp.
 )!!!";
         size32_t usageStrLength = size32_t(strlen(usageStr));
         out.put(usageStrLength, usageStr);

--- a/tools/evtool/evtsim.cpp
+++ b/tools/evtool/evtsim.cpp
@@ -54,9 +54,9 @@ public:
         EventRecorder& recorder = queryRecorder();
         if (!recorder.startRecording(options, name, false))
             throw makeStringException(-1, "failed to start event recording");
-        CPropertyTreeEvents eventsIt(*input);
+        Owned<IEventIterator> eventsIt = createPropertyTreeEvents(*input, PTEFliteralParsing);
         CEvent event;
-        while (eventsIt.nextEvent(event))
+        while (eventsIt->nextEvent(event))
             recorder.recordEvent(event);
         if (!recorder.stopRecording(nullptr))
             throw makeStringException(-1, "failed to stop event recording");


### PR DESCRIPTION
- Create a multiplexing event iterator that distributes events originating from multiple event iterators in chronological order. All event timestamps are assumed to be based on the same clock, which is not guaranteed.
- Improve the property tree event iterator to mimic file iteration behavior by default, while supporting lenient parsing requirements for unit tests and literal parsing requirements for the evtool sim command.
- Change the meta state class to manage FileId mappings from multiple event sources.
- Change evtool command line processing to accept multiple input filename parameters.
- Change event consumption operations to choose the multiplexing iterator when multiple input paths are provided.
- Update unit test code to support simulating input events from multiple sources and add unit tests for multipexing testing.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [ ] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
