### PR TITLE
HPCC-36106 Default saving Dali store in binary format

### DIFF
--- a/dali/base/dasds.cpp
+++ b/dali/base/dasds.cpp
@@ -6175,7 +6175,7 @@ CCovenSDSManager::CCovenSDSManager(ICoven &_coven, const char *_dataPath, const 
     clientProps->setPropBool("@serverIterAvailable", true);
     clientProps->setPropBool("@useAppendOpt", true);
     clientProps->setPropBool("@serverGetIdsAvailable", true);
-    bool saveBinary = config->getPropBool("@saveBinary", isDebugBuild());
+    bool saveBinary = config->getPropBool("@saveBinary", true);
     clientProps->setPropBool("@saveBinary", saveBinary);
     bool saveAsync = config->getPropBool("@saveAsync", true);
     clientProps->setPropBool("@saveAsync", saveAsync);

--- a/helm/hpcc/values.schema.json
+++ b/helm/hpcc/values.schema.json
@@ -1575,8 +1575,8 @@
         },
         "saveBinary": {
           "type": "boolean",
-          "default": false,
-          "description": "Save the store in binary format after the store was saved in XML format"
+          "default": true,
+          "description": "When enabled, also save the store in binary format. If saveAsync is true, XML and binary saves occur in parallel; if saveAsync is false, XML is saved first and then binary."
         },
         "saveAsync": {
           "type": "boolean",

--- a/initfiles/componentfiles/configschema/xsd/dali.xsd
+++ b/initfiles/componentfiles/configschema/xsd/dali.xsd
@@ -52,7 +52,7 @@
                                   hpcc:displayName="Enable Autorecover for Delta Files" hpcc:presetValue="true"
                                   hpcc:tooltip="Switch on to autorecover from corruption to delta files on load"/>
                     <xs:attribute name="saveBinary" type="xs:boolean"
-                                  hpcc:displayName="Enable Saving Store in Binary Format" hpcc:presetValue="false"
+                                  hpcc:displayName="Enable Saving Store in Binary Format" hpcc:presetValue="true"
                                   hpcc:tooltip="Switch on to save the store in binary format"/>
                     <xs:attribute name="saveAsync" type="xs:boolean"
                                   hpcc:displayName="Enable Saving Store Asynchronously in XML and Binary formats" hpcc:presetValue="true"

--- a/initfiles/componentfiles/configxml/dali.xsd
+++ b/initfiles/componentfiles/configxml/dali.xsd
@@ -274,7 +274,7 @@
         </xs:appinfo>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="saveBinary" type="xs:boolean" default="false">
+    <xs:attribute name="saveBinary" type="xs:boolean" default="true">
       <xs:annotation>
         <xs:appinfo>
           <tooltip>Switch on saving the store in binary format</tooltip>


### PR DESCRIPTION
Set Dali store save binary default to true.

<!-- Thank you for submitting a pull request to the HPCC project

 PLEASE READ the following before proceeding.

 This project only accepts pull requests related to open JIRA issues.
 If suggesting a new feature or change, please discuss it in a JIRA issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
 The title line of the pull request (and of each commit within it) should refer to the
 associated issue using the format:

 HPCC-nnnnn Short description of issue

 This will allow the Jira ticket to be automatically updated to refer to this pull request,
 and will ensure that the automatically-generated changelog is properly formatted.
 Where a pull request contains a single commit the pull request title will be set automatically,
 assuming that the commit has followed the proper guidelines.

 Please go over all the following points, and put an `x` in all the boxes that apply. You may find
 it easier to press the 'Create' button first then click on the checkboxes to edit the comment.
-->

## Type of change:
- [ ] This change is a bug fix (non-breaking change which fixes an issue).
- [x] This change is a new feature (non-breaking change which adds functionality).
- [ ] This change improves the code (refactor or other change that does not change the functionality)
- [ ] This change fixes warnings (the fix does not alter the functionality or the generated code)
- [ ] This change is a breaking change (fix or feature that will cause existing behavior to change).
- [ ] This change alters the query API (existing queries will have to be recompiled)

## Checklist:
- [x] My code follows the code style of this project.
  - [ ] My code does not create any new warnings from compiler, build system, or lint.
- [x] The commit message is properly formatted and free of typos.
  - [ ] The commit message title makes sense in a changelog, by itself.
  - [ ] The commit is signed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly, or...
  - [ ] I have created a JIRA ticket to update the documentation.
  - [ ] Any new interfaces or exported functions are appropriately commented.
- [x] I have read the CONTRIBUTORS document.
- [x] The change has been fully tested:
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [ ] I have checked that this change does not introduce memory leaks.
  - [ ] I have used Valgrind or similar tools to check for potential issues.
- [ ] I have given due consideration to all of the following potential concerns:
  - [ ] Scalability
  - [ ] Performance
  - [ ] Security
  - [ ] Thread-safety
  - [ ] Cloud-compatibility
  - [ ] Premature optimization
  - [ ] Existing deployed queries will not be broken
  - [ ] This change fixes the problem, not just the symptom
  - [ ] The target branch of this pull request is appropriate for such a change.
- [ ] There are no similar instances of the same problem that should be addressed
  - [ ] I have addressed them here
  - [ ] I have raised JIRA issues to address them separately
- [ ] This is a user interface / front-end modification
  - [ ] I have tested my changes in multiple modern browsers
  - [ ] The component(s) render as expected

## Smoketest:
- [x] Send notifications about my Pull Request position in Smoketest queue.
- [x] Test my draft Pull Request.

## Testing:
Issuing a Dali store save via stopping Dali and using `dalidiag`:

```
dave@RISKAZ-06905526:~/hpccDebug/opt/HPCCSystems/bin$ bme;rm -rf  ~/hpccDebug/var/log/HPCCSystems/*;rm -rf  ~/hpccDebug/var/lib/HPCCSystems/*
Stopping mytoposerver...       [   OK    ]
Stopping mythor...             [   OK    ]
Stopping mysasha...            [   OK    ]
Stopping myroxie...            [   OK    ]
Stopping myesp...              [   OK    ]
Stopping myeclscheduler...     [   OK    ]
Stopping myeclccserver...      [   OK    ]
Stopping myeclagent...         [   OK    ]
Stopping mydfuserver...        [   OK    ]
Stopping mydali...             [   OK    ]
Service dafilesrv, mydafilesrv is already stopped.
Stopping mydafilesrv...        [   OK    ]
dave@RISKAZ-06905526:~/hpccDebug/etc/init.d$ ~/hpccDebug/etc/init.d/hpcc-init start -c mydali
Starting mydali ...            [   OK    ]
dave@RISKAZ-06905526:~/hpccDebug/etc/init.d$ ~/hpccDebug/etc/init.d/hpcc-init stop -c mydali
Stopping mydali...             [   OK    ]
dave@RISKAZ-06905526:~/hpccDebug/etc/init.d$ bme;rm -rf  ~/hpccDebug/var/log/HPCCSystems/*;rm -rf  ~/hpccDebug/var/lib/HPCCSystems/*
Stopping mytoposerver...       [   OK    ]
Stopping mythor...             [   OK    ]
Stopping mysasha...            [   OK    ]
Stopping myroxie...            [   OK    ]
Stopping myesp...              [   OK    ]
Stopping myeclscheduler...     [   OK    ]
Stopping myeclccserver...      [   OK    ]
Stopping myeclagent...         [   OK    ]
Stopping mydfuserver...        [   OK    ]
Stopping mydali...             [   OK    ]
Service dafilesrv, mydafilesrv is already stopped.
Stopping mydafilesrv...        [   OK    ]
dave@RISKAZ-06905526:~/hpccDebug/etc/init.d$ ls -la /home/dave/hpccDebug/var/lib/HPCCSystems/hpcc-data/dali/;ls -la /home/dave/hpccDebug/var/lib/HPCCSystems/hpcc-mirror/dali/
ls: cannot access '/home/dave/hpccDebug/var/lib/HPCCSystems/hpcc-data/dali/': No such file or directory
ls: cannot access '/home/dave/hpccDebug/var/lib/HPCCSystems/hpcc-mirror/dali/': No such file or directory
dave@RISKAZ-06905526:~/hpccDebug/etc/init.d$ ~/hpccDebug/etc/init.d/hpcc-init start -c mydali
Starting mydali ...            [   OK    ]
dave@RISKAZ-06905526:~/hpccDebug/etc/init.d$ ~/hpccDebug/etc/init.d/hpcc-init stop -c mydali
Stopping mydali...             [   OK    ]
dave@RISKAZ-06905526:~/hpccDebug/etc/init.d$ ls -la /home/dave/hpccDebug/var/lib/HPCCSystems/hpcc-data/dali/;ls -la /home/dave/hpccDebug/var/lib/HPCCSystems/hpcc-mirror/dali/
total 120
drwxr-xr-x 2 dave dave  4096 Apr  8 16:22 .
drwxr-xr-x 3 dave dave  4096 Apr  8 16:21 ..
-rw-r--r-- 1 dave dave   179 Apr  8 16:22 dalicoven.xml
-rw-r--r-- 1 dave dave  1839 Apr  8 16:21 daliinc.xml
-rw-r--r-- 1 dave dave 38221 Apr  8 16:22 dalisds1.bin
-rw-r--r-- 1 dave dave 60597 Apr  8 16:22 dalisds1.xml
-rw-r--r-- 1 dave dave     8 Apr  8 16:22 store.1
total 124
drwxr-xr-x 2 dave dave  4096 Apr  8 16:22 .
drwxr-xr-x 3 dave dave  4096 Apr  8 16:21 ..
-rw-r--r-- 1 dave dave  2042 Apr  8 16:21 daliconf.xml
-rw-r--r-- 1 dave dave   179 Apr  8 16:22 dalicoven.xml
-rw-r--r-- 1 dave dave  1839 Apr  8 16:21 daliinc.xml
-rw-r--r-- 1 dave dave 38221 Apr  8 16:22 dalisds1.bin
-rw-r--r-- 1 dave dave 60597 Apr  8 16:22 dalisds1.xml
-rw-r--r-- 1 dave dave     8 Apr  8 16:22 store.1
dave@RISKAZ-06905526:~/hpccDebug/etc/init.d$ ~/hpccDebug/etc/init.d/hpcc-init start -c mydali
Starting mydali ...            [   OK    ]
dave@RISKAZ-06905526:~/hpccDebug/etc/init.d$ cd ~/hpccDebug/opt/HPCCSystems/bin;./dalidiag . -save
00000000 USR 2026-04-08 16:22:19.021 315593 315593 "MP TLS: off acceptThreadPoolSize: 0"
00000001 USR 2026-04-08 16:22:19.028 315593 315593 "Requesting SDS save"
00000002 USR 2026-04-08 16:22:19.032 315593 315593 "SDS store saved"
dave@RISKAZ-06905526:~/hpccDebug/opt/HPCCSystems/bin$ ls -la /home/dave/hpccDebug/var/lib/HPCCSystems/hpcc-data/dali/;ls -la /home/dave/hpccDebug/var/lib/HPCCSystems/hpcc-mirror/dali/
total 224
drwxr-xr-x 2 dave dave  4096 Apr  8 16:22 .
drwxr-xr-x 3 dave dave  4096 Apr  8 16:21 ..
-rw-r--r-- 1 dave dave   179 Apr  8 16:22 dalicoven.xml
-rw-r--r-- 1 dave dave  1839 Apr  8 16:21 daliinc.xml
-rw-r--r-- 1 dave dave   854 Apr  8 16:22 daliinc1.xml
-rw-r--r-- 1 dave dave 38221 Apr  8 16:22 dalisds1.bin
-rw-r--r-- 1 dave dave 60597 Apr  8 16:22 dalisds1.xml
-rw-r--r-- 1 dave dave 38199 Apr  8 16:22 dalisds2.bin
-rw-r--r-- 1 dave dave 60573 Apr  8 16:22 dalisds2.xml
-rw-r--r-- 1 dave dave     8 Apr  8 16:22 store.2
total 228
drwxr-xr-x 2 dave dave  4096 Apr  8 16:22 .
drwxr-xr-x 3 dave dave  4096 Apr  8 16:21 ..
-rw-r--r-- 1 dave dave  2042 Apr  8 16:22 daliconf.xml
-rw-r--r-- 1 dave dave   179 Apr  8 16:22 dalicoven.xml
-rw-r--r-- 1 dave dave  1839 Apr  8 16:21 daliinc.xml
-rw-r--r-- 1 dave dave   854 Apr  8 16:22 daliinc1.xml
-rw-r--r-- 1 dave dave 38221 Apr  8 16:22 dalisds1.bin
-rw-r--r-- 1 dave dave 60597 Apr  8 16:22 dalisds1.xml
-rw-r--r-- 1 dave dave 38199 Apr  8 16:22 dalisds2.bin
-rw-r--r-- 1 dave dave 60573 Apr  8 16:22 dalisds2.xml
-rw-r--r-- 1 dave dave     8 Apr  8 16:22 store.2
dave@RISKAZ-06905526:~/hpccDebug/opt/HPCCSystems/bin$ hexdump /home/dave/hpccDebug/var/lib/HPCCSystems/hpcc-data/dali/store.2
0000000 2ff9 cd3d 9562 ed16
0000008
dave@RISKAZ-06905526:~/hpccDebug/opt/HPCCSystems/bin$
```
<!-- Please describe how this change has been tested.-->

<!-- Thank you for taking the time to submit this pull request and to answer all of the above-->
