### PR TITLE
HPCC-35764 DFU Server backtrace while running a job and now unable to abort it

### DIFF
--- a/dali/dfu/dfurun.cpp
+++ b/dali/dfu/dfurun.cpp
@@ -1292,6 +1292,13 @@ public:
         IRemoteConnection *recoveryconn;
         Owned<IRemoteConnection> runningconn;
         wu->queryRecoveryStore(recoveryconn,recovery,runningpath.clear());
+        if (recovery)
+        {
+            // Record the owning process session so stalled recovery can be detected later.
+            recovery->setPropInt64("@session", myProcessSession());
+            if (recoveryconn)
+                recoveryconn->commit();
+        }
         DFUstate s = progress->getState();
         switch (s) {
         case DFUstate_aborting:
@@ -1986,11 +1993,24 @@ public:
                                 break;
                             }
                         }
+
+                        // Clear existing recovery details before replication starts,
+                        // while preserving the owning session id across this reset.
+                        SessionId recoverySession = myProcessSession();
+                        if (recovery)
+                        {
+                            SessionId existingSession = (SessionId) recovery->getPropInt64("@session", 0);
+                            if (existingSession > 0)
+                                recoverySession = existingSession;
+                        }
                         wu->removeRecoveryStore();
                         wu->queryRecoveryStore(recoveryconn,recovery,runningpath.clear());
