### PR TITLE
HPCC-35922: Support conditional Path attribute output styles

### DIFF
--- a/common/eventconsumption/eventdump.cpp
+++ b/common/eventconsumption/eventdump.cpp
@@ -28,23 +28,23 @@ bool CDumpEventsOp::doOp()
     switch (format)
     {
     case OutputFormat::json:
-        visitor.setown(createDumpJSONEventVisitor(*out));
+        visitor.setown(createDumpJSONEventVisitor(*out, queryMetaInfoState(), isFullPathOutput()));
         break;
     case OutputFormat::text:
-        visitor.setown(createDumpTextEventVisitor(*out));
+        visitor.setown(createDumpTextEventVisitor(*out, queryMetaInfoState(), isFullPathOutput()));
         break;
     case OutputFormat::xml:
-        visitor.setown(createDumpXMLEventVisitor(*out));
+        visitor.setown(createDumpXMLEventVisitor(*out, queryMetaInfoState(), isFullPathOutput()));
         break;
     case OutputFormat::yaml:
-        visitor.setown(createDumpYAMLEventVisitor(*out));
+        visitor.setown(createDumpYAMLEventVisitor(*out, queryMetaInfoState(), isFullPathOutput()));
         break;
     case OutputFormat::csv:
-        visitor.setown(createDumpCSVEventVisitor(*out, queryIteratorProperties()));
+        visitor.setown(createDumpCSVEventVisitor(*out, queryIteratorProperties(), queryMetaInfoState(), isFullPathOutput()));
         break;
     case OutputFormat::tree:
         {
-            Owned<IEventPTreeCreator> creator = createEventPTreeCreator();
+            Owned<IEventPTreeCreator> creator = createEventPTreeCreator(queryMetaInfoState(), isFullPathOutput());
             if (traverseEvents(creator->queryVisitor()))
             {
                 StringBuffer yaml;

--- a/common/eventconsumption/eventdump.h
+++ b/common/eventconsumption/eventdump.h
@@ -22,20 +22,20 @@
 #include "eventoperation.h"
 
 // Get a visitor that streams visited event data in JSON format.
-extern event_decl IEventVisitor* createDumpJSONEventVisitor(IBufferedSerialOutputStream& out);
+extern event_decl IEventVisitor* createDumpJSONEventVisitor(IBufferedSerialOutputStream& out, CMetaInfoState& metaState, bool fullPathOutput);
 
 // Get a visitor that streams visited event data in a flat text format.
-extern event_decl IEventVisitor* createDumpTextEventVisitor(IBufferedSerialOutputStream& out);
+extern event_decl IEventVisitor* createDumpTextEventVisitor(IBufferedSerialOutputStream& out, CMetaInfoState& metaState, bool fullPathOutput);
 
 // Get a visitor that streams visited event data in XML format.
-extern event_decl IEventVisitor* createDumpXMLEventVisitor(IBufferedSerialOutputStream& out);
+extern event_decl IEventVisitor* createDumpXMLEventVisitor(IBufferedSerialOutputStream& out, CMetaInfoState& metaState, bool fullPathOutput);
 
 // Get a visitor that streams visited event data in YAML format.
-extern event_decl IEventVisitor* createDumpYAMLEventVisitor(IBufferedSerialOutputStream& out);
+extern event_decl IEventVisitor* createDumpYAMLEventVisitor(IBufferedSerialOutputStream& out, CMetaInfoState& metaState, bool fullPathOutput);
 
 // Get a visitor that streams visited event data in CSV format.
 // The properties parameter is used to determine which optional columns to include.
-extern event_decl IEventVisitor* createDumpCSVEventVisitor(IBufferedSerialOutputStream& out, const EventFileProperties& properties);
+extern event_decl IEventVisitor* createDumpCSVEventVisitor(IBufferedSerialOutputStream& out, const EventFileProperties& properties, CMetaInfoState& metaState, bool fullPathOutput);
 
 // Encapsulation of a visitor that stores visited event data in a property tree and
 // access to the tree.
@@ -46,7 +46,7 @@ interface IEventPTreeCreator : extends IInterface
 };
 
 // Get an event property tree creator.
-extern event_decl IEventPTreeCreator* createEventPTreeCreator();
+extern event_decl IEventPTreeCreator* createEventPTreeCreator(CMetaInfoState& metaState, bool fullPathOutput);
 
 // Supported dump output formats.
 enum class OutputFormat : byte

--- a/common/eventconsumption/eventdump.hpp
+++ b/common/eventconsumption/eventdump.hpp
@@ -54,28 +54,18 @@ constexpr static const char* DUMP_STRUCTURE_FILE_BYTES_READ = "bytesRead";
 //  `virtual void recordAttribute(EventAttr id, const char* name, const char* value, bool quoted) = 0;`
 class CDumpEventVisitor : public CInterfaceOf<IEventVisitor>
 {
+public:
+    CDumpEventVisitor(CMetaInfoState& _metaState, bool _fullPathOutput)
+        : metaState(_metaState), fullPathOutput(_fullPathOutput)
+    {
+    }
+
 public: // IEventVisitor
     virtual bool visitEvent(CEvent& event) override
     {
         visitEvent(event.queryType());
-        for (CEventAttribute& attr : event.assignedAttributes)
-        {
-            switch (attr.queryTypeClass())
-            {
-            case EATCtext:
-            case EATCtimestamp:
-                doVisitAttribute(attr.queryId(), attr.queryTextValue());
-                break;
-            case EATCnumeric:
-                doVisitAttribute(attr.queryId(), attr.queryNumericValue());
-                break;
-            case EATCboolean:
-                doVisitAttribute(attr.queryId(), attr.queryBooleanValue());
-                break;
-            default:
-                throw makeStringExceptionV(-1, "unsupported attribute type class %u", attr.queryTypeClass());
-            }
-        }
+        for (const CEventAttribute& attr : event.assignedAttributes)
+            doVisitAttribute(event, attr);
         departEvent();
         return true;
     }
@@ -84,6 +74,39 @@ protected:
     virtual void visitEvent(EventType id) {};
 
     virtual void departEvent() {};
+
+    void doVisitAttribute(CEvent& event, const CEventAttribute& attr)
+    {
+        EventAttr attrId = attr.queryId();
+        switch (attr.queryTypeClass())
+        {
+        case EATCtext:
+            // Special handling for Path: resolve through FileId if present
+            if (EvAttrPath == attrId && event.hasAttribute(EvAttrFileId))
+            {
+                StringBuffer path;
+                metaState.selectFilePath(path, event.queryNumericValue(EvAttrFileId), fullPathOutput);
+                if (!path.isEmpty())
+                {
+                    doVisitAttribute(attrId, path);
+                    break;
+                }
+            }
+            doVisitAttribute(attrId, attr.queryTextValue());
+            break;
+        case EATCtimestamp:
+            doVisitAttribute(attrId, attr.queryTextValue());
+            break;
+        case EATCnumeric:
+            doVisitAttribute(attrId, attr.queryNumericValue());
+            break;
+        case EATCboolean:
+            doVisitAttribute(attrId, attr.queryBooleanValue());
+            break;
+        default:
+            throw makeStringExceptionV(-1, "unsupported attribute type class %u for attribute %s", attr.queryTypeClass(), queryEventAttributeName(attrId));
+        }
+    }
 
 protected:
     void doVisitHeader(const char* filename, uint32_t version)
@@ -133,4 +156,8 @@ protected:
     }
 
     virtual void recordAttribute(EventAttr id, const char* name, const char* value, bool quoted) = 0;
+
+protected:
+    CMetaInfoState& metaState;
+    bool fullPathOutput;
 };

--- a/common/eventconsumption/eventdumpptree.cpp
+++ b/common/eventconsumption/eventdumpptree.cpp
@@ -22,6 +22,8 @@
 class CPTreeEventVisitor : public CDumpEventVisitor
 {
 public:
+    using CDumpEventVisitor::CDumpEventVisitor;
+
     virtual bool visitFile(const char* filename, uint32_t version) override
     {
         tree.setown(createPTree(DUMP_STRUCTURE_ROOT));
@@ -64,7 +66,7 @@ protected:
     IPropertyTree* active = nullptr;
 };
 
-IEventPTreeCreator* createEventPTreeCreator()
+IEventPTreeCreator* createEventPTreeCreator(CMetaInfoState& metaState, bool fullPathOutput)
 {
     class Creator : public CInterfaceOf<IEventPTreeCreator>
     {
@@ -79,13 +81,13 @@ IEventPTreeCreator* createEventPTreeCreator()
             return visitor->queryTree();
         }
 
-        Creator()
+        Creator(CMetaInfoState& _metaState, bool _fullPathOutput)
         {
-            visitor.setown(new CPTreeEventVisitor);
+            visitor.setown(new CPTreeEventVisitor(_metaState, _fullPathOutput));
         }
 
     private:
         Owned<CPTreeEventVisitor> visitor;
     };
-    return new Creator;
+    return new Creator(metaState, fullPathOutput);
 }

--- a/common/eventconsumption/eventdumpstream.cpp
+++ b/common/eventconsumption/eventdumpstream.cpp
@@ -26,8 +26,8 @@ protected: // new abstract method(s)
     virtual void recordAttribute(EventAttr id, const char* name, const char* value, bool quoted) = 0;
 
 public:
-    CDumpStreamEventVisitor(IBufferedSerialOutputStream& _out)
-        : out(&_out)
+    CDumpStreamEventVisitor(IBufferedSerialOutputStream& _out, CMetaInfoState& _metaState, bool _fullPathOutput)
+        : CDumpEventVisitor(_metaState, _fullPathOutput), out(&_out)
     {
     }
 
@@ -123,9 +123,9 @@ protected:
     }
 };
 
