### PR TITLE
HPCC-35937 fix(dfs): super copy hang

### DIFF
--- a/dali/base/dadfs.cpp
+++ b/dali/base/dadfs.cpp
@@ -920,7 +920,7 @@ static void foreignDaliSendRecv(const INode *foreigndali,CMessageBuffer &mb, uns
     comm->sendRecv(mb,0,MPTAG_DFS_REQUEST);
 }
 
-static bool isLocalDali(const INode *foreigndali)
+bool isLocalDali(const INode *foreigndali)
 {
     if (!foreigndali)
         return true;

--- a/dali/base/dadfs.hpp
+++ b/dali/base/dadfs.hpp
@@ -929,6 +929,8 @@ extern da_decl void ensureFileScope(const CDfsLogicalFileName &dlfn, unsigned ti
 
 extern da_decl bool checkLogicalName(const char *lfn,IUserDescriptor *user,bool readreq,bool createreq,bool allowquery,const char *specialnotallowedmsg);
 
+extern da_decl bool isLocalDali(const INode *foreigndali);
+
 extern da_decl cost_type calcFileAtRestCost(const char * cluster, double sizeGB, double fileAgeDays);
 extern da_decl cost_type calcFileAccessCost(const char * cluster, __int64 numDiskWrites, __int64 numDiskReads);
 extern da_decl cost_type calcFileAccessCost(IDistributedFile *f, __int64 numDiskWrites, __int64 numDiskReads);

--- a/dali/dfu/dfurun.cpp
+++ b/dali/dfu/dfurun.cpp
@@ -1071,30 +1071,26 @@ public:
         return (state==DFUstate_finished);
     }
 
-    void doSuperForeignCopy(sSuperCopyContext &ctx,const char *dstlfn,INode *foreigndalinode,const char *srclfn, CDfsLogicalFileName &dlfn)
+    void doSuperForeignCopy(sSuperCopyContext &ctx, const char *dstlfn, const char *srclfn, CDfsLogicalFileName &dlfn)
     {
         ctx.level++;
-        Linked<INode> srcdali = foreigndalinode;
         CDfsLogicalFileName slfn;
         slfn.set(srclfn);
-        if (slfn.isForeign()) // trying to confuse me
-        {
-            SocketEndpoint ep;
-            slfn.getEp(ep);
-            slfn.clearForeign();
-            srcdali.setown(createINode(ep));
-        }
-        Owned<IDistributedFile> file = wsdfs::lookup(srclfn, ctx.user, AccessMode::tbdRead, false, false, nullptr, defaultPrivilegedUser, INFINITE);
+
+        SocketEndpoint foreignEp;
+        bool isForeign = slfn.isForeign(&foreignEp); // caller has normalized, to ensure this is truly foreign and not referring to a local env file with a foreign prefix
+
+        Owned<IDistributedFile> file = wsdfs::lookup(slfn.get(), ctx.user, AccessMode::tbdRead, false, false, nullptr, defaultPrivilegedUser, INFINITE);
 
         if (!file.get())
         {
             StringBuffer s;
-            throw MakeStringException(-1,"Source file %s could not be found in Dali %s",slfn.get(),srcdali?srcdali->endpoint().getEndpointHostText(s).str():"(local)");
+            throw makeStringExceptionV(-1, "Source file %s could not be found in Dali %s", slfn.get(true), isForeign?foreignEp.getEndpointHostText(s).str():"(local)");
         }
         // now we can create name
         StringBuffer newroxieprefix;
         constructDestinationName(dstlfn,file->queryAttributes().queryProp("@roxiePrefix"),ctx.superdestination,dlfn,newroxieprefix);
-        if (!srcdali.get()||queryCoven().inCoven(srcdali))
+        if (!isForeign)
         {
             // if dali is local and filenames same
             if (strcmp(slfn.get(),dlfn.get())==0)
@@ -1118,7 +1114,7 @@ public:
                     ((unsigned)file->queryAttributes().getPropInt64("@fileCrc")==(unsigned)dfile->queryAttributes().getPropInt64("@fileCrc"))&&
                     (file->queryAttributes().getPropInt64("@size")==dfile->getFileSize(false,false))))
                 {
-                    PROGLOG("File copy of %s not done as file unchanged",srclfn);
+                    PROGLOG("File copy of %s not done as file unchanged",slfn.get(true));
                     return;
                 }
             }
@@ -1132,10 +1128,12 @@ public:
             StringAttr wuid;
             const char *kind = fileAttrs.queryProp("@kind");
             bool iskey = kind&&(strcmp(kind,"key")==0);
+            Owned<INode> srcdali;
+            if (isForeign)
+                srcdali.setown(createINode(foreignEp));
             // note  dstlfn doesn't have roxie prefix
-            if (!doSubFileCopy(ctx,dstlfn,srcdali,srclfn,wuid,iskey,newroxieprefix.str()))
+            if (!doSubFileCopy(ctx,dstlfn,srcdali,slfn.get(true),wuid,iskey,newroxieprefix.str()))
                 throw MakeStringException(-1,"File %s could not be copied - see %s",dstlfn,wuid.isEmpty()?"unknown":wuid.get());
-
         }
         else
         {
@@ -1150,7 +1148,7 @@ public:
                 CDfsLogicalFileName dlfnsub;
                 dlfnsub.set(name);
                 CDfsLogicalFileName dlfnres;
-                doSuperForeignCopy(ctx, dlfnsub.get(true), foreigndalinode, name, dlfnres);
+                doSuperForeignCopy(ctx, dlfnsub.get(true), name, dlfnres);
                 numdone++;
                 subfiles.append(dlfnres.get());
                 if ((ctx.level==1)&&ctx.feedback)
@@ -1193,6 +1191,23 @@ public:
         source->getLogicalName(srcname);
         if (!srcname.length())
             throw MakeStringException(-1,"Source file not specified");
+        // Normalize srclfn: ensure it carries foreign prefix if it's truly foreign
+        CDfsLogicalFileName srclfn;
+        srclfn.set(srcname);
+        SocketEndpoint foreignEp;
+        if (srclfn.isForeign(&foreignEp))
+        {
+            // srclfn already has foreign - it takes precedence over foreigndalinode
+            foreigndalinode.setown(createINode(foreignEp));
+            if (isLocalDali(foreigndalinode))
+            {
+                srclfn.clearForeign();
+                foreigndalinode.clear();
+            }
+        }
+        else if (foreigndalinode && !isLocalDali(foreigndalinode))
+            srclfn.setForeign(foreigndalinode->endpoint(), false);
+
         StringBuffer dstname;
         destination->getLogicalName(dstname);
         if (!dstname.length())
@@ -1210,8 +1225,7 @@ public:
         ctx.superprogress->setSubInProgress("");
         ctx.superprogress->setSubDone("");
         CDfsLogicalFileName dlfn;
-        doSuperForeignCopy(ctx,dstname.str(),foreigndalinode,srcname, dlfn);
-
+        doSuperForeignCopy(ctx, dstname.str(), srclfn.get(), dlfn);
     }
 
     DFUstate runWU(const char *dfuwuid)


### PR DESCRIPTION
If copying a superfile from a foreign dali, and the name of the source super is the same as the destination super, the code used to mistakenly open the local version instead of the foreign version, and then attempt to re-open and change to write mode and deadlock.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