-                        if (recoveryconn&&recovery) {
-                            recovery->setPropBool("@replicating",true);
-                            recoveryconn->commit();
+                        if (recovery)
+                        {
+                            recovery->setPropBool("@replicating", true);
+                            recovery->setPropInt64("@session", recoverySession);
+                            if (recoveryconn)
+                                recoveryconn->commit();
                         }
                         fsys.replicate(fdesc.get(), mode, recovery, recoveryconn, filter, opttree, &feedback, &abortnotify, dfuwuid);
                         if (!abortnotify.abortRequested()) {

--- a/dali/dfu/dfuwu.cpp
+++ b/dali/dfu/dfuwu.cpp
@@ -723,53 +723,17 @@ public:
     void setState(DFUstate state)
     {
         CriticalBlock block(parent->crit);
-        CDateTime dt;
-        bool noted = queryRoot()->getPropBool("@noted", false);
-        bool subtask = isSubTaskWuid(parent->queryId());
-        switch (state) {
-        case DFUstate_started:
-            dt.setTimeStamp(getTimeStampNowValue());
-            setTimeStarted(dt);
-            break;
-        case DFUstate_aborting:
-            {
-                DFUstate oldstate = getState();
-                if ((oldstate==DFUstate_aborted)||(oldstate==DFUstate_failed)||(oldstate==DFUstate_finished))
-                    state = oldstate;
-            }
-            // fall through
-        case DFUstate_aborted:
-        case DFUstate_failed:
-        case DFUstate_finished:
-            if (parent->removeQueue()&&(state==DFUstate_aborting))
-                state = DFUstate_aborted;
-            dt.setTimeStamp(getTimeStampNowValue());
-            setTimeStopped(dt);
-            if (subtask && !noted)
-                queryRoot()->setPropBool("@noted", true);
-            break;
-        }
-        StringBuffer s;
-        encodeDFUstate(state,s);
-        queryRoot()->setProp("@state",s.str());
-
-        parent->commit();
-        if (subtask && !noted)
-            notePublisherSubTaskState(parent->queryId(), state);
+        setStateWhileLocked(state);
     }
     void setTimeStarted(const CDateTime &val)
     {
         CriticalBlock block(parent->crit);
-        StringBuffer str;
-        val.getString(str);
-        queryRoot()->setProp("@timestarted",str.str());
+        setTimeStartedWhileLocked(val);
     }
     void setTimeStopped(const CDateTime &val)
     {
         CriticalBlock block(parent->crit);
-        StringBuffer str;
-        val.getString(str);
-        queryRoot()->setProp("@timestopped",str.str());
+        setTimeStoppedWhileLocked(val);
     }
     void setTotalNodes(unsigned val)
     {
@@ -825,6 +789,117 @@ public:
         queryRoot()->setPropTree("TransferOptions", createPTreeFromIPT(options));
     }
 
+    void checkRecoverySessionStateWhileLocked(bool persistStateChange)
+    {
+        DFUstate state = queryDfuStateUnderLock();
+        switch (state)
+        {
+        case DFUstate_scheduled:
+        case DFUstate_queued:
+        case DFUstate_started:
+        case DFUstate_monitoring:
+        case DFUstate_aborting:
+            break;
+        default:
+            return;
+        }
+
+        IPropertyTree *recovery = parent->root ? parent->root->queryPropTree("Recovery") : nullptr;
+        if (!recovery)
+            return;
+
+        SessionId sessionId = (SessionId)recovery->getPropInt64("@session", 0);
+        if (sessionId <= 0)
+            return;
+
+        bool stopped = false;
+        try
+        {
+            stopped = querySessionManager().sessionStopped(sessionId, 0);
+        }
+        catch (IException *e)
+        {
+            EXCLOG(e, "CDFUprogress::checkRecoverySessionStateWhileLocked");
+            e->Release();
+            return;
+        }
+
+        if (!stopped)
+            return;
+
+        if (persistStateChange)
+            setStateWhileLocked(DFUstate_failed);
+        else
+        {
+            StringBuffer s;
+            encodeDFUstate(DFUstate_failed, s);
+            queryRoot()->setProp("@state", s.str());
+        }
+    }
+
+private:
+    DFUstate queryDfuStateUnderLock() const
+    {
+        return decodeDFUstate(queryRoot()->queryProp("@state"));
+    }
+
+    void setTimeStartedWhileLocked(const CDateTime &val)
+    {
+        StringBuffer str;
+        val.getString(str);
+        queryRoot()->setProp("@timestarted", str.str());
+    }
+
+    void setTimeStoppedWhileLocked(const CDateTime &val)
+    {
+        StringBuffer str;
+        val.getString(str);
+        queryRoot()->setProp("@timestopped", str.str());
+    }
+
+    void setStateWhileLocked(DFUstate state)
+    {
+        CDateTime dt;
+        bool noted = queryRoot()->getPropBool("@noted", false);
+        bool subtask = isSubTaskWuid(parent->queryId());
+        switch (state)
+        {
+        case DFUstate_started:
+            dt.setTimeStamp(getTimeStampNowValue());
+            setTimeStartedWhileLocked(dt);
+            break;
+        case DFUstate_aborting:
+        {
+            DFUstate oldstate = queryDfuStateUnderLock();
+            switch (oldstate)
+            {
+            case DFUstate_aborted:
+            case DFUstate_failed:
+            case DFUstate_finished:
+                state = oldstate;
+                break;
+            }
+        }
+            // fall through
+        case DFUstate_aborted:
+        case DFUstate_failed:
+        case DFUstate_finished:
+            if (parent->removeQueue() && (state == DFUstate_aborting))
+                state = DFUstate_aborted;
+            dt.setTimeStamp(getTimeStampNowValue());
+            setTimeStoppedWhileLocked(dt);
+            if (subtask && !noted)
+                queryRoot()->setPropBool("@noted", true);
+            break;
+        }
+        StringBuffer s;
+        encodeDFUstate(state, s);
+        queryRoot()->setProp("@state", s.str());
+
+        parent->commit();
+        if (subtask && !noted)
+            notePublisherSubTaskState(parent->queryId(), state);
+    }
 };
 
 class CDFUmonitor: public CLinkedDFUWUchild, implements IDFUmonitor
@@ -2664,6 +2739,7 @@ public:
                 return NULL;
             progress.reinit();
         }
+        progress.checkRecoverySessionStateWhileLocked(updating);
         return &progress;
     }
 
@@ -2907,6 +2983,8 @@ public:
 
     IDFUprogress *queryUpdateProgress()
     {
+        CriticalBlock block(crit);
+        progress.checkRecoverySessionStateWhileLocked(true);
         return &progress;
     }
 


### PR DESCRIPTION
Problem:
DFU jobs could get stuck in an in-progress state and become unable to abort when their controlling process session terminated unexpectedly.

Solution:
- Detect terminated recovery sessions and auto-transition jobs to failed state
- New helper method `checkRecoverySessionStateWhileLocked()` handles detection and state update
- Thread-safe with robust error handling

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [x] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [ ] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [x] Send notifications about my Pull Request position in Smoketest queue.
- [x] Test my draft Pull Request.

## Testing:
A 200GB DFU file spray was started and killed before completion, the DFU work unit was set to failed, see: [DFU Server kill test 20th April 2026 10.48.docx](https://reedelsevier.sharepoint.com/:u:/r/sites/OG-HPCCPlatformTeam/Shared%20Documents/Misc/HPCC-35764%20DFU%20Server%20running,%20unable%20to%20abort/DFU%20Server%20kill%20test%2020th%20April%202026%2010.48.zip?csf=1&web=1&e=lesM88)
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
