### PR TITLE
HPCC-35784 Add WsSMC.GetBanner to reduce dali usage

### DIFF
--- a/esp/scm/ws_smc.ecm
+++ b/esp/scm/ws_smc.ecm
@@ -272,6 +272,21 @@ ESPresponse [exceptions_inline] SetBannerResponse
 {
 };
 
+ESPrequest [nil_remove, min_ver("1.30")] GetBannerRequest
+{
+};
+
+ESPresponse [exceptions_inline, min_ver("1.30")] GetBannerResponse
+{
+    string BannerContent;
+    string BannerColor;
+    string BannerSize;
+    string BannerScroll;
+    string ChatURL;
+    int BannerAction(0);
+    int ShowChatURL(0);
+};
+
 ESPrequest NotInCommunityEditionRequest
 {
     string EEPortal; 
@@ -489,7 +504,7 @@ ESPresponse [exceptions_inline, nil_remove] RecordGlobalMetricsResponse
     string Result;                              // Success or partial success message
 };
 
-ESPservice [auth_feature("DEFERRED"), noforms, version("1.29"), default_client_version("1.29"), exceptions_inline("./smc_xslt/exceptions.xslt"), use_method_name] WsSMC
+ESPservice [auth_feature("DEFERRED"), noforms, version("1.30"), default_client_version("1.30"), exceptions_inline("./smc_xslt/exceptions.xslt"), use_method_name] WsSMC
 {
     ESPmethod Index(SMCIndexRequest, SMCIndexResponse);
     ESPmethod [resp_xsl_default("/esp/xslt/index.xslt")] Activity(ActivityRequest, ActivityResponse);
@@ -510,6 +525,7 @@ ESPservice [auth_feature("DEFERRED"), noforms, version("1.29"), default_client_v
     ESPmethod GetThorQueueAvailability(GetThorQueueAvailabilityRequest, GetThorQueueAvailabilityResponse);
 //this one ensures superuser, but no feature check is done, Kevin/Tony?
     ESPmethod [auth_feature("NONE")] SetBanner(SetBannerRequest, SetBannerResponse);
+    ESPmethod [auth_feature("NONE"), min_ver("1.30")] GetBanner(GetBannerRequest, GetBannerResponse);
 //this one ensures superuser, but no feature check is done, Kevin/Tony?
     ESPmethod [auth_feature("NONE")] NotInCommunityEdition(NotInCommunityEditionRequest, NotInCommunityEditionResponse);
 

--- a/esp/scm/ws_smc.ecm
+++ b/esp/scm/ws_smc.ecm
@@ -283,7 +283,7 @@ ESPresponse [exceptions_inline, min_ver("1.30")] GetBannerResponse
     string BannerSize;
     string BannerScroll;
     string ChatURL;
-    int BannerAction(0);
+    int ShowBanner(0);
     int ShowChatURL(0);
 };
 

--- a/esp/services/ws_smc/ws_smcService.cpp
+++ b/esp/services/ws_smc/ws_smcService.cpp
@@ -2065,6 +2065,28 @@ bool CWsSMCEx::onSetBanner(IEspContext &context, IEspSetBannerRequest &req, IEsp
     return true;
 }
 
+bool CWsSMCEx::onGetBanner(IEspContext &context, IEspGetBannerRequest &req, IEspGetBannerResponse& resp)
+{
+    context.ensureFeatureAccess(FEATURE_URL, SecAccess_Read, ECLWATCH_SMC_ACCESS_DENIED, SMC_ACCESS_DENIED);
+    
+    try
+    {
+        // Similar to setBannerAndChatData, return the banner information stored in member variables
+        resp.setBannerAction(m_BannerAction);
+        resp.setShowChatURL(m_EnableChatURL);
+        resp.setBannerContent(m_Banner.str());
+        resp.setBannerSize(m_BannerSize.str());
+        resp.setBannerColor(m_BannerColor.str());
+        resp.setBannerScroll(m_BannerScroll.str());
+        resp.setChatURL(m_ChatURL.str());
+    }
+    catch(IException* e)
+    {
+        FORWARDEXCEPTION(context, e,  ECLWATCH_INTERNAL_ERROR);
+    }
+    return true;
+}
+
 bool CWsSMCEx::onNotInCommunityEdition(IEspContext &context, IEspNotInCommunityEditionRequest &req, IEspNotInCommunityEditionResponse &resp)
 {
    return true;

--- a/esp/services/ws_smc/ws_smcService.cpp
+++ b/esp/services/ws_smc/ws_smcService.cpp
@@ -2072,7 +2072,7 @@ bool CWsSMCEx::onGetBanner(IEspContext &context, IEspGetBannerRequest &req, IEsp
     try
     {
         // Similar to setBannerAndChatData, return the banner information stored in member variables
-        resp.setBannerAction(m_BannerAction);
+        resp.setShowBanner(m_BannerAction);
         resp.setShowChatURL(m_EnableChatURL);
         resp.setBannerContent(m_Banner.str());
         resp.setBannerSize(m_BannerSize.str());

--- a/esp/services/ws_smc/ws_smcService.hpp
+++ b/esp/services/ws_smc/ws_smcService.hpp
@@ -209,6 +209,7 @@ public:
     bool onSetJobPriority(IEspContext &context, IEspSMCPriorityRequest &req, IEspSMCPriorityResponse &resp);
     bool onGetThorQueueAvailability(IEspContext &context, IEspGetThorQueueAvailabilityRequest &req, IEspGetThorQueueAvailabilityResponse& resp);
     bool onSetBanner(IEspContext &context, IEspSetBannerRequest &req, IEspSetBannerResponse& resp);
+    bool onGetBanner(IEspContext &context, IEspGetBannerRequest &req, IEspGetBannerResponse& resp);
     bool onNotInCommunityEdition(IEspContext &context, IEspNotInCommunityEditionRequest &req, IEspNotInCommunityEditionResponse &resp);
 
     virtual bool attachServiceToDali() override


### PR DESCRIPTION
* Add GetBanner method to WsSMC service (version 1.30)

---------

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [x] All new and existing tests passed.
  - [x] I have checked that this change does not introduce memory leaks.
  - [x] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [x] Scalability
  - [x] Performance
  - [x] Security
  - [x] Thread-safety
  - [x] Cloud-compatibility
  - [x] Premature optimization
  - [x] Existing deployed queries will not be broken
  - [x] This change fixes the problem, not just the symptom
  - [x] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
