### PR TITLE
HPCC-34683 Add tests to compare round trip times for Dali save

### DIFF
--- a/testing/unittests/dalitests.cpp
+++ b/testing/unittests/dalitests.cpp
@@ -28,6 +28,7 @@
 #include "daclient.hpp"
 #include "dadfs.hpp"
 #include "dafdesc.hpp"
+#include "dadiags.hpp"
 #include "dasds.hpp"
 #include "danqs.hpp"
 #include "dautils.hpp"
@@ -37,6 +38,8 @@
 
 #include <vector>
 #include <future>
+#include <cstdint>
+#include <cstdlib>
 #include <math.h>
 
 #include "jthread.hpp"
@@ -4506,6 +4509,414 @@ testCategory2[] (1999011313..1999011313) => {TimeLocalExecute=40}
 
 CPPUNIT_TEST_SUITE_REGISTRATION( DaliGlobalMetricsTester );
 CPPUNIT_TEST_SUITE_NAMED_REGISTRATION( DaliGlobalMetricsTester, "DaliGlobalMetricsTester" );
+
+//---------------------------------------------------------------------------------------------------------------------
+
+class DaliStoreLoadAndSaveTimingStressTest : public CppUnit::TestFixture
+{
+    CPPUNIT_TEST_SUITE(DaliStoreLoadAndSaveTimingStressTest);
+    CPPUNIT_TEST(testStoreRoundTripTiming);
+    CPPUNIT_TEST_SUITE_END();
+
+    struct XmlTimingResults
+    {
+        double avgLoadTimeMs{0.0};
+        double avgSaveTimeMs{0.0};
+        double avgDiagSaveTimeMs{0.0};
+    };
+
+    class DaliClientScope
+    {
+    public:
+        DaliClientScope()
+        {
+            daliClientInit();
+        }
+        ~DaliClientScope()
+        {
+            daliClientEnd();
+        }
+    };
+
+    bool loadXmlData(const char *filename, MemoryBuffer &xmlData, size32_t &xmlDataLen)
+    {
+        Owned<IFile> file = createIFile(filename);
+        if (!file->exists())
+            return false;
+
+        Owned<IFileIO> fileIO = file->open(IFOread);
+        if (!fileIO)
+            return false;
+
+        offset_t fileSize = fileIO->size();
+        // Keep the file size within signed 32-bit range before narrowing casts and avoid huge XML files.
+        if (fileSize <= 0 || fileSize > INT32_MAX)
+            return false;
+
+        xmlDataLen = (size32_t)fileSize;
+        xmlData.setLength(xmlDataLen);
+        size32_t numRead = fileIO->read(0, xmlDataLen, xmlData.bufferBase());
+        return numRead == xmlDataLen;
+    }
+
+    void assertDaliRunning()
+    {
+        constexpr unsigned timeoutMs{5000};
+        try
+        {
+            Owned<IRemoteConnection> conn = querySDS().connect("/", myProcessSession(), RTM_LOCK_READ, timeoutMs);
+            if (!conn)
+                CPPUNIT_FAIL("Dali is not running or not reachable (unable to connect to /)");
+        }
+        catch (IException *e)
+        {
+            StringBuffer msg;
+            e->errorMessage(msg);
+            e->Release();
+            VStringBuffer failMsg("Dali is not running or not reachable: %s", msg.str());
+            CPPUNIT_FAIL(failMsg.str());
+        }
+    }
+
+    bool queryCurrentStoreEdition(unsigned &edition, StringBuffer &dataPath)
+    {
+        edition = 0;
+        dataPath.clear();
+        querySDS().queryProperties().getProp("@dataPathUrl", dataPath);
+        if (!dataPath.length())
+            return false;
+
+        addPathSepChar(dataPath);
+        Owned<IDirectoryIterator> dIter = createDirectoryIterator(dataPath, "store.*");
+        if (!dIter || !dIter->first())
+            return false;
+
+        bool found = false;
+        do
+        {
+            const char *filename = dIter->query().queryFilename();
+            if (!filename)
+                continue;
+
+            StringBuffer tail, ext;
+            splitFilename(filename, NULL, NULL, &tail, &ext);
+            StringBuffer storeName;
+            storeName.append(tail).append(ext);
+            if (!startsWith(storeName.str(), "store."))
+                continue;
+
+            const char *editionText = storeName.str() + 6;
+            if (!editionText || !*editionText)
+                continue;
+
+            char *end = nullptr;
+            unsigned long parsed = strtoul(editionText, &end, 10);
+            if (!end || *end)
+                continue;
+
+            unsigned candidate = (unsigned)parsed;
+            if (!found || candidate > edition)
+            {
+                edition = candidate;
+                found = true;
+            }
+        } while (dIter->next());
+
+        return found;
+    }
+
+    bool queryCurrentStoreXmlPath(StringBuffer &storeFilename, unsigned &edition)
+    {
+        storeFilename.clear();
+        StringBuffer dataPath;
+        if (!queryCurrentStoreEdition(edition, dataPath))
+            return false;
+
+        addPathSepChar(dataPath);
+        VStringBuffer preferredStorePath("%sdalisds%u.xml", dataPath.str(), edition);
+        Owned<IFile> preferredStore = createIFile(preferredStorePath.str());
+        if (preferredStore->exists())
+        {
+            storeFilename.set(preferredStorePath.str());
+            return true;
+        }
+
+        // Fallback: choose the highest edition dalisds*.xml if the preferred edition file is absent.
+        Owned<IDirectoryIterator> dIter = createDirectoryIterator(dataPath, "dalisds*.xml");
+        if (!dIter || !dIter->first())
+            return false;
+
+        bool found = false;
+        unsigned highestEdition = 0;
+        do
+        {
+            const char *filename = dIter->query().queryFilename();
+            if (!filename)
+                continue;
+
+            StringBuffer tail, ext;
+            splitFilename(filename, NULL, NULL, &tail, &ext);
+            if (stricmp(ext.str(), ".xml") != 0)
+                continue;
+
+            const char *baseName = tail.str();
+            if (!startsWith(baseName, "dalisds"))
+                continue;
+
+            const char *editionText = baseName + strlen("dalisds");
+            if (!editionText || !*editionText)
+                continue;
+
+            char *end = nullptr;
+            unsigned long parsed = strtoul(editionText, &end, 10);
+            if (!end || *end)
+                continue;
+
+            unsigned candidate = (unsigned)parsed;
+            if (!found || candidate > highestEdition)
+                highestEdition = candidate;
+            found = true;
+        } while (dIter->next());
+
+        if (!found)
+            return false;
+
+        edition = highestEdition;
+        storeFilename.clear().append(dataPath).append("dalisds").append(edition).append(".xml");
+        return true;
+    }
+
+    Owned<IPropertyTree> runLoadPhase(const char *sourceXPath, byte flags, bool cloneToLocal, unsigned timeoutMs, CCycleTimer &timer, __uint64 &totalLoadNs)
+    {
+        Owned<IRemoteConnection> readConn = querySDS().connect(sourceXPath, myProcessSession(), RTM_LOCK_READ, timeoutMs);
+        CPPUNIT_ASSERT(readConn);
+        timer.reset();
+        IPropertyTree *readRoot = readConn->queryRoot();
+        totalLoadNs += timer.elapsedNs();
+        CPPUNIT_ASSERT(readRoot);
+        IPropertyTree *sourceTree = readRoot->queryPropTree("Store");
+        CPPUNIT_ASSERT(sourceTree);
+
+        Owned<IPropertyTree> tree;
+        if (cloneToLocal)
+            tree.setown(createPTreeFromIPT(sourceTree, (ipt_flags)flags));
+        else
+            tree.setown(createPTreeFromIPT(sourceTree, ipt_none));
+        return tree.getClear();
+    }
+
+    void runSdsSavePhase(const char *xpath, IPropertyTree *tree, unsigned timeoutMs, CCycleTimer &timer, __uint64 &totalSaveNs)
+    {
+        unsigned mode = RTM_CREATE_QUERY | RTM_LOCK_WRITE;
+        Owned<IRemoteConnection> conn = querySDS().connect(xpath, myProcessSession(), mode, timeoutMs);
+        CPPUNIT_ASSERT(conn);
+        IPropertyTree *root = conn->queryRoot();
+        CPPUNIT_ASSERT(root);
+        root->setPropTree("Store", LINK(tree));
+        timer.reset();
+        conn->commit();
+        totalSaveNs += timer.elapsedNs();
+    }
+
+    void runVerifyAndListPhase(const char *xpath, unsigned timeoutMs)
+    {
+        Owned<IRemoteConnection> verifyConn = querySDS().connect(xpath, myProcessSession(), RTM_LOCK_READ, timeoutMs);
+        CPPUNIT_ASSERT(verifyConn);
+        IPropertyTree *verifyRoot = verifyConn->queryRoot();
+        CPPUNIT_ASSERT(verifyRoot);
+        CPPUNIT_ASSERT(verifyRoot->queryPropTree("Store") != nullptr);
+
+        unsigned rootAttrCount{0};
+        {
+            Owned<IAttributeIterator> rootAttrs = verifyRoot->getAttributes();
+            ForEach(*rootAttrs)
+                rootAttrCount++;
+        }
+        unsigned rootChildCount{0};
+        {
+            Owned<IPropertyTreeIterator> rootChildren = verifyRoot->getElements("*");
+            ForEach(*rootChildren)
+                rootChildCount++;
+        }
+        fprintf(stdout, "sds-ls -la %s\n", xpath);
+        fprintf(stdout, "drwxr-xr-x 1 sds sds %5u %s (attrs=%u)\n", rootChildCount, xpath, rootAttrCount);
+        Owned<IPropertyTreeIterator> entryIter = verifyRoot->getElements("*");
+        ForEach(*entryIter)
+        {
+            IPropertyTree &entry = entryIter->query();
+            const char *entryName = entry.queryName();
+            if (!entryName)
+                entryName = "__unnamed__";
+            unsigned entryAttrCount{0};
+            Owned<IAttributeIterator> entryAttrs = entry.getAttributes();
+            ForEach(*entryAttrs)
+                entryAttrCount++;
+            unsigned entryChildCount{0};
+            Owned<IPropertyTreeIterator> entryChildren = entry.getElements("*");
+            ForEach(*entryChildren)
+                entryChildCount++;
+            StringBuffer entryXml;
+            toXML(&entry, entryXml);
+            char entryType = entryChildCount ? 'd' : '-';
+            fprintf(stdout, "%crw-r--r-- 1 sds sds %5u %s/%s (attrs=%u children=%u)\n", entryType, (unsigned)entryXml.length(), xpath, entryName, entryAttrCount, entryChildCount);
+        }
+    }
+
+    void runDiagSavePhaseAndVerifyStoreEdition(CCycleTimer &timer, __uint64 &totalDiagSaveNs)
+    {
+        unsigned editionBeforeDiagSave{0};
+        StringBuffer dataPath;
+        CPPUNIT_ASSERT(queryCurrentStoreEdition(editionBeforeDiagSave, dataPath));
+
+        MemoryBuffer saveRequest;
+        saveRequest.append("save");
+        timer.reset();
+        getDaliDiagnosticValue(saveRequest);
+        totalDiagSaveNs += timer.elapsedNs();
+
+        unsigned editionAfterDiagSave = 0;
+        StringBuffer verifyDataPath;
+        CPPUNIT_ASSERT(queryCurrentStoreEdition(editionAfterDiagSave, verifyDataPath));
+        if (editionAfterDiagSave == editionBeforeDiagSave)
+        {
+            VStringBuffer msg("Dalidiag save did not advance store edition in '%s' (before=%u after=%u)",
+                              verifyDataPath.str(),
+                              editionBeforeDiagSave,
+                              editionAfterDiagSave);
+            CPPUNIT_FAIL(msg.str());
+        }
+    }
+
+    void runTiming(const char *sourceXPath, byte flags, const char *modeLabel, bool cloneToLocal, unsigned iterations, XmlTimingResults &results)
+    {
+        __uint64 totalLoadNs{0};
+        __uint64 totalSaveNs{0};
+        __uint64 totalDiagSaveNs{0};
+        CCycleTimer timer;
+        constexpr unsigned timeoutMs{20000};
+
+        for (unsigned i = 0; i < iterations; i++)
+        {
+            // Phase 1: Load from SDS and clone to a local tree for the selected mode.
+            Owned<IPropertyTree> tree = runLoadPhase(sourceXPath, flags, cloneToLocal, timeoutMs, timer, totalLoadNs);
+
+            // Phase 2: Save the cloned tree to SDS and time the commit.
+            VStringBuffer xpath("/DaliStoreLoadAndSaveTimingStressTest/%s/i%u", modeLabel, i);
+            runSdsSavePhase(xpath.str(), tree, timeoutMs, timer, totalSaveNs);
+
+            // Phase 3: Reopen and verify saved content, then print a ls-style diagnostic listing.
+            runVerifyAndListPhase(xpath.str(), timeoutMs);
+
+            // Phase 4: Force dalidiag-style SDS save, time it, and verify store edition advanced.
+            runDiagSavePhaseAndVerifyStoreEdition(timer, totalDiagSaveNs);
+        }
+
+        constexpr double nsPerMs{1000000.0};
+        results.avgLoadTimeMs = (double)totalLoadNs / (double)iterations / nsPerMs;
+        results.avgSaveTimeMs = (double)totalSaveNs / (double)iterations / nsPerMs;
+        results.avgDiagSaveTimeMs = (double)totalDiagSaveNs / (double)iterations / nsPerMs;
+    }
+
+    void printResults(const char *storeFilename, size32_t xmlDataLen, unsigned iterations, const XmlTimingResults &xmlNormalResults, const XmlTimingResults &xmlLowMemResults)
+    {
+        double lowMemLoadDiff{0.0};
+        if (xmlNormalResults.avgLoadTimeMs != 0.0)
+            lowMemLoadDiff = ((xmlLowMemResults.avgLoadTimeMs - xmlNormalResults.avgLoadTimeMs) * 100.0) / xmlNormalResults.avgLoadTimeMs;
+
+        double lowMemSaveDiff{0.0};
+        if (xmlNormalResults.avgSaveTimeMs != 0.0)
+            lowMemSaveDiff = ((xmlLowMemResults.avgSaveTimeMs - xmlNormalResults.avgSaveTimeMs) * 100.0) / xmlNormalResults.avgSaveTimeMs;
+
+        double lowMemDiagSaveDiff{0.0};
+        if (xmlNormalResults.avgDiagSaveTimeMs != 0.0)
+            lowMemDiagSaveDiff = ((xmlLowMemResults.avgDiagSaveTimeMs - xmlNormalResults.avgDiagSaveTimeMs) * 100.0) / xmlNormalResults.avgDiagSaveTimeMs;
+
+        fprintf(stdout, "\n=== XML TIMING COMPARISON TEST ===\n");
+        fprintf(stdout, "Store file: %s\n", storeFilename);
+        fprintf(stdout, "XML data size: %u bytes\n", xmlDataLen);
+        fprintf(stdout, "Iterations: %u\n", iterations);
+        fprintf(stdout, "┌──────────────────────┬─────────────────┬─────────────────┬─────────────────┐\n");
+        fprintf(stdout, "│ Mode                 │ Avg SDS Load    │ Avg SDS Save    │ Avg Diag Save   │\n");
+        fprintf(stdout, "│                      │ (ms)            │ (ms)            │ (ms)            │\n");
+        fprintf(stdout, "├──────────────────────┼─────────────────┼─────────────────┼─────────────────┤\n");
+        fprintf(stdout, "│ XML Normal           │ %15.6f │ %15.6f │ %15.6f │\n",
+                xmlNormalResults.avgLoadTimeMs,
+                xmlNormalResults.avgSaveTimeMs,
+                xmlNormalResults.avgDiagSaveTimeMs);
+        fprintf(stdout, "│ XML Low Memory       │ %15.6f │ %15.6f │ %15.6f │\n",
+                xmlLowMemResults.avgLoadTimeMs,
+                xmlLowMemResults.avgSaveTimeMs,
+                xmlLowMemResults.avgDiagSaveTimeMs);
+        fprintf(stdout, "│ XML LowMem Diff      │ %+14.2f%% │ %+14.2f%% │ %+14.2f%% │\n",
+                lowMemLoadDiff,
+                lowMemSaveDiff,
+                lowMemDiagSaveDiff);
+        fprintf(stdout, "└──────────────────────┴─────────────────┴─────────────────┴─────────────────┘\n");
+        fflush(stdout);
+    }
+
+public:
+    void testStoreRoundTripTiming()
+    {
+        START_TEST
+
+        DaliClientScope daliClientScope;
+        assertDaliRunning();
+
+        StringBuffer selectedStoreFilename;
+        unsigned selectedStoreEdition = 0;
+        const char *configuredStoreFilename = queryUnitTestDaliStorePath();
+        if (configuredStoreFilename && *configuredStoreFilename)
+            selectedStoreFilename.set(configuredStoreFilename);
+        else
+        {
+            if (!queryCurrentStoreXmlPath(selectedStoreFilename, selectedStoreEdition))
+            {
+                DBGLOG("Skipping DaliStoreLoadAndSaveTimingStressTest. Supply --dali-store <path> or ensure @dataPathUrl contains dalisds*.xml");
+                return;
+            }
+            DBGLOG("Auto-selected dali store file '%s' (edition=%u)", selectedStoreFilename.str(), selectedStoreEdition);
+        }
+        const char *storeFilename = selectedStoreFilename.str();
+
+        unsigned iterations = queryUnitTestDaliStoreIterations();
+        CPPUNIT_ASSERT(iterations != 0);
+
+        MemoryBuffer xmlData;
+        size32_t xmlDataLen{0};
+        if (!loadXmlData(storeFilename, xmlData, xmlDataLen))
+        {
+            VStringBuffer msg("Unable to open or read dali store file '%s'", storeFilename);
+            CPPUNIT_FAIL(msg.str());
+        }
+
+        const char *xmlText = static_cast<const char *>(xmlData.bufferBase());
+        constexpr const char *sourceXPath = "/DaliStoreLoadAndSaveTimingStressTest/source";
+        {
+            Owned<IPropertyTree> sourceTree = createPTreeFromXMLString(xmlDataLen, xmlText, ipt_none, ptr_ignoreWhiteSpace, nullptr);
+            constexpr unsigned timeoutMs{20000};
+            unsigned mode = RTM_CREATE_QUERY | RTM_LOCK_WRITE;
+            Owned<IRemoteConnection> sourceConn = querySDS().connect(sourceXPath, myProcessSession(), mode, timeoutMs);
+            CPPUNIT_ASSERT(sourceConn);
+            IPropertyTree *sourceRoot = sourceConn->queryRoot();
+            CPPUNIT_ASSERT(sourceRoot);
+            sourceRoot->setPropTree("Store", LINK(sourceTree));
+            sourceConn->commit();
+        }
+
+        XmlTimingResults xmlNormalResults;
+        runTiming(sourceXPath, ipt_none, "normal", true, iterations, xmlNormalResults);
+        XmlTimingResults xmlLowMemResults;
+        runTiming(sourceXPath, ipt_lowmem, "lowmem", true, iterations, xmlLowMemResults);
+
+        printResults(storeFilename, xmlDataLen, iterations, xmlNormalResults, xmlLowMemResults);
+
+        END_TEST
+    }
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION(DaliStoreLoadAndSaveTimingStressTest);
+CPPUNIT_TEST_SUITE_NAMED_REGISTRATION(DaliStoreLoadAndSaveTimingStressTest, "DaliStoreLoadAndSaveTimingStressTest");
 
 //---------------------------------------------------------------------------------------------------------------------
 

--- a/testing/unittests/unittests.cpp
+++ b/testing/unittests/unittests.cpp
@@ -25,6 +25,10 @@
 #include "thorhelper.hpp"
 #include "libbase58.h"
 
+#include <climits>
+#include <cstdlib>
+#include <cstring>
+
 /*
  * This is the main unittest driver for HPCC. From here,
  * all unit tests, be they internal or external (API),
@@ -58,6 +62,10 @@ void usage()
     "    -l  --list       List matching tests but do not execute them\n"
     "    -u  --unload     Unload dynamically-loaded dlls before termination (may crash on some systems)\n"
     "    -x  --exclude    Exclude subsequent test names\n"
+    "        --dali-store <path>\n"
+    "                     XML file used by DaliStoreLoadAndSaveTimingStressTest\n"
+    "        --dali-store-iterations <count>\n"
+    "                     Iterations for DaliStoreLoadAndSaveTimingStressTest (default 5)\n"
     "\n");
 }
 
@@ -135,6 +143,33 @@ global:
       category: data
 )!!";
 
+static StringAttr daliStorePath;
+static unsigned daliStoreIterations = 5;
+
+const char * queryUnitTestDaliStorePath()
+{
+    return daliStorePath.get();
+}
+
+unsigned queryUnitTestDaliStoreIterations()
+{
+    return daliStoreIterations;
+}
+
+static bool parsePositiveUnsigned(const char * text, unsigned & value)
+{
+    if (!text || !*text)
+        return false;
+
+    char * end = nullptr;
+    unsigned long parsed = strtoul(text, &end, 10);
+    if ((end == text) || *end || parsed == 0 || parsed > UINT_MAX)
+        return false;
+
+    value = (unsigned)parsed;
+    return true;
+}
+
 int main(int argc, const char *argv[])
 {
     InitModuleObjects();
@@ -176,6 +211,38 @@ int main(int argc, const char *argv[])
                 argNo++;
                 if (argNo<argc)
                    loadLocations.append(argv[argNo]);
+            }
+            else if (streq(arg, "--dali-store"))
+            {
+                argNo++;
+                if (argNo<argc)
+                    daliStorePath.set(argv[argNo]);
+                else
+                {
+                    usage();
+                    exit(4);
+                }
+            }
+            else if (strncmp(arg, "--dali-store=", 13) == 0)
+                daliStorePath.set(arg + 13);
+            else if (streq(arg, "--dali-store-iterations"))
+            {
+                argNo++;
+                if (argNo<argc && parsePositiveUnsigned(argv[argNo], daliStoreIterations))
+                    ;
+                else
+                {
+                    usage();
+                    exit(4);
+                }
+            }
+            else if (strncmp(arg, "--dali-store-iterations=", 24) == 0)
+            {
+                if (!parsePositiveUnsigned(arg + 24, daliStoreIterations))
+                {
+                    usage();
+                    exit(4);
+                }
             }
             else
             {
@@ -971,7 +1038,7 @@ class RelaxedAtomicTimingTest : public CppUnit::TestFixture
 
         for (int a = 0; a < 201; a++)
             ra[a] = 0;
-        
+
         class T : public CThreaded
         {
         public:
@@ -1037,7 +1104,7 @@ class RelaxedAtomicTimingTest : public CppUnit::TestFixture
             CriticalSection &lock;
         } t1a(count, ra[0], lock[0], mode), t2a(count, ra[0], lock[0], mode), t3a(count, ra[0], lock[0], mode),
           t1b(count, ra[0], lock[0], mode), t2b(count, ra[1], lock[1], mode), t3b(count, ra[2], lock[2], mode),
-          t1c(count, ra[0], lock[0], mode), t2c(count, ra[100], lock[100], mode), t3c(count, ra[200], lock[200], mode);;  
+          t1c(count, ra[0], lock[0], mode), t2c(count, ra[100], lock[100], mode), t3c(count, ra[200], lock[200], mode);;
         DBGLOG("Testing RelaxedAtomics (test mode %u)", mode);
         t1a.start(false);
         t2a.start(false);
@@ -1080,7 +1147,7 @@ class compressToBufferTest : public CppUnit::TestFixture
 
     bool testOne(unsigned len, CompressionMethod method, bool prevResult, const char *options=nullptr)
     {
-        constexpr const char *in = 
+        constexpr const char *in =
           "HelloHelloHelloHelloHelloHelloHelloHelloHelloHello"
           "HelloHelloHelloHelloHelloHelloHelloHelloHelloHello"
           "HelloHelloHelloHelloHelloHelloHelloHelloHelloHello"
@@ -1119,7 +1186,7 @@ class compressToBufferTest : public CppUnit::TestFixture
                DBGLOG("compressToBuffer %x size %u did not compress", (byte) method, len);
             ret = false;
         }
-        else 
+        else
         {
             if (!prevResult)
                 DBGLOG("compressToBuffer %x size %u compressed to %u in %lluns", (byte) method, len, compressed.length(), start.elapsedNs());

--- a/testing/unittests/unittests.hpp
+++ b/testing/unittests/unittests.hpp
@@ -75,3 +75,6 @@ public:
         e->Release(); \
         CPPUNIT_FAIL(msg.str()); \
     }
+
+const char * queryUnitTestDaliStorePath();
+unsigned queryUnitTestDaliStoreIterations();


### PR DESCRIPTION
1. Added a new unit test that can be used to compare the round trip time for loading and saving a running dali store for ipt_none vs ipt_lowmem from running Bare Metal.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [x] Send notifications about my Pull Request position in Smoketest queue.
- [x] Test my draft Pull Request.

## Testing:
Steps:
1. Run up bare metal
2. Run commands:
- ~/hpccDebug/etc/init.d/hpcc-init stop -c mydali
- ~/hpccDebug/etc/init.d/hpcc-init start -c mydali
- ~/build/Debug-install/Debug/bin/unittests -v -e DaliStoreLoadAndSaveTimingStressTest

Output:

```
16:04:02.109974 14390 UNK UNK Including test DaliStoreLoadAndSaveTimingStressTest
.16:04:02.134749 14390 UNK UNK MP TLS: off acceptThreadPoolSize: 0
16:04:02.140532 14390 UNK UNK Auto-selected dali store file '//192.168.1.115/home/dave/hpccDebug/var/lib/HPCCSystems/hpcc-data/dali/dalisds1.xml' (edition=1)
sds-ls -la /DaliStoreLoadAndSaveTimingStressTest/normal/i0
drwxr-xr-x 1 sds sds     1 /DaliStoreLoadAndSaveTimingStressTest/normal/i0 (attrs=0)
drw-r--r-- 1 sds sds 67686 /DaliStoreLoadAndSaveTimingStressTest/normal/i0/Store (attrs=0 children=15)
sds-ls -la /DaliStoreLoadAndSaveTimingStressTest/normal/i1
drwxr-xr-x 1 sds sds     1 /DaliStoreLoadAndSaveTimingStressTest/normal/i1 (attrs=0)
drw-r--r-- 1 sds sds 67686 /DaliStoreLoadAndSaveTimingStressTest/normal/i1/Store (attrs=0 children=15)
sds-ls -la /DaliStoreLoadAndSaveTimingStressTest/normal/i2
drwxr-xr-x 1 sds sds     1 /DaliStoreLoadAndSaveTimingStressTest/normal/i2 (attrs=0)
drw-r--r-- 1 sds sds 67686 /DaliStoreLoadAndSaveTimingStressTest/normal/i2/Store (attrs=0 children=15)
sds-ls -la /DaliStoreLoadAndSaveTimingStressTest/normal/i3
drwxr-xr-x 1 sds sds     1 /DaliStoreLoadAndSaveTimingStressTest/normal/i3 (attrs=0)
drw-r--r-- 1 sds sds 67686 /DaliStoreLoadAndSaveTimingStressTest/normal/i3/Store (attrs=0 children=15)
sds-ls -la /DaliStoreLoadAndSaveTimingStressTest/normal/i4
drwxr-xr-x 1 sds sds     1 /DaliStoreLoadAndSaveTimingStressTest/normal/i4 (attrs=0)
drw-r--r-- 1 sds sds 67686 /DaliStoreLoadAndSaveTimingStressTest/normal/i4/Store (attrs=0 children=15)
sds-ls -la /DaliStoreLoadAndSaveTimingStressTest/lowmem/i0
drwxr-xr-x 1 sds sds     1 /DaliStoreLoadAndSaveTimingStressTest/lowmem/i0 (attrs=0)
drw-r--r-- 1 sds sds 67686 /DaliStoreLoadAndSaveTimingStressTest/lowmem/i0/Store (attrs=0 children=15)
sds-ls -la /DaliStoreLoadAndSaveTimingStressTest/lowmem/i1
drwxr-xr-x 1 sds sds     1 /DaliStoreLoadAndSaveTimingStressTest/lowmem/i1 (attrs=0)
drw-r--r-- 1 sds sds 67686 /DaliStoreLoadAndSaveTimingStressTest/lowmem/i1/Store (attrs=0 children=15)
sds-ls -la /DaliStoreLoadAndSaveTimingStressTest/lowmem/i2
drwxr-xr-x 1 sds sds     1 /DaliStoreLoadAndSaveTimingStressTest/lowmem/i2 (attrs=0)
drw-r--r-- 1 sds sds 67686 /DaliStoreLoadAndSaveTimingStressTest/lowmem/i2/Store (attrs=0 children=15)
sds-ls -la /DaliStoreLoadAndSaveTimingStressTest/lowmem/i3
drwxr-xr-x 1 sds sds     1 /DaliStoreLoadAndSaveTimingStressTest/lowmem/i3 (attrs=0)
drw-r--r-- 1 sds sds 67686 /DaliStoreLoadAndSaveTimingStressTest/lowmem/i3/Store (attrs=0 children=15)
sds-ls -la /DaliStoreLoadAndSaveTimingStressTest/lowmem/i4
drwxr-xr-x 1 sds sds     1 /DaliStoreLoadAndSaveTimingStressTest/lowmem/i4 (attrs=0)
drw-r--r-- 1 sds sds 67686 /DaliStoreLoadAndSaveTimingStressTest/lowmem/i4/Store (attrs=0 children=15)

=== XML TIMING COMPARISON TEST ===
Store file: //192.168.1.115/home/dave/hpccDebug/var/lib/HPCCSystems/hpcc-data/dali/dalisds1.xml
XML data size: 67682 bytes
Iterations: 5
┌──────────────────────┬─────────────────┬─────────────────┬─────────────────┐
│ Mode                 │ Avg SDS Load    │ Avg SDS Save    │ Avg Diag Save   │
│                      │ (ms)            │ (ms)            │ (ms)            │
├──────────────────────┼─────────────────┼─────────────────┼─────────────────┤
│ XML Normal           │        0.000286 │       11.184660 │       14.168543 │
│ XML Low Memory       │        0.000395 │       11.656103 │       26.447048 │
│ XML LowMem Diff      │         +37.97% │          +4.22% │         +86.66% │
└──────────────────────┴─────────────────┴─────────────────┴─────────────────┘



OK (1 tests)
```
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
