### PR TITLE
HPCC-31546 Daylight saving handling in cloud environments

### DIFF
--- a/ecllibrary/std/Date.ecl
+++ b/ecllibrary/std/Date.ecl
@@ -1243,14 +1243,76 @@ END;
 
 
 /**
+ * IsUSDaylightSavingsInEffect
+ *
+ * Returns TRUE if Daylight Saving Time (DST) is considered in effect for the given
+ * date under U.S. federal DST schedules (where they existed), otherwise FALSE.
+ *
+ * This function intentionally uses a date-only approximation:
+ *  - DST is treated as active starting on the start-transition Sunday (inclusive)
+ *  - and inactive starting on the end-transition Sunday (exclusive).
+ *
+ * This avoids ambiguity around the local 02:00 transition time (and the midnight–02:00
+ * window on the “fall back” day). If you need hour-level correctness, use a
+ * timestamp + timezone rules (e.g., IANA tzdata) instead.
+ *
+ * Historical notes / limitations:
+ *  - 1967+ follows the Uniform Time Act schedules (with the 1974–1975 exceptions and
+ *    the 1987 and 2007 rule changes).
+ *  - 1942–1945 models WWII “War Time” as continuous DST (starting 1942-02-09, ending 1945-09-30).
+ *  - 1920–1941 and 1946–1966 return FALSE because DST was not federally standardized
+ *    and varied by state/locality.
+ *  - This does NOT account for state/local exemptions (e.g., areas that do not observe DST).
+ *
+ * @param   date    The date in question, in YYYYMMDD format; REQUIRED
+ *
+ * @return  TRUE if daylight saving time was in effect on that date (after 2am), FALSE otherwise.
+ */
+EXPORT BOOLEAN IsUSDaylightSavingsInEffect(Date_t date) := FUNCTION
+    // Helper functions
+    Date_t SundayDateBefore(Date_t d, UNSIGNED1 nthSunday = 1) := FUNCTION
+        delta := (DayOfWeek(d) - 1) + ((nthSunday - 1) * 7);
+        RETURN AdjustDate(d, day_delta := -delta);
+    END;
+    Date_t SundayDateAfter(Date_t d, UNSIGNED1 nthSunday = 1) := FUNCTION
+        delta := ((8 - DayOfWeek(d)) % 7) + ((nthSunday - 1) * 7);
+        RETURN AdjustDate(d, day_delta := delta);
+    END;
+
+    myYear := Year(date);
+
+    RETURN MAP
+        (
+            myYear >= 2007 => (date >= SundayDateAfter(DateFromParts(myYear, 3, 1), 2) AND date < SundayDateAfter(DateFromParts(myYear, 11, 1))),
+            myYear >= 1987 => (date >= SundayDateAfter(DateFromParts(myYear, 4, 1)) AND date < SundayDateBefore(DateFromParts(myYear, 10, 31))),
+            myYear >= 1976 => (date >= SundayDateBefore(DateFromParts(myYear, 4, 30)) AND date < SundayDateBefore(DateFromParts(myYear, 10, 31))),
+            myYear =  1975 => (date >= SundayDateBefore(DateFromParts(myYear, 2, 28)) AND date < SundayDateBefore(DateFromParts(myYear, 10, 31))),
+            myYear =  1974 => (date >= SundayDateAfter(DateFromParts(myYear, 1, 1)) AND date < SundayDateBefore(DateFromParts(myYear, 10, 31))),
+            myYear >= 1967 => (date >= SundayDateBefore(DateFromParts(myYear, 4, 30)) AND date < SundayDateBefore(DateFromParts(myYear, 10, 31))),
+            myYear >= 1946 => FALSE, // DST not federally mandated (varied by locality)
+            myYear =  1945 => (date < SundayDateBefore(DateFromParts(myYear, 9, 30))),
+            myYear >= 1943 => TRUE, // "war time" (continuous DST)
+            myYear =  1942 => (date >= SundayDateAfter(DateFromParts(myYear, 2, 1), 2)),
+            myYear >= 1920 => FALSE, // DST not federally mandated (varied by locality)
+            myYear >= 1918 => (date >= SundayDateBefore(DateFromParts(myYear, 3, 31)) AND date < SundayDateBefore(DateFromParts(myYear, 10, 31))),
+            FALSE
+        );
+END;
+
+
+/**
  * Returns a boolean indicating whether daylight savings time is currently
  * in effect locally.
  *
  * @return      TRUE if daylight savings time is currently in effect, FALSE otherwise.
  */
 
