### PR TITLE
HPCC-34914 add WsWorkunits/WUHelperFileArchive

### DIFF
--- a/esp/scm/ws_workunits.ecm
+++ b/esp/scm/ws_workunits.ecm
@@ -25,7 +25,7 @@ EspInclude(ws_workunits_queryset_req_resp);
 
 ESPservice [
     auth_feature("DEFERRED"), //This declares that the method logic handles feature level authorization
-    version("2.05"), default_client_version("2.05"), cache_group("ESPWsWUs"),
+    version("2.06"), default_client_version("2.06"), cache_group("ESPWsWUs"),
     noforms,exceptions_inline("./smc_xslt/exceptions.xslt"),use_method_name] WsWorkunits
 {
     ESPmethod [cache_seconds(60), resp_xsl_default("/esp/xslt/workunits.xslt")]     WUQuery(WUQueryRequest, WUQueryResponse);
@@ -116,6 +116,7 @@ ESPservice [
     ESPmethod [cache_seconds(60), min_ver("1.74")] WUGetThorJobList(WUGetThorJobListRequest, WUGetThorJobListResponse);
     ESPmethod [cache_seconds(60), min_ver("1.79")] WUGetPlugins(WUGetPluginsRequest, WUGetPluginsResponse);
     ESPmethod [min_ver("1.94")] WUAnalyseHotspot(WUAnalyseHotspotRequest, WUAnalyseHotspotResponse);
+    ESPmethod [min_ver("2.06")] WUHelperFileArchive(WUHelperFileArchiveRequest, WUHelperFileArchiveResponse);
 };
 
 

--- a/esp/scm/ws_workunits_req_resp.ecm
+++ b/esp/scm/ws_workunits_req_resp.ecm
@@ -1145,3 +1145,17 @@ ESPresponse [exceptions_inline] WUAnalyseHotspotResponse
 };
 
 // ----------------------------------------------------------------------------------
+
+ESPrequest [nil_remove] WUHelperFileArchiveRequest
+{
+    string Wuid;
+    ESPenum WUFileDownloadOption DownloadOption(2); // defaults to ZIP
+    ESParray<ESPstruct WUFileOption> WUFileOptions;
+};
+
+ESPresponse [exceptions_inline] WUHelperFileArchiveResponse
+{
+    [http_content("application/octet-stream")] binary thefile;
+};
+
+// ----------------------------------------------------------------------------------