-IEventVisitor* createDumpTextEventVisitor(IBufferedSerialOutputStream& out)
+IEventVisitor* createDumpTextEventVisitor(IBufferedSerialOutputStream& out, CMetaInfoState& metaState, bool fullPathOutput)
 {
-    return new CDumpTextEventVisitor(out);
+    return new CDumpTextEventVisitor(out, metaState, fullPathOutput);
 }
 
 // Extension of CDumpStreamEventVisitor that outputs XML-formatted text. Header and Footer elements
@@ -205,9 +205,9 @@ private:
     unsigned indentLevel{0};
 };
 
-IEventVisitor* createDumpXMLEventVisitor(IBufferedSerialOutputStream& out)
+IEventVisitor* createDumpXMLEventVisitor(IBufferedSerialOutputStream& out, CMetaInfoState& metaState, bool fullPathOutput)
 {
-    return new CDumpXMLEventVisitor(out);
+    return new CDumpXMLEventVisitor(out, metaState, fullPathOutput);
 }
 
 // Extension of CDumpStreamEventVisitor that outputs JSON-formatted text. Header and Footer objects
@@ -337,9 +337,9 @@ private:
     bool firstEvent{true};
 };
 
-IEventVisitor* createDumpJSONEventVisitor(IBufferedSerialOutputStream& out)
+IEventVisitor* createDumpJSONEventVisitor(IBufferedSerialOutputStream& out, CMetaInfoState& metaState, bool fullPathOutput)
 {
-    return new CDumpJSONEventVisitor(out);
+    return new CDumpJSONEventVisitor(out, metaState, fullPathOutput);
 }
 
 // Extension of CDumpStreamEventVisitor that outputs YAML-formatted text. Header and Footer objects
