### PR TITLE
HPCC-36084 refactor(hthor): useLocalFiles implies no cluster-hopping

### DIFF
--- a/ecl/hthor/hthor.cpp
+++ b/ecl/hthor/hthor.cpp
@@ -434,14 +434,17 @@ ClusterWriteHandler *createClusterWriteHandler(IAgentContext &agent, IHThorIndex
     return clusterHandler.getClear();
 }
 
-bool usingClusterHopping(IConstWorkUnit * wu)
+static bool usingClusterHopping(IAgentContext &agent)
 {
+    if (agent.queryResolveFilesLocally())
+        return false;
+    IConstWorkUnit *wu = agent.queryWorkUnit();
     return (wu && wu->getDebugValueBool("usingClusterHopping", false));
 }
 
-unsigned temporaryFileMask(IConstWorkUnit * wu)
+static unsigned temporaryFileMask(IAgentContext &agent)
 {
-    if (usingClusterHopping(wu))
+    if (usingClusterHopping(agent))
         return TDXtemporary;
     else
         return TDXtemporary|TDXjobtemp;
@@ -500,7 +503,7 @@ void CHThorDiskWriteActivity::stop()
         uncompressedBytesWritten = outSeq->getPosition();
     close();
     updateWorkUnitResult(numRecords);
-    if((helperFlags & temporaryFileMask(agent.queryWorkUnit())) == 0 && !agent.queryResolveFilesLocally())
+    if((helperFlags & temporaryFileMask(agent)) == 0 && !agent.queryResolveFilesLocally())
         publish();
     incomplete = false;
     if(clusterHandler)
@@ -513,7 +516,7 @@ void CHThorDiskWriteActivity::stop()
 void CHThorDiskWriteActivity::resolve()
 {
     OwnedRoxieString rawname = helper.getFileName();
-    if ((helperFlags & TDXjobtemp) && usingClusterHopping(agent.queryWorkUnit()))
+    if ((helperFlags & TDXjobtemp) && usingClusterHopping(agent))
     {
         mangleTemporaryFileName(mangledHelperFileName, rawname, agent.queryWuid(), agent.queryWorkUnit()->queryUser());
     }
@@ -534,7 +537,7 @@ void CHThorDiskWriteActivity::resolve()
     bool forceCompression = agent.queryWorkUnit()->getDebugValueBool("compressAllOutputs", isContainerized());
     fileAccessOptions.updateFromWriteHelper(helper, defaultPlane.str(), forceCompression, compressHint);
 
-    if((helperFlags & temporaryFileMask(agent.queryWorkUnit())) == 0)
+    if((helperFlags & temporaryFileMask(agent)) == 0)
     {
         Owned<ILocalOrDistributedFile> f = agent.resolveLFN(mangledHelperFileName.str(),"Cannot write, invalid logical name",true,false,AccessMode::tbdWrite,&lfn,defaultPrivilegedUser);
         if (f)
@@ -891,8 +894,6 @@ void CHThorDiskWriteActivity::updateWorkUnitResult(unsigned __int64 reccount)
                 fileKind = WUFileStandard;
             wu->addFile(lfn.str(), &clusters, helper.getTempUsageCount(), fileKind, NULL);
         }
-        else if ((TDXtemporary | TDXjobtemp) & helperFlags)
-            agent.noteTemporaryFilespec(filename);//note for later deletion
         if (!(helperFlags & TDXtemporary) && helper.getSequence() >= 0)
         {
             Owned<IWUResult> result = wu->updateResultBySequence(helper.getSequence());
@@ -8586,7 +8587,7 @@ void CHThorDiskReadBaseActivity::checkFileType(IDistributedFile *file)
 void CHThorDiskReadBaseActivity::resolve()
 {
     OwnedRoxieString fileName(helper.getFileName());
-    if ((helper.getFlags() & TDXjobtemp) && usingClusterHopping(agent.queryWorkUnit()))
+    if ((helper.getFlags() & TDXjobtemp) && usingClusterHopping(agent))
     {
         mangleTemporaryFileName(mangledHelperFileName, fileName, agent.queryWuid(), agent.queryWorkUnit()->queryUser());
     }
@@ -8594,7 +8595,7 @@ void CHThorDiskReadBaseActivity::resolve()
     {
         mangleHelperFileName(mangledHelperFileName, fileName, agent.queryWuid(), helper.getFlags());
     }
-    if (helper.getFlags() & temporaryFileMask(agent.queryWorkUnit()))
+    if (helper.getFlags() & temporaryFileMask(agent))
     {
         StringBuffer mangledFilename;
         mangleLocalTempFilename(mangledFilename, mangledHelperFileName.str(), nullptr);
@@ -9539,7 +9540,7 @@ const void *CHThorDiskCountActivity::nextRow()
 
     unsigned __int64 totalCount = 0;
     if (fieldFilters.ordinality() == 0 && !helper.hasFilter() &&
-        (fixedDiskRecordSize != 0) && !(helper.getFlags() & temporaryFileMask(agent.queryWorkUnit())) &&
+        (fixedDiskRecordSize != 0) && !(helper.getFlags() & temporaryFileMask(agent)) &&
         !((helper.getFlags() & TDXcompress) && agent.queryResolveFilesLocally()) )
     {
         resolve();
@@ -11033,7 +11034,7 @@ void CHThorNewDiskReadBaseActivity::resolveFile()
 
     OwnedRoxieString fileName(helper.getFileName());
     mangleHelperFileName(mangledHelperFileName, fileName, agent.queryWuid(), helperFlags);
-    if (helperFlags & temporaryFileMask(agent.queryWorkUnit()))
+    if (helperFlags & temporaryFileMask(agent))
     {
         StringBuffer mangledFilename;
         mangleLocalTempFilename(mangledFilename, mangledHelperFileName.str(), nullptr);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [ ] This change is a new feature (non-breaking change which adds functionality).
- [x] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [ ] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [x] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [x] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [ ] Send notifications about my Pull Request position in Smoketest queue.
- [ ] Test my draft Pull Request.

## Testing:
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