--- a/esp/services/ws_workunits/ws_workunitsHelpers.cpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.cpp
@@ -242,7 +242,7 @@ void streamFilteredLogsToFile(const char* outFile, LogAccessConditions & logFetc
     StringBuffer logcontent;
     unsigned totalRecsRead = 0;
     unsigned recsRead = 0;
-    
+
     if (logFormat == LOGACCESS_LOGFORMAT_json)
         writeStringToStream(*outIOS, "{\"lines\": [");
     else if (logFormat == LOGACCESS_LOGFORMAT_xml)
@@ -273,19 +273,19 @@ void streamFilteredLogsToFile(const char* outFile, LogAccessConditions & logFetc
         if (logFormat == LOGACCESS_LOGFORMAT_json)
         {
             VStringBuffer jsonMessage("], \"Message\": \"%s\"}", truncationWarnmessage.str()); //close lines array, append Message object
-            writeStringToStream(*outIOS, jsonMessage.str()); 
+            writeStringToStream(*outIOS, jsonMessage.str());
         }
         else if (logFormat == LOGACCESS_LOGFORMAT_xml)
         {
             VStringBuffer xmlMessage("</lines>\n<!-- %s -->", truncationWarnmessage.str()); //close lines element, append comment message
-            writeStringToStream(*outIOS, xmlMessage.str()); 
+            writeStringToStream(*outIOS, xmlMessage.str());
         }
         else if (logFormat == LOGACCESS_LOGFORMAT_csv)
         {
-            writeStringToStream(*outIOS, truncationWarnmessage); 
+            writeStringToStream(*outIOS, truncationWarnmessage);
         }
     }
-    else //close the lines container 
+    else //close the lines container
     {
         if (logFormat == LOGACCESS_LOGFORMAT_json)
             writeStringToStream(*outIOS, "]}");
@@ -2546,7 +2546,7 @@ void WsWuInfo::readWorkunitThorLog(const char* processName, const char* log, con
         {
             StringBuffer thorMasterLog, ext;
             splitFilename(logSpec, nullptr, nullptr, &thorMasterLog, &ext);
-    
+
             StringBuffer logSpecStr(log);
             addPathSepChar(logSpecStr);
             //Append the file name of the slave log to logSpecStr.
@@ -2569,7 +2569,7 @@ void WsWuInfo::readWorkunitThorLog(const char* processName, const char* log, con
             if (!rFile)
                 throw MakeStringException(ECLWATCH_CANNOT_OPEN_FILE, "Cannot open file %s.", logSpec);
         }
-    
+
         readWorkunitThorLogOneDay(rFile, processID, buf, outIOS);
     }
 }
@@ -2603,7 +2603,7 @@ void WsWuInfo::readWorkunitThorLogOneDay(IFile* sourceFile, unsigned& processID,
     bool outputThisLine = false;
     if (processID > 0) //after the 1st page of the log
         outputThisLine = true;
-    bool foundEndWUID = false; 
+    bool foundEndWUID = false;
     while (!eof)
     {
         if (outputThisLine)
@@ -2666,7 +2666,7 @@ void WsWuInfo::getWUProcessLogSpecs(const char* processName, const char* logSpec
             //Parse the process name from the logSpec or logDir.
             if (isEmptyString(logSpec) && isEmptyString(logDir))
                 throw makeStringException(ECLWATCH_ECLAGENT_LOG_NOT_FOUND, "Process name and log file not specified");
-    
+
             StringBuffer path, process;
             if (!isEmptyString(logDir))
                 path.set(logDir);
@@ -5141,6 +5141,66 @@ void CWsWuFileHelper::readLocalFileToBuffer(const char* file, offset_t sizeLimit
 
     if (read(sourceIO, 0, len, mb) != len)
         throw MakeStringException(ECLWATCH_CANNOT_READ_FILE, "Cannot read %s.", file);
+}
+
+void CWsWuFileHelper::createHelperFileArchive(IEspContext& context, const char* wuid,
+    IArrayOf<IConstWUFileOption>& wuFileOptions, bool useGZip, const char* tempDirName,
+    StringBuffer& archiveFileName, StringBuffer& archiveFileNameWithPath)
+{
+    StringBuffer workingFolder;
+    workingFolder.set(tempDirName).append(PATHSEPCHAR).append("files");
+    Owned<IFile> workingDir = createIFile(workingFolder.str());
+    workingDir->createDirectory();
+
+    bool hasLogsAccess = context.validateFeatureAccess(LOG_ACCESS_FEATURE, SecAccess_Read, false);
+    WsWuInfo winfo(context, wuid);
+    unsigned filesAdded = 0;
+    ForEachItemIn(i, wuFileOptions)
+    {
+        StringBuffer fileName, fileMimeType;
+        try
+        {
+            CWUFileType fileType = wuFileOptions.item(i).getFileType();
+            switch (fileType)
+            {
+            case CWUFileType_ThorLog:
+            case CWUFileType_ThorSlaveLog:
+            case CWUFileType_EclAgentLog:
+            case CWUFileType_ComponentLog:
+                if (!hasLogsAccess)
+                    throw makeStringExceptionV(ECLWATCH_ACCESS_TO_FILE_DENIED,
+                        "Access to log files is denied. You are missing permission %s:READ - check with your system admin.",
+                        LOG_ACCESS_FEATURE);
+                break;
+            default:
+                break;
+            }
+            readWUFile(wuid, workingFolder.str(), winfo, wuFileOptions.item(i), fileName, fileMimeType);
+            filesAdded++;
+        }
+        catch (IException* e)
+        {
+            StringBuffer msg;
+            WARNLOG("Failed to read helper file for workunit %s: %s", wuid, e->errorMessage(msg).str());
+            e->Release();
+        }
+    }
+
+    if (filesAdded == 0)
+        throw makeStringExceptionV(ECLWATCH_INVALID_INPUT, "No helper files could be retrieved for workunit %s.", wuid);
+
+    StringBuffer userName;
+    if (context.queryUser())
+        userName.append(context.queryUser()->getName());
+    archiveFileName.set("WUHelpers_").append(wuid).append('_').append(userName.str());
+    archiveFileName.append(useGZip ? ".gz" : ".zip");
+    archiveFileNameWithPath.set(tempDirName).append(PATHSEPCHAR).append(archiveFileName.str());
+
+    int zipRet = zipAFolder(workingFolder.str(), useGZip, archiveFileNameWithPath.str());
+    cleanFolder(workingDir, true);
+
+    if (zipRet != 0)
+        throw makeStringExceptionV(ECLWATCH_CANNOT_COMPRESS_DATA, "Failed to create helper file archive for workunit %s.", wuid);
 }
 
 void CWsWuEmailHelper::send(const char* body, const void* attachment, size32_t lenAttachment, StringArray& warnings)

--- a/esp/services/ws_workunits/ws_workunitsHelpers.hpp
+++ b/esp/services/ws_workunits/ws_workunitsHelpers.hpp
@@ -225,7 +225,7 @@ struct WUComponentLogOptions
             {
                 StringBuffer customFieldsList;
                 zapHttpRequest->getParameter("LogFilter_CustomColumns", customFieldsList);
-            
+
                 if(!customFieldsList.isEmpty())
                     customFields.appendList(customFieldsList.str(), ",");
             }
@@ -354,7 +354,7 @@ struct WUComponentLogOptions
 
         logFetchOptions.setFilter(logFetchFilter.getClear());
         CSortDirection espSortDirection = logFilterReq.getSortByTimeDirection();
-        logFetchOptions.addSortByCondition(LOGACCESS_MAPPEDFIELD_timestamp, "", espSortDirection == CSortDirection_ASC 
+        logFetchOptions.addSortByCondition(LOGACCESS_MAPPEDFIELD_timestamp, "", espSortDirection == CSortDirection_ASC
                                         ? SORTBY_DIRECTION_ascending : SORTBY_DIRECTION_descending);
     }
 };
@@ -916,6 +916,9 @@ public:
 
     IFileIOStream* createWUFileIOStream(IEspContext &context, const char *wuid, IArrayOf<IConstWUFileOption> &wuFileOptions,
         CWUFileDownloadOption &downloadOptions, StringBuffer &contentType);
+
+    void createHelperFileArchive(IEspContext &context, const char *wuid, IArrayOf<IConstWUFileOption> &wuFileOptions,
+        bool useGZip, const char *tempDirName, StringBuffer &archiveFileName, StringBuffer &archiveFileNameWithPath);
 
     void validateFilePath(const char *file, WsWuInfo &winfo, CWUFileType wuFileType, bool UNCFileName, const char *fileType, const char *compType, const char *compName);
     bool validateWUFile(const char *file, WsWuInfo &winfo, CWUFileType wuFileType);

--- a/esp/services/ws_workunits/ws_workunitsService.cpp
+++ b/esp/services/ws_workunits/ws_workunitsService.cpp
@@ -4268,6 +4268,51 @@ bool CWsWorkunitsEx::onWUAnalyseHotspot(IEspContext &context, IEspWUAnalyseHotsp
     return true;
 }
 
+bool CWsWorkunitsEx::onWUHelperFileArchive(IEspContext &context, IEspWUHelperFileArchiveRequest &req, IEspWUHelperFileArchiveResponse &resp)
+{
+    try
+    {
+        StringBuffer wuid(req.getWuid());
+        WsWuHelpers::checkAndTrimWorkunit("WUHelperFileArchive", wuid);
+        ensureWsWorkunitAccess(context, wuid.str(), SecAccess_Read);
+        PROGLOG("WUHelperFileArchive: %s", wuid.str());
+
+        IArrayOf<IConstWUFileOption>& wuFileOptions = req.getWUFileOptions();
+        if (!wuFileOptions.ordinality())
+            throw MakeStringException(ECLWATCH_INVALID_INPUT, "No file options specified.");
+
+        bool useGZip = (req.getDownloadOption() == CWUFileDownloadOption_GZIP);
+        Owned<IFile> tempDir = createUniqueTempDirectory();
+
+        StringBuffer archiveFileName, archiveFileNameWithPath;
+        CWsWuFileHelper helper(directories);
+        helper.createHelperFileArchive(context, wuid.str(), wuFileOptions, useGZip,
+            tempDir->queryFilename(), archiveFileName, archiveFileNameWithPath);
+
+        Owned<IFile> f = createIFile(archiveFileNameWithPath.str());
+        Owned<IFileIO> io = f->open(IFOread);
+        unsigned archiveSize = (unsigned) io->size();
+        if (archiveSize > MAX_ZAP_BUFFER_SIZE)
+            throw MakeStringException(ECLWATCH_INVALID_INPUT, "WUHelperFileArchive: archive file size is too big (>10M) to be retrieved.");
+
+        MemoryBuffer mb;
+        void* data = mb.reserve(archiveSize);
+        size32_t bytesRead = io->read(0, (size32_t) archiveSize, data);
+        mb.setLength(bytesRead);
+        resp.setThefile(mb);
+        resp.setThefile_mimetype(useGZip ? "application/x-gzip" : "application/zip");
+        VStringBuffer headerStr("attachment; filename=\"%s\"", archiveFileName.str());
+        context.addCustomerHeader("Content-Disposition", headerStr.str());
+        io->close();
+        recursiveRemoveDirectory(tempDir);
+    }
+    catch(IException* e)
+    {
+        FORWARDEXCEPTION(context, e, ECLWATCH_INTERNAL_ERROR);
+    }
+    return true;
+}
+
 
 static void getWUDetailsMetaProperties(double version, IArrayOf<IEspWUDetailsMetaProperty> & properties)
 {
@@ -4625,7 +4670,7 @@ int CWsWorkunitsSoapBindingEx::onStartUpload(IEspContext &ctx, CHttpRequest* req
             getUserWuAccessFlags(ctx, accessOwn, accessOthers, false);
             if ((accessOwn != SecAccess_Full) || (accessOthers != SecAccess_Full))
                 throw makeStringExceptionV(-1, "Resources %s and/or %s : Permission denied. Full Access Required.", OWN_WU_ACCESS, OTHERS_WU_ACCESS);
-    
+
             StringBuffer password;
             request->getParameter("Password", password);
 
@@ -4977,7 +5022,7 @@ bool CWsWorkunitsEx::onWUCreateZAPInfo(IEspContext &context, IEspWUCreateZAPInfo
         Owned<IFile> tempDir = createUniqueTempDirectory();
 
         StringBuffer zipFileName, zipFileNameWithPath;
-        //CWsWuFileHelper may need ESP's <Directories> settings to locate log files. 
+        //CWsWuFileHelper may need ESP's <Directories> settings to locate log files.
         CWsWuFileHelper helper(directories);
         helper.createWUZAPFile(context, cwu, zapInfoReq, tempDir->queryFilename(), zipFileName, zipFileNameWithPath, thorSlaveLogThreadPoolSize);
 

--- a/esp/services/ws_workunits/ws_workunitsService.hpp
+++ b/esp/services/ws_workunits/ws_workunitsService.hpp
@@ -341,6 +341,7 @@ public:
     bool onWUEclDefinitionAction(IEspContext &context, IEspWUEclDefinitionActionRequest &req, IEspWUEclDefinitionActionResponse &resp);
     bool onWUGetPlugins(IEspContext &context, IEspWUGetPluginsRequest &req, IEspWUGetPluginsResponse &resp);
     virtual bool onWUAnalyseHotspot(IEspContext &context, IEspWUAnalyseHotspotRequest &req, IEspWUAnalyseHotspotResponse &resp) override;
+    bool onWUHelperFileArchive(IEspContext &context, IEspWUHelperFileArchiveRequest &req, IEspWUHelperFileArchiveResponse &resp);
 
     bool unsubscribeServiceFromDali() override
     {

--- a/esp/src/src-react/components/Helpers.tsx
+++ b/esp/src/src-react/components/Helpers.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { CommandBar, ContextualMenuItemType, ICommandBarItemProps } from "@fluentui/react";
 import { TreeItemValue } from "@fluentui/react-components";
+import { scopedLogger } from "@hpcc-js/util";
 import { convertedSize } from "src/Utility";
 import nlsHPCC from "src/nlsHPCC";
 import { HelperRow, useWorkunitHelpersTree } from "../hooks/workunit";
@@ -11,6 +12,8 @@ import { pushUrl } from "../util/history";
 import { ShortVerticalDivider } from "./Common";
 import { FlatTreeItem, FlatTreeEx } from "./controls/FlatTreeEx";
 import { FetchEditor } from "./SourceEditor";
+
+const logger = scopedLogger("src-react/components/Helpers.tsx");
 
 function getURL(wuid: string, item: HelperRow, option?: number) {
     let params = "";
@@ -142,6 +145,70 @@ export const Helpers: React.FunctionComponent<HelpersProps> = ({
         return treeItems.filter(item => item.url !== "");
     }, [treeItems]);
 
+    const downloadHelpers = React.useCallback((type: "zip" | "gz") => {
+        const params = new URLSearchParams();
+        params.append("Wuid", wuid);
+        params.append("DownloadOption", type === "zip" ? "2" : "3");
+
+        checkedRows.forEach((item, i) => {
+            const prefix = `WUFileOptions.WUFileOption.${i}`;
+            switch (item.Type) {
+                case "Archive Query":
+                    params.append(`${prefix}.FileType`, "ArchiveQuery");
+                    break;
+                case "ECL":
+                    params.append(`${prefix}.FileType`, "WUECL");
+                    break;
+                case "Workunit XML":
+                    params.append(`${prefix}.FileType`, "XML");
+                    break;
+                default:
+                    params.append(`${prefix}.FileType`, item.Type);
+            }
+            if (item.Orig?.Name) params.append(`${prefix}.Name`, item.Orig?.Name);
+            if (item.Orig?.IPAddress) params.append(`${prefix}.IPAddress`, item.Orig?.IPAddress);
+            if (item.Description) params.append(`${prefix}.Description`, item.Description);
+            if (item.Orig?.PID) params.set(`${prefix}.Process`, item.Orig?.PID);
+            if (item.Orig?.SlaveNumber) params.append(`${prefix}.SlaveNumber`, item.Orig?.SlaveNumber);
+            if (item.Orig?.LogDate) params.append(`${prefix}.LogDate`, item.Orig?.LogDate);
+            if (item.Orig?.ProcessName) {
+                params.set(`${prefix}.Process`, item.Orig?.ProcessName);
+                params.append(`${prefix}.ClusterGroup`, item.Orig?.ProcessName);
+            }
+        });
+        params.append("WUFileOptions.WUFileOption.itemcount", checkedRows.length.toString());
+
+        fetch("/WsWorkunits/WUHelperFileArchive", {
+            method: "POST",
+            headers: { "Content-Type": "application/x-www-form-urlencoded" },
+            body: params
+        }).then(async response => {
+            if (!response.ok) {
+                throw new Error(`HTTP error: ${response.status} ${response.statusText}`);
+            }
+            const blob = await response.blob();
+            const disposition = response.headers.get("Content-Disposition");
+
+            let filename = `WUHelpers_${wuid}.${type}`;
+            const match = /filename="?([^";\n]+)"?/.exec(disposition ?? "");
+            if (match) {
+                filename = match[1].trim();
+            }
+
+            const link = document.createElement("a");
+            const urlBlob = window.URL.createObjectURL(blob);
+
+            link.href = urlBlob;
+            link.download = filename;
+            document.body.appendChild(link);
+            link.click();
+            document.body.removeChild(link);
+            window.URL.revokeObjectURL(urlBlob);
+        }).catch(err => {
+            logger.error(err)
+        });
+    }, [checkedRows, wuid]);
+
     //  Command Bar  ---
     const buttons = React.useMemo((): ICommandBarItemProps[] => [
         {
@@ -162,30 +229,14 @@ export const Helpers: React.FunctionComponent<HelpersProps> = ({
             }
         },
         {
-            key: "file", text: nlsHPCC.File, disabled: checkedRows.filter(item => item.url !== "").length === 0, iconProps: { iconName: "Download" },
-            onClick: () => {
-                checkedRows.forEach(item => {
-                    window.open(getURL(wuid, item, 1));
-                });
-            }
+            key: "zip", text: nlsHPCC.Zip, disabled: checkedRows.length === 0, iconProps: { iconName: "Download" },
+            onClick: () => downloadHelpers("zip")
         },
         {
-            key: "zip", text: nlsHPCC.Zip, disabled: checkedRows.filter(item => item.url !== "").length === 0, iconProps: { iconName: "Download" },
-            onClick: () => {
-                checkedRows.forEach(item => {
-                    window.open(getURL(wuid, item, 2));
-                });
-            }
-        },
-        {
-            key: "gzip", text: nlsHPCC.GZip, disabled: checkedRows.filter(item => item.url !== "").length === 0, iconProps: { iconName: "Download" },
-            onClick: () => {
-                checkedRows.forEach(item => {
-                    window.open(getURL(wuid, item, 3));
-                });
-            }
+            key: "gzip", text: nlsHPCC.GZip, disabled: checkedRows.length === 0, iconProps: { iconName: "Download" },
+            onClick: () => downloadHelpers("gz")
         }
-    ], [checkedItems.length, checkedRows, refreshData, treeItemLeafNodes, wuid]);
+    ], [checkedItems.length, checkedRows, downloadHelpers, refreshData, treeItemLeafNodes]);
 
     const rightButtons = React.useMemo((): ICommandBarItemProps[] => [
         {


### PR DESCRIPTION
adds the WUHelperFileArchive endpoint to WsWorkunits, enabling ESP to generate a .gz or .zip archive containing the specified helper files

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