@@ -431,9 +431,9 @@ protected:
     uint8_t indentLevel{0};
 };
 
-IEventVisitor* createDumpYAMLEventVisitor(IBufferedSerialOutputStream& out)
+IEventVisitor* createDumpYAMLEventVisitor(IBufferedSerialOutputStream& out, CMetaInfoState& metaState, bool fullPathOutput)
 {
-    return new CDumpYAMLEventVisitor(out);
+    return new CDumpYAMLEventVisitor(out, metaState, fullPathOutput);
 }
 
 class CDumpCSVEventVisitor : public CDumpStreamEventVisitor
@@ -460,29 +460,14 @@ public:
         if (inHeader())
             state = State::Events;
         encodeCSVColumn(markup, queryEventName(event.queryType()));
+
         for (const CEventAttribute& attr : event.allAttributes)
         {
             if (skipAttribute(attr.queryId()))
                 continue;
             markup.append(",");
             if (attr.isAssigned())
-            {
-                switch (attr.queryTypeClass())
-                {
-                case EATCtext:
-                case EATCtimestamp:
-                    doVisitAttribute(attr.queryId(), attr.queryTextValue());
-                    break;
-                case EATCnumeric:
-                    doVisitAttribute(attr.queryId(), attr.queryNumericValue());
-                    break;
-                case EATCboolean:
-                    doVisitAttribute(attr.queryId(), attr.queryBooleanValue());
-                    break;
-                default:
-                    throw makeStringExceptionV(-1, "unsupported attribute type class %u", attr.queryTypeClass());
-                }
-            }
+                doVisitAttribute(event, attr);
         }
         dump(true);
         return true;
@@ -522,8 +507,8 @@ protected:
     }
 
 public:
