### PR TITLE
HPCC-36003 fix(dali): prevent concurrent saves from corrupting ignore…

### DIFF
--- a/dali/base/dadiags.cpp
+++ b/dali/base/dadiags.cpp
@@ -195,9 +195,18 @@ public:
                     if (success)
                         mb.append(connectionInfo);
                 }
-                else if (0 == stricmp(id, "save")) {
+                else if (0 == stricmp(id, "save"))
+                {
                     PROGLOG("Dalidiag requests SDS save");
-                    querySDSServer().saveRequest();
+                    try
+                    {
+                        querySDSServer().saveRequest();
+                    }
+                    catch (IException *e)
+                    {
+                        serializeException(e, mb);
+                        e->Release();
+                    }
                 }
                 else if (0 == stricmp(id, "settracetransactions")) {
                     PROGLOG("Dalidiag requests Trace Transactions");

--- a/dali/base/dasds.cpp
+++ b/dali/base/dasds.cpp
@@ -2069,7 +2069,7 @@ public: // data
     CheckedCriticalSection treeRegCrit;
     Owned<Thread> unhandledThread;
     unsigned writeTransactions;
-    bool ignoreExternals;
+    std::atomic<bool> ignoreExternals;
     StringAttr dataPath;
     StringAttr daliName;
     Owned<IPropertyTree> properties;
@@ -6617,11 +6617,6 @@ void CCovenSDSManager::loadStore(const char *storeName, const bool *abort)
 
 void CCovenSDSManager::saveStore(const char *storeName, SaveStoreFlags flags)
 {
-    struct CIgnore
-    {
-        CIgnore() { SDSManager->ignoreExternals=true; }
-        ~CIgnore() { SDSManager->ignoreExternals=false; }
-    } ignore;
     if (hasMask(flags, ssf_stop))
     {
         // Dali is stopping, we don't care about any inflight transactions any more, we're about to save and quit
@@ -6633,6 +6628,14 @@ void CCovenSDSManager::saveStore(const char *storeName, SaveStoreFlags flags)
         // lock blockedSaveCrit after flush, since deltaWriter itself blocks on blockedSaveCrit
         deltaWriter.flush(); // transactions will be blocked at this stage, no new deltas will be added to writer
     }
+
+    if (ignoreExternals.exchange(true)) // NB: This is set during save to prevent serialization of externals during the save
+    {
+        Owned<IException> exception = makeStringException(0, "Save already in progress");
+        EXCLOG(exception);
+        throw exception.getClear();
+    }
+    COnScopeExit resetIgnoreExternals([&]() { ignoreExternals = false; });
     CHECKEDCRITICALBLOCK(blockedSaveCrit, fakeCritTimeout);
     iStoreHelper->saveStore(root, NULL);
     unsigned initNodeTableSize = allNodes.maxElements()+OVERFLOWSIZE;

--- a/dali/dalidiag/dalidiag.cpp
+++ b/dali/dalidiag/dalidiag.cpp
@@ -640,7 +640,16 @@ int main(int _argc, char* argv[])
                     MemoryBuffer mb;
                     mb.append("save");
                     getDaliDiagnosticValue(mb);
-                    PROGLOG("SDS store saved");
+                    Owned<IException> exception;
+                    if (mb.length())
+                        exception.setown(deserializeException(mb));
+                    if (exception)
+                    {
+                        StringBuffer errMsg;
+                        PROGLOG("Dali SDS save failed: [%d, %s]", exception->errorCode(), exception->errorMessage(errMsg).str());
+                    }
+                    else
+                        PROGLOG("SDS store saved");
                     break;
                 }
                 if (0 == stricmp(arg, "locks")) {


### PR DESCRIPTION
…Externals state

Before this fix, ignoreExternals was set and cleared via a RAII object scoped within saveStore(). If a second save request arrived while one was already in progress, the nested CIgnore destructor would reset ignoreExternals to false, before the next save started, causing it to serialize all externals into the XML store file.

- Make ignoreExternals std::atomic<bool> and check it before entering the save to detect and reject concurrent save attempts with an exception.
- Move the CIgnore RAII reset inside the blockedSaveCrit section so it only clears after the save completes.
- Propagate save-failure exceptions from the dadiags handler back to the dalidiag client so errors are reported instead of silently ignored.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
