### PR TITLE
HPCC-35929 fix(dali): out of order Dali transactions

### DIFF
--- a/dali/base/dasds.cpp
+++ b/dali/base/dasds.cpp
@@ -1118,7 +1118,7 @@ public:
 
 static constexpr unsigned defaultSaveThresholdSecs = 0; // disabled
 static constexpr unsigned defaultDeltaSaveTransactionThreshold = 0; // disabled
-static constexpr unsigned defaultDeltaMemMaxMB = 10;
+static constexpr unsigned defaultDeltaMemMaxMB = 64; // 64MB a reasonably large default, to cope with large blobs being committed
 static constexpr unsigned defaultDeltaTransactionQueueLimit = 10000;
 class CDeltaWriter : implements IThreaded
 {
@@ -1126,7 +1126,7 @@ class CDeltaWriter : implements IThreaded
     StringBuffer dataPath;
     StringBuffer backupPath;
     unsigned transactionQueueLimit = defaultDeltaTransactionQueueLimit; // absolute limit, will block if this far behind
-    memsize_t transactionMaxMem = defaultDeltaMemMaxMB * 0x100000; // 10MB
+    memsize_t transactionMaxMem = defaultDeltaMemMaxMB * 0x100000;
     unsigned totalQueueLimitHits = 0;
     unsigned saveThresholdSecs = 0;
     cycle_t lastSaveTime = 0;
@@ -1412,40 +1412,34 @@ public:
                 // keep going whilst there's things pending
                 while (true)
                 {
-                    CLeavableCriticalBlock b(pendingCrit);
-                    std::queue<Owned<CTransactionItem>> todo = std::move(pending);
-                    if (0 == todo.size())
-                    {
-                        if (writeRequested)
-                        {
-                            // NB: if here, implies someone signalled via requestAsyncWrite()
-
-                            // if reason we're here is because sem timedout, consume the signal that was sent
-                            if (semTimedout)
-                                pendingTransactionsSem.wait();
-
-                            writeRequested = false;
-                            if (signalWhenAllWritten) // can only be true if writeRequested was true
-                            {
-                                signalWhenAllWritten = false;
-                                allWrittenSem.signal();
-                            }
-                        }
-                        break;
-                    }
-                    pendingSz = 0;
-
-                    b.leave(); // NB: addToQueue could add to pending between here and regaining lock below
                     // NB: ensure consistent lock ordering of blockedSaveCrit and pendingCrit
                     CHECKEDCRITICALBLOCK(blockedSaveCrit, fakeCritTimeout); // because if Dali is saving state (::blockingSave), it will clear pending
-                    b.enter();
-                    // check if new items added in window above
-                    while (pending.size())
+                    std::queue<Owned<CTransactionItem>> todo;
                     {
-                        todo.push(std::move(pending.front()));
-                        pending.pop();
+                        CriticalBlock b(pendingCrit);
+                        todo = std::move(pending);
+                        if (0 == todo.size())
+                        {
+                            if (writeRequested)
+                            {
+                                // NB: if here, implies someone signalled via requestAsyncWrite()
+
+                                // if reason we're here is because sem timedout, consume the signal that was sent
+                                if (semTimedout)
+                                    pendingTransactionsSem.wait();
+
+                                writeRequested = false;
+                                if (signalWhenAllWritten) // can only be true if writeRequested was true
+                                {
+                                    signalWhenAllWritten = false;
+                                    allWrittenSem.signal();
+                                }
+                            }
+                            break;
+                        }
+                        pendingSz = 0;
                     }
-                    b.leave();
+
                     // Because blockedSaveCrit is held, it will also block 'synchronous save' (see addToQueue)
                     // i.e. if stuck here, the transactions will start building up, and trigger a 'Forced synchronous save',
                     // which will in turn block. This must complete!
@@ -2227,6 +2221,7 @@ void CBinaryFileExternal::write(const char *name, IPropertyTree &tree)
 void CDeltaWriter::addToQueue(CTransactionItem *item)
 {
     bool needsSyncSave = false;
+    size_t items;
     {
         CriticalBlock b(pendingCrit);
         pending.push(item);
@@ -2234,7 +2229,7 @@ void CDeltaWriter::addToQueue(CTransactionItem *item)
         // it will act. as a rough guide to appoaching size threshold. It is not worth
         // synchronously preparing and serializing here (which will be done asynchronously later)
         pendingSz += (CTransactionItem::f_addext == item->type) ? item->ext.dataLength : 100;
-        size_t items = pending.size();
+        items = pending.size();
         if ((pendingSz < transactionMaxMem) && (items < transactionQueueLimit))
         {
             if (lastSaveTime && ((get_cycles_now() - lastSaveTime) < thresholdDuration))
@@ -2254,12 +2249,12 @@ void CDeltaWriter::addToQueue(CTransactionItem *item)
         ++totalQueueLimitHits;
         // force a synchronous save
         CCycleTimer timer;
-        PROGLOG("Forcing synchronous save of %u transactions (pendingSz=%zu)", (unsigned)pending.size(), pendingSz);
+        PROGLOG("Forcing synchronous save of %u transactions (pendingSz=%zu)", (unsigned)items, pendingSz);
 
         // NB: ensure consistent lock ordering of blockedSaveCrit and pendingCrit
         CHECKEDCRITICALBLOCK(blockedSaveCrit, fakeCritTimeout); // because if Dali is saving state (::blockingSave), it will clear pending
         CriticalBlock b(pendingCrit);
-        size_t items = pending.size();
+        items = pending.size();
         // NB: items could be 0. It's possible that the delta writer has caught up and flushed pending already
         if (items && save(pending)) // if temporarily blocked, continue, meaning queue limit will overrun a bit (blocking window is short)
         {


### PR DESCRIPTION
Severity: Critical

A race condition triggered by large transaction causes transactions to be commited to disk out of sequence.
The consequence is that when loading the transactions (typically in Sasha), the coalesce will fail.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [ ] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