-    CDumpCSVEventVisitor(IBufferedSerialOutputStream& out, const EventFileProperties& _properties)
-        : CDumpStreamEventVisitor(out), properties(_properties)
+    CDumpCSVEventVisitor(IBufferedSerialOutputStream& out, const EventFileProperties& _properties, CMetaInfoState& _metaState, bool _fullPathOutput)
+        : CDumpStreamEventVisitor(out, _metaState, _fullPathOutput), properties(_properties)
     {
     }
 
@@ -531,7 +516,7 @@ private:
     EventFileProperties properties;  // Copied to avoid lifetime issues
 };
 
-IEventVisitor* createDumpCSVEventVisitor(IBufferedSerialOutputStream& out, const EventFileProperties& properties)
+IEventVisitor* createDumpCSVEventVisitor(IBufferedSerialOutputStream& out, const EventFileProperties& properties, CMetaInfoState& metaState, bool fullPathOutput)
 {
-    return new CDumpCSVEventVisitor(out, properties);
+    return new CDumpCSVEventVisitor(out, properties, metaState, fullPathOutput);
 }

--- a/common/eventconsumption/eventindexhotspot.cpp
+++ b/common/eventconsumption/eventindexhotspot.cpp
@@ -91,9 +91,10 @@ class CHotspotEventVisitor : public CInterfaceOf<IEventVisitor>
             }
         };
     public:
-        CActivity(CMetaInfoState& _metaInfoState, __uint64 _id)
+        CActivity(CMetaInfoState& _metaInfoState, __uint64 _id, bool _fullPath)
             : metaInfoState(_metaInfoState)
             , id(_id)
+            , fullPath(_fullPath)
         {
         }
 
@@ -106,8 +107,9 @@ class CHotspotEventVisitor : public CInterfaceOf<IEventVisitor>
         {
             if (!hasActivity()) // suppress inactive files
                 return;
-            const char* path = metaInfoState.queryFilePath(id);
-            visitor.arrive(id, path);
+            StringBuffer filePath;
+            metaInfoState.selectFilePath(filePath, id, fullPath);
+            visitor.arrive(id, filePath.str());
             for (unsigned kind = 0; kind < NumNodeKinds; kind++)
                 activity[kind].forEachBucket(visitor, NodeKind(kind));
             visitor.depart();
@@ -127,6 +129,7 @@ class CHotspotEventVisitor : public CInterfaceOf<IEventVisitor>
     private:
         CMetaInfoState& metaInfoState;
         __uint64 id{0};
+        bool fullPath{false};
         Activity activity[NumNodeKinds];
     };
 
@@ -145,7 +148,7 @@ public: // IEventVisitor
             return true;
         __uint64 fileId = event.queryNumericValue(EvAttrFileId);
         NodeKind nodeKind = queryIndexNodeKind(event);
-        auto [it, inserted] = activity.try_emplace(fileId, operation.queryMetaInfoState(), fileId);
+        auto [it, inserted] = activity.try_emplace(fileId, operation.queryMetaInfoState(), fileId, operation.isFullPathOutput());
         it->second.recordEvent(event.queryNumericValue(EvAttrFileOffset), nodeKind, granularityBits);
         return true;
     }