-EXPORT BOOLEAN IsLocalDaylightSavingsInEffect() :=
-    TimeLib.IsLocalDaylightSavingsInEffect();
+EXPORT BOOLEAN IsLocalDaylightSavingsInEffect() := FUNCTION
+    #IF(TimeLib.LocalTimeZoneOffset() = 0)
+        #WARNING('Std.Date.IsLocalDaylightSavingsInEffect() has been called on a cluster in the UTC time zone')
+    #END
+    RETURN TimeLib.IsLocalDaylightSavingsInEffect();
+END;
 
 
 /**
@@ -1286,7 +1348,12 @@ EXPORT Date_t CurrentDate(BOOLEAN in_local_time = FALSE) :=
  * @return              A Date_t representing the current date.
  */
 
-EXPORT Date_t Today() := CurrentDate(TRUE);
+EXPORT Date_t Today() := FUNCTION
+    #IF(TimeLib.LocalTimeZoneOffset() = 0)
+        #WARNING('Std.Date.Today() has been called on a cluster in the UTC time zone')
+    #END
+    RETURN CurrentDate(TRUE);
+END;
 
 
 /**

--- a/ecllibrary/teststd/Date/TestDate.ecl
+++ b/ecllibrary/teststd/Date/TestDate.ecl
@@ -146,6 +146,67 @@ EXPORT TestDate := MODULE
 
     ASSERT(EXISTS(Date.TimeZone.TZ_Data), CONST);
 
+    ASSERT(Date.IsUSDaylightSavingsInEffect(20250301) = FALSE, CONST);   // Saturday before 2nd Sun Mar 2025 (Mar 9)
+    ASSERT(Date.IsUSDaylightSavingsInEffect(20250309) = TRUE,  CONST);   // Start day inclusive
+    ASSERT(Date.IsUSDaylightSavingsInEffect(20250308) = FALSE, CONST);   // Day before start
+    ASSERT(Date.IsUSDaylightSavingsInEffect(20251102) = FALSE, CONST);   // End day exclusive (first Sun Nov)
+    ASSERT(Date.IsUSDaylightSavingsInEffect(20251031) = TRUE,  CONST);   // Day before end
+    ASSERT(Date.IsUSDaylightSavingsInEffect(20250715) = TRUE,  CONST);   // Mid-summer
+    ASSERT(Date.IsUSDaylightSavingsInEffect(20250115) = FALSE, CONST);   // Winter
+
+    // 1987–2006 rules (first Sunday April → last Sunday October)
+    ASSERT(Date.IsUSDaylightSavingsInEffect(20060401) = FALSE, CONST);   // Before first Sun Apr (Apr 2)
+    ASSERT(Date.IsUSDaylightSavingsInEffect(20060402) = TRUE,  CONST);
+    ASSERT(Date.IsUSDaylightSavingsInEffect(20061029) = FALSE, CONST);   // Last Sun Oct exclusive
+    ASSERT(Date.IsUSDaylightSavingsInEffect(20061030) = FALSE, CONST);   // Monday after last Sun
+
+    // 1976–1986 rules (last Sunday April → last Sunday October)
+    ASSERT(Date.IsUSDaylightSavingsInEffect(19860426) = FALSE, CONST);   // Before last Sun Apr (Apr 27)
+    ASSERT(Date.IsUSDaylightSavingsInEffect(19860427) = TRUE,  CONST);   // last Sunday April = start inclusive
+    ASSERT(Date.IsUSDaylightSavingsInEffect(19861025) = TRUE,  CONST);
+    ASSERT(Date.IsUSDaylightSavingsInEffect(19861026) = FALSE, CONST);
+
+    // 1975 special (last Sun Feb → last Sun Oct)
+    ASSERT(Date.IsUSDaylightSavingsInEffect(19750223) = TRUE,  CONST);   // SundayBefore(Feb 28) — Feb 23 was a Sunday in '75
+    ASSERT(Date.IsUSDaylightSavingsInEffect(19750222) = FALSE, CONST);
+    ASSERT(Date.IsUSDaylightSavingsInEffect(19751025) = TRUE,  CONST);
+    ASSERT(Date.IsUSDaylightSavingsInEffect(19751026) = FALSE, CONST);
+
+    // 1974 special (Jan 6 start → last Sun Oct) — code approximates with SundayAfter(Jan 1, 1)
+    ASSERT(Date.IsUSDaylightSavingsInEffect(19740105) = FALSE, CONST);
+    ASSERT(Date.IsUSDaylightSavingsInEffect(19740106) = TRUE,  CONST);   // SundayAfter(Jan 1) was Jan 6 in 1974
+    ASSERT(Date.IsUSDaylightSavingsInEffect(19741026) = TRUE,  CONST);
+    ASSERT(Date.IsUSDaylightSavingsInEffect(19741027) = FALSE, CONST);
+
+    // 1967–1973 rules (last Sunday April → last Sunday October)
+    ASSERT(Date.IsUSDaylightSavingsInEffect(19670430) = TRUE,  CONST);   // last Sun Apr 1967
+    ASSERT(Date.IsUSDaylightSavingsInEffect(19670429) = FALSE, CONST);
+    ASSERT(Date.IsUSDaylightSavingsInEffect(19671028) = TRUE,  CONST);
+    ASSERT(Date.IsUSDaylightSavingsInEffect(19671029) = FALSE, CONST);
+
+    // Pre-1967: 1946–1966 → FALSE
+    ASSERT(Date.IsUSDaylightSavingsInEffect(19500704) = FALSE, CONST);
+    ASSERT(Date.IsUSDaylightSavingsInEffect(19661231) = FALSE, CONST);
+
+    // WWII era
+    // 1945: continuous until SundayBefore(Sep 30) exclusive → Sep 29 true, Sep 30 false
+    ASSERT(Date.IsUSDaylightSavingsInEffect(19450929) = TRUE,  CONST);
+    ASSERT(Date.IsUSDaylightSavingsInEffect(19450930) = FALSE, CONST);
+    ASSERT(Date.IsUSDaylightSavingsInEffect(19450101) = TRUE,  CONST);   // full year-ish
+
+    // 1943–1944: full TRUE (war time continuous)
+    ASSERT(Date.IsUSDaylightSavingsInEffect(19430704) = TRUE,  CONST);
+    ASSERT(Date.IsUSDaylightSavingsInEffect(19431225) = TRUE,  CONST);
+
+    // 1942: starts SundayAfter(Feb 1, 2) = second Sunday Feb (Feb 8, 1942)
+    ASSERT(Date.IsUSDaylightSavingsInEffect(19420207) = FALSE, CONST);
+    ASSERT(Date.IsUSDaylightSavingsInEffect(19420208) = TRUE,  CONST);
+    ASSERT(Date.IsUSDaylightSavingsInEffect(19421231) = TRUE,  CONST);
+
+    // Pre-1942: 1920–1941 → FALSE (and earlier)
+    ASSERT(Date.IsUSDaylightSavingsInEffect(19300615) = FALSE, CONST);
+    ASSERT(Date.IsUSDaylightSavingsInEffect(19180704) = TRUE, CONST);
+
     ASSERT(TRUE, CONST)
   ];
 


### PR DESCRIPTION
Emit workunit warnings for functions that may respond incorrectly when environment is running on UTC. UTC does not have daylight saving time and most (all?) cloud providers have their environments set to only UTC.  Developers who are used to in-house clusters, with local time zones set, need to be aware of this change.

Additionally, add a new function for determining daylight savings in the U.S. via legal definitions for any given date.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [x] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [x] I have created a JIRA ticket to update the documentation.
  - [x] Any new interfaces or exported functions are appropriately commented.
- [ ] I have read the CONTRIBUTORS document.
- [ ] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
