### PR TITLE
HPCC-36039 Fix coverity-flagged dead code and related underflow

### DIFF
--- a/esp/logging/logginglib/logconfigptree.hpp
+++ b/esp/logging/logginglib/logconfigptree.hpp
@@ -22,6 +22,10 @@
 #include "jstring.hpp"
 #include "tokenserialization.hpp"
 
+#ifdef _USE_CPPUNIT
+#include "jexcept.hpp"
+#endif
+
 namespace LogConfigPTree
 {
     /**
@@ -40,13 +44,17 @@ namespace LogConfigPTree
             msg << "unexpected default value '" << defaultValue << "'";
             if (!isEmptyString(xpath))
                 msg << " for configuration XPath '" << xpath << "'";
+#if defined(_USE_CPPUNIT)
+            if (!isEmptyString(xpath) && streq(xpath, "UNITTEST"))
+                throw makeStringExceptionV(isError ? 999 : 998, "%s", msg.str());
+#endif
             if (isError)
                 IERRLOG("%s", msg.str());
             else
                 IWARNLOG("%s", msg.str());
         };
 
-        if (std::is_integral<value_t>() == std::is_integral<default_t>())
+        if (std::is_integral<value_t>() && std::is_integral<default_t>())
         {
             if (std::is_signed<value_t>() == std::is_signed<default_t>())
             {

--- a/esp/services/ws_topology/CMakeLists.txt
+++ b/esp/services/ws_topology/CMakeLists.txt
@@ -57,6 +57,7 @@ include_directories (
          ./../../bindings/SOAP/xpp
          ./../..//esplib
          ${HPCC_SOURCE_DIR}/common/thorhelper
+         ${HPCC_SOURCE_DIR}/testing/unittests
     )
 
 ADD_DEFINITIONS( -D_USRDLL -DWS_TOPOLOGY_EXPORTS -DWSWU_API_LOCAL -DESP_SERVICE_WsTopology)

--- a/esp/services/ws_topology/ws_topologyService.cpp
+++ b/esp/services/ws_topology/ws_topologyService.cpp
@@ -655,8 +655,9 @@ bool CWsTopologyEx::readLastLogDateTime(const char *logName, IFileIO* rIO, size3
             break;
 
         previousPartialLine.clear().append(partialLineEndPtr - contentBuffer.str(), contentBuffer.str());
-        readFrom -= readSize;
-        if (readFrom < 0)
+        if ( readSize < readFrom)
+            readFrom -= readSize;
+        else
             readFrom = 0;
     }
     return false;
@@ -2131,3 +2132,32 @@ bool CWsTopologyEx::onTpComponentConfiguration(IEspContext &context, IEspTpCompo
     }
     return true;
 }
+
+#ifdef _USE_CPPUNIT
+#include "unittests.hpp"
+
+class WsTopologyTests : public CppUnit::TestFixture
+{
+    CPPUNIT_TEST_SUITE(WsTopologyTests);
+    CPPUNIT_TEST(testReadLastLogDateTime_Underflow);
+    CPPUNIT_TEST_SUITE_END();
+
+public:
+    void testReadLastLogDateTime_Underflow()
+    {
+        const char *logname = "in_memory_mocked_log_file";
+        StringBuffer filebuf;
+        filebuf.appendN(100, 'X');
+        OwnedIFileIO memIO = createIFileI(filebuf.length(), filebuf.str());
+        CWsTopologyEx topologyService;
+        ReadLog readLogReq;
+        readLogReq.ltBytes = 1;
+        readLogReq.logfields = MSGFIELD_LEGACY;
+        CDateTime latestLogTime;
+        topologyService.readLastLogDateTime(logname, memIO, 100, 80, readLogReq, latestLogTime);
+    }
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION(WsTopologyTests);
+CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(WsTopologyTests, "WsTopologyTests");
+#endif

--- a/esp/services/ws_topology/ws_topologyService.hpp
+++ b/esp/services/ws_topology/ws_topologyService.hpp
@@ -85,6 +85,8 @@ public:
 
 class CWsTopologyEx : public CWsTopology
 {
+    friend class WsTopologyTests;
+
 private:
 
     CTpWrapper m_TpWrapper;

--- a/testing/unittests/loggingtests.cpp
+++ b/testing/unittests/loggingtests.cpp
@@ -19,7 +19,9 @@
 #include "loggingmanager.hpp"
 #include "modularlogagent.ipp"
 #include "unittests.hpp"
+#include "logconfigptree.hpp"
 #include <vector>
+#include <functional>
 
 using namespace ModularLogAgent;
 
@@ -334,5 +336,85 @@ CPPUNIT_TEST_SUITE_REGISTRATION( LoggingIdFilterTests );
 CPPUNIT_TEST_SUITE_NAMED_REGISTRATION( LoggingIdFilterTests, "loggingidfiltertests" );
 
 
+class LogConfigPTreeTests : public CppUnit::TestFixture
+{
+    CPPUNIT_TEST_SUITE(LogConfigPTreeTests);
+        CPPUNIT_TEST(testIntegralSameSignedness);
+        CPPUNIT_TEST(testIntegralMixedSignedness);
+        CPPUNIT_TEST(testFloat);
+        CPPUNIT_TEST(testMixedIntegralFloat);
+    CPPUNIT_TEST_SUITE_END();
+
+    void expectException(int expectedErrorCode, std::function<void()> func, const char* msg)
+    {
+        try {
+            func();
+            CPPUNIT_FAIL(VStringBuffer("Expected exception %d: %s", expectedErrorCode, msg).str());
+        } catch (IException* e) {
+            CPPUNIT_ASSERT_EQUAL_MESSAGE(msg, expectedErrorCode, e->errorCode());
+            e->Release();
+        }
+    }
+
+public:
+    void testIntegralSameSignedness()
+    {
+        using namespace LogConfigPTree;
+        
+        // INT / INT: In bounds -> no throw
+        applyDefault<int, int>(10, "UNITTEST");
+        applyDefault<int, long long>(10LL, "UNITTEST");
+        
+        // Out of bounds long long -> int (both signed) expects ERROR
+        expectException(999, []{ applyDefault<int, long long>(99999999999999LL, "UNITTEST"); }, "long long > int::max");
+        expectException(999, []{ applyDefault<int, long long>(-99999999999999LL, "UNITTEST"); }, "long long < int::min");
+
+        // UINT / UINT: In bounds -> no throw
+        applyDefault<unsigned, unsigned>(10U, "UNITTEST");
+        
+        // Out of bounds unsigned long long -> unsigned expects ERROR
+        expectException(999, []{ applyDefault<unsigned, unsigned long long>(99999999999999ULL, "UNITTEST"); }, "unsigned long long > unsigned::max");
+    }
+
+    void testIntegralMixedSignedness()
+    {
+        using namespace LogConfigPTree;
+
+        // INT / UINT (Signed value, unsigned default): out of bounds MAX -> ERROR
+        expectException(999, []{ applyDefault<int, unsigned>(0xFFFFFFFFU, "UNITTEST"); }, "unsigned > int::max");
+
+        // UINT / INT (Unsigned value, signed default): out of bounds (<0 or >max) -> WARN
+        expectException(998, []{ applyDefault<unsigned, int>(-1, "UNITTEST"); }, "signed < 0 for unsigned");
+    }
+
+    void testFloat()
+    {
+        using namespace LogConfigPTree;
+
+        // FLOAT / FLOAT: In bounds -> no throw
+        // Added to prevent regression that routes two floats to the integral block
+        // which then fails the bounds check and throws an exception erroneously.
+        applyDefault<float, double>(-1.0, "UNITTEST");
+
+        // These legitimately exceed float bounds -> ERROR
+        expectException(999, []{ applyDefault<float, double>(1e300, "UNITTEST"); }, "double > float::max");
+        expectException(999, []{ applyDefault<float, double>(-1e300, "UNITTEST"); }, "double < lowest float");
+    }
+
+    void testMixedIntegralFloat()
+    {
+        using namespace LogConfigPTree;
+
+        // FLOAT / INT -> WARN
+        expectException(998, []{ applyDefault<float, int>(10, "UNITTEST"); }, "float vs int should WARN (998)");
+
+        // INT / FLOAT -> WARN
+        expectException(998, []{ applyDefault<int, float>(10.0f, "UNITTEST"); }, "int vs float should WARN (998)");
+    }
+
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION( LogConfigPTreeTests );
+CPPUNIT_TEST_SUITE_NAMED_REGISTRATION( LogConfigPTreeTests, "logconfigptreetests" );
 
 #endif // _USE_CPPUNIT


### PR DESCRIPTION
- Change LogConfigPTree::applyDefault is_integral<>() comparison from == to &&. It was incorrectly returning true in cases where both types were non-integral, making the dual is_floating_point<>() check unreachable.
- Add unittests that validate expected behavior for combinations of float and int values that are in and out of range, including a test that now succeeds with the fix in place.
- CWsTopologyEx::readLastLogDateTime checked an unsigned for <0 to keep value in bounds, but that check would always fail, resulting in dead code.
- Fix that underflow and thereby dead code.
- Add unittest to ensure underflow bug is removed.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [x] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [x] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [x] The commit message title makes sense in a changelog, by itself.
  - [x] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [ ] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [x] I have added tests to cover my changes.
  - [x] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [x] Scalability
  - [x] Performance
  - [x] Security
  - [x] Thread-safety
  - [x] Cloud-compatibility
  - [x] Premature optimization
  - [x] Existing deployed queries will not be broken
  - [x] This change fixes the problem, not just the symptom
  - [x] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