--- a/common/eventconsumption/eventindexsummarize.cpp
+++ b/common/eventconsumption/eventindexsummarize.cpp
@@ -368,8 +368,9 @@ protected:
 
         for (SummaryStats::value_type& e : summary)
         {
-            const char* filePath = operation.queryMetaInfoState().queryFilePath(e.first);
-            appendCSVColumns(line, e.first, filePath ? filePath : "");
+            StringBuffer filePath;
+            operation.selectFilePath(filePath, e.first);
+            appendCSVColumns(line, e.first, filePath);
             for (unsigned nodeKind = 0; nodeKind < NumNodeKinds; nodeKind++)
             {
                 if (!haveNodeKindEntries[nodeKind])
@@ -490,8 +491,9 @@ protected:
             {
                 const IndexHashKey& key = entry.first;
                 NodeStats& nodeStats = entry.second;
-                const char* filePath = operation.queryMetaInfoState().queryFilePath(key.fileId);
-                appendCSVColumns(line, key.fileId, filePath ? filePath : "", key.offset);
+                StringBuffer filePath;
+                operation.selectFilePath(filePath, key.fileId);
+                appendCSVColumns(line, key.fileId, filePath, key.offset);
                 appendCSVColumn(line, mapNodeKind((NodeKind)nodeKind));
                 appendCSVColumn(line, nodeStats.inMemorySize);
                 appendCSVEvents(line, nodeStats.events);

--- a/common/eventconsumption/eventmetaparser.cpp
+++ b/common/eventconsumption/eventmetaparser.cpp
@@ -83,6 +83,92 @@ const char* CMetaInfoState::queryFilePath(__uint64 fileId) const
     return (it != fileIdToPath.end()) ? it->second->str() : nullptr;
 }
 
+// The relationship between a full index file path and the logical file is:
+//   [ <local install path> ] '/var/lib/HPCCSystems/hpcc-data/roxie/' [ 'd' <unsigned> '/' ] <logical file path> [ '/' <crc> ]
+// This method splits a presumed full path into parts, identifies the leading and trailing parts
+// that are not part of the logical file path, and reassembles the logical file path from the
+// remaining parts.
+//
+// Given a full path that deviates from this format, the full path is returned as the logical
+// file path.
+StringBuffer& CMetaInfoState::getLogicalFile(StringBuffer& file, __uint64 fileId) const
+{
+    const char* fullPath = queryFilePath(fileId);
+    if (isEmptyString(fullPath))
+        return file;
+    StringArray pathParts;
+    pathParts.appendList(fullPath, "/");
+    if (pathParts.ordinality() == 0)
+    {
+        file.append(fullPath);
+        return file;
+    }
+    aindex_t firstPart = 0, lastPart = pathParts.ordinality() - 1;
+    // skip parts until the installed root is found
+    while (firstPart <= lastPart && !streq(pathParts.item(firstPart), "var"))
+        firstPart++;
+    // skip fixed parts (var/lib/HPCCSystems/hpcc-data/roxie/)
+    if (firstPart + 5 > lastPart ||
+        !streq(pathParts.item(firstPart), "var") ||
+        !streq(pathParts.item(firstPart + 1), "lib") ||
+        !streq(pathParts.item(firstPart + 2), "HPCCSystems") ||
+        !streq(pathParts.item(firstPart + 3), "hpcc-data") ||
+        !streq(pathParts.item(firstPart + 4), "roxie"))
+    {
+        // Not in expected format, return full path
+        file.append(fullPath);
+        return file;
+    }
+    firstPart += 5;
+    // skip optional storage part
+    if (firstPart <= lastPart)
+    {
+        const char* tmp = pathParts.item(firstPart);
+        char* endptr = nullptr;
+        if (*tmp == 'd' && *(tmp + 1) != '\0' && isdigit((unsigned char)*(tmp + 1)))
+        {
+            (void)strtoul(tmp + 1, &endptr, 10);
+            if (*endptr == '\0')
+                firstPart++;
+        }
+    }
+    // skip the crc suffix (#/#) if present
+    while (firstPart < lastPart)
+    {
+        const char* tmp = pathParts.item(lastPart);
+        char* endptr = nullptr;
+        (void)strtoull(tmp, &endptr, 10);
+        if (*endptr != '\0')
+            break;
+        lastPart--;
+    }
+    // assemble and return the output path
+    if (firstPart <= lastPart)
+    {
+        while (firstPart < lastPart)
+        {
+            file.append(pathParts.item(firstPart)).append('/');
+            firstPart++;
+        }
+        file.append(pathParts.item(lastPart));
+    }
+    else
+        file.append(fullPath);
+    return file;
+}
+
+StringBuffer& CMetaInfoState::selectFilePath(StringBuffer& buf, __uint64 fileId, bool fullPath) const
+{
+    if (fullPath)
+    {
+        const char* path = queryFilePath(fileId);
+        if (path)
+            buf.append(path);
+        return buf;
+    }
+    return getLogicalFile(buf, fileId);
+}
+
 bool CMetaInfoState::hasFileMapping(__uint64 fileId) const
 {
     return fileIdToPath.find(fileId) != fileIdToPath.end();
@@ -193,3 +279,219 @@ uint32_t CMetaInfoState::generateRuntimeFileId(const CEvent& event)
         throw makeStringExceptionV(-1, "Exceeded maximum number of index files (=%u) supported in event meta parser", UINT32_MAX);
     return static_cast<uint32_t>(indexFiles.size() + 1);
 }
+
+#ifdef _USE_CPPUNIT
+
+#include "eventunittests.hpp"
+
+class MetaInfoStateTest : public CppUnit::TestFixture
+{
+    CPPUNIT_TEST_SUITE(MetaInfoStateTest);
+    CPPUNIT_TEST(testLogicalFileStandardFormat);
+    CPPUNIT_TEST(testLogicalFileWithStoragePart);
+    CPPUNIT_TEST(testLogicalFileWithCRCSuffix);
+    CPPUNIT_TEST(testLogicalFileWithStorageAndCRC);
+    CPPUNIT_TEST(testLogicalFileNonStandardFormat);
+    CPPUNIT_TEST(testLogicalFileShortPath);
+    CPPUNIT_TEST(testLogicalFileNoVarPrefix);
+    CPPUNIT_TEST(testLogicalFileEmptyPath);
+    CPPUNIT_TEST(testLogicalFileUnmappedId);
+    CPPUNIT_TEST(testLogicalFileMultiplePaths);
+    CPPUNIT_TEST_SUITE_END();
+
+private:
+    void injectFileInformation(CMetaInfoState& metaState, IEventVisitationLink& collector, __uint64 fileId, const char* path)
+    {
+        CEvent event;
+        event.reset(MetaFileInformation);
+        event.setValue(EvAttrFileId, fileId);
+        event.setValue(EvAttrPath, path);
+
+        collector.visitEvent(event);
+    }
+
+    Owned<IEventVisitationLink> startFileInjection(CMetaInfoState& metaState)
+    {
+        Owned<IEventVisitationLink> collector = metaState.getCollector();
+        collector->visitFile("test.evt", 1);
+        return collector;
+    }
+
+    void endFileInjection(IEventVisitationLink& collector)
+    {
+        collector.departFile(0);
+    }
+
+public:
+    void testLogicalFileStandardFormat()
+    {
+        START_TEST
+        CMetaInfoState metaState;
+        const char* fullPath = "/var/lib/HPCCSystems/hpcc-data/roxie/mydata/myfile/myindex";
+
+        Owned<IEventVisitationLink> collector = startFileInjection(metaState);
+        injectFileInformation(metaState, *collector, 1, fullPath);
+        endFileInjection(*collector);
+
+        StringBuffer result;
+        metaState.getLogicalFile(result, 1);
+        CPPUNIT_ASSERT_EQUAL_STR("mydata/myfile/myindex", result.str());
+        END_TEST
+    }
+
+    void testLogicalFileWithStoragePart()
+    {
+        START_TEST
+        CMetaInfoState metaState;
+        const char* fullPath = "/var/lib/HPCCSystems/hpcc-data/roxie/d5/mydata/myfile/myindex";
+
+        Owned<IEventVisitationLink> collector = startFileInjection(metaState);
+        injectFileInformation(metaState, *collector, 1, fullPath);
+        endFileInjection(*collector);
+
+        StringBuffer result;
+        metaState.getLogicalFile(result, 1);
+        CPPUNIT_ASSERT_EQUAL_STR("mydata/myfile/myindex", result.str());
+        END_TEST
+    }
+
+    void testLogicalFileWithCRCSuffix()
+    {
+        START_TEST
+        CMetaInfoState metaState;
+        const char* fullPath = "/var/lib/HPCCSystems/hpcc-data/roxie/mydata/myfile/myindex/12345/67890";
+
+        Owned<IEventVisitationLink> collector = startFileInjection(metaState);
+        injectFileInformation(metaState, *collector, 1, fullPath);
+        endFileInjection(*collector);
+
+        StringBuffer result;
+        metaState.getLogicalFile(result, 1);
+        CPPUNIT_ASSERT_EQUAL_STR("mydata/myfile/myindex", result.str());
+        END_TEST
+    }
+
+    void testLogicalFileWithStorageAndCRC()
+    {
+        START_TEST
+        CMetaInfoState metaState;
+        const char* fullPath = "/some/prefix/var/lib/HPCCSystems/hpcc-data/roxie/d3/mydata/myfile/myindex/12345/67890";
+
+        Owned<IEventVisitationLink> collector = startFileInjection(metaState);
+        injectFileInformation(metaState, *collector, 1, fullPath);
+        endFileInjection(*collector);
+
+        StringBuffer result;
+        metaState.getLogicalFile(result, 1);
+        CPPUNIT_ASSERT_EQUAL_STR("mydata/myfile/myindex", result.str());
+        END_TEST
+    }
+
+    void testLogicalFileNonStandardFormat()
+    {
+        START_TEST
+        CMetaInfoState metaState;
+        const char* fullPath = "/opt/mydata/myindex";
+
+        Owned<IEventVisitationLink> collector = startFileInjection(metaState);
+        injectFileInformation(metaState, *collector, 1, fullPath);
+        endFileInjection(*collector);
+
+        StringBuffer result;
+        metaState.getLogicalFile(result, 1);
+        CPPUNIT_ASSERT_EQUAL_STR("/opt/mydata/myindex", result.str());
+        END_TEST
+    }
+
+    void testLogicalFileShortPath()
+    {
+        START_TEST
+        CMetaInfoState metaState;
+        const char* fullPath = "/var/lib/HPCCSystems/hpcc-data/myindex";
+
+        Owned<IEventVisitationLink> collector = startFileInjection(metaState);
+        injectFileInformation(metaState, *collector, 1, fullPath);
+        endFileInjection(*collector);
+
+        StringBuffer result;
+        metaState.getLogicalFile(result, 1);
+        // Path too short to match expected format, returns full path
+        CPPUNIT_ASSERT_EQUAL_STR("/var/lib/HPCCSystems/hpcc-data/myindex", result.str());
+        END_TEST
+    }
+
+    void testLogicalFileNoVarPrefix()
+    {
+        START_TEST
+        CMetaInfoState metaState;
+        const char* fullPath = "/home/lib/HPCCSystems/hpcc-data/roxie/mydata/myindex";
+
+        Owned<IEventVisitationLink> collector = startFileInjection(metaState);
+        injectFileInformation(metaState, *collector, 1, fullPath);
+        endFileInjection(*collector);
+
+        StringBuffer result;
+        metaState.getLogicalFile(result, 1);
+        // Doesn't start with expected path, returns full path
+        CPPUNIT_ASSERT_EQUAL_STR("/home/lib/HPCCSystems/hpcc-data/roxie/mydata/myindex", result.str());
+        END_TEST
+    }
+
+    void testLogicalFileEmptyPath()
+    {
+        START_TEST
+        CMetaInfoState metaState;
+
+        Owned<IEventVisitationLink> collector = startFileInjection(metaState);
+        injectFileInformation(metaState, *collector, 1, "");
+        endFileInjection(*collector);
+
+        StringBuffer result;
+        metaState.getLogicalFile(result, 1);
+        // Empty path returns empty result
+        CPPUNIT_ASSERT_EQUAL_STR("", result.str());
+        END_TEST
+    }
+
+    void testLogicalFileUnmappedId()
+    {
+        START_TEST
+        CMetaInfoState metaState;
+
+        StringBuffer result;
+        metaState.getLogicalFile(result, 999);
+        // Unmapped file ID returns empty result
+        CPPUNIT_ASSERT_EQUAL_STR("", result.str());
+        END_TEST
+    }
+
+    void testLogicalFileMultiplePaths()
+    {
+        START_TEST
+        CMetaInfoState metaState;
+        const char* fullPath1 = "/var/lib/HPCCSystems/hpcc-data/roxie/dataset1/part1/12345";
+        const char* fullPath2 = "/var/lib/HPCCSystems/hpcc-data/roxie/d2/dataset2/part2";
+        const char* fullPath3 = "/custom/path/to/data";
+
+        Owned<IEventVisitationLink> collector = startFileInjection(metaState);
+        injectFileInformation(metaState, *collector, 1, fullPath1);
+        injectFileInformation(metaState, *collector, 2, fullPath2);
+        injectFileInformation(metaState, *collector, 3, fullPath3);
+        endFileInjection(*collector);
+
+        StringBuffer result1, result2, result3;
+        metaState.getLogicalFile(result1, 1);
+        metaState.getLogicalFile(result2, 2);
+        metaState.getLogicalFile(result3, 3);
+
+        CPPUNIT_ASSERT_EQUAL_STR("dataset1/part1", result1.str());
+        CPPUNIT_ASSERT_EQUAL_STR("dataset2/part2", result2.str());
+        CPPUNIT_ASSERT_EQUAL_STR("/custom/path/to/data", result3.str());
+        END_TEST
+    }
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION(MetaInfoStateTest);
+CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(MetaInfoStateTest, "MetaInfoStateTest");
+
+#endif // _USE_CPPUNIT

--- a/common/eventconsumption/eventmetaparser.hpp
+++ b/common/eventconsumption/eventmetaparser.hpp
@@ -57,6 +57,8 @@ public:
     IEventVisitationLink* getCollector();
     // Accessor functions for file ID to path mappings
     const char* queryFilePath(__uint64 fileId) const;
+    StringBuffer& getLogicalFile(StringBuffer& file, __uint64 fileId) const;
+    StringBuffer& selectFilePath(StringBuffer& buf, __uint64 fileId, bool fullPath) const;
     bool hasFileMapping(__uint64 fileId) const;
     void clearFileMappings();
 

--- a/common/eventconsumption/eventoperation.cpp
+++ b/common/eventconsumption/eventoperation.cpp
@@ -41,6 +41,11 @@ void CEventConsumingOp::setOutput(IBufferedSerialOutputStream& _out)
     out.set(&_out);
 }
 
+StringBuffer& CEventConsumingOp::selectFilePath(StringBuffer& buf, __uint64 fileId) const
+{
+    return metaState->selectFilePath(buf, fileId, fullPathOutput);
+}
+
 bool CEventConsumingOp::acceptEvents(const char* eventNames)
 {
     return ensureFilter()->acceptEvents(eventNames);

--- a/common/eventconsumption/eventoperation.h
+++ b/common/eventconsumption/eventoperation.h
@@ -43,6 +43,11 @@ public:
     bool acceptEvents(const char* eventNames);
     bool acceptAttribute(EventAttr attr, const char* values);
     bool acceptModel(const IPropertyTree& config);
+    // Option: output full file path instead of logical file
+    void setFullPathOutput(bool value) { fullPathOutput = value; }
+    bool isFullPathOutput() const { return fullPathOutput; }
+    // Utility: select logical file or full path based on option
+    StringBuffer& selectFilePath(StringBuffer& buf, __uint64 fileId) const;
 protected:
     IEventFilter* ensureFilter();
     bool traverseEvents(IEventVisitor& visitor);
@@ -56,6 +61,7 @@ protected:
     Owned<CMetaInfoState> metaState;
     std::set<std::string> inputPaths;
     Linked<IBufferedSerialOutputStream> out;
+    bool fullPathOutput = false;
 private:
     Owned<IEventFilter> filter;
     Owned<IEventModel> model;

--- a/testing/unittests/jlibtests2.cpp
+++ b/testing/unittests/jlibtests2.cpp
@@ -34,6 +34,7 @@
 #include "jfile.hpp"
 #include "jevent.hpp"
 #include "eventdump.h"
+#include "eventmetaparser.hpp"
 #include "jthread.hpp"
 #include "unittests.hpp"
 
@@ -1184,7 +1185,8 @@ attribute: DataSize = 73
     IEventVisitor* createVisitor(StringBuffer& out)
     {
         Owned<IBufferedSerialOutputStream> stream = createBufferedSerialOutputStream(out);
-        Owned<IEventVisitor> visitor = createDumpTextEventVisitor(*stream);
+        Owned<CMetaInfoState> metaState = new CMetaInfoState();
+        Owned<IEventVisitor> visitor = createDumpTextEventVisitor(*stream, *metaState, false);
         return new MockEventVisitor(*visitor);
     }
 

--- a/tools/evtool/evtool.hpp
+++ b/tools/evtool/evtool.hpp
@@ -148,6 +148,20 @@ protected:
                 return false;
             return op.acceptModel(*config);
         }
+        if (streq(key, "path-style"))
+        {
+            if (streq(value, "full"))
+            {
+                op.setFullPathOutput(true);
+                return true;
+            }
+            else if (streq(value, "logical"))
+            {
+                op.setFullPathOutput(false);
+                return true;
+            }
+            return false;
+        }
         return CEvToolCommand::acceptKVOption(key, value);
     }
 
@@ -172,7 +186,10 @@ Parameters:
     virtual void usageOptions(IBufferedSerialOutputStream& out) override
     {
         constexpr const char* usageStr =
-R"!!!(    --model=<filename>        Apply a model to the data using the specified
+R"!!!(    --path-style=<style>      Select path output style: "full" for complete file
+                              paths, "logical" for shortened logical names.
+                              Default is "logical".
+    --model=<filename>        Apply a model to the data using the specified
                               YAML/XML/JSON configuration file.
 )!!!";
         size32_t usageStrLength = size32_t(strlen(usageStr));


### PR DESCRIPTION
- Change the default Path value output to be the logical file path.
- Add a command line option to override the default output with the full path.
- Update the dump, index summarize, and index hotspot operations to support both styles.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
